### PR TITLE
[1.15.x] Fix validation in RotationBuilder#angle (fixes #6323)

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -550,7 +550,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
              */
             public RotationBuilder angle(float angle) {
                 // Same logic from BlockPart.Deserializer#parseAngle
-                Preconditions.checkArgument(angle != 0.0F && MathHelper.abs(angle) != 22.5F && MathHelper.abs(angle) != 45.0F, "Invalid rotation %f found, only -45/-22.5/0/22.5/45 allowed", angle);
+                Preconditions.checkArgument(angle == 0.0F || MathHelper.abs(angle) == 22.5F || MathHelper.abs(angle) == 45.0F, "Invalid rotation %f found, only -45/-22.5/0/22.5/45 allowed", angle);
                 this.angle = angle;
                 return this;
             }


### PR DESCRIPTION
1.15 version of #6339.

This inverts the validation logic in `RotationBuilder#angle` such that it only accepts the valid values (0, +/- 22.5, +/- 45) instead of accepting any value except the valid values.

This fixes #6323.