### PR TITLE
Added LivingVisibilityEvent as a replacement for PlayerEvent.Visibility

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -83,6 +83,15 @@
           this.func_82142_c(this.func_70644_a(Effects.field_76441_p));
        }
  
+@@ -671,7 +683,7 @@
+          }
+       }
+ 
+-      return d0;
++      return net.minecraftforge.common.ForgeHooks.getLivingVisibility(this, p_213340_1_, d0);
+    }
+ 
+    public boolean func_213336_c(LivingEntity p_213336_1_) {
 @@ -705,7 +717,10 @@
  
           boolean flag;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -132,6 +132,7 @@ import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.LivingVisibilityEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
@@ -374,7 +375,18 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(event);
         return event.getLootingLevel();
     }
-
+    
+    public static double getLivingVisibility(LivingEntity living, @Nullable Entity lookingEntity, double visibility)
+    {
+    	LivingVisibilityEvent event = new LivingVisibilityEvent(living, lookingEntity, visibility);
+        MinecraftForge.EVENT_BUS.post(event);
+        double value = event.getVisibility();
+        if(living instanceof PlayerEntity) {
+            value = getPlayerVisibilityDistance((PlayerEntity)living, value, visibility);
+        }
+        return value;
+    }
+    
     public static double getPlayerVisibilityDistance(PlayerEntity player, double xzDistance, double maxXZDistance)
     {
         PlayerEvent.Visibility event = new PlayerEvent.Visibility(player);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -378,13 +378,13 @@ public class ForgeHooks
     
     public static double getLivingVisibility(LivingEntity living, @Nullable Entity lookingEntity, double visibility)
     {
-    	LivingVisibilityEvent event = new LivingVisibilityEvent(living, lookingEntity, visibility);
-        MinecraftForge.EVENT_BUS.post(event);
-        double value = event.getVisibility();
+        double value = visibility;
         if(living instanceof PlayerEntity) {
-            value = getPlayerVisibilityDistance((PlayerEntity)living, value, visibility);
+            value = getPlayerVisibilityDistance((PlayerEntity)living, visibility, visibility);
         }
-        return value;
+        LivingVisibilityEvent event = new LivingVisibilityEvent(living, lookingEntity, value);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getVisibility();
     }
     
     public static double getPlayerVisibilityDistance(PlayerEntity player, double xzDistance, double maxXZDistance)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingVisibilityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingVisibilityEvent.java
@@ -31,6 +31,13 @@ import net.minecraftforge.common.MinecraftForge;
  * This event is fired whenever the visibility is determined in
  * {@link LivingEntity#getVisibilityMultiplier(Entity)}. <br>
  * <br>
+ * The visibility value determined by this event is multiplied with the distance
+ * between {@link #lookingEntity} and the entity of this event. <br>
+ * If the multiplied value exceeds the distance of the lookingEntity's vision range,
+ * the entity is determined to be visible (and can be targeted). <br>
+ * In vanilla Minecraft, the visibility value is a value in the range [0.0, 1.0], but the value can theoretically be in the range [-Infinity, Infinity]. <br>
+ * By default, a player has a visibility of 1. This value is reduced for example by sneaking, being invisible, or wearing a particular mob skull. <br>
+ * <br>
  * This event is fired via the {@link ForgeHooks#getLivingVisibility(LivingEntity, Entity, double)}.<br>
  * <br>
  * {@link #originalVisibility} contains the original visibility value determined by vanilla. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingVisibilityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingVisibilityEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+
+/**
+ * LivingVisibilityEvent is fired when a LivingEntity is checked to be visible (e.g. by the AI of another entity). <br>
+ * This event is fired whenever the visibility is determined in
+ * {@link LivingEntity#getVisibilityMultiplier(Entity)}. <br>
+ * <br>
+ * This event is fired via the {@link ForgeHooks#getLivingVisibility(LivingEntity, Entity, double)}.<br>
+ * <br>
+ * {@link #originalVisibility} contains the original visibility value determined by vanilla. <br>
+ * {@link #newVisibility} contains the new visibility value that will be used and can be changed. <br>
+ * <br>
+ * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ *<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+public class LivingVisibilityEvent extends LivingEvent
+{
+    private final double originalVisibility;
+    private double newVisibility;
+    private final Entity lookingEntity;
+    public LivingVisibilityEvent(LivingEntity entity, @Nullable Entity lookingEntity, double visibility)
+    {
+        super(entity);
+        this.originalVisibility = visibility;
+        this.newVisibility = visibility;
+        this.lookingEntity = lookingEntity;
+    }
+
+    public double getOriginalVisibility() { return this.originalVisibility; }
+    public double getVisibility() { return newVisibility; }
+    
+    public void setVisibility(double visibility)
+    {
+        this.newVisibility = visibility;
+    }
+    
+    @Nullable public Entity getLookingEntity() { return this.lookingEntity; }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -375,7 +375,7 @@ public class PlayerEvent extends LivingEvent
      * @deprecated
      * Use {link: LivingVisibilityEvent} instead.
      */
-    @Deprecated
+    @Deprecated // Deprecated; Removed in 1.15
     public static class Visibility extends PlayerEvent
     {
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -371,7 +371,11 @@ public class PlayerEvent extends LivingEvent
      * Fired when the world checks if a player is near enough to be attacked by an entity.
      * The resulting visibility modifier is multiplied by the one calculated by Minecraft (based on sneaking and more) and used to calculate the radius a player has to be in (targetDistance*modifier).
      * This can also be used to increase the visibility of a player, if it was decreased by Minecraft or other mods. But the resulting value cannot be higher than the standard target distance.
+     *
+     * @deprecated
+     * Use {link: LivingVisibilityEvent} instead.
      */
+    @Deprecated
     public static class Visibility extends PlayerEvent
     {
 

--- a/src/test/java/net/minecraftforge/debug/entity/living/VisibilityEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/VisibilityEventTest.java
@@ -1,0 +1,75 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.entity.living;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.entity.monster.SkeletonEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.Items;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingVisibilityEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * This test mod makes skeletons not see entities which wear a leather chestplate.
+ * This test mod quadruples the visibility of entities which wear a golden chestplate.
+ * This test mod demonstrates that the deprecated {link: PlayerEvent.Visibility} is still called.
+ */
+@Mod(value = VisibilityEventTest.MODID)
+public class VisibilityEventTest
+{
+
+	public static final String MODID = "visibility_event_test";
+	private static final Logger LOGGER = LogManager.getLogger(MODID);
+	
+	public VisibilityEventTest() {
+		MinecraftForge.EVENT_BUS.register(this);
+	}
+
+	@SubscribeEvent
+	public void onLivingVisibility(LivingVisibilityEvent event)
+	{
+		double prevVisibility = event.getVisibility();
+		if(event.getEntityLiving().getItemStackFromSlot(EquipmentSlotType.CHEST).getItem() == Items.LEATHER_CHESTPLATE) {
+			if(event.getLookingEntity() != null && event.getLookingEntity() instanceof SkeletonEntity) {
+				event.setVisibility(0F);
+				LOGGER.info("Setting visibility for entity " + event.getEntityLiving().getName().getFormattedText()
+						+ " from " + prevVisibility + " to " + event.getVisibility() + ".");
+				return;
+			}
+		}
+		if(event.getEntityLiving().getItemStackFromSlot(EquipmentSlotType.CHEST).getItem() == Items.GOLDEN_CHESTPLATE) {
+			event.setVisibility(event.getVisibility() * 4.0);
+			LOGGER.info("Setting visibility for entity " + event.getEntityLiving().getName().getFormattedText()
+					+ " from " + prevVisibility + " to " + event.getVisibility() + ".");
+			return;
+		}
+	}
+	
+	@SuppressWarnings("deprecation")
+	@SubscribeEvent
+	public void onPlayerVisibility(PlayerEvent.Visibility event) {
+		LOGGER.info("Deprecated PlayerEvent.Visibility was called.");
+	}
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -57,3 +57,5 @@ loaderVersion="[28,)"
     modId="player_xp_event_test"
 [[mods]]
     modId="forgeblockstatesloader"
+[[mods]]
+    modId="visibility_event_test"


### PR DESCRIPTION
In 1.12.x, we had the PlayerEvent.Visibility to allow mods to change the modifier that is applied to the distance limit the AI uses when it determines whether a mob can see the player.

That event has not been hooked up yet in 1.14.x.

This PR adds a new, more general, LivingVisibilityEvent, which is called not only when the player's visibility is checked, but also for other living entities (such as sheep which might be seen by wolves).

Additionally, the new event includes the (nullable) entity which is performing the visibility check, which allows modders to react to it.

The old PlayerEvent.Visibility is now called again for players, but is marked as deprecated and suggests moving to the new event.

The PR includes a test mod which adds the following functionality:
- Players which wear a leather chestplate are not seen by skeletons
- Players which wear a golden chestplate are seen from all mobs from 4 times as far away
- A debug call which shows that the old PlayerEvent.Visibility event is called