### PR TITLE
[1.15.x] Add missing --existing argument to MDK data run (fixes #6322)

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -74,7 +74,7 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'),  '--existing', '"' + sourceSets.main.resources.srcDirs[0] + '"'
+            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'),  '--existing', sourceSets.main.resources.srcDirs[0]
 
             mods {
                 examplemod {

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -74,7 +74,11 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'),  '--existing', '"' + sourceSets.main.resources.srcDirs[0] + '"'
+            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+
+            sourceSets.main.resources.srcDirs.forEach { File dir ->
+                args '--existing', dir
+            }
 
             mods {
                 examplemod {

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -74,7 +74,7 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'),  '--existing', '"' + sourceSets.main.resources.srcDirs[0] + '"'
 
             mods {
                 examplemod {

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -74,11 +74,7 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
-
-            sourceSets.main.resources.srcDirs.forEach { File dir ->
-                args '--existing', dir
-            }
+            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'),  '--existing', '"' + sourceSets.main.resources.srcDirs[0] + '"'
 
             mods {
                 examplemod {


### PR DESCRIPTION
1.15 version of #6340.

This adds the missing `--existing` argument to the MDK's data run, allowing mod resources to be loaded correctly during data generation.

This fixes #6322.