### PR TITLE
Fix game crashing when modded entities are present

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
@@ -1,17 +1,26 @@
 --- a/net/minecraft/client/renderer/entity/EntityRendererManager.java
 +++ b/net/minecraft/client/renderer/entity/EntityRendererManager.java
-@@ -183,9 +183,8 @@
+@@ -183,15 +183,17 @@
        this.field_178637_m = new PlayerRenderer(this);
        this.field_178636_l.put("default", this.field_178637_m);
        this.field_178636_l.put("slim", new PlayerRenderer(this, true));
--
++   }
+ 
++   //FORGE: Validate the existence of a renderer for each entity type after modded entity renderers have been added
++   public void validateRendererExistence() {
        for(EntityType<?> entitytype : Registry.field_212629_r) {
--         if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
-+         if (entitytype.getRegistryName().func_110624_b().equals("minecraft") && entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) { //FORGE: Skip check for modded entities as they have not had the chance to add their renderers
+          if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
              throw new IllegalStateException("No renderer registered for " + Registry.field_212629_r.func_177774_c(entitytype));
           }
        }
-@@ -445,4 +444,8 @@
+-
+    }
+-
++   
+    public <T extends Entity> EntityRenderer<? super T> func_78713_a(T p_78713_1_) {
+       if (p_78713_1_ instanceof AbstractClientPlayerEntity) {
+          String s = ((AbstractClientPlayerEntity)p_78713_1_).func_175154_l();
+@@ -445,4 +447,8 @@
     public FontRenderer func_78716_a() {
        return this.field_78736_p;
     }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/entity/EntityRendererManager.java
 +++ b/net/minecraft/client/renderer/entity/EntityRendererManager.java
-@@ -183,15 +183,17 @@
+@@ -183,13 +183,15 @@
        this.field_178637_m = new PlayerRenderer(this);
        this.field_178636_l.put("default", this.field_178637_m);
        this.field_178636_l.put("slim", new PlayerRenderer(this, true));
@@ -15,11 +15,8 @@
        }
 -
     }
--
-+   
+ 
     public <T extends Entity> EntityRenderer<? super T> func_78713_a(T p_78713_1_) {
-       if (p_78713_1_ instanceof AbstractClientPlayerEntity) {
-          String s = ((AbstractClientPlayerEntity)p_78713_1_).func_175154_l();
 @@ -445,4 +447,8 @@
     public FontRenderer func_78716_a() {
        return this.field_78736_p;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/renderer/entity/EntityRendererManager.java
 +++ b/net/minecraft/client/renderer/entity/EntityRendererManager.java
+@@ -183,7 +183,7 @@
+       this.field_178637_m = new PlayerRenderer(this);
+       this.field_178636_l.put("default", this.field_178637_m);
+       this.field_178636_l.put("slim", new PlayerRenderer(this, true));
+-
++      if(false) //FORGE: Disallow game from crashing, modded renderers haven't been added yet
+       for(EntityType<?> entitytype : Registry.field_212629_r) {
+          if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
+             throw new IllegalStateException("No renderer registered for " + Registry.field_212629_r.func_177774_c(entitytype));
 @@ -445,4 +445,8 @@
     public FontRenderer func_78716_a() {
        return this.field_78736_p;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
@@ -1,15 +1,17 @@
 --- a/net/minecraft/client/renderer/entity/EntityRendererManager.java
 +++ b/net/minecraft/client/renderer/entity/EntityRendererManager.java
-@@ -183,7 +183,7 @@
+@@ -183,9 +183,8 @@
        this.field_178637_m = new PlayerRenderer(this);
        this.field_178636_l.put("default", this.field_178637_m);
        this.field_178636_l.put("slim", new PlayerRenderer(this, true));
 -
-+      if(false) //FORGE: Disallow game from crashing, modded renderers haven't been added yet
        for(EntityType<?> entitytype : Registry.field_212629_r) {
-          if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
+-         if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
++         if (entitytype.getRegistryName().func_110624_b().equals("minecraft") && entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) { //FORGE: Skip check for modded entities as they have not had the chance to add their renderers
              throw new IllegalStateException("No renderer registered for " + Registry.field_212629_r.func_177774_c(entitytype));
-@@ -445,4 +445,8 @@
+          }
+       }
+@@ -445,4 +444,8 @@
     public FontRenderer func_78716_a() {
        return this.field_78736_p;
     }

--- a/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
@@ -47,6 +47,7 @@ public class RenderingRegistry
     public static void loadEntityRenderers(EntityRendererManager manager)
     {
         INSTANCE.entityRenderers.forEach((key, value) -> register(manager, key, value));
+        manager.validateRendererExistence();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Due to the way `EntityRendererManager` registers vanilla entity renderers and verifies their existence for all registered entity types, the game crashes when a modded entity type has been registered because `FMLClientSetupEvent` was not fired yet, which is the place for modders to register their entity renderers. This pull request pulls the check out of `EntityRendererManager`s constructor and calls it from RenderingRegistry#loadEntityRenderers, after modded entity renderers were registered.