### PR TITLE
Add FluidStack methods to IForgePacketBuffer

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
@@ -126,4 +126,28 @@ public interface IForgePacketBuffer
             throw new IllegalArgumentException("Attempted to read an registryValue of the wrong type from the Buffer!");
         return value;
     }
+
+    /**
+     * Writes a FluidStack to the packet buffer, easy enough. If EMPTY, writes a FALSE.
+     * This behavior provides parity with the ItemStack method in PacketBuffer.
+     *
+     * @param stack FluidStack to be written to the packet buffer.
+     */
+    public void writeFluidStack(FluidStack stack)
+    {
+        if (stack.isEmpty()) {
+            writeBoolean(false);
+        } else {
+            writeBoolean(true);
+            stack.writeToPacket(this);
+        }
+    }
+
+    /**
+     * Reads a FluidStack from this buffer.
+     */
+    public FluidStack readFluidStack()
+    {
+        return !readBoolean() ? FluidStack.EMPTY : FluidStack.readFromPacket(this);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.extensions;
 import com.google.common.base.Preconditions;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
@@ -133,7 +134,7 @@ public interface IForgePacketBuffer
      *
      * @param stack FluidStack to be written to the packet buffer.
      */
-    public void writeFluidStack(FluidStack stack)
+    default void writeFluidStack(FluidStack stack)
     {
         if (stack.isEmpty()) {
             writeBoolean(false);
@@ -146,7 +147,7 @@ public interface IForgePacketBuffer
     /**
      * Reads a FluidStack from this buffer.
      */
-    public FluidStack readFluidStack()
+    default FluidStack readFluidStack()
     {
         return !readBoolean() ? FluidStack.EMPTY : FluidStack.readFromPacket(this);
     }


### PR DESCRIPTION
...providing network-level parity for ItemStacks and FluidStacks.

The intention here is just to allow mods using the PacketBuffer class to read/write ItemStacks and FluidStacks with the same syntax and underlying logic.

Easy QoL.