### PR TITLE
Fix the item highlight timer not resetting for items with different highlight tips

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/IngameGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/IngameGui.java.patch
@@ -40,3 +40,12 @@
              RenderSystem.disableBlend();
              RenderSystem.popMatrix();
           }
+@@ -1045,7 +1056,7 @@
+          ItemStack itemstack = this.field_73839_d.field_71439_g.field_71071_by.func_70448_g();
+          if (itemstack.func_190926_b()) {
+             this.field_92017_k = 0;
+-         } else if (!this.field_92016_l.func_190926_b() && itemstack.func_77973_b() == this.field_92016_l.func_77973_b() && itemstack.func_200301_q().equals(this.field_92016_l.func_200301_q())) {
++         } else if (!this.field_92016_l.func_190926_b() && itemstack.func_77973_b() == this.field_92016_l.func_77973_b() && (itemstack.func_200301_q().equals(this.field_92016_l.func_200301_q()) && itemstack.getHighlightTip(itemstack.func_200301_q().func_150261_e()).equals(field_92016_l.getHighlightTip(field_92016_l.func_200301_q().func_150261_e())))) {
+             if (this.field_92017_k > 0) {
+                --this.field_92017_k;
+             }


### PR DESCRIPTION
Forge provides modders with `Item::getHighlightTip(ItemStack, String)` to supply items with an additional, unchangeable tooltip when displaying the item's name after being selected in the hotbar. However, because vanilla does not reset the highlight timer for items with the same name (i.e. unnamed Sand or Dirt) and only compares against the item's display name, this doesn't take into account the highlight tip. Consequently, items with the name name but different highlight tips are considered similar and do not reset the highlight timer.

This PR aims to address this issue by including an additional check to ensure item highlights also differ while still maintaining vanilla-familiar functionality (i.e. items with the same name will not reset the highlight timer).