### PR TITLE
Made canRiderInteract boolean in IForgeEntity actually work

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/projectile/ProjectileHelper.java
++++ b/net/minecraft/entity/projectile/ProjectileHelper.java
+@@ -89,7 +89,7 @@
+             Vec3d vec3d1 = optional.get();
+             double d1 = p_221273_1_.func_72436_e(vec3d1);
+             if (d1 < d0 || d0 == 0.0D) {
+-               if (entity1.func_184208_bv() == p_221273_0_.func_184208_bv()) {
++               if (entity1.func_184208_bv() == p_221273_0_.func_184208_bv() && !entity1.canRiderInteract()) {
+                   if (d0 == 0.0D) {
+                      entity = entity1;
+                      vec3d = vec3d1;


### PR DESCRIPTION
Currently, _canRiderInteract()_ in **IForgeEntity** doesn't get called. This pr makes it now work. With this pr, it will allow mods making ridable entities to be able to be interacted by the player.

For example, this is great for mods making entities that make their entities grab the player through riding, and this now allows those mods' entities to be interacted and attacked.