### PR TITLE
The recent changes to 1.15.x left out the license header

### DIFF
--- a/src/test/java/net/minecraftforge/debug/client/model/TRSRTransformerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/TRSRTransformerTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client.model;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
Minor build-break given the license check/lint.

May want to just touch up the file?

It may already be a known issue, but it's still in the code as of this post.
