### PR TITLE
Add item tag for beacon payment

### DIFF
--- a/src/generated/resources/data/forge/tags/items/beacon_payment.json
+++ b/src/generated/resources/data/forge/tags/items/beacon_payment.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:emerald",
+    "minecraft:diamond",
+    "minecraft:gold_ingot",
+    "minecraft:iron_ingot"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -124,6 +124,7 @@ public class Tags
     public static class Items
     {
         public static final Tag<Item> ARROWS = tag("arrows");
+        public static final Tag<Item> BEACON_PAYMENT = tag("beacon_payment");
         public static final Tag<Item> BONES = tag("bones");
         public static final Tag<Item> BOOKSHELVES = tag("bookshelves");
         public static final Tag<Item> CHESTS = tag("chests");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -52,6 +52,7 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         filter = this.tagToBuilder.entrySet().stream().map(e -> e.getKey().getId()).collect(Collectors.toSet());
 
         getBuilder(Tags.Items.ARROWS).add(Items.ARROW, Items.TIPPED_ARROW, Items.SPECTRAL_ARROW);
+        getBuilder(Tags.Items.BEACON_PAYMENT).add(Items.EMERALD, Items.DIAMOND, Items.GOLD_INGOT, Items.IRON_INGOT);
         getBuilder(Tags.Items.BONES).add(Items.BONE);
         getBuilder(Tags.Items.BOOKSHELVES).add(Items.BOOKSHELF);
         copy(Tags.Blocks.CHESTS, Tags.Items.CHESTS);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -51,6 +51,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.ToolType;
 import net.minecraftforge.common.animation.ITimeValue;
 
@@ -615,7 +616,7 @@ public interface IForgeItem
      */
     default boolean isBeaconPayment(ItemStack stack)
     {
-        return this == Items.EMERALD || this == Items.DIAMOND || this == Items.GOLD_INGOT || this == Items.IRON_INGOT;
+        return Tags.Items.BEACON_PAYMENT.contains(stack.getItem());
     }
 
     /**


### PR DESCRIPTION
This pull requests adds the item tag `beacon_payment` for items that can be used to activate a beacon and modifies the default implementation of IForgeItem#isBeaconPayment to use that tag.