### PR TITLE
Fixed invocation of Vanilla spawn logic

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -188,7 +188,7 @@ public class ForgeEventFactory
     {
         Result result = canEntitySpawn(entity, world, x, y, z, spawner, SpawnReason.SPAWNER);
         if (result == Result.DEFAULT)
-            return entity.canSpawn(world, SpawnReason.SPAWNER) || !entity.isNotColliding(world); // vanilla logic
+            return entity.canSpawn(world, SpawnReason.SPAWNER) && entity.isNotColliding(world); // vanilla logic (inverted)
         else
             return result == Result.ALLOW;
     }


### PR DESCRIPTION
Forge's replacement of the Vanilla logic gets inverted, so the Vanilla logic inside that replacement must be inverted to correct for this.
(Fixes #6332)