### PR TITLE
Add Axe and Shovel Use Events

### DIFF
--- a/patches/minecraft/net/minecraft/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/AxeItem.java.patch
@@ -9,3 +9,12 @@
     }
  
     public float func_150893_a(ItemStack p_150893_1_, BlockState p_150893_2_) {
+@@ -32,6 +32,8 @@
+    public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
+       World world = p_195939_1_.func_195991_k();
+       BlockPos blockpos = p_195939_1_.func_195995_a();
++      int hook = net.minecraftforge.event.ForgeEventFactory.onAxeUse(p_195939_1_);
++      if (hook != 0) return hook > 0 ? ActionResultType.SUCCESS : ActionResultType.FAIL;
+       BlockState blockstate = world.func_180495_p(blockpos);
+       Block block = field_203176_a.get(blockstate.func_177230_c());
+       if (block != null) {

--- a/patches/minecraft/net/minecraft/item/ShovelItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/ShovelItem.java.patch
@@ -9,11 +9,13 @@
     }
  
     public boolean func_150897_b(BlockState p_150897_1_) {
-@@ -32,7 +32,7 @@
+@@ -32,7 +32,9 @@
     public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
        World world = p_195939_1_.func_195991_k();
        BlockPos blockpos = p_195939_1_.func_195995_a();
 -      if (p_195939_1_.func_196000_l() != Direction.DOWN && world.func_180495_p(blockpos.func_177984_a()).func_196958_f()) {
++      int hook = net.minecraftforge.event.ForgeEventFactory.onShovelUse(p_195939_1_);
++      if (hook != 0) return hook > 0 ? ActionResultType.SUCCESS : ActionResultType.FAIL;
 +      if (p_195939_1_.func_196000_l() != Direction.DOWN && world.func_180495_p(blockpos.func_177984_a()).isAir(world, blockpos.func_177984_a())) {
           BlockState blockstate = field_195955_e.get(world.func_180495_p(blockpos).func_177230_c());
           if (blockstate != null) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -116,7 +116,9 @@ import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
+import net.minecraftforge.event.entity.player.UseAxeEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
+import net.minecraftforge.event.entity.player.UseShovelEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
@@ -341,9 +343,33 @@ public class ForgeEventFactory
         return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
     }
 
+    public static int onAxeUse(ItemUseContext context)
+    {
+        UseAxeEvent event = new UseAxeEvent(context);
+        if (MinecraftForge.EVENT_BUS.post(event)) return -1;
+        if (event.getResult() == Result.ALLOW)
+        {
+            context.getItem().damageItem(1, context.getPlayer(), player -> player.sendBreakAnimation(context.getHand()));
+            return 1;
+        }
+        return 0;
+    }
+
     public static int onHoeUse(ItemUseContext context)
     {
         UseHoeEvent event = new UseHoeEvent(context);
+        if (MinecraftForge.EVENT_BUS.post(event)) return -1;
+        if (event.getResult() == Result.ALLOW)
+        {
+            context.getItem().damageItem(1, context.getPlayer(), player -> player.sendBreakAnimation(context.getHand()));
+            return 1;
+        }
+        return 0;
+    }
+
+    public static int onShovelUse(ItemUseContext context)
+    {
+        UseShovelEvent event = new UseShovelEvent(context);
         if (MinecraftForge.EVENT_BUS.post(event)) return -1;
         if (event.getResult() == Result.ALLOW)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/UseAxeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseAxeEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import javax.annotation.Nonnull;
+import net.minecraft.item.ItemUseContext;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event.HasResult;
+
+/**
+ * This event is fired when a player attempts to use an axe on a block, it
+ * can be canceled to completely prevent any further processing.
+ *
+ * You can also set the result to ALLOW to mark the event as processed
+ * and damage the axe.
+ */
+@Cancelable
+@HasResult
+public class UseAxeEvent extends PlayerEvent
+{
+    private final ItemUseContext context;;
+
+    public UseAxeEvent(ItemUseContext context)
+    {
+        super(context.getPlayer());
+        this.context = context;
+    }
+
+    @Nonnull
+    public ItemUseContext getContext()
+    {
+        return context;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/UseShovelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseShovelEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import javax.annotation.Nonnull;
+import net.minecraft.item.ItemUseContext;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event.HasResult;
+
+/**
+ * This event is fired when a player attempts to use a Shovel on a block, it
+ * can be canceled to completely prevent any further processing.
+ *
+ * You can also set the result to ALLOW to mark the event as processed
+ * and damage the hoe.
+ */
+@Cancelable
+@HasResult
+public class UseShovelEvent extends PlayerEvent
+{
+    private final ItemUseContext context;;
+
+    public UseShovelEvent(ItemUseContext context)
+    {
+        super(context.getPlayer());
+        this.context = context;
+    }
+
+    @Nonnull
+    public ItemUseContext getContext()
+    {
+        return context;
+    }
+}


### PR DESCRIPTION
Adds two events (and corresponding hooks in the `ForgeEventFactory`, `onAxeUse` and `onShovelUse`) called `UseAxeEvent` and `UseShovelEvent`. These events/hooks mirror the `UseHoeEvent` (and `onHoeUse`), except are for axes and shovels respectively. I believe these would be useful so that mods can add in extra checking to be able to add custom handling (`Result.ALLOW`), or deny converting:
- (Axes): logs to stripped logs
- (Shovels): grass to grass paths