### PR TITLE
Improve forge startup time by reducing runtime class-writing overhead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,7 @@ project(':forge') {
         installer 'org.ow2.asm:asm:7.2'
         installer 'org.ow2.asm:asm-commons:7.2'
         installer 'org.ow2.asm:asm-tree:7.2'
-        installer 'cpw.mods:modlauncher:5.0.+'
+        installer 'cpw.mods:modlauncher:5.1.+'
         installer 'cpw.mods:grossjava9hacks:1.1.+'
         installer 'net.minecraftforge:accesstransformers:2.0.+:shadowed'
         installer 'net.minecraftforge:eventbus:2.0.+:service'

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
@@ -52,13 +52,19 @@ public class CapabilityInjectDefinalize implements ILaunchPluginService {
         return isEmpty ? NAY : YAY;
     }
 
+    @Override
+    public boolean processClass(Phase phase, ClassNode classNode, Type classType)
+    {
+        throw new RuntimeException("Legacy modLauncher method called!");
+    }
+
     private boolean hasHolder(List<AnnotationNode> lst)
     {
         return lst != null && lst.stream().anyMatch(n -> n.desc.equals(CAP_INJECT));
     }
 
     @Override
-    public boolean processClass(Phase phase, ClassNode classNode, Type classType)
+    public ILaunchPluginService.ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
     {
         final int flags = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
         AtomicBoolean changed = new AtomicBoolean();
@@ -70,7 +76,7 @@ public class CapabilityInjectDefinalize implements ILaunchPluginService {
             changed.compareAndSet(false, prev != f.access);
         });
 
-        return changed.get();
+        return changed.get() ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
     }
 
 }

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
@@ -64,7 +64,7 @@ public class CapabilityInjectDefinalize implements ILaunchPluginService {
     }
 
     @Override
-    public ILaunchPluginService.ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
+    public int processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
     {
         final int flags = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
         AtomicBoolean changed = new AtomicBoolean();
@@ -76,7 +76,7 @@ public class CapabilityInjectDefinalize implements ILaunchPluginService {
             changed.compareAndSet(false, prev != f.access);
         });
 
-        return changed.get() ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
+        return changed.get() ? ComputeFlags.SIMPLE_REWRITE : ComputeFlags.NO_REWRITE;
     }
 
 }

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
@@ -75,6 +75,12 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
     @Override
     public boolean processClass(Phase phase, ClassNode classNode, Type classType)
     {
+        throw new RuntimeException("Legacy modLauncher method called!");
+    }
+
+    @Override
+    public ILaunchPluginService.ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
+    {
         AtomicBoolean changes = new AtomicBoolean();
         //Must be public static finals, and non-array objects
         final int flags = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
@@ -107,7 +113,7 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
                 changes.compareAndSet(false, prev != f.access);
             });
         }
-        return changes.get();
+        return changes.get() ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
     }
 
 }

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
@@ -79,7 +79,7 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
     }
 
     @Override
-    public ILaunchPluginService.ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
+    public int processClassNew(Phase phase, ClassNode classNode, Type classType, String reason)
     {
         AtomicBoolean changes = new AtomicBoolean();
         //Must be public static finals, and non-array objects
@@ -113,7 +113,7 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
                 changes.compareAndSet(false, prev != f.access);
             });
         }
-        return changes.get() ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
+        return changes.get() ? ComputeFlags.SIMPLE_REWRITE : ComputeFlags.NO_REWRITE;
     }
 
 }

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -74,9 +74,9 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
     }
 
     @Override
-    public ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
+    public int processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
         if ((classNode.access & Opcodes.ACC_ENUM) == 0)
-            return ComputeLevel.NO_REWRITE;
+            return ComputeFlags.NO_REWRITE;
 
         Type array = Type.getType("[" + classType.getDescriptor());
         final int flags = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC;
@@ -84,7 +84,7 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
         FieldNode values = classNode.fields.stream().filter(f -> f.desc.contentEquals(array.getDescriptor()) && ((f.access & flags) == flags)).findFirst().orElse(null);
         
         if (!classNode.interfaces.contains(MARKER_IFACE.getInternalName())) {
-            return ComputeLevel.NO_REWRITE;
+            return ComputeFlags.NO_REWRITE;
         }
         
         //Static methods named "create" with first argument as a string
@@ -227,7 +227,7 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
                 ins.areturn(classType);
             }
         });
-        return ComputeLevel.COMPUTE_FRAMES;
+        return ComputeFlags.COMPUTE_FRAMES;
     }
 
 }

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -69,10 +69,14 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
     }
 
     @Override
-    public boolean processClass(Phase phase, ClassNode classNode, Type classType)
-    {
+    public boolean processClass(Phase phase, ClassNode classNode, Type classType) {
+        throw new RuntimeException("Legacy modLauncher method called!");
+    }
+
+    @Override
+    public ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
         if ((classNode.access & Opcodes.ACC_ENUM) == 0)
-            return false;
+            return ComputeLevel.NO_REWRITE;
 
         Type array = Type.getType("[" + classType.getDescriptor());
         final int flags = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC;
@@ -80,7 +84,7 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
         FieldNode values = classNode.fields.stream().filter(f -> f.desc.contentEquals(array.getDescriptor()) && ((f.access & flags) == flags)).findFirst().orElse(null);
         
         if (!classNode.interfaces.contains(MARKER_IFACE.getInternalName())) {
-            return false;
+            return ComputeLevel.NO_REWRITE;
         }
         
         //Static methods named "create" with first argument as a string
@@ -223,7 +227,7 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
                 ins.areturn(classType);
             }
         });
-        return true;
+        return ComputeLevel.COMPUTE_FRAMES;
     }
 
 }


### PR DESCRIPTION
This PR patches forge to use the new processClass method of modlauncher, which improves startup performance by around 2.5-3 seconds (from 15.9 seconds to 13.0 seconds) when combined with the AccessTransformer PR.
This is done by telling modlauncher that is does not need to recompute all frames just because one transformer changed the class.
In fact, there is only one transformer in forge that requires frame recomputation, and that is the RuntimeEnumExtender.
All other transformers do not add or remove local variables and do not inject code, but alter existing code, which does not require maxs or frames of methods to be recomputed.
Requires https://github.com/cpw/modlauncher/pull/41
See https://gist.github.com/ichttt/98da420deabd8e904ac53fece883df16 for the raw performance test numbers