### PR TITLE
Reduce event spam for certain projectiles

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/AbstractArrowEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/AbstractArrowEntity.java.patch
@@ -14,7 +14,7 @@
              }
  
 -            if (raytraceresult != null && !flag) {
-+         if (raytraceresult != null && !flag && !net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, raytraceresult)) {
++         if (raytraceresult != null && raytraceresult.func_216346_c() != RayTraceResult.Type.MISS && !flag && !net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, raytraceresult)) {
                 this.func_184549_a(raytraceresult);
                 this.field_70160_al = true;
              }

--- a/patches/minecraft/net/minecraft/entity/projectile/LlamaSpitEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/LlamaSpitEntity.java.patch
@@ -5,7 +5,7 @@
           return !p_213879_1_.func_175149_v() && p_213879_1_ != this.field_190539_a;
        }, RayTraceContext.BlockMode.OUTLINE, true);
 -      if (raytraceresult != null) {
-+      if (raytraceresult != null && !net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, raytraceresult)) {
++      if (raytraceresult != null && raytraceresult.func_216346_c() != RayTraceResult.Type.MISS && !net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, raytraceresult)) {
           this.func_190536_a(raytraceresult);
        }
  


### PR DESCRIPTION
Added a couple of raytraceresult.getType() != MISS checks in places where they were absent. This corrects a couple of vanilla oversights and also greatly reduces Forge bus event spam for arrows and llama spit.

Signed-off-by: King Lemming <kinglemming@gmail.com>