### PR TITLE
1.14 - Added FENCES_WOODEN and FENCE_GATES_WOODEN tags as smeltables in AbstractFurnaceTileEntity

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
@@ -8,7 +8,28 @@
     public static Map<Item, Integer> func_214001_f() {
        Map<Item, Integer> map = Maps.newLinkedHashMap();
        func_213996_a(map, Items.field_151129_at, 20000);
-@@ -169,9 +170,9 @@
+@@ -98,18 +99,8 @@
+       func_213992_a(map, ItemTags.field_202899_i, 150);
+       func_213992_a(map, ItemTags.field_212188_k, 300);
+       func_213992_a(map, ItemTags.field_202900_j, 300);
+-      func_213996_a(map, Blocks.field_180407_aO, 300);
+-      func_213996_a(map, Blocks.field_180404_aQ, 300);
+-      func_213996_a(map, Blocks.field_180408_aP, 300);
+-      func_213996_a(map, Blocks.field_180403_aR, 300);
+-      func_213996_a(map, Blocks.field_180406_aS, 300);
+-      func_213996_a(map, Blocks.field_180405_aT, 300);
+-      func_213996_a(map, Blocks.field_180390_bo, 300);
+-      func_213996_a(map, Blocks.field_180392_bq, 300);
+-      func_213996_a(map, Blocks.field_180391_bp, 300);
+-      func_213996_a(map, Blocks.field_180386_br, 300);
+-      func_213996_a(map, Blocks.field_180385_bs, 300);
+-      func_213996_a(map, Blocks.field_180387_bt, 300);
++      func_213992_a(map, net.minecraftforge.common.Tags.Items.FENCES_WOODEN, 300);
++      func_213992_a(map, net.minecraftforge.common.Tags.Items.FENCE_GATES_WOODEN, 300);
+       func_213996_a(map, Blocks.field_196586_al, 300);
+       func_213996_a(map, Blocks.field_150342_X, 300);
+       func_213996_a(map, Blocks.field_222428_lQ, 300);
+@@ -169,9 +160,9 @@
        super.func_145839_a(p_145839_1_);
        this.field_214012_a = NonNullList.func_191197_a(this.func_70302_i_(), ItemStack.field_190927_a);
        ItemStackHelper.func_191283_b(p_145839_1_, this.field_214012_a);

--- a/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
@@ -21,7 +21,7 @@
        this.field_214019_k = this.func_213997_a(this.field_214012_a.get(1));
        int i = p_145839_1_.func_74765_d("RecipesUsedSize");
  
-@@ -185,9 +186,9 @@
+@@ -185,9 +176,9 @@
  
     public CompoundNBT func_189515_b(CompoundNBT p_189515_1_) {
        super.func_189515_b(p_189515_1_);
@@ -34,7 +34,7 @@
        ItemStackHelper.func_191282_a(p_189515_1_, this.field_214012_a);
        p_189515_1_.func_74777_a("RecipesUsedSize", (short)this.field_214022_n.size());
        int i = 0;
-@@ -217,12 +218,14 @@
+@@ -217,12 +208,14 @@
                 this.field_214019_k = this.field_214018_j;
                 if (this.func_214006_r()) {
                    flag1 = true;
@@ -51,7 +51,7 @@
                       }
                    }
                 }
-@@ -266,10 +269,10 @@
+@@ -266,10 +259,10 @@
                 return true;
              } else if (!itemstack1.func_77969_a(itemstack)) {
                 return false;
@@ -64,7 +64,7 @@
              }
           }
        } else {
-@@ -285,7 +288,7 @@
+@@ -285,7 +278,7 @@
           if (itemstack2.func_190926_b()) {
              this.field_214012_a.set(2, itemstack1.func_77946_l());
           } else if (itemstack2.func_77973_b() == itemstack1.func_77973_b()) {
@@ -73,7 +73,7 @@
           }
  
           if (!this.field_145850_b.field_72995_K) {
-@@ -305,7 +308,7 @@
+@@ -305,7 +298,7 @@
           return 0;
        } else {
           Item item = p_213997_1_.func_77973_b();
@@ -82,7 +82,7 @@
        }
     }
  
-@@ -314,7 +317,7 @@
+@@ -314,7 +307,7 @@
     }
  
     public static boolean func_213991_b(ItemStack p_213991_0_) {
@@ -91,7 +91,7 @@
     }
  
     public int[] func_180463_a(Direction p_180463_1_) {
-@@ -462,4 +465,27 @@
+@@ -462,4 +455,27 @@
        }
  
     }


### PR DESCRIPTION
This allows for mods adding new Wooden Fences and Wooden Fence Gates to be smeltable like Vanilla's Wooden Fences and Wooden Fence Gates.

Smeltable tags like this are already in Vanilla such as LOGS, WOODEN_STAIRS, PLANKS, WOODEN_SLABS, WOODEN_TRAPDOORS, and WOODEN_PRESSURE_PLATES. However, this is not the same for Wooden Fences and Wooden Fence Gates because their tags are never registered for smelting, which this PR intends to fix.