### PR TITLE
[1.15.x] Added entity nameplate rendering event hook

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/client/renderer/entity/EntityRenderer.java
++++ b/net/minecraft/client/renderer/entity/EntityRenderer.java
+@@ -15,6 +15,7 @@
+ import net.minecraft.world.LightType;
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
++import net.minecraftforge.eventbus.api.Event;
+ 
+ @OnlyIn(Dist.CLIENT)
+ public abstract class EntityRenderer<T extends Entity> {
+@@ -54,8 +55,10 @@
+    }
+ 
+    public void func_225623_a_(T p_225623_1_, float p_225623_2_, float p_225623_3_, MatrixStack p_225623_4_, IRenderTypeBuffer p_225623_5_, int p_225623_6_) {
+-      if (this.func_177070_b(p_225623_1_)) {
+-         this.func_225629_a_(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), p_225623_4_, p_225623_5_, p_225623_6_);
++      net.minecraftforge.client.event.RenderNameplateEvent renderNameplateEvent = new net.minecraftforge.client.event.RenderNameplateEvent(p_225623_1_,p_225623_1_.func_145748_c_().func_150254_d());
++      if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(renderNameplateEvent)) return;
++      if (!renderNameplateEvent.getResult().equals(Event.Result.DENY) && (renderNameplateEvent.getResult().equals(Event.Result.ALLOW) || this.func_177070_b(p_225623_1_))) {
++         this.func_225629_a_(p_225623_1_, renderNameplateEvent.getContent(), p_225623_4_, p_225623_5_, p_225623_6_);
+       }
+    }
+ 

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.client.event;
+
+import com.google.common.base.Strings;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * RenderNameplateEvent is fired whenever the entity renderer attempts to render a name plate/tag of an entity.
+ * <br>
+ * {@link #entity} contains the entity in which the plate is being rendered to. This cannot be changed by mods.<br>
+ * {@link #nameplateContent} contains the content being rendered on the name plate/tag. This can be changed by mods.<br>
+ * {@link #originalContent} contains the original content being rendered on the name plate/tag. This cannot be changed by mods.<br>
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If this event is canceled, the entity name plate/tag will not be rendered.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class RenderNameplateEvent extends Event {
+
+    private final Entity entity;
+    private String nameplateContent;
+    private final String originalContent;
+
+    public RenderNameplateEvent(Entity entity, String content){
+        this.entity = entity;
+        this.setContent(content);
+        this.originalContent = Strings.nullToEmpty(content);
+    }
+
+    /**
+     * The entity in which the name plate/tag is being rendered to
+     */
+    public Entity getEntity(){
+        return this.entity;
+    }
+
+    /**
+     * Sets the content that is to be rendered on the name plate/tag
+     */
+    public void setContent(String contents){
+        this.nameplateContent = Strings.nullToEmpty(contents);
+    }
+
+    /**
+     * The content being rendered on the name plate/tag
+     */
+    public String getContent(){
+        return this.nameplateContent;
+    }
+
+    /**
+     * The original content being rendered on the name plate/tag
+     */
+    public String getOriginalContent(){
+        return this.nameplateContent;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraft.entity.passive.CowEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.client.event.RenderNameplateEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("nameplate_render_test")
+@Mod.EventBusSubscriber
+public class NameplateRenderingEventTest {
+
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onNameplateRender(RenderNameplateEvent event) {
+
+        if(!ENABLED){
+            return;
+        }
+
+        if(event.getEntity() instanceof CowEntity) {
+            event.setContent(TextFormatting.RED + "Evil Cow");
+            event.setResult(Event.Result.ALLOW);
+        }
+
+        if(event.getEntity() instanceof PlayerEntity){
+            event.setContent(TextFormatting.GOLD + "" + (event.getEntity()).getDisplayName().getString());
+        }
+
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -55,3 +55,5 @@ loaderVersion="[28,)"
     modId="forgedebugmultilayermodel"
 [[mods]]
     modId="trsr_transformer_test"
+[[mods]]
+    modId="nameplate_render_test"


### PR DESCRIPTION
Adds a new event hook RenderNameplateEvent, which lets modders change, cancel or force the rendering of the nameplate and its contents.