### PR TITLE
[1.15] Add event to rotate EntityModel before rendering

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/LivingRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/LivingRenderer.java.patch
@@ -30,6 +30,7 @@
           f5 = p_225623_1_.field_184619_aG - p_225623_1_.field_70721_aZ * (1.0F - p_225623_3_);
           if (p_225623_1_.func_70631_g_()) {
 @@ -132,6 +135,7 @@
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.RenderModel<T, M>(p_225623_1_, this, p_225623_3_, p_225623_4_));
  
        p_225623_4_.func_227865_b_();
        super.func_225623_a_(p_225623_1_, p_225623_2_, p_225623_3_, p_225623_4_, p_225623_5_, p_225623_6_);

--- a/patches/minecraft/net/minecraft/client/renderer/entity/LivingRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/LivingRenderer.java.patch
@@ -29,8 +29,15 @@
           f8 = MathHelper.func_219799_g(p_225623_3_, p_225623_1_.field_184618_aE, p_225623_1_.field_70721_aZ);
           f5 = p_225623_1_.field_184619_aG - p_225623_1_.field_70721_aZ * (1.0F - p_225623_3_);
           if (p_225623_1_.func_70631_g_()) {
-@@ -132,6 +135,7 @@
+@@ -119,6 +122,7 @@
+       }
+ 
+       if (flag1 || flag2 || flag) {
 +         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.RenderModel<T, M>(p_225623_1_, this, p_225623_3_, p_225623_4_));
+          IVertexBuilder ivertexbuilder = p_225623_5_.getBuffer(rendertype);
+          int i = func_229117_c_(p_225623_1_, this.func_225625_b_(p_225623_1_, p_225623_3_));
+          this.field_77045_g.func_225598_a_(p_225623_4_, ivertexbuilder, p_225623_6_, i, 1.0F, 1.0F, 1.0F, flag2 ? 0.15F : 1.0F);
+@@ -132,6 +136,7 @@
  
        p_225623_4_.func_227865_b_();
        super.func_225623_a_(p_225623_1_, p_225623_2_, p_225623_3_, p_225623_4_, p_225623_5_, p_225623_6_);

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -51,6 +51,10 @@ public abstract class RenderLivingEvent<T extends LivingEntity, M extends Entity
     {
         public Pre(LivingEntity entity, LivingRenderer<T, M> renderer, float partialRenderTick, MatrixStack matrixStack){ super(entity, renderer, partialRenderTick, matrixStack); }
     }
+    public static class RenderModel<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
+    {
+        public RenderModel(LivingEntity entity, LivingRenderer<T, M> renderer, float partialRenderTick, MatrixStack matrixStack) { super(entity, renderer, partialRenderTick, matrixStack);}
+    }
     public static class Post<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
     {
         public Post(LivingEntity entity, LivingRenderer<T, M> renderer, float partialRenderTick, MatrixStack matrixStack){ super(entity, renderer, partialRenderTick, matrixStack); }

--- a/src/test/java/net/minecraftforge/debug/client/model/RenderLivingModelTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/RenderLivingModelTestMod.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.debug.client.model;
+
+import net.minecraft.client.entity.player.AbstractClientPlayerEntity;
+import net.minecraft.client.renderer.entity.model.BipedModel;
+import net.minecraft.item.Items;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("render_living_model_test")
+public class RenderLivingModelTestMod {
+
+    public RenderLivingModelTestMod() {
+        MinecraftForge.EVENT_BUS.addListener(this::onModelRender);
+    }
+
+    public void onModelRender(RenderLivingEvent.RenderModel event) {
+        if(event.getEntity() instanceof AbstractClientPlayerEntity && event.getRenderer().getEntityModel() instanceof BipedModel) {
+            AbstractClientPlayerEntity player = (AbstractClientPlayerEntity)event.getEntity();
+            BipedModel model = (BipedModel)event.getRenderer().getEntityModel();
+            if(player.getHeldItemMainhand().getItem() == Items.TORCH) {
+                model.bipedRightArm.rotateAngleX = -2F;
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -51,3 +51,5 @@ loaderVersion="[28,)"
     modId="custom_tnt_test"
 [[mods]]
     modId="new_model_loader_test"
+[[mods]]
+    modid="render_living_model_test"


### PR DESCRIPTION
1.15 version of #6365 

In 1.15 the EntityModel is setup directly in the LivingRenderer (only for LivingEntity of course) so I just added a RenderLivingEvent.RenderModel sub-event that is fired before rendering but after the model is setup so we can make changes to the model that will not be overwritten before rendering.

This will also allow to modify model of all LivingEntity instead of just those which use a BipedModel.