### PR TITLE
Add support for custom nether portal frame blocks

### DIFF
--- a/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
@@ -9,3 +9,48 @@
           netherportalblock$size.func_150859_c();
           return true;
        } else {
+@@ -241,13 +241,13 @@
+          int i;
+          for(i = 0; i < 22; ++i) {
+             BlockPos blockpos = p_180120_1_.func_177967_a(p_180120_2_, i);
+-            if (!this.func_196900_a(this.field_150867_a.func_180495_p(blockpos)) || this.field_150867_a.func_180495_p(blockpos.func_177977_b()).func_177230_c() != Blocks.field_150343_Z) {
++            if (!this.func_196900_a(this.field_150867_a.func_180495_p(blockpos)) || !this.field_150867_a.func_180495_p(blockpos.func_177977_b()).isPortalFrame(this.field_150867_a, blockpos.func_177977_b())) {
+                break;
+             }
+          }
+ 
+-         Block block = this.field_150867_a.func_180495_p(p_180120_1_.func_177967_a(p_180120_2_, i)).func_177230_c();
+-         return block == Blocks.field_150343_Z ? i : 0;
++         BlockPos framePos = p_180120_1_.func_177967_a(p_180120_2_, i);
++         return this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos) ? i : 0;
+       }
+ 
+       public int func_181100_a() {
+@@ -274,13 +274,13 @@
+                }
+ 
+                if (i == 0) {
+-                  block = this.field_150867_a.func_180495_p(blockpos.func_177972_a(this.field_150863_d)).func_177230_c();
+-                  if (block != Blocks.field_150343_Z) {
++                  BlockPos framePos = blockpos.func_177972_a(this.field_150863_d);
++                  if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                      break label56;
+                   }
+                } else if (i == this.field_150868_h - 1) {
+-                  block = this.field_150867_a.func_180495_p(blockpos.func_177972_a(this.field_150866_c)).func_177230_c();
+-                  if (block != Blocks.field_150343_Z) {
++                  BlockPos framePos = blockpos.func_177972_a(this.field_150866_c);
++                  if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                      break label56;
+                   }
+                }
+@@ -288,7 +288,8 @@
+          }
+ 
+          for(int j = 0; j < this.field_150868_h; ++j) {
+-            if (this.field_150867_a.func_180495_p(this.field_150861_f.func_177967_a(this.field_150866_c, j).func_177981_b(this.field_150862_g)).func_177230_c() != Blocks.field_150343_Z) {
++            BlockPos framePos = this.field_150861_f.func_177967_a(this.field_150866_c, j).func_177981_b(this.field_150862_g);
++            if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                this.field_150862_g = 0;
+                break;
+             }

--- a/patches/minecraft/net/minecraft/item/FlintAndSteelItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/FlintAndSteelItem.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/item/FlintAndSteelItem.java
++++ b/net/minecraft/item/FlintAndSteelItem.java
+@@ -65,7 +65,8 @@
+       boolean flag = false;
+ 
+       for(Direction direction : Direction.Plane.HORIZONTAL) {
+-         if (p_219996_1_.func_180495_p(p_219996_2_.func_177972_a(direction)).func_177230_c() == Blocks.field_150343_Z && ((NetherPortalBlock)Blocks.field_150427_aO).func_201816_b(p_219996_1_, p_219996_2_) != null) {
++         BlockPos framePos = p_219996_2_.func_177972_a(direction);
++         if (p_219996_1_.func_180495_p(framePos).isPortalFrame(p_219996_1_, framePos) && ((NetherPortalBlock)Blocks.field_150427_aO).func_201816_b(p_219996_1_, p_219996_2_) != null) {
+             flag = true;
+          }
+       }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -571,6 +571,19 @@ public interface IForgeBlock
     {
         return Tags.Blocks.SUPPORTS_BEACON.contains(state.getBlock());
     }
+
+    /**
+     * Determines if this block can be used as part of a frame of a nether portal.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True, to support being part of a nether portal frame, false otherwise.
+     */
+    default boolean isPortalFrame(BlockState state, IWorldReader world, BlockPos pos)
+    {
+        return state.getBlock() == Blocks.OBSIDIAN;
+    }
+
    /**
     * Gathers how much experience this block drops when broken.
     *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -575,6 +575,7 @@ public interface IForgeBlock
     /**
      * Determines if this block can be used as part of a frame of a nether portal.
      *
+     * @param state The current state
      * @param world The current world
      * @param pos Block position in world
      * @return True, to support being part of a nether portal frame, false otherwise.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -495,6 +495,18 @@ public interface IForgeBlockState
         return getBlockState().getBlock().isBeaconBase(getBlockState(), world, pos, beacon);
     }
 
+    /**
+     * Determines if this block can be used as part of a frame of a nether portal.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True, to support being part of a nether portal frame, false otherwise.
+     */
+    default boolean isPortalFrame(IWorldReader world, BlockPos pos)
+    {
+        return getBlockState().getBlock().isPortalFrame(getBlockState(), world, pos);
+    }
+
    /**
     * Gathers how much experience this block drops when broken.
     *


### PR DESCRIPTION
This PR adds support for being able to override and add custom blocks as being valid nether portal frames. The use case I have for this is that in 1.12 someone PRd into Mekanism a registry override for vanilla's nether portal block so that it could support portals made out of both obsidian and refined obsidian blocks. This is more of a pain in 1.15, due to `NetherPortalBlock#createPatternHelper` now being static, and I also believe it would be much cleaner (and cross mod compatible), to have a forge patch that performs a similar function to the custom beacon base blocks.

I tested this patch, and it works properly (including when the portal attempts to be started from a different block than obsidian being lit on fire). ~The one thing I am not sure about is if I should have it default to being true for obsidian (what I currently am doing), OR if I should default it to being true for the `Tag<Block>` for obsidian (or maybe have its own tag that has a default of `#forge:obsidian` so that players can set their own custom blocks for the nether portal frame).~

Edit: Lex said not to do it as tags, so I am leaving it as be with the direct check against obsidian currently.