### PR TITLE
Cull particles outside of view frustum.

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/client/particle/ParticleManager.java
 +++ b/net/minecraft/client/particle/ParticleManager.java
-@@ -63,7 +63,7 @@
+@@ -28,6 +28,7 @@
+ import net.minecraft.client.renderer.ActiveRenderInfo;
+ import net.minecraft.client.renderer.BufferBuilder;
+ import net.minecraft.client.renderer.Tessellator;
++import net.minecraft.client.renderer.culling.ICamera;
+ import net.minecraft.client.renderer.texture.AtlasTexture;
+ import net.minecraft.client.renderer.texture.MissingTextureSprite;
+ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+@@ -63,7 +64,7 @@
     private final Queue<EmitterParticle> field_178933_d = Queues.newArrayDeque();
     private final TextureManager field_78877_c;
     private final Random field_78875_d = new Random();
@@ -9,7 +17,7 @@
     private final Queue<Particle> field_187241_h = Queues.newArrayDeque();
     private final Map<ResourceLocation, ParticleManager.AnimatedSpriteImpl> field_215242_i = Maps.newHashMap();
     private final AtlasTexture field_215243_j = new AtlasTexture("textures/particle");
-@@ -137,13 +137,13 @@
+@@ -137,13 +138,13 @@
     }
  
     public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {
@@ -25,7 +33,7 @@
     }
  
     public CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
-@@ -230,11 +230,12 @@
+@@ -230,11 +231,12 @@
  
     @Nullable
     private <T extends IParticleData> Particle func_199927_b(T p_199927_1_, double p_199927_2_, double p_199927_4_, double p_199927_6_, double p_199927_8_, double p_199927_10_, double p_199927_12_) {
@@ -39,7 +47,16 @@
        this.field_187241_h.add(p_78873_1_);
     }
  
-@@ -306,7 +307,8 @@
+@@ -296,7 +298,7 @@
+       }
+    }
+ 
+-   public void func_215233_a(ActiveRenderInfo p_215233_1_, float p_215233_2_) {
++   public void renderParticles(ActiveRenderInfo p_215233_1_, ICamera icamera, float p_215233_2_) {
+       float f = MathHelper.func_76134_b(p_215233_1_.func_216778_f() * ((float)Math.PI / 180F));
+       float f1 = MathHelper.func_76126_a(p_215233_1_.func_216778_f() * ((float)Math.PI / 180F));
+       float f2 = -f1 * MathHelper.func_76126_a(p_215233_1_.func_216777_e() * ((float)Math.PI / 180F));
+@@ -306,7 +308,8 @@
        Particle.field_70554_ao = p_215233_1_.func_216785_c().field_72448_b;
        Particle.field_70555_ap = p_215233_1_.func_216785_c().field_72449_c;
  
@@ -49,7 +66,15 @@
           Iterable<Particle> iterable = this.field_78876_b.get(iparticlerendertype);
           if (iterable != null) {
              GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-@@ -342,7 +344,7 @@
+@@ -316,6 +319,7 @@
+ 
+             for(Particle particle : iterable) {
+                try {
++                  if (!icamera.func_78546_a(particle.func_187116_l())) continue; // Forge: Don't render particles outside frustum.
+                   particle.func_180434_a(bufferbuilder, p_215233_1_, p_215233_2_, f, f4, f1, f2, f3);
+                } catch (Throwable throwable) {
+                   CrashReport crashreport = CrashReport.func_85055_a(throwable, "Rendering Particle");
+@@ -342,7 +346,7 @@
     }
  
     public void func_180533_a(BlockPos p_180533_1_, BlockState p_180533_2_) {
@@ -58,7 +83,7 @@
           VoxelShape voxelshape = p_180533_2_.func_196954_c(this.field_78878_a, p_180533_1_);
           double d0 = 0.25D;
           voxelshape.func_197755_b((p_199284_3_, p_199284_5_, p_199284_7_, p_199284_9_, p_199284_11_, p_199284_13_) -> {
-@@ -414,6 +416,12 @@
+@@ -414,6 +418,12 @@
        return String.valueOf(this.field_78876_b.values().stream().mapToInt(Collection::size).sum());
     }
  

--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -1,14 +1,6 @@
 --- a/net/minecraft/client/particle/ParticleManager.java
 +++ b/net/minecraft/client/particle/ParticleManager.java
-@@ -28,6 +28,7 @@
- import net.minecraft.client.renderer.ActiveRenderInfo;
- import net.minecraft.client.renderer.BufferBuilder;
- import net.minecraft.client.renderer.Tessellator;
-+import net.minecraft.client.renderer.culling.ICamera;
- import net.minecraft.client.renderer.texture.AtlasTexture;
- import net.minecraft.client.renderer.texture.MissingTextureSprite;
- import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-@@ -63,7 +64,7 @@
+@@ -63,7 +63,7 @@
     private final Queue<EmitterParticle> field_178933_d = Queues.newArrayDeque();
     private final TextureManager field_78877_c;
     private final Random field_78875_d = new Random();
@@ -17,7 +9,7 @@
     private final Queue<Particle> field_187241_h = Queues.newArrayDeque();
     private final Map<ResourceLocation, ParticleManager.AnimatedSpriteImpl> field_215242_i = Maps.newHashMap();
     private final AtlasTexture field_215243_j = new AtlasTexture("textures/particle");
-@@ -137,13 +138,13 @@
+@@ -137,13 +137,13 @@
     }
  
     public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {
@@ -33,7 +25,7 @@
     }
  
     public CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
-@@ -230,11 +231,12 @@
+@@ -230,11 +230,12 @@
  
     @Nullable
     private <T extends IParticleData> Particle func_199927_b(T p_199927_1_, double p_199927_2_, double p_199927_4_, double p_199927_6_, double p_199927_8_, double p_199927_10_, double p_199927_12_) {
@@ -47,16 +39,16 @@
        this.field_187241_h.add(p_78873_1_);
     }
  
-@@ -296,7 +298,7 @@
+@@ -296,7 +297,7 @@
        }
     }
  
 -   public void func_215233_a(ActiveRenderInfo p_215233_1_, float p_215233_2_) {
-+   public void renderParticles(ActiveRenderInfo p_215233_1_, ICamera icamera, float p_215233_2_) {
++   public void renderParticles(ActiveRenderInfo p_215233_1_, net.minecraft.client.renderer.culling.ICamera icamera, float p_215233_2_) {
        float f = MathHelper.func_76134_b(p_215233_1_.func_216778_f() * ((float)Math.PI / 180F));
        float f1 = MathHelper.func_76126_a(p_215233_1_.func_216778_f() * ((float)Math.PI / 180F));
        float f2 = -f1 * MathHelper.func_76126_a(p_215233_1_.func_216777_e() * ((float)Math.PI / 180F));
-@@ -306,7 +308,8 @@
+@@ -306,7 +307,8 @@
        Particle.field_70554_ao = p_215233_1_.func_216785_c().field_72448_b;
        Particle.field_70555_ap = p_215233_1_.func_216785_c().field_72449_c;
  
@@ -66,7 +58,7 @@
           Iterable<Particle> iterable = this.field_78876_b.get(iparticlerendertype);
           if (iterable != null) {
              GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-@@ -316,6 +319,7 @@
+@@ -316,6 +318,7 @@
  
              for(Particle particle : iterable) {
                 try {
@@ -74,7 +66,7 @@
                    particle.func_180434_a(bufferbuilder, p_215233_1_, p_215233_2_, f, f4, f1, f2, f3);
                 } catch (Throwable throwable) {
                    CrashReport crashreport = CrashReport.func_85055_a(throwable, "Rendering Particle");
-@@ -342,7 +346,7 @@
+@@ -342,7 +345,7 @@
     }
  
     public void func_180533_a(BlockPos p_180533_1_, BlockState p_180533_2_) {
@@ -83,7 +75,7 @@
           VoxelShape voxelshape = p_180533_2_.func_196954_c(this.field_78878_a, p_180533_1_);
           double d0 = 0.25D;
           voxelshape.func_197755_b((p_199284_3_, p_199284_5_, p_199284_7_, p_199284_9_, p_199284_11_, p_199284_13_) -> {
-@@ -414,6 +418,12 @@
+@@ -414,6 +417,12 @@
        return String.valueOf(this.field_78876_b.values().stream().mapToInt(Collection::size).sum());
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -90,15 +90,18 @@
           worldrenderer.func_215325_a(activerenderinfo, this.field_78531_r.field_71476_x, 0);
           GlStateManager.enableAlphaTest();
        }
-@@ -725,7 +735,7 @@
+@@ -725,9 +735,9 @@
        this.field_78531_r.func_110434_K().func_110581_b(AtlasTexture.field_110575_b).func_174935_a();
        GlStateManager.disableBlend();
        this.func_180436_i();
 -      this.field_205003_A.func_217618_a(activerenderinfo, 0);
 +      this.field_205003_A.setupFog(activerenderinfo, 0, p_181560_1_);
        this.field_78531_r.func_213239_aq().func_219895_b("particles");
-       particlemanager.func_215233_a(activerenderinfo, p_181560_1_);
+-      particlemanager.func_215233_a(activerenderinfo, p_181560_1_);
++      particlemanager.renderParticles(activerenderinfo, icamera, p_181560_1_);
        this.func_175072_h();
+       GlStateManager.depthMask(false);
+       GlStateManager.enableCull();
 @@ -739,7 +749,7 @@
        GlStateManager.enableCull();
        GlStateManager.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);


### PR DESCRIPTION
This is a relatively simple patch that prevents particles we can't see from rendering.

https://puu.sh/ELfhJ/55eba95262.png - Control (Looking at particles)
https://puu.sh/ELfj1/41fa8559de.png - Current (Particles still rendered)
https://puu.sh/ELfjI/5622df57bb.png - Changed (Particles not rendered)

We're just passing icamera to the renderParticles method, where we check if the bounding box of the particle is inside it.

As you can see in the screenshots, when we aren't rendering the particles we get a decent FPS boost. This will change from PC to PC, but will be a free gain nonetheless.