### PR TITLE
Some improvements to the buildscript (companion to ForgeGradle#648)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,8 +252,6 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
-                environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
-
                 mods {
                     TestMods { sources sourceSets.test }
                 }
@@ -283,8 +281,6 @@ project(':forge') {
             forge_test_server {
                 parent runs.forge_server
                 taskName 'forge_test_server'
-
-                environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
 
                 mods {
                     TestMods { sources sourceSets.test }
@@ -318,8 +314,6 @@ project(':forge') {
             forge_test_data {
                 parent runs.forge_data
                 taskName 'forge_test_data'
-
-                environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
 
                 mods {
                     tests { sources  sourceSets.test }

--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,12 @@ project(':forge') {
                 srcDirs = ["$rootDir/src/userdev/resources"]
             }
         }
+        userdev_test {
+            compileClasspath += sourceSets.userdev.runtimeClasspath
+            runtimeClasspath += sourceSets.userdev.runtimeClasspath
+            compileClasspath += sourceSets.test.runtimeClasspath
+            runtimeClasspath += sourceSets.test.runtimeClasspath
+        }
     }
     //Eclipse adds the sourcesets twice, once where we tell it to, once in the projects folder. No idea why. So delete them
     eclipse.classpath.file.whenMerged { cls -> cls.entries.removeIf { e -> e instanceof SourceFolder && e.path.startsWith('src/') && !e.path.startsWith('src/main/') } }
@@ -252,6 +258,8 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
+                ideaModule "${rootProject.name}.${project.name}.userdev_test"
+
                 mods {
                     TestMods { sources sourceSets.test }
                 }
@@ -281,6 +289,8 @@ project(':forge') {
             forge_test_server {
                 parent runs.forge_server
                 taskName 'forge_test_server'
+
+                ideaModule "${rootProject.name}.${project.name}.userdev_test"
 
                 mods {
                     TestMods { sources sourceSets.test }
@@ -314,6 +324,8 @@ project(':forge') {
             forge_test_data {
                 parent runs.forge_data
                 taskName 'forge_test_data'
+
+                ideaModule "${rootProject.name}.${project.name}.userdev_test"
 
                 mods {
                     tests { sources  sourceSets.test }


### PR DESCRIPTION
In [the corresponding ForgeGradle PR](https://github.com/MinecraftForge/ForgeGradle/pull/648), I reworked MOD_CLASSES calculation. ~~This required removing support for the `source_roots` replacement template, which is no longer necessary.~~
~~This PR removes mentions of this token, which needs to be removed in order for the automatic run config generation to work.~~
This PR now only removes the "dummy" hack, which is no longer necessary. The replacement token is technically also not necessary, but I chose to leave it in, since it's preferable this way.