### PR TITLE
Make it easier to add custom TNT blocks

### DIFF
--- a/patches/minecraft/net/minecraft/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FireBlock.java.patch
@@ -92,7 +92,7 @@
 -            TNTBlock tntblock = (TNTBlock)block;
 -            TNTBlock.func_196534_a(p_176536_1_, p_176536_2_);
 -         }
-+         if (blockstate.isExplosive(blockstate, p_176536_1_, p_176536_2_)) blockstate.createExplosion(p_176536_1_, p_176536_2_, null);
++         blockstate.catchFire(p_176536_1_, p_176536_2_, face, null);
        }
  
     }

--- a/patches/minecraft/net/minecraft/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FireBlock.java.patch
@@ -88,7 +88,7 @@
           if (block instanceof TNTBlock) {
              TNTBlock tntblock = (TNTBlock)block;
 -            TNTBlock.func_196534_a(p_176536_1_, p_176536_2_);
-+            tntblock.createExplosion(p_176536_1_, p_176536_2_);
++            tntblock.createExplosion(p_176536_1_, p_176536_2_, null);
           }
        }
  

--- a/patches/minecraft/net/minecraft/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FireBlock.java.patch
@@ -83,6 +83,15 @@
        if (p_176536_4_.nextInt(p_176536_3_) < i) {
           BlockState blockstate = p_176536_1_.func_180495_p(p_176536_2_);
           if (p_176536_4_.nextInt(p_176536_5_ + 10) < 5 && !p_176536_1_.func_175727_C(p_176536_2_)) {
+@@ -191,7 +195,7 @@
+          Block block = blockstate.func_177230_c();
+          if (block instanceof TNTBlock) {
+             TNTBlock tntblock = (TNTBlock)block;
+-            TNTBlock.func_196534_a(p_176536_1_, p_176536_2_);
++            tntblock.createExplosion(p_176536_1_, p_176536_2_);
+          }
+       }
+ 
 @@ -199,7 +203,7 @@
  
     private boolean func_196447_a(IBlockReader p_196447_1_, BlockPos p_196447_2_) {

--- a/patches/minecraft/net/minecraft/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FireBlock.java.patch
@@ -83,16 +83,19 @@
        if (p_176536_4_.nextInt(p_176536_3_) < i) {
           BlockState blockstate = p_176536_1_.func_180495_p(p_176536_2_);
           if (p_176536_4_.nextInt(p_176536_5_ + 10) < 5 && !p_176536_1_.func_175727_C(p_176536_2_)) {
-@@ -191,7 +195,7 @@
-          Block block = blockstate.func_177230_c();
-          if (block instanceof TNTBlock) {
-             TNTBlock tntblock = (TNTBlock)block;
--            TNTBlock.func_196534_a(p_176536_1_, p_176536_2_);
-+            tntblock.createExplosion(p_176536_1_, p_176536_2_, null);
+@@ -188,18 +192,14 @@
+             p_176536_1_.func_217377_a(p_176536_2_, false);
           }
+ 
+-         Block block = blockstate.func_177230_c();
+-         if (block instanceof TNTBlock) {
+-            TNTBlock tntblock = (TNTBlock)block;
+-            TNTBlock.func_196534_a(p_176536_1_, p_176536_2_);
+-         }
++         if (blockstate.isExplosive(blockstate, p_176536_1_, p_176536_2_)) blockstate.createExplosion(p_176536_1_, p_176536_2_, null);
        }
  
-@@ -199,7 +203,7 @@
+    }
  
     private boolean func_196447_a(IBlockReader p_196447_1_, BlockPos p_196447_2_) {
        for(Direction direction : Direction.values()) {
@@ -101,7 +104,7 @@
              return true;
           }
        }
-@@ -215,13 +219,14 @@
+@@ -215,13 +215,14 @@
  
           for(Direction direction : Direction.values()) {
              BlockState blockstate = p_176538_1_.func_180495_p(p_176538_2_.func_177972_a(direction));
@@ -117,7 +120,7 @@
     public boolean func_196446_i(BlockState p_196446_1_) {
        return this.func_220275_r(p_196446_1_) > 0;
     }
-@@ -246,8 +251,8 @@
+@@ -246,8 +247,8 @@
  
        BlockPos blockpos = p_180655_3_.func_177977_b();
        BlockState blockstate = p_180655_2_.func_180495_p(blockpos);
@@ -128,7 +131,7 @@
              for(int j = 0; j < 2; ++j) {
                 double d3 = (double)p_180655_3_.func_177958_n() + p_180655_4_.nextDouble() * (double)0.1F;
                 double d8 = (double)p_180655_3_.func_177956_o() + p_180655_4_.nextDouble();
-@@ -256,7 +261,7 @@
+@@ -256,7 +257,7 @@
              }
           }
  
@@ -137,7 +140,7 @@
              for(int k = 0; k < 2; ++k) {
                 double d4 = (double)(p_180655_3_.func_177958_n() + 1) - p_180655_4_.nextDouble() * (double)0.1F;
                 double d9 = (double)p_180655_3_.func_177956_o() + p_180655_4_.nextDouble();
-@@ -265,7 +270,7 @@
+@@ -265,7 +266,7 @@
              }
           }
  
@@ -146,7 +149,7 @@
              for(int l = 0; l < 2; ++l) {
                 double d5 = (double)p_180655_3_.func_177958_n() + p_180655_4_.nextDouble();
                 double d10 = (double)p_180655_3_.func_177956_o() + p_180655_4_.nextDouble();
-@@ -274,7 +279,7 @@
+@@ -274,7 +275,7 @@
              }
           }
  
@@ -155,7 +158,7 @@
              for(int i1 = 0; i1 < 2; ++i1) {
                 double d6 = (double)p_180655_3_.func_177958_n() + p_180655_4_.nextDouble();
                 double d11 = (double)p_180655_3_.func_177956_o() + p_180655_4_.nextDouble();
-@@ -283,7 +288,7 @@
+@@ -283,7 +284,7 @@
              }
           }
  
@@ -164,7 +167,7 @@
              for(int j1 = 0; j1 < 2; ++j1) {
                 double d7 = (double)p_180655_3_.func_177958_n() + p_180655_4_.nextDouble();
                 double d12 = (double)(p_180655_3_.func_177956_o() + 1) - p_180655_4_.nextDouble() * (double)0.1F;
-@@ -311,10 +316,23 @@
+@@ -311,10 +312,23 @@
     }
  
     public void func_180686_a(Block p_180686_1_, int p_180686_2_, int p_180686_3_) {

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -5,7 +5,7 @@
        if (p_220082_4_.func_177230_c() != p_220082_1_.func_177230_c()) {
           if (p_220082_2_.func_175640_z(p_220082_3_)) {
 -            func_196534_a(p_220082_2_, p_220082_3_);
-+            createExplosion(p_220082_2_, p_220082_3_);
++            createExplosion(p_220082_2_, p_220082_3_, null);
              p_220082_2_.func_217377_a(p_220082_3_, false);
           }
  
@@ -14,7 +14,7 @@
     public void func_220069_a(BlockState p_220069_1_, World p_220069_2_, BlockPos p_220069_3_, Block p_220069_4_, BlockPos p_220069_5_, boolean p_220069_6_) {
        if (p_220069_2_.func_175640_z(p_220069_3_)) {
 -         func_196534_a(p_220069_2_, p_220069_3_);
-+         createExplosion(p_220069_2_, p_220069_3_);
++         createExplosion(p_220069_2_, p_220069_3_, null);
           p_220069_2_.func_217377_a(p_220069_3_, false);
        }
  
@@ -23,7 +23,7 @@
     public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
        if (!p_176208_1_.func_201670_d() && !p_176208_4_.func_184812_l_() && p_176208_3_.func_177229_b(field_212569_a)) {
 -         func_196534_a(p_176208_1_, p_176208_2_);
-+         createExplosion(p_176208_1_, p_176208_2_);
++         createExplosion(p_176208_1_, p_176208_2_, null);
        }
  
        super.func_176208_a(p_176208_1_, p_176208_2_, p_176208_3_, p_176208_4_);
@@ -40,14 +40,10 @@
     private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
        if (!p_196535_0_.field_72995_K) {
           TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
-@@ -74,13 +76,21 @@
+@@ -74,13 +76,17 @@
        }
     }
  
-+   public void createExplosion(World world, BlockPos pos) {
-+      createExplosion(world, pos, null);
-+   }
-+
 +   public void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter) {
 +      func_196535_a(world, pos, igniter);
 +   }
@@ -63,7 +59,7 @@
           p_220051_2_.func_180501_a(p_220051_3_, Blocks.field_150350_a.func_176223_P(), 11);
           if (item == Items.field_151033_d) {
              itemstack.func_222118_a(1, p_220051_4_, (p_220287_1_) -> {
-@@ -100,7 +110,7 @@
+@@ -100,7 +106,7 @@
           Entity entity = abstractarrowentity.func_212360_k();
           if (abstractarrowentity.func_70027_ad()) {
              BlockPos blockpos = p_220066_3_.func_216350_a();

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -31,26 +31,16 @@
        }
     }
  
-+   @Deprecated //Forge: Prefer using the instance method that mods can override
++   @Deprecated //Forge: Prefer using IForgeBlock#onBlockExploded
     public static void func_196534_a(World p_196534_0_, BlockPos p_196534_1_) {
        func_196535_a(p_196534_0_, p_196534_1_, (LivingEntity)null);
     }
  
-+   @Deprecated //Forge: Prefer using the instance method that mods can override
-    private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
++   @Deprecated //Forge: Prefer using IForgeBlock#onBlockExploded
+    public static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
        if (!p_196535_0_.field_72995_K) {
           TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
-@@ -74,13 +76,17 @@
-       }
-    }
- 
-+   public void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter) {
-+      func_196535_a(world, pos, igniter);
-+   }
-+
-    public boolean func_220051_a(BlockState p_220051_1_, World p_220051_2_, BlockPos p_220051_3_, PlayerEntity p_220051_4_, Hand p_220051_5_, BlockRayTraceResult p_220051_6_) {
-       ItemStack itemstack = p_220051_4_.func_184586_b(p_220051_5_);
-       Item item = itemstack.func_77973_b();
+@@ -80,7 +82,7 @@
        if (item != Items.field_151033_d && item != Items.field_151059_bz) {
           return super.func_220051_a(p_220051_1_, p_220051_2_, p_220051_3_, p_220051_4_, p_220051_5_, p_220051_6_);
        } else {
@@ -59,7 +49,7 @@
           p_220051_2_.func_180501_a(p_220051_3_, Blocks.field_150350_a.func_176223_P(), 11);
           if (item == Items.field_151033_d) {
              itemstack.func_222118_a(1, p_220051_4_, (p_220287_1_) -> {
-@@ -100,7 +106,7 @@
+@@ -100,7 +102,7 @@
           Entity entity = abstractarrowentity.func_212360_k();
           if (abstractarrowentity.func_70027_ad()) {
              BlockPos blockpos = p_220066_3_.func_216350_a();

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -1,30 +1,6 @@
 --- a/net/minecraft/block/TNTBlock.java
 +++ b/net/minecraft/block/TNTBlock.java
-@@ -22,16 +22,31 @@
- 
- public class TNTBlock extends Block {
-    public static final BooleanProperty field_212569_a = BlockStateProperties.field_212646_x;
-+   private static final TNTEntityCreator defaultTNTEntityCreator = TNTEntity::new;
- 
-+   private final TNTEntityCreator tntEntityCreator;
-+
-+   /**
-+    * @deprecated Mods should use the constructor that allows for specifying which TNT Entity will be created
-+    */
-+   @Deprecated
-    public TNTBlock(Block.Properties p_i48309_1_) {
-+      this(p_i48309_1_, defaultTNTEntityCreator);
-+   }
-+
-+   /**
-+    * For mod use, eliminates (or at least lowers) the need to extend this class for purposes of creating custom TNT.
-+    */
-+   public TNTBlock(Block.Properties p_i48309_1_, TNTEntityCreator tntEntityCreator) {
-       super(p_i48309_1_);
-       this.func_180632_j(this.func_176223_P().func_206870_a(field_212569_a, Boolean.valueOf(false)));
-+      this.tntEntityCreator = tntEntityCreator;
-    }
- 
+@@ -31,7 +31,7 @@
     public void func_220082_b(BlockState p_220082_1_, World p_220082_2_, BlockPos p_220082_3_, BlockState p_220082_4_, boolean p_220082_5_) {
        if (p_220082_4_.func_177230_c() != p_220082_1_.func_177230_c()) {
           if (p_220082_2_.func_175640_z(p_220082_3_)) {
@@ -33,7 +9,7 @@
              p_220082_2_.func_217377_a(p_220082_3_, false);
           }
  
-@@ -40,7 +55,7 @@
+@@ -40,7 +40,7 @@
  
     public void func_220069_a(BlockState p_220069_1_, World p_220069_2_, BlockPos p_220069_3_, Block p_220069_4_, BlockPos p_220069_5_, boolean p_220069_6_) {
        if (p_220069_2_.func_175640_z(p_220069_3_)) {
@@ -42,7 +18,7 @@
           p_220069_2_.func_217377_a(p_220069_3_, false);
        }
  
-@@ -48,7 +63,7 @@
+@@ -48,7 +48,7 @@
  
     public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
        if (!p_176208_1_.func_201670_d() && !p_176208_4_.func_184812_l_() && p_176208_3_.func_177229_b(field_212569_a)) {
@@ -51,46 +27,29 @@
        }
  
        super.func_176208_a(p_176208_1_, p_176208_2_, p_176208_3_, p_176208_4_);
-@@ -56,16 +71,24 @@
- 
-    public void func_180652_a(World p_180652_1_, BlockPos p_180652_2_, Explosion p_180652_3_) {
-       if (!p_180652_1_.field_72995_K) {
--         TNTEntity tntentity = new TNTEntity(p_180652_1_, (double)((float)p_180652_2_.func_177958_n() + 0.5F), (double)p_180652_2_.func_177956_o(), (double)((float)p_180652_2_.func_177952_p() + 0.5F), p_180652_3_.func_94613_c());
-+         TNTEntity tntentity = tntEntityCreator.create(p_180652_1_, (double)((float)p_180652_2_.func_177958_n() + 0.5F), (double)p_180652_2_.func_177956_o(), (double)((float)p_180652_2_.func_177952_p() + 0.5F), p_180652_3_.func_94613_c());
-          tntentity.func_184534_a((short)(p_180652_1_.field_73012_v.nextInt(tntentity.func_184536_l() / 4) + tntentity.func_184536_l() / 8));
-          p_180652_1_.func_217376_c(tntentity);
+@@ -62,10 +62,12 @@
        }
     }
  
-+   /**
-+    * @deprecated Prefer using the local method
-+    */
-+   @Deprecated
++   @Deprecated //Forge: Prefer using the instance method that mods can override
     public static void func_196534_a(World p_196534_0_, BlockPos p_196534_1_) {
        func_196535_a(p_196534_0_, p_196534_1_, (LivingEntity)null);
     }
  
-+   /**
-+    * @deprecated Prefer using the one that mods can override
-+    */
-+   @Deprecated
++   @Deprecated //Forge: Prefer using the instance method that mods can override
     private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
        if (!p_196535_0_.field_72995_K) {
           TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
-@@ -74,13 +97,25 @@
+@@ -74,13 +76,21 @@
        }
     }
  
-+   public void createExplosion(World p_196534_0_, BlockPos p_196534_1_) {
-+      createExplosion(p_196534_0_, p_196534_1_, null);
++   public void createExplosion(World world, BlockPos pos) {
++      createExplosion(world, pos, null);
 +   }
 +
-+   private void createExplosion(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
-+      if (!p_196535_0_.field_72995_K) {
-+         TNTEntity tntentity = tntEntityCreator.create(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
-+         p_196535_0_.func_217376_c(tntentity);
-+         p_196535_0_.func_184148_a(null, tntentity.field_70165_t, tntentity.field_70163_u, tntentity.field_70161_v, SoundEvents.field_187904_gd, SoundCategory.BLOCKS, 1.0F, 1.0F);
-+      }
++   public void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter) {
++      func_196535_a(world, pos, igniter);
 +   }
 +
     public boolean func_220051_a(BlockState p_220051_1_, World p_220051_2_, BlockPos p_220051_3_, PlayerEntity p_220051_4_, Hand p_220051_5_, BlockRayTraceResult p_220051_6_) {
@@ -104,7 +63,7 @@
           p_220051_2_.func_180501_a(p_220051_3_, Blocks.field_150350_a.func_176223_P(), 11);
           if (item == Items.field_151033_d) {
              itemstack.func_222118_a(1, p_220051_4_, (p_220287_1_) -> {
-@@ -100,7 +135,7 @@
+@@ -100,7 +110,7 @@
           Entity entity = abstractarrowentity.func_212360_k();
           if (abstractarrowentity.func_70027_ad()) {
              BlockPos blockpos = p_220066_3_.func_216350_a();
@@ -113,14 +72,3 @@
              p_220066_1_.func_217377_a(blockpos, false);
           }
        }
-@@ -114,4 +149,10 @@
-    protected void func_206840_a(StateContainer.Builder<Block, BlockState> p_206840_1_) {
-       p_206840_1_.func_206894_a(field_212569_a);
-    }
-+
-+   @FunctionalInterface
-+   public interface TNTEntityCreator {
-+
-+      TNTEntity create(World world, double xPos, double yPos, double zPos, @Nullable LivingEntity entity);
-+   }
- }

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -1,0 +1,126 @@
+--- a/net/minecraft/block/TNTBlock.java
++++ b/net/minecraft/block/TNTBlock.java
+@@ -22,16 +22,31 @@
+ 
+ public class TNTBlock extends Block {
+    public static final BooleanProperty field_212569_a = BlockStateProperties.field_212646_x;
++   private static final TNTEntityCreator defaultTNTEntityCreator = TNTEntity::new;
+ 
++   private final TNTEntityCreator tntEntityCreator;
++
++   /**
++    * @deprecated Mods should use the constructor that allows for specifying which TNT Entity will be created
++    */
++   @Deprecated
+    public TNTBlock(Block.Properties p_i48309_1_) {
++      this(p_i48309_1_, defaultTNTEntityCreator);
++   }
++
++   /**
++    * For mod use, eliminates (or at least lowers) the need to extend this class for purposes of creating custom TNT.
++    */
++   public TNTBlock(Block.Properties p_i48309_1_, TNTEntityCreator tntEntityCreator) {
+       super(p_i48309_1_);
+       this.func_180632_j(this.func_176223_P().func_206870_a(field_212569_a, Boolean.valueOf(false)));
++      this.tntEntityCreator = tntEntityCreator;
+    }
+ 
+    public void func_220082_b(BlockState p_220082_1_, World p_220082_2_, BlockPos p_220082_3_, BlockState p_220082_4_, boolean p_220082_5_) {
+       if (p_220082_4_.func_177230_c() != p_220082_1_.func_177230_c()) {
+          if (p_220082_2_.func_175640_z(p_220082_3_)) {
+-            func_196534_a(p_220082_2_, p_220082_3_);
++            createExplosion(p_220082_2_, p_220082_3_);
+             p_220082_2_.func_217377_a(p_220082_3_, false);
+          }
+ 
+@@ -40,7 +55,7 @@
+ 
+    public void func_220069_a(BlockState p_220069_1_, World p_220069_2_, BlockPos p_220069_3_, Block p_220069_4_, BlockPos p_220069_5_, boolean p_220069_6_) {
+       if (p_220069_2_.func_175640_z(p_220069_3_)) {
+-         func_196534_a(p_220069_2_, p_220069_3_);
++         createExplosion(p_220069_2_, p_220069_3_);
+          p_220069_2_.func_217377_a(p_220069_3_, false);
+       }
+ 
+@@ -48,7 +63,7 @@
+ 
+    public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
+       if (!p_176208_1_.func_201670_d() && !p_176208_4_.func_184812_l_() && p_176208_3_.func_177229_b(field_212569_a)) {
+-         func_196534_a(p_176208_1_, p_176208_2_);
++         createExplosion(p_176208_1_, p_176208_2_);
+       }
+ 
+       super.func_176208_a(p_176208_1_, p_176208_2_, p_176208_3_, p_176208_4_);
+@@ -56,16 +71,24 @@
+ 
+    public void func_180652_a(World p_180652_1_, BlockPos p_180652_2_, Explosion p_180652_3_) {
+       if (!p_180652_1_.field_72995_K) {
+-         TNTEntity tntentity = new TNTEntity(p_180652_1_, (double)((float)p_180652_2_.func_177958_n() + 0.5F), (double)p_180652_2_.func_177956_o(), (double)((float)p_180652_2_.func_177952_p() + 0.5F), p_180652_3_.func_94613_c());
++         TNTEntity tntentity = tntEntityCreator.create(p_180652_1_, (double)((float)p_180652_2_.func_177958_n() + 0.5F), (double)p_180652_2_.func_177956_o(), (double)((float)p_180652_2_.func_177952_p() + 0.5F), p_180652_3_.func_94613_c());
+          tntentity.func_184534_a((short)(p_180652_1_.field_73012_v.nextInt(tntentity.func_184536_l() / 4) + tntentity.func_184536_l() / 8));
+          p_180652_1_.func_217376_c(tntentity);
+       }
+    }
+ 
++   /**
++    * @deprecated Prefer using the local method
++    */
++   @Deprecated
+    public static void func_196534_a(World p_196534_0_, BlockPos p_196534_1_) {
+       func_196535_a(p_196534_0_, p_196534_1_, (LivingEntity)null);
+    }
+ 
++   /**
++    * @deprecated Prefer using the one that mods can override
++    */
++   @Deprecated
+    private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
+       if (!p_196535_0_.field_72995_K) {
+          TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
+@@ -74,13 +97,25 @@
+       }
+    }
+ 
++   public void createExplosion(World p_196534_0_, BlockPos p_196534_1_) {
++      createExplosion(p_196534_0_, p_196534_1_, null);
++   }
++
++   private void createExplosion(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
++      if (!p_196535_0_.field_72995_K) {
++         TNTEntity tntentity = tntEntityCreator.create(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
++         p_196535_0_.func_217376_c(tntentity);
++         p_196535_0_.func_184148_a(null, tntentity.field_70165_t, tntentity.field_70163_u, tntentity.field_70161_v, SoundEvents.field_187904_gd, SoundCategory.BLOCKS, 1.0F, 1.0F);
++      }
++   }
++
+    public boolean func_220051_a(BlockState p_220051_1_, World p_220051_2_, BlockPos p_220051_3_, PlayerEntity p_220051_4_, Hand p_220051_5_, BlockRayTraceResult p_220051_6_) {
+       ItemStack itemstack = p_220051_4_.func_184586_b(p_220051_5_);
+       Item item = itemstack.func_77973_b();
+       if (item != Items.field_151033_d && item != Items.field_151059_bz) {
+          return super.func_220051_a(p_220051_1_, p_220051_2_, p_220051_3_, p_220051_4_, p_220051_5_, p_220051_6_);
+       } else {
+-         func_196535_a(p_220051_2_, p_220051_3_, p_220051_4_);
++         createExplosion(p_220051_2_, p_220051_3_, p_220051_4_);
+          p_220051_2_.func_180501_a(p_220051_3_, Blocks.field_150350_a.func_176223_P(), 11);
+          if (item == Items.field_151033_d) {
+             itemstack.func_222118_a(1, p_220051_4_, (p_220287_1_) -> {
+@@ -100,7 +135,7 @@
+          Entity entity = abstractarrowentity.func_212360_k();
+          if (abstractarrowentity.func_70027_ad()) {
+             BlockPos blockpos = p_220066_3_.func_216350_a();
+-            func_196535_a(p_220066_1_, blockpos, entity instanceof LivingEntity ? (LivingEntity)entity : null);
++            createExplosion(p_220066_1_, blockpos, entity instanceof LivingEntity ? (LivingEntity)entity : null);
+             p_220066_1_.func_217377_a(blockpos, false);
+          }
+       }
+@@ -114,4 +149,10 @@
+    protected void func_206840_a(StateContainer.Builder<Block, BlockState> p_206840_1_) {
+       p_206840_1_.func_206894_a(field_212569_a);
+    }
++
++   @FunctionalInterface
++   public interface TNTEntityCreator {
++
++      TNTEntity create(World world, double xPos, double yPos, double zPos, @Nullable LivingEntity entity);
++   }
+ }

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -1,60 +1,67 @@
 --- a/net/minecraft/block/TNTBlock.java
 +++ b/net/minecraft/block/TNTBlock.java
-@@ -31,7 +31,7 @@
+@@ -28,10 +28,14 @@
+       this.func_180632_j(this.func_176223_P().func_206870_a(field_212569_a, Boolean.valueOf(false)));
+    }
+ 
++   public void catchFire(BlockState state, World world, BlockPos pos, @Nullable net.minecraft.util.Direction face, @Nullable LivingEntity igniter) {
++      func_196535_a(world, pos, igniter);
++   }
++
     public void func_220082_b(BlockState p_220082_1_, World p_220082_2_, BlockPos p_220082_3_, BlockState p_220082_4_, boolean p_220082_5_) {
        if (p_220082_4_.func_177230_c() != p_220082_1_.func_177230_c()) {
           if (p_220082_2_.func_175640_z(p_220082_3_)) {
 -            func_196534_a(p_220082_2_, p_220082_3_);
-+            createExplosion(p_220082_2_, p_220082_3_, null);
++            catchFire(p_220082_1_, p_220082_2_, p_220082_3_, null, null);
              p_220082_2_.func_217377_a(p_220082_3_, false);
           }
  
-@@ -40,7 +40,7 @@
+@@ -40,7 +44,7 @@
  
     public void func_220069_a(BlockState p_220069_1_, World p_220069_2_, BlockPos p_220069_3_, Block p_220069_4_, BlockPos p_220069_5_, boolean p_220069_6_) {
        if (p_220069_2_.func_175640_z(p_220069_3_)) {
 -         func_196534_a(p_220069_2_, p_220069_3_);
-+         createExplosion(p_220069_2_, p_220069_3_, null);
++         catchFire(p_220069_1_, p_220069_2_, p_220069_3_, null, null);
           p_220069_2_.func_217377_a(p_220069_3_, false);
        }
  
-@@ -48,7 +48,7 @@
+@@ -48,7 +52,7 @@
  
     public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
        if (!p_176208_1_.func_201670_d() && !p_176208_4_.func_184812_l_() && p_176208_3_.func_177229_b(field_212569_a)) {
 -         func_196534_a(p_176208_1_, p_176208_2_);
-+         createExplosion(p_176208_1_, p_176208_2_, null);
++         catchFire(p_176208_3_, p_176208_1_, p_176208_2_, null, null);
        }
  
        super.func_176208_a(p_176208_1_, p_176208_2_, p_176208_3_, p_176208_4_);
-@@ -62,10 +62,12 @@
+@@ -62,10 +66,12 @@
        }
     }
  
-+   @Deprecated //Forge: Prefer using IForgeBlock#onBlockExploded
++   @Deprecated //Forge: Prefer using IForgeBlock#catchFire
     public static void func_196534_a(World p_196534_0_, BlockPos p_196534_1_) {
        func_196535_a(p_196534_0_, p_196534_1_, (LivingEntity)null);
     }
  
-+   @Deprecated //Forge: Prefer using IForgeBlock#onBlockExploded
-    public static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
++   @Deprecated //Forge: Prefer using IForgeBlock#catchFire
+    private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
        if (!p_196535_0_.field_72995_K) {
           TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)((float)p_196535_1_.func_177958_n() + 0.5F), (double)p_196535_1_.func_177956_o(), (double)((float)p_196535_1_.func_177952_p() + 0.5F), p_196535_2_);
-@@ -80,7 +82,7 @@
+@@ -80,7 +86,7 @@
        if (item != Items.field_151033_d && item != Items.field_151059_bz) {
           return super.func_220051_a(p_220051_1_, p_220051_2_, p_220051_3_, p_220051_4_, p_220051_5_, p_220051_6_);
        } else {
 -         func_196535_a(p_220051_2_, p_220051_3_, p_220051_4_);
-+         createExplosion(p_220051_2_, p_220051_3_, p_220051_4_);
++         catchFire(p_220051_1_, p_220051_2_, p_220051_3_, p_220051_6_.func_216354_b(), p_220051_4_);
           p_220051_2_.func_180501_a(p_220051_3_, Blocks.field_150350_a.func_176223_P(), 11);
           if (item == Items.field_151033_d) {
              itemstack.func_222118_a(1, p_220051_4_, (p_220287_1_) -> {
-@@ -100,7 +102,7 @@
+@@ -100,7 +106,7 @@
           Entity entity = abstractarrowentity.func_212360_k();
           if (abstractarrowentity.func_70027_ad()) {
              BlockPos blockpos = p_220066_3_.func_216350_a();
 -            func_196535_a(p_220066_1_, blockpos, entity instanceof LivingEntity ? (LivingEntity)entity : null);
-+            createExplosion(p_220066_1_, blockpos, entity instanceof LivingEntity ? (LivingEntity)entity : null);
++            catchFire(p_220066_2_, p_220066_1_, blockpos, null, entity instanceof LivingEntity ? (LivingEntity)entity : null);
              p_220066_1_.func_217377_a(blockpos, false);
           }
        }

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/dispenser/IDispenseItemBehavior.java
 +++ b/net/minecraft/dispenser/IDispenseItemBehavior.java
-@@ -270,8 +270,8 @@
+@@ -270,8 +270,9 @@
                 world.func_175656_a(blockpos, Blocks.field_150480_ab.func_176223_P());
              } else if (FlintAndSteelItem.func_219997_a(blockstate)) {
                 world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));
@@ -8,10 +8,11 @@
 -               TNTBlock.func_196534_a(world, blockpos);
 +            } else if (blockstate.isFlammable(world, blockpos, p_82487_1_.func_189992_e().func_177229_b(DispenserBlock.field_176441_a).func_176734_d())) {
 +               blockstate.catchFire(world, blockpos, p_82487_1_.func_189992_e().func_177229_b(DispenserBlock.field_176441_a).func_176734_d(), null);
++               if (blockstate.func_177230_c() instanceof TNTBlock)
                 world.func_217377_a(blockpos, false);
              } else {
                 this.field_218407_b = false;
-@@ -370,15 +370,23 @@
+@@ -370,15 +371,23 @@
        }
  
        DispenserBlock.func_199774_a(Items.field_151097_aZ.func_199767_j(), new OptionalDispenseBehavior() {

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/dispenser/IDispenseItemBehavior.java
 +++ b/net/minecraft/dispenser/IDispenseItemBehavior.java
+@@ -271,7 +271,7 @@
+             } else if (FlintAndSteelItem.func_219997_a(blockstate)) {
+                world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));
+             } else if (blockstate.func_177230_c() instanceof TNTBlock) {
+-               TNTBlock.func_196534_a(world, blockpos);
++               ((TNTBlock) blockstate.func_177230_c()).createExplosion(world, blockpos);
+                world.func_217377_a(blockpos, false);
+             } else {
+                this.field_218407_b = false;
 @@ -370,15 +370,23 @@
        }
  

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -5,7 +5,7 @@
                 world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));
              } else if (blockstate.func_177230_c() instanceof TNTBlock) {
 -               TNTBlock.func_196534_a(world, blockpos);
-+               ((TNTBlock) blockstate.func_177230_c()).createExplosion(world, blockpos);
++               ((TNTBlock) blockstate.func_177230_c()).createExplosion(world, blockpos, null);
                 world.func_217377_a(blockpos, false);
              } else {
                 this.field_218407_b = false;

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/dispenser/IDispenseItemBehavior.java
 +++ b/net/minecraft/dispenser/IDispenseItemBehavior.java
-@@ -271,7 +271,7 @@
+@@ -270,8 +270,8 @@
+                world.func_175656_a(blockpos, Blocks.field_150480_ab.func_176223_P());
              } else if (FlintAndSteelItem.func_219997_a(blockstate)) {
                 world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));
-             } else if (blockstate.func_177230_c() instanceof TNTBlock) {
+-            } else if (blockstate.func_177230_c() instanceof TNTBlock) {
 -               TNTBlock.func_196534_a(world, blockpos);
-+               ((TNTBlock) blockstate.func_177230_c()).createExplosion(world, blockpos, null);
++            } else if (blockstate.isExplosive(blockstate, world, blockpos)) {
++               blockstate.createExplosion(world, blockpos, null);
                 world.func_217377_a(blockpos, false);
              } else {
                 this.field_218407_b = false;

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -6,8 +6,8 @@
                 world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));
 -            } else if (blockstate.func_177230_c() instanceof TNTBlock) {
 -               TNTBlock.func_196534_a(world, blockpos);
-+            } else if (blockstate.isExplosive(blockstate, world, blockpos)) {
-+               blockstate.createExplosion(world, blockpos, null);
++            } else if (blockstate.isFlammable(world, blockpos, p_82487_1_.func_189992_e().func_177229_b(DispenserBlock.field_176441_a).func_176734_d())) {
++               blockstate.catchFire(world, blockpos, p_82487_1_.func_189992_e().func_177229_b(DispenserBlock.field_176441_a).func_176734_d(), null);
                 world.func_217377_a(blockpos, false);
              } else {
                 this.field_218407_b = false;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -35,7 +35,6 @@ import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IBeaconBeamColorProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.SoundType;
-import net.minecraft.block.TNTBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.particle.ParticleManager;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IBeaconBeamColorProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.SoundType;
+import net.minecraft.block.TNTBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.particle.ParticleManager;
@@ -1027,6 +1028,34 @@ public interface IForgeBlock
     {
         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
         getBlock().onExplosionDestroy(world, pos, explosion);
+    }
+
+    /**
+     * Determines if the block is explosive and {@link #createExplosion(World, BlockPos, LivingEntity)} should be called.
+     *
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True if the block can explode, false otherwise.
+     */
+    default boolean isExplosive(BlockState state, IBlockReader world, BlockPos pos)
+    {
+        return getBlock() instanceof TNTBlock;
+    }
+
+    /**
+     * If the block is explosive, this is called when it should create an explosion.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @param igniter The entity that caused the explosion to occur
+     */
+    default void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter)
+    {
+        if (getBlock() instanceof TNTBlock)
+        {
+            TNTBlock.explode(world, pos, igniter);
+        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -925,6 +925,17 @@ public interface IForgeBlock
     }
 
     /**
+     * If the block is flammable, this is called when it gets lit on fire.
+     *
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
+     * @param face The face that the fire is coming from
+     * @param igniter The entity that lit the fire
+     */
+    default void catchFire(BlockState state, World world, BlockPos pos, @Nullable Direction face, @Nullable LivingEntity igniter) {}
+
+    /**
      * Called when fire is updating on a neighbor block.
      * The higher the number returned, the faster fire will spread around this block.
      *
@@ -1028,34 +1039,6 @@ public interface IForgeBlock
     {
         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
         getBlock().onExplosionDestroy(world, pos, explosion);
-    }
-
-    /**
-     * Determines if the block is explosive and {@link #createExplosion(World, BlockPos, LivingEntity)} should be called.
-     *
-     * @param state The current state
-     * @param world The current world
-     * @param pos Block position in world
-     * @return True if the block can explode, false otherwise.
-     */
-    default boolean isExplosive(BlockState state, IBlockReader world, BlockPos pos)
-    {
-        return getBlock() instanceof TNTBlock;
-    }
-
-    /**
-     * If the block is explosive, this is called when it should create an explosion.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     * @param igniter The entity that caused the explosion to occur
-     */
-    default void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter)
-    {
-        if (getBlock() instanceof TNTBlock)
-        {
-            TNTBlock.explode(world, pos, igniter);
-        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -772,6 +772,19 @@ public interface IForgeBlockState
     }
 
     /**
+     * If the block is flammable, this is called when it gets lit on fire.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @param face The face that the fire is coming from
+     * @param igniter The entity that lit the fire
+     */
+    default void catchFire(World world, BlockPos pos, @Nullable Direction face, @Nullable LivingEntity igniter)
+    {
+        getBlockState().getBlock().catchFire(getBlockState(), world, pos, face, igniter);
+    }
+
+    /**
      * Called when fire is updating on a neighbor block.
      * The higher the number returned, the faster fire will spread around this block.
      *
@@ -869,31 +882,6 @@ public interface IForgeBlockState
     default void onBlockExploded(World world, BlockPos pos, Explosion explosion)
     {
         getBlockState().getBlock().onBlockExploded(getBlockState(), world, pos, explosion);
-    }
-
-    /**
-     * Determines if the block is explosive and {@link #createExplosion(World, BlockPos, LivingEntity)} should be called.
-     *
-     * @param state The current state
-     * @param world The current world
-     * @param pos Block position in world
-     * @return True if the block can explode, false otherwise.
-     */
-    default boolean isExplosive(BlockState state, IBlockReader world, BlockPos pos)
-    {
-        return getBlockState().getBlock().isExplosive(getBlockState(), world, pos);
-    }
-
-    /**
-     * If the block is explosive, this is called when it should create an explosion.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     * @param igniter The entity that caused the explosion to occur
-     */
-    default void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter)
-    {
-        getBlockState().getBlock().createExplosion(world, pos, igniter);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -872,6 +872,31 @@ public interface IForgeBlockState
     }
 
     /**
+     * Determines if the block is explosive and {@link #createExplosion(World, BlockPos, LivingEntity)} should be called.
+     *
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True if the block can explode, false otherwise.
+     */
+    default boolean isExplosive(BlockState state, IBlockReader world, BlockPos pos)
+    {
+        return getBlockState().getBlock().isExplosive(getBlockState(), world, pos);
+    }
+
+    /**
+     * If the block is explosive, this is called when it should create an explosion.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @param igniter The entity that caused the explosion to occur
+     */
+    default void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter)
+    {
+        getBlockState().getBlock().createExplosion(world, pos, igniter);
+    }
+
+    /**
      * Determines if this block's collision box should be treated as though it can extend above its block space.
      * This can be used to replicate fence and wall behavior.
      */

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -99,7 +99,7 @@ public net.minecraft.entity.ai.brain.memory.MemoryModuleType <init>(Ljava/util/O
 public net.minecraft.entity.ai.brain.schedule.Activity <init>(Ljava/lang/String;)V
 public net.minecraft.entity.ai.brain.sensor.SensorType <init>(Ljava/util/function/Supplier;)V
 public net.minecraft.entity.item.ExperienceOrbEntity field_70530_e # xpValue
-protected net.minecraft.entity.item.TNTEntity func_70515_d()V # explode - make it easier to extent TNTEntity with custom explosion logic
+protected net.minecraft.entity.item.TNTEntity func_70515_d()V # explode - make it easier to extend TNTEntity with custom explosion logic
 public net.minecraft.entity.merchant.villager.VillagerProfession <init>(Ljava/lang/String;Lnet/minecraft/village/PointOfInterestType;Lcom/google/common/collect/ImmutableSet;Lcom/google/common/collect/ImmutableSet;)V
 protected net.minecraft.entity.monster.AbstractSkeletonEntity func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
 protected net.minecraft.entity.monster.SkeletonEntity func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -6,7 +6,6 @@ public net.minecraft.block.Block$Properties func_200947_a(Lnet/minecraft/block/S
 public net.minecraft.block.Block$Properties func_200951_a(I)Lnet/minecraft/block/Block$Properties; # lightValue
 public net.minecraft.block.Block$Properties func_208770_d()Lnet/minecraft/block/Block$Properties; # variableOpacity
 public net.minecraft.block.Block$Properties func_222380_e()Lnet/minecraft/block/Block$Properties; # noDrops
-public net.minecraft.block.TNTBlock func_196535_a(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/LivingEntity;)V # explode
 public net.minecraft.client.Minecraft field_71446_o # textureManager
 public net.minecraft.client.Minecraft func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; # storeTEInStack
 public net.minecraft.client.Minecraft func_193986_ar()V # populateSearchTreeManager

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -6,6 +6,7 @@ public net.minecraft.block.Block$Properties func_200947_a(Lnet/minecraft/block/S
 public net.minecraft.block.Block$Properties func_200951_a(I)Lnet/minecraft/block/Block$Properties; # lightValue
 public net.minecraft.block.Block$Properties func_208770_d()Lnet/minecraft/block/Block$Properties; # variableOpacity
 public net.minecraft.block.Block$Properties func_222380_e()Lnet/minecraft/block/Block$Properties; # noDrops
+public net.minecraft.block.TNTBlock func_196535_a(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/LivingEntity;)V # explode
 public net.minecraft.client.Minecraft field_71446_o # textureManager
 public net.minecraft.client.Minecraft func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; # storeTEInStack
 public net.minecraft.client.Minecraft func_193986_ar()V # populateSearchTreeManager

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -99,6 +99,7 @@ public net.minecraft.entity.ai.brain.memory.MemoryModuleType <init>(Ljava/util/O
 public net.minecraft.entity.ai.brain.schedule.Activity <init>(Ljava/lang/String;)V
 public net.minecraft.entity.ai.brain.sensor.SensorType <init>(Ljava/util/function/Supplier;)V
 public net.minecraft.entity.item.ExperienceOrbEntity field_70530_e # xpValue
+protected net.minecraft.entity.item.TNTEntity func_70515_d()V # explode - make it easier to extent TNTEntity with custom explosion logic
 public net.minecraft.entity.merchant.villager.VillagerProfession <init>(Ljava/lang/String;Lnet/minecraft/village/PointOfInterestType;Lcom/google/common/collect/ImmutableSet;Lcom/google/common/collect/ImmutableSet;)V
 protected net.minecraft.entity.monster.AbstractSkeletonEntity func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
 protected net.minecraft.entity.monster.SkeletonEntity func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -97,16 +97,19 @@ public class CustomTNTTest {
         }
     }
 
+    /**
+     * Custom TNT Entity that has a fuse of a quarter length, and four times the explosion strength
+     */
     public static class CustomTNTEntity extends TNTEntity {
 
         public CustomTNTEntity(EntityType<CustomTNTEntity> type, World world) {
             super(type, world);
-            setFuse(20);
+            setFuse(getFuse() / 4);
         }
 
         public CustomTNTEntity(World world, double x, double y, double z, @Nullable LivingEntity placer) {
             super(world, x, y, z, placer);
-            setFuse(20);
+            setFuse(getFuse() / 4);
         }
 
         @Nonnull
@@ -117,7 +120,7 @@ public class CustomTNTTest {
 
         @Override
         protected void explode() {
-            this.world.createExplosion(this, this.posX, this.posY, this.posZ, 10.0F, Explosion.Mode.BREAK);
+            this.world.createExplosion(this, this.posX, this.posY, this.posZ, 16.0F, Explosion.Mode.BREAK);
         }
 
         @Nonnull

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import javax.annotation.Nonnull;

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -30,6 +30,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.TNTEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.network.IPacket;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
@@ -40,6 +41,7 @@ import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -116,6 +118,12 @@ public class CustomTNTTest {
         @Override
         protected void explode() {
             this.world.createExplosion(this, this.posX, this.posY, this.posZ, 10.0F, Explosion.Mode.BREAK);
+        }
+
+        @Nonnull
+        @Override
+        public IPacket<?> createSpawnPacket() {
+            return NetworkHooks.getEntitySpawningPacket(this);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.debug.block;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.TNTBlock;
@@ -10,6 +11,9 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.TNTEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -22,8 +26,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 @Mod(CustomTNTTest.MODID)
 @Mod.EventBusSubscriber(modid = CustomTNTTest.MODID, bus = Bus.MOD)
-public class CustomTNTTest
-{
+public class CustomTNTTest {
+
     static final String MODID = "custom_tnt_test";
     static final String BLOCK_ID = "test_tnt";
 
@@ -31,10 +35,10 @@ public class CustomTNTTest
     private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MODID);
     private static final DeferredRegister<EntityType<?>> ENTITIES = new DeferredRegister<>(ForgeRegistries.ENTITIES, MODID);
 
-    public static final RegistryObject<TNTBlock> CUSTOM_TNT = BLOCKS.register(BLOCK_ID, () -> new TNTBlock(Block.Properties.from(Blocks.TNT), CustomTNTEntity::new));
+    public static final RegistryObject<TNTBlock> CUSTOM_TNT = BLOCKS.register(BLOCK_ID, () -> new CustomTNTBlock(Block.Properties.from(Blocks.TNT)));
     public static final RegistryObject<EntityType<CustomTNTEntity>> CUSTOM_TNT_ENTITY = ENTITIES.register(BLOCK_ID, () -> EntityType.Builder
-                .create((EntityType.IFactory<CustomTNTEntity>) CustomTNTEntity::new, EntityClassification.MISC)
-                .build(BLOCK_ID));
+          .create((EntityType.IFactory<CustomTNTEntity>) CustomTNTEntity::new, EntityClassification.MISC)
+          .build(BLOCK_ID));
 
     static {
         ITEMS.register(BLOCK_ID, () -> new BlockItem(CUSTOM_TNT.get(), new Item.Properties()));
@@ -47,6 +51,31 @@ public class CustomTNTTest
         ENTITIES.register(modBus);
     }
 
+    public static class CustomTNTBlock extends TNTBlock {
+
+        public CustomTNTBlock(Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        public void onExplosionDestroy(World world, BlockPos pos, Explosion explosion) {
+            if (!world.isRemote) {
+                TNTEntity tnt = new CustomTNTEntity(world, (float) pos.getX() + 0.5F, pos.getY(), (float) pos.getZ() + 0.5F, explosion.getExplosivePlacedBy());
+                tnt.setFuse((short) (world.rand.nextInt(tnt.getFuse() / 4) + tnt.getFuse() / 8));
+                world.addEntity(tnt);
+            }
+        }
+
+        @Override
+        public void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter) {
+            if (!world.isRemote) {
+                TNTEntity tnt = new CustomTNTEntity(world, pos.getX() + 0.5F, pos.getY(), pos.getZ() + 0.5F, igniter);
+                world.addEntity(tnt);
+                world.playSound(null, tnt.posX, tnt.posY, tnt.posZ, SoundEvents.ENTITY_TNT_PRIMED, SoundCategory.BLOCKS, 1.0F, 1.0F);
+            }
+        }
+    }
+
     public static class CustomTNTEntity extends TNTEntity {
 
         public CustomTNTEntity(EntityType<CustomTNTEntity> type, World world) {
@@ -54,7 +83,7 @@ public class CustomTNTTest
             setFuse(20);
         }
 
-        public CustomTNTEntity(World world, double x, double y, double z, LivingEntity placer) {
+        public CustomTNTEntity(World world, double x, double y, double z, @Nullable LivingEntity placer) {
             super(world, x, y, z, placer);
             setFuse(20);
         }

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.debug.block;
+
+import javax.annotation.Nonnull;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.TNTBlock;
+import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.item.TNTEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod(CustomTNTTest.MODID)
+@Mod.EventBusSubscriber(modid = CustomTNTTest.MODID, bus = Bus.MOD)
+public class CustomTNTTest
+{
+    static final String MODID = "custom_tnt_test";
+    static final String BLOCK_ID = "test_tnt";
+
+    private static final DeferredRegister<Block> BLOCKS = new DeferredRegister<>(ForgeRegistries.BLOCKS, MODID);
+    private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MODID);
+    private static final DeferredRegister<EntityType<?>> ENTITIES = new DeferredRegister<>(ForgeRegistries.ENTITIES, MODID);
+
+    public static final RegistryObject<TNTBlock> CUSTOM_TNT = BLOCKS.register(BLOCK_ID, () -> new TNTBlock(Block.Properties.from(Blocks.TNT), CustomTNTEntity::new));
+    public static final RegistryObject<EntityType<CustomTNTEntity>> CUSTOM_TNT_ENTITY = ENTITIES.register(BLOCK_ID, () -> EntityType.Builder
+                .create((EntityType.IFactory<CustomTNTEntity>) CustomTNTEntity::new, EntityClassification.MISC)
+                .build(BLOCK_ID));
+
+    static {
+        ITEMS.register(BLOCK_ID, () -> new BlockItem(CUSTOM_TNT.get(), new Item.Properties()));
+    }
+
+    public CustomTNTTest() {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        BLOCKS.register(modBus);
+        ITEMS.register(modBus);
+        ENTITIES.register(modBus);
+    }
+
+    public static class CustomTNTEntity extends TNTEntity {
+
+        public CustomTNTEntity(EntityType<CustomTNTEntity> type, World world) {
+            super(type, world);
+            setFuse(20);
+        }
+
+        public CustomTNTEntity(World world, double x, double y, double z, LivingEntity placer) {
+            super(world, x, y, z, placer);
+            setFuse(20);
+        }
+
+        @Nonnull
+        @Override
+        public EntityType<?> getType() {
+            return CUSTOM_TNT_ENTITY.get();
+        }
+
+        @Override
+        protected void explode() {
+            this.world.createExplosion(this, this.posX, this.posY, this.posZ, 10.0F, Explosion.Mode.BREAK);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomTNTTest.java
@@ -22,6 +22,7 @@ package net.minecraftforge.debug.block;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.TNTBlock;
 import net.minecraft.entity.EntityClassification;
@@ -31,6 +32,7 @@ import net.minecraft.entity.item.TNTEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.network.IPacket;
+import net.minecraft.util.Direction;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
@@ -88,7 +90,7 @@ public class CustomTNTTest {
         }
 
         @Override
-        public void createExplosion(World world, BlockPos pos, @Nullable LivingEntity igniter) {
+        public void catchFire(BlockState state, World world, BlockPos pos, @Nullable Direction face, @Nullable LivingEntity igniter) {
             if (!world.isRemote) {
                 TNTEntity tnt = new CustomTNTEntity(world, pos.getX() + 0.5F, pos.getY(), pos.getZ() + 0.5F, igniter);
                 world.addEntity(tnt);

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -57,3 +57,5 @@ loaderVersion="[28,)"
     modId="player_xp_event_test"
 [[mods]]
     modId="forgeblockstatesloader"
+[[mods]]
+    modId="custom_tnt_test"

--- a/src/test/resources/assets/custom_tnt_test/blockstates/test_tnt.json
+++ b/src/test/resources/assets/custom_tnt_test/blockstates/test_tnt.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "": { "model": "block/tnt" }
+    }
+}

--- a/src/test/resources/assets/custom_tnt_test/models/item/test_tnt.json
+++ b/src/test/resources/assets/custom_tnt_test/models/item/test_tnt.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/tnt"
+}


### PR DESCRIPTION
Adds back an instance method variant for TNTBlock explosion, to allow mods to preform simple overrides. This fixes #5841 and also adds an AT entry to make it a lot cleaner to override the existing TNT entity without requiring each mod adding custom TNT to AT the method or have a copy of the vanilla implementation of TNTEntity#tick.

Includes a test mod that has 1/4 the fuse time and 4 times the explosion strength as vanilla TNT.