### PR TITLE
Make PotionExpiryEvent be fired on both sides (not just on server)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -66,7 +66,7 @@
              EffectInstance effectinstance = this.field_70713_bf.get(effect);
              if (!effectinstance.func_76455_a(this)) {
 -               if (!this.field_70170_p.field_72995_K) {
-+               if (!this.field_70170_p.field_72995_K && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionExpiryEvent(this, effectinstance))) {
++               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionExpiryEvent(this, effectinstance)) && !this.field_70170_p.field_72995_K) {
                    iterator.remove();
                    this.func_70688_c(effectinstance);
                 }


### PR DESCRIPTION
This PR is to make it so that the PotionExpiryEvent gets fired on both sides not just on the server.
Because all other PotionEvents are fired on both sides just this one was server only.