### PR TITLE
Fix javadoc thread note regarding ModelData

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -190,7 +190,7 @@ public interface IForgeTileEntity extends ICapabilitySerializable<CompoundNBT>
      * Allows you to return additional model data.
      * This data can be used to provide additional functionality in your {@link net.minecraft.client.renderer.model.IBakedModel}
      * You need to schedule a refresh of you model data via {@link #requestModelDataUpdate()} if the result of this function changes.
-     * <b>Note that this method may be called on a chunk render thread instead of the main client thread</b>
+     * This method is only called on the main client thread
      * @return Your model data
      */
      default @Nonnull IModelData getModelData()


### PR DESCRIPTION
Fixes an invalid javadoc I introduced in 06a30e9f23289a45c3c58e83d84c3dee01757e2b
I somehow confused the TileEntity method with the one in the IForgeBakedModel class, and tterag is right, this is only called on the client