### PR TITLE
Add Event to rotate BipedModel before rendering

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/model/BipedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/model/BipedModel.java.patch
@@ -4,7 +4,7 @@
  
     public void func_78088_a(T p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_, float p_78088_6_, float p_78088_7_) {
        this.func_212844_a_(p_78088_1_, p_78088_2_, p_78088_3_, p_78088_4_, p_78088_5_, p_78088_6_, p_78088_7_);
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderBipedModelEvent(this, p_78088_1_, p_78088_2_, p_78088_3_, p_78088_4_, p_78088_5_, p_78088_6_, p_78088_7_));
++      if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderBipedModelEvent(this, p_78088_1_, p_78088_2_, p_78088_3_, p_78088_4_, p_78088_5_, p_78088_6_, p_78088_7_))) return;
        GlStateManager.pushMatrix();
        if (this.field_217114_e) {
           float f = 2.0F;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/model/BipedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/model/BipedModel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/renderer/entity/model/BipedModel.java
++++ b/net/minecraft/client/renderer/entity/model/BipedModel.java
+@@ -62,6 +62,7 @@
+ 
+    public void func_78088_a(T p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_, float p_78088_6_, float p_78088_7_) {
+       this.func_212844_a_(p_78088_1_, p_78088_2_, p_78088_3_, p_78088_4_, p_78088_5_, p_78088_6_, p_78088_7_);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderBipedModelEvent(this, p_78088_1_, p_78088_2_, p_78088_3_, p_78088_4_, p_78088_5_, p_78088_6_, p_78088_7_));
+       GlStateManager.pushMatrix();
+       if (this.field_217114_e) {
+          float f = 2.0F;

--- a/src/main/java/net/minecraftforge/client/event/RenderBipedModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBipedModelEvent.java
@@ -1,0 +1,61 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.renderer.entity.model.BipedModel;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * This event is fired on {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ * after the {@link net.minecraft.client.renderer.entity.model.BipedModel#setRotationAngles(LivingEntity, float, float, float, float, float, float)}.
+ * Allows to modify rotation of the model's parts before it gets rendered
+ * If Canceled the model will not be rendered.
+ */
+@net.minecraftforge.eventbus.api.Cancelable
+public class RenderBipedModelEvent extends Event {
+
+    private BipedModel model;
+    private Entity entity;
+    private float limbSwing;
+    private float limbSwingAmount;
+    private float ageInTicks;
+    private float netHeadYeaw;
+    private float headPitch;
+    private float scale;
+
+    public RenderBipedModelEvent(BipedModel model, Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
+        this.model = model;
+        this.entity = entity;
+        this.limbSwing = limbSwing;
+        this.limbSwingAmount = limbSwingAmount;
+        this.ageInTicks = ageInTicks;
+        this.netHeadYeaw = netHeadYaw;
+        this.headPitch = headPitch;
+        this.scale = scale;
+    }
+
+    public BipedModel getMainModel() {
+        return model;
+    }
+    public Entity getEntity() {
+        return entity;
+    }
+    public float getLimbSwing() {
+        return limbSwing;
+    }
+    public float getLimbSwingAmount() {
+        return limbSwingAmount;
+    }
+    public float getAgeInTicks() {
+        return ageInTicks;
+    }
+    public float getNetHeadYeaw() {
+        return netHeadYeaw;
+    }
+    public float getHeadPitch() {
+        return headPitch;
+    }
+    public float getScale() {
+        return scale;
+    }
+}


### PR DESCRIPTION
Similar PR to #3350 for 1.14 (since this event was never implemented).

This add a RenderBipedModelEvent that is fired each ticks just before the model is rendered (but after the model is setup so all the changes done to the model in the event will not been overwritted).

The event is cancelable, if canceled the model will not be rendered.

This affects all entities that use a BipedModel such as PlayerEntity, Enderman, Skeleton, Zombies, ArmorStand and Vex.