### PR TITLE
InputEvent.RawMouseEvent fix

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,15 +1,14 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
-@@ -65,7 +65,7 @@
- 
+@@ -66,6 +66,7 @@
              this.field_198042_g = -1;
           }
--
+ 
 +         if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
           boolean[] aboolean = new boolean[]{false};
           if (this.field_198036_a.field_213279_p == null) {
              if (this.field_198036_a.field_71462_r == null) {
-@@ -77,11 +77,15 @@
+@@ -77,11 +78,15 @@
                 double d1 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
                 if (flag) {
                    Screen.wrapScreenError(() -> {
@@ -27,7 +26,7 @@
                    }, "mouseReleased event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
                 }
              }
-@@ -105,7 +109,7 @@
+@@ -105,7 +110,7 @@
                 }
              }
           }
@@ -36,7 +35,7 @@
        }
     }
  
-@@ -116,7 +120,9 @@
+@@ -116,7 +121,9 @@
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
                 double d2 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
@@ -47,7 +46,7 @@
              } else if (this.field_198036_a.field_71439_g != null) {
                 if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
                    this.field_200542_o = 0.0D;
-@@ -129,6 +135,7 @@
+@@ -129,6 +136,7 @@
                 }
  
                 this.field_200542_o -= (double)f1;
@@ -55,7 +54,7 @@
                 if (this.field_198036_a.field_71439_g.func_175149_v()) {
                    if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
                       this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
-@@ -180,7 +187,9 @@
+@@ -180,7 +188,9 @@
                 double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
                 double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
                 Screen.wrapScreenError(() -> {
@@ -66,7 +65,7 @@
                 }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
              }
           }
-@@ -245,6 +254,10 @@
+@@ -245,6 +255,10 @@
        return this.field_198039_d;
     }
  
@@ -77,7 +76,7 @@
     public double func_198024_e() {
        return this.field_198040_e;
     }
-@@ -253,6 +266,14 @@
+@@ -253,6 +267,14 @@
        return this.field_198041_f;
     }
  

--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,12 +1,15 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
-@@ -72,16 +72,21 @@
-                if (!this.field_198051_p && flag) {
-                   this.func_198034_i();
-                }
-+               if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
-             } else {
-                double d0 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
+@@ -65,7 +65,7 @@
+ 
+             this.field_198042_g = -1;
+          }
+-
++         if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
+          boolean[] aboolean = new boolean[]{false};
+          if (this.field_198036_a.field_213279_p == null) {
+             if (this.field_198036_a.field_71462_r == null) {
+@@ -77,11 +77,15 @@
                 double d1 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
                 if (flag) {
                    Screen.wrapScreenError(() -> {
@@ -24,7 +27,7 @@
                    }, "mouseReleased event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
                 }
              }
-@@ -105,7 +110,7 @@
+@@ -105,7 +109,7 @@
                 }
              }
           }
@@ -33,7 +36,7 @@
        }
     }
  
-@@ -116,7 +121,9 @@
+@@ -116,7 +120,9 @@
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
                 double d2 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
@@ -44,7 +47,7 @@
              } else if (this.field_198036_a.field_71439_g != null) {
                 if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
                    this.field_200542_o = 0.0D;
-@@ -129,6 +136,7 @@
+@@ -129,6 +135,7 @@
                 }
  
                 this.field_200542_o -= (double)f1;
@@ -52,7 +55,7 @@
                 if (this.field_198036_a.field_71439_g.func_175149_v()) {
                    if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
                       this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
-@@ -180,7 +188,9 @@
+@@ -180,7 +187,9 @@
                 double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
                 double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
                 Screen.wrapScreenError(() -> {
@@ -63,7 +66,7 @@
                 }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
              }
           }
-@@ -245,6 +255,10 @@
+@@ -245,6 +254,10 @@
        return this.field_198039_d;
     }
  
@@ -74,7 +77,7 @@
     public double func_198024_e() {
        return this.field_198040_e;
     }
-@@ -253,6 +267,14 @@
+@@ -253,6 +266,14 @@
        return this.field_198041_f;
     }
  


### PR DESCRIPTION
Fixes a minor issue where the mouse has already been grabbed before the event was fired.

Listeners can easily call the grabMouse() method if needed, but if you didn't want the mouse grabbed, you had to keep the mouse location cached, ungrab the mouse, and reset the mouse position to what it was before to persist the cursor's location in a non jarring way. 