### PR TITLE
[1.14] Add support for custom nether portal frame blocks

### DIFF
--- a/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
@@ -9,3 +9,48 @@
           netherportalblock$size.func_150859_c();
           return true;
        } else {
+@@ -241,13 +241,13 @@
+          int i;
+          for(i = 0; i < 22; ++i) {
+             BlockPos blockpos = p_180120_1_.func_177967_a(p_180120_2_, i);
+-            if (!this.func_196900_a(this.field_150867_a.func_180495_p(blockpos)) || this.field_150867_a.func_180495_p(blockpos.func_177977_b()).func_177230_c() != Blocks.field_150343_Z) {
++            if (!this.func_196900_a(this.field_150867_a.func_180495_p(blockpos)) || !this.field_150867_a.func_180495_p(blockpos.func_177977_b()).isPortalFrame(this.field_150867_a, blockpos.func_177977_b())) {
+                break;
+             }
+          }
+ 
+-         Block block = this.field_150867_a.func_180495_p(p_180120_1_.func_177967_a(p_180120_2_, i)).func_177230_c();
+-         return block == Blocks.field_150343_Z ? i : 0;
++         BlockPos framePos = p_180120_1_.func_177967_a(p_180120_2_, i);
++         return this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos) ? i : 0;
+       }
+ 
+       public int func_181100_a() {
+@@ -274,13 +274,13 @@
+                }
+ 
+                if (i == 0) {
+-                  block = this.field_150867_a.func_180495_p(blockpos.func_177972_a(this.field_150863_d)).func_177230_c();
+-                  if (block != Blocks.field_150343_Z) {
++                  BlockPos framePos = blockpos.func_177972_a(this.field_150863_d);
++                  if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                      break label56;
+                   }
+                } else if (i == this.field_150868_h - 1) {
+-                  block = this.field_150867_a.func_180495_p(blockpos.func_177972_a(this.field_150866_c)).func_177230_c();
+-                  if (block != Blocks.field_150343_Z) {
++                  BlockPos framePos = blockpos.func_177972_a(this.field_150866_c);
++                  if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                      break label56;
+                   }
+                }
+@@ -288,7 +288,8 @@
+          }
+ 
+          for(int j = 0; j < this.field_150868_h; ++j) {
+-            if (this.field_150867_a.func_180495_p(this.field_150861_f.func_177967_a(this.field_150866_c, j).func_177981_b(this.field_150862_g)).func_177230_c() != Blocks.field_150343_Z) {
++            BlockPos framePos = this.field_150861_f.func_177967_a(this.field_150866_c, j).func_177981_b(this.field_150862_g);
++            if (!this.field_150867_a.func_180495_p(framePos).isPortalFrame(this.field_150867_a, framePos)) {
+                this.field_150862_g = 0;
+                break;
+             }

--- a/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/NetherPortalBlock.java.patch
@@ -9,7 +9,7 @@
           netherportalblock$size.func_150859_c();
           return true;
        } else {
-@@ -241,13 +241,13 @@
+@@ -245,13 +245,13 @@
           int i;
           for(i = 0; i < 22; ++i) {
              BlockPos blockpos = p_180120_1_.func_177967_a(p_180120_2_, i);
@@ -26,7 +26,7 @@
        }
  
        public int func_181100_a() {
-@@ -274,13 +274,13 @@
+@@ -278,13 +278,13 @@
                 }
  
                 if (i == 0) {
@@ -44,7 +44,7 @@
                       break label56;
                    }
                 }
-@@ -288,7 +288,8 @@
+@@ -292,7 +292,8 @@
           }
  
           for(int j = 0; j < this.field_150868_h; ++j) {

--- a/patches/minecraft/net/minecraft/item/FlintAndSteelItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/FlintAndSteelItem.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/item/FlintAndSteelItem.java
++++ b/net/minecraft/item/FlintAndSteelItem.java
+@@ -65,7 +65,8 @@
+       boolean flag = false;
+ 
+       for(Direction direction : Direction.Plane.HORIZONTAL) {
+-         if (p_219996_1_.func_180495_p(p_219996_2_.func_177972_a(direction)).func_177230_c() == Blocks.field_150343_Z && ((NetherPortalBlock)Blocks.field_150427_aO).func_201816_b(p_219996_1_, p_219996_2_) != null) {
++         BlockPos framePos = p_219996_2_.func_177972_a(direction);
++         if (p_219996_1_.func_180495_p(framePos).isPortalFrame(p_219996_1_, framePos) && ((NetherPortalBlock)Blocks.field_150427_aO).func_201816_b(p_219996_1_, p_219996_2_) != null) {
+             flag = true;
+          }
+       }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -592,6 +592,20 @@ public interface IForgeBlock
     {
         return Tags.Blocks.SUPPORTS_BEACON.contains(state.getBlock());
     }
+
+    /**
+     * Determines if this block can be used as part of a frame of a nether portal.
+     *
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True, to support being part of a nether portal frame, false otherwise.
+     */
+    default boolean isPortalFrame(BlockState state, IWorldReader world, BlockPos pos)
+    {
+        return state.getBlock() == Blocks.OBSIDIAN;
+    }
+
    /**
     * Gathers how much experience this block drops when broken.
     *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -514,6 +514,18 @@ public interface IForgeBlockState
         return getBlockState().getBlock().isBeaconBase(getBlockState(), world, pos, beacon);
     }
 
+    /**
+     * Determines if this block can be used as part of a frame of a nether portal.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @return True, to support being part of a nether portal frame, false otherwise.
+     */
+    default boolean isPortalFrame(IWorldReader world, BlockPos pos)
+    {
+        return getBlockState().getBlock().isPortalFrame(getBlockState(), world, pos);
+    }
+
    /**
     * Gathers how much experience this block drops when broken.
     *


### PR DESCRIPTION
This PR adds support for custom blocks in nether portal frames to 1.14.  This is a cherry pick of #6389, though I reran `genPatches` to make the patch more accurate to 1.14. I tested it and it allows both using custom blocks in the frame and starting the portal on a block other than obsidian.