### PR TITLE
Fix IForgeBlock#getLightValue not being respected

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -13,6 +13,15 @@
     private static final Direction[] field_212556_a = new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH, Direction.DOWN, Direction.UP};
     private static final LoadingCache<VoxelShape, Boolean> field_223006_b = CacheBuilder.newBuilder().maximumSize(512L).weakKeys().build(new CacheLoader<VoxelShape, Boolean>() {
        public Boolean load(VoxelShape p_load_1_) {
+@@ -151,7 +152,7 @@
+ 
+    @Deprecated
+    public boolean func_220067_a(BlockState p_220067_1_, IBlockReader p_220067_2_, BlockPos p_220067_3_, EntityType<?> p_220067_4_) {
+-      return p_220067_1_.func_224755_d(p_220067_2_, p_220067_3_, Direction.UP) && this.field_149784_t < 14;
++      return p_220067_1_.func_224755_d(p_220067_2_, p_220067_3_, Direction.UP) && p_220067_1_.getLightValue(p_220067_2_, p_220067_3_) < 14;
+    }
+ 
+    @Deprecated
 @@ -246,6 +247,10 @@
        this.field_149781_w = p_i48440_1_.field_200958_f;
        this.field_149782_v = p_i48440_1_.field_200959_g;

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
@@ -6,10 +6,11 @@
  
 +   @Deprecated //Forge: Model data argument
     public boolean func_228802_a_(ILightReader p_228802_1_, IBakedModel p_228802_2_, BlockState p_228802_3_, BlockPos p_228802_4_, MatrixStack p_228802_5_, IVertexBuilder p_228802_6_, boolean p_228802_7_, Random p_228802_8_, long p_228802_9_, int p_228802_11_) {
+-      boolean flag = Minecraft.func_71379_u() && p_228802_3_.func_185906_d() == 0 && p_228802_2_.func_177555_b();
 +      return renderModel(p_228802_1_, p_228802_2_, p_228802_3_, p_228802_4_, p_228802_5_, p_228802_6_, p_228802_7_, p_228802_8_, p_228802_9_, p_228802_11_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }
 +   public boolean renderModel(ILightReader p_228802_1_, IBakedModel p_228802_2_, BlockState p_228802_3_, BlockPos p_228802_4_, MatrixStack p_228802_5_, IVertexBuilder p_228802_6_, boolean p_228802_7_, Random p_228802_8_, long p_228802_9_, int p_228802_11_, net.minecraftforge.client.model.data.IModelData modelData) {
-       boolean flag = Minecraft.func_71379_u() && p_228802_3_.func_185906_d() == 0 && p_228802_2_.func_177555_b();
++      boolean flag = Minecraft.func_71379_u() && p_228802_3_.getLightValue(p_228802_1_, p_228802_4_) == 0 && p_228802_2_.func_177555_b();
        Vec3d vec3d = p_228802_3_.func_191059_e(p_228802_1_, p_228802_4_);
        p_228802_5_.func_227861_a_(vec3d.field_72450_a, vec3d.field_72448_b, vec3d.field_72449_c);
 +      modelData = p_228802_2_.getModelData(p_228802_1_, p_228802_4_, p_228802_3_, modelData);

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -96,6 +96,15 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
+@@ -2432,7 +2447,7 @@
+       } else {
+          int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
+          int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
+-         int k = p_228420_1_.func_185906_d();
++         int k = p_228420_1_.getLightValue(p_228420_0_, p_228420_2_);
+          if (j < k) {
+             j = k;
+          }
 @@ -2445,6 +2460,11 @@
        return this.field_175015_z;
     }

--- a/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
+++ b/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/IBlockReader.java
++++ b/net/minecraft/world/IBlockReader.java
+@@ -23,7 +23,7 @@
+    IFluidState func_204610_c(BlockPos p_204610_1_);
+ 
+    default int func_217298_h(BlockPos p_217298_1_) {
+-      return this.func_180495_p(p_217298_1_).func_185906_d();
++      return this.func_180495_p(p_217298_1_).getLightValue(this, p_217298_1_);
+    }
+ 
+    default int func_201572_C() {

--- a/patches/minecraft/net/minecraft/world/chunk/ChunkPrimer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/ChunkPrimer.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/world/chunk/ChunkPrimer.java
++++ b/net/minecraft/world/chunk/ChunkPrimer.java
+@@ -136,13 +136,13 @@
+          if (this.field_201661_i[j >> 4] == Chunk.field_186036_a && p_177436_2_.func_177230_c() == Blocks.field_150350_a) {
+             return p_177436_2_;
+          } else {
+-            if (p_177436_2_.func_185906_d() > 0) {
++            if (p_177436_2_.getLightValue(this, p_177436_1_) > 0) {
+                this.field_201663_k.add(new BlockPos((i & 15) + this.func_76632_l().func_180334_c(), j, (k & 15) + this.func_76632_l().func_180333_d()));
+             }
+ 
+             ChunkSection chunksection = this.func_217332_a(j >> 4);
+             BlockState blockstate = chunksection.func_222629_a(i & 15, j & 15, k & 15, p_177436_2_);
+-            if (this.field_201658_f.func_209003_a(ChunkStatus.field_222613_i) && p_177436_2_ != blockstate && (p_177436_2_.func_200016_a(this, p_177436_1_) != blockstate.func_200016_a(this, p_177436_1_) || p_177436_2_.func_185906_d() != blockstate.func_185906_d() || p_177436_2_.func_215691_g() || blockstate.func_215691_g())) {
++            if (this.field_201658_f.func_209003_a(ChunkStatus.field_222613_i) && p_177436_2_ != blockstate && (p_177436_2_.func_200016_a(this, p_177436_1_) != blockstate.func_200016_a(this, p_177436_1_) || p_177436_2_.getLightValue(this, p_177436_1_) != blockstate.getLightValue(this, p_177436_1_) || p_177436_2_.func_215691_g() || blockstate.func_215691_g())) {
+                WorldLightManager worldlightmanager = this.func_217307_e();
+                worldlightmanager.func_215568_a(p_177436_1_);
+             }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
@@ -8,6 +8,15 @@
        } else {
           ChunkPrimer chunkprimer = new ChunkPrimer(p_222656_3_, upgradedata, achunksection, chunkprimerticklist, chunkprimerticklist1);
           chunkprimer.func_225548_a_(biomecontainer);
+@@ -143,7 +144,7 @@
+ 
+          if (!flag && chunkprimer.func_201589_g().func_209003_a(ChunkStatus.field_222614_j)) {
+             for(BlockPos blockpos : BlockPos.func_191531_b(p_222656_3_.func_180334_c(), 0, p_222656_3_.func_180333_d(), p_222656_3_.func_180332_e(), 255, p_222656_3_.func_180330_f())) {
+-               if (ichunk.func_180495_p(blockpos).func_185906_d() != 0) {
++               if (ichunk.func_180495_p(blockpos).getLightValue(ichunk, blockpos) != 0) {
+                   chunkprimer.func_201637_h(blockpos);
+                }
+             }
 @@ -294,12 +295,22 @@
           for(int k = 0; k < chunk.func_177429_s().length; ++k) {
              for(Entity entity : chunk.func_177429_s()[k]) {

--- a/patches/minecraft/net/minecraft/world/gen/NoiseChunkGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/NoiseChunkGenerator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/gen/NoiseChunkGenerator.java
++++ b/net/minecraft/world/gen/NoiseChunkGenerator.java
+@@ -378,7 +378,7 @@
+                         }
+ 
+                         if (blockstate != field_222562_i) {
+-                           if (blockstate.func_185906_d() != 0) {
++                           if (blockstate.getLightValue(p_222537_1_, new BlockPos(j3, j2, i4)) != 0) {
+                               blockpos$mutable.func_181079_c(j3, j2, i4);
+                               chunkprimer.func_201637_h(blockpos$mutable);
+                            }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -70,7 +70,6 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockReader;
-import net.minecraft.world.ILightReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.IWorldWriter;
@@ -112,12 +111,12 @@ public interface IForgeBlock
     /**
      * Get a light value for this block, taking into account the given state and coordinates, normal ranges are between 0 and 15
      *
-     * @param state
-     * @param world
-     * @param pos
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
      * @return The light value
      */
-    default int getLightValue(BlockState state, ILightReader world, BlockPos pos)
+    default int getLightValue(BlockState state, IBlockReader world, BlockPos pos)
     {
         return state.getLightValue();
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -45,7 +45,6 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockReader;
-import net.minecraft.world.ILightReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
@@ -84,7 +83,7 @@ public interface IForgeBlockState
     /**
      * Get a light value for this block, taking into account the given state and coordinates, normal ranges are between 0 and 15
      */
-    default int getLightValue(ILightReader world, BlockPos pos)
+    default int getLightValue(IBlockReader world, BlockPos pos)
     {
         return getBlockState().getBlock().getLightValue(getBlockState(), world, pos);
     }


### PR DESCRIPTION
This PR fixes #6430, by rehooking up the the `getLightValue` method in `IForgeBlock`. I believe the changes to method signatures is a breaking change (I did not bother marking the old one as deprecated due to 1.15.1 still not having an RB), but it was done as block's do have a concept of light with just a `IBlockReader` instead of only with an `ILightReader`. And there was no clean way to otherwise patch `IBlockReader#getLightValue`