### PR TITLE
[1.14.x] Remove unused parameter from ElementBuilder#rotation (fixes #6321)

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -370,7 +370,15 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
             return faces.computeIfAbsent(dir, FaceBuilder::new);
         }
 
+        /**
+         * @deprecated Use {@link #rotation()}
+         */
+        @Deprecated
         public RotationBuilder rotation(BlockPartRotation rotation) {
+            return rotation();
+        }
+
+        public RotationBuilder rotation() {
             if (this.rotation == null) {
                 this.rotation = new RotationBuilder();
             }


### PR DESCRIPTION
This deprecates the existing `ElementBuilder#rotation(BlockPartRotation)` method (which ignores its parameter) in favour of the new `ElementBuilder#rotation()` overload.

This fixes #6321.