### PR TITLE
Fixed Conduit and Beacon Activation on Vanilla Servers

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/ConduitTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ConduitTileEntity.java.patch
@@ -6,7 +6,7 @@
  
 -                  for(Block block : field_205042_e) {
 -                     if (blockstate.func_177230_c() == block) {
-+                  if (blockstate.isConduitFrame(this.field_145850_b, blockpos1, func_174877_v())) {
++                      if (blockstate.isConduitFrame(this.field_145850_b, blockpos1, func_174877_v())) {
                          this.field_205046_i.add(blockpos1);
 -                     }
                    }

--- a/patches/minecraft/net/minecraft/tileentity/ConduitTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ConduitTileEntity.java.patch
@@ -1,11 +1,14 @@
 --- a/net/minecraft/tileentity/ConduitTileEntity.java
 +++ b/net/minecraft/tileentity/ConduitTileEntity.java
-@@ -131,7 +131,7 @@
+@@ -131,10 +131,8 @@
                    BlockPos blockpos1 = this.field_174879_c.func_177982_a(j1, k1, l1);
                    BlockState blockstate = this.field_145850_b.func_180495_p(blockpos1);
  
 -                  for(Block block : field_205042_e) {
-+                  for(Block block : net.minecraftforge.common.Tags.Blocks.SUPPORTS_CONDUIT.func_199885_a()) {
-                      if (blockstate.func_177230_c() == block) {
+-                     if (blockstate.func_177230_c() == block) {
++                  if (blockstate.isConduitFrame(this.field_145850_b, blockpos1, func_174877_v())) {
                          this.field_205046_i.add(blockpos1);
-                      }
+-                     }
+                   }
+                }
+             }

--- a/src/generated/resources/data/forge/tags/blocks/supports_beacon.json
+++ b/src/generated/resources/data/forge/tags/blocks/supports_beacon.json
@@ -1,9 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:emerald_block",
-    "minecraft:gold_block",
-    "minecraft:diamond_block",
-    "minecraft:iron_block"
-  ]
-}

--- a/src/generated/resources/data/forge/tags/blocks/supports_conduit.json
+++ b/src/generated/resources/data/forge/tags/blocks/supports_conduit.json
@@ -1,9 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:prismarine",
-    "minecraft:prismarine_bricks",
-    "minecraft:sea_lantern",
-    "minecraft:dark_prismarine"
-  ]
-}

--- a/src/generated/resources/data/forge/tags/items/supports_beacon.json
+++ b/src/generated/resources/data/forge/tags/items/supports_beacon.json
@@ -1,9 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:emerald_block",
-    "minecraft:gold_block",
-    "minecraft:diamond_block",
-    "minecraft:iron_block"
-  ]
-}

--- a/src/generated/resources/data/forge/tags/items/supports_conduit.json
+++ b/src/generated/resources/data/forge/tags/items/supports_conduit.json
@@ -1,9 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:prismarine",
-    "minecraft:prismarine_bricks",
-    "minecraft:sea_lantern",
-    "minecraft:dark_prismarine"
-  ]
-}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -112,9 +112,6 @@ public class Tags
         public static final Tag<Block> STORAGE_BLOCKS_QUARTZ = tag("storage_blocks/quartz");
         public static final Tag<Block> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
 
-        public static final Tag<Block> SUPPORTS_BEACON = tag("supports_beacon");
-        public static final Tag<Block> SUPPORTS_CONDUIT = tag("supports_conduit");
-
         private static Tag<Block> tag(String name)
         {
             return new BlockTags.Wrapper(new ResourceLocation("forge", name));
@@ -269,9 +266,6 @@ public class Tags
         public static final Tag<Item> STORAGE_BLOCKS_QUARTZ = tag("storage_blocks/quartz");
         public static final Tag<Item> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
         public static final Tag<Item> STRING = tag("string");
-
-        public static final Tag<Item> SUPPORTS_BEACON = tag("supports_beacon");
-        public static final Tag<Item> SUPPORTS_CONDUIT = tag("supports_conduit");
 
         private static Tag<Item> tag(String name)
         {

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -96,8 +96,6 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
         getBuilder(STORAGE_BLOCKS_LAPIS).add(Blocks.LAPIS_BLOCK);
         getBuilder(STORAGE_BLOCKS_QUARTZ).add(Blocks.QUARTZ_BLOCK);
         getBuilder(STORAGE_BLOCKS_REDSTONE).add(Blocks.REDSTONE_BLOCK);
-        getBuilder(SUPPORTS_BEACON).add(Blocks.EMERALD_BLOCK, Blocks.GOLD_BLOCK, Blocks.DIAMOND_BLOCK, Blocks.IRON_BLOCK);
-        getBuilder(SUPPORTS_CONDUIT).add(Blocks.PRISMARINE, Blocks.PRISMARINE_BRICKS, Blocks.SEA_LANTERN, Blocks.DARK_PRISMARINE);
     }
 
     private void addColored(Consumer<Block> consumer, Tag<Block> group, String pattern)

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -142,8 +142,6 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.STORAGE_BLOCKS_QUARTZ, Tags.Items.STORAGE_BLOCKS_QUARTZ);
         copy(Tags.Blocks.STORAGE_BLOCKS_REDSTONE, Tags.Items.STORAGE_BLOCKS_REDSTONE);
         getBuilder(Tags.Items.STRING).add(Items.STRING);
-        copy(Tags.Blocks.SUPPORTS_BEACON, Tags.Items.SUPPORTS_BEACON);
-        copy(Tags.Blocks.SUPPORTS_CONDUIT, Tags.Items.SUPPORTS_CONDUIT);
     }
 
     private void addColored(Consumer<Tag<Item>> consumer, Tag<Item> group, String pattern)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -37,7 +37,6 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.ParticleManager;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -78,10 +77,9 @@ import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.dimension.EndDimension;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.common.*;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.network.ConnectionType;
-import net.minecraftforge.fml.network.NetworkHooks;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.common.ToolType;
 
 @SuppressWarnings("deprecation")
 public interface IForgeBlock
@@ -568,30 +566,10 @@ public interface IForgeBlock
     */
     default boolean isBeaconBase(BlockState state, IWorldReader world, BlockPos pos, BlockPos beacon)
     {
-        return DistExecutor.runForDist(()->()->{
-            //Client
-            if (Minecraft.getInstance().player != null)
-            {
-                return
-                    //Forge Connection
-                    (NetworkHooks.getConnectionType(()->Minecraft.getInstance().player.connection.getNetworkManager()) == ConnectionType.MODDED &&
-                    Tags.Blocks.SUPPORTS_BEACON.contains(state.getBlock())) ||
-
-                    //Vanilla Connection
-                    (NetworkHooks.getConnectionType(()->Minecraft.getInstance().player.connection.getNetworkManager()) == ConnectionType.VANILLA &&
-                        (
-                            state.getBlock() == Blocks.IRON_BLOCK ||
-                            state.getBlock() == Blocks.GOLD_BLOCK ||
-                            state.getBlock() == Blocks.DIAMOND_BLOCK ||
-                            state.getBlock() == Blocks.EMERALD_BLOCK
-                        )
-                    );
-            }
-            else
-            {
-                return false;
-            }
-        }, ()->()->Tags.Blocks.SUPPORTS_BEACON.contains(state.getBlock())); //Server
+        return  state.getBlock() == Blocks.IRON_BLOCK ||
+                state.getBlock() == Blocks.GOLD_BLOCK ||
+                state.getBlock() == Blocks.DIAMOND_BLOCK ||
+                state.getBlock() == Blocks.EMERALD_BLOCK;
     }
 
     /**
@@ -604,27 +582,10 @@ public interface IForgeBlock
      */
     default boolean isConduitFrame(BlockState state, IWorldReader world, BlockPos pos, BlockPos conduit)
     {
-        return DistExecutor.runForDist(()->()->{
-            //Client
-            if (Minecraft.getInstance().player != null)
-            {
-                return
-                    //Forge Connection
-                    (NetworkHooks.getConnectionType(()->Minecraft.getInstance().player.connection.getNetworkManager()) == ConnectionType.MODDED &&
-                    Tags.Blocks.SUPPORTS_CONDUIT.contains(state.getBlock())) ||
-
-                    //Vanilla Connection
-                    (NetworkHooks.getConnectionType(()->Minecraft.getInstance().player.connection.getNetworkManager()) == ConnectionType.VANILLA &&
-                        (
-                            state.getBlock() == Blocks.PRISMARINE ||
-                            state.getBlock() == Blocks.PRISMARINE_BRICKS ||
-                            state.getBlock() == Blocks.SEA_LANTERN ||
-                            state.getBlock() == Blocks.DARK_PRISMARINE
-                        )
-                    );
-            }
-            return false;
-        }, ()->()->Tags.Blocks.SUPPORTS_CONDUIT.contains(state.getBlock())); //Server
+        return  state.getBlock() == Blocks.PRISMARINE ||
+                state.getBlock() == Blocks.PRISMARINE_BRICKS ||
+                state.getBlock() == Blocks.SEA_LANTERN ||
+                state.getBlock() == Blocks.DARK_PRISMARINE;
     }
 
     /**
@@ -901,6 +862,7 @@ public interface IForgeBlock
 
     /**
      * Determines if another block can connect to this block
+     *
      * @param world The current world
      * @param pos The position of this block
      * @param facing The side the connecting block is on

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -496,6 +496,19 @@ public interface IForgeBlockState
     }
 
     /**
+     * Determines if this block can be used as the frame of a conduit.
+     *
+     * @param world The current world
+     * @param pos Block position in world
+     * @param conduit Conduit position in world
+     * @return True, to support the conduit, and make it active with this block.
+     */
+    default boolean isConduitFrame(IWorldReader world, BlockPos pos, BlockPos conduit)
+    {
+        return getBlockState().getBlock().isConduitFrame(getBlockState(), world, pos, conduit);
+    }
+
+    /**
      * Determines if this block can be used as part of a frame of a nether portal.
      *
      * @param world The current world


### PR DESCRIPTION
~~This solution uses DistExecutor so a better solution might be preferred, however this change allows Vanilla logic to be invoked when a Forge client connects to a Vanilla server and has its Forge tags wiped.~~
Update: As usual, Lex is right, I'm starting to see why using tags for game logic is not a good idea.