### PR TITLE
[1.15.1] Add event for when a chat packet is about to be sent from the server to a client

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
@@ -23,7 +23,29 @@
              ActionResultType actionresulttype = this.field_147369_b.field_71134_c.func_219441_a(this.field_147369_b, serverworld, itemstack, hand, blockraytraceresult);
              if (actionresulttype.func_226247_b_()) {
                 this.field_147369_b.func_226292_a_(hand, true);
-@@ -968,7 +972,9 @@
+@@ -925,6 +929,10 @@
+          if (chatvisibility == ChatVisibility.SYSTEM && !schatpacket.func_148916_d()) {
+             return;
+          }
++         p_211148_1_ = net.minecraftforge.common.ForgeHooks.onSChatPacket(schatpacket, field_147369_b);
++         if (p_211148_1_ == null) {
++            return;
++         }
+       }
+ 
+       try {
+@@ -932,8 +940,9 @@
+       } catch (Throwable throwable) {
+          CrashReport crashreport = CrashReport.func_85055_a(throwable, "Sending packet");
+          CrashReportCategory crashreportcategory = crashreport.func_85058_a("Packet being sent");
++         IPacket<?> finalPacketIn = p_211148_1_;
+          crashreportcategory.func_189529_a("Packet class", () -> {
+-            return p_211148_1_.getClass().getCanonicalName();
++            return finalPacketIn.getClass().getCanonicalName();
+          });
+          throw new ReportedException(crashreport);
+       }
+@@ -968,7 +977,9 @@
           if (s.startsWith("/")) {
              this.func_147361_d(s);
           } else {
@@ -34,7 +56,7 @@
              this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
           }
  
-@@ -1061,6 +1067,7 @@
+@@ -1061,6 +1072,7 @@
                 this.field_147369_b.func_190775_a(entity, hand);
              } else if (p_147340_1_.func_149565_c() == CUseEntityPacket.Action.INTERACT_AT) {
                 Hand hand1 = p_147340_1_.func_186994_b();
@@ -42,7 +64,7 @@
                 ActionResultType actionresulttype = entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), hand1);
                 if (actionresulttype.func_226247_b_()) {
                    this.field_147369_b.func_226292_a_(hand1, true);
-@@ -1094,7 +1101,7 @@
+@@ -1094,7 +1106,7 @@
                 return;
              }
  
@@ -51,7 +73,7 @@
              if (this.field_147367_d.func_71199_h()) {
                 this.field_147369_b.func_71033_a(GameType.SPECTATOR);
                 this.field_147369_b.func_71121_q().func_82736_K().func_223585_a(GameRules.field_223613_p).func_223570_a(false, this.field_147367_d);
-@@ -1268,6 +1275,8 @@
+@@ -1268,6 +1280,8 @@
     }
  
     public void func_147349_a(CCustomPayloadPacket p_147349_1_) {

--- a/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
@@ -23,18 +23,15 @@
              ActionResultType actionresulttype = this.field_147369_b.field_71134_c.func_219441_a(this.field_147369_b, serverworld, itemstack, hand, blockraytraceresult);
              if (actionresulttype.func_226247_b_()) {
                 this.field_147369_b.func_226292_a_(hand, true);
-@@ -925,6 +929,10 @@
+@@ -925,6 +929,7 @@
           if (chatvisibility == ChatVisibility.SYSTEM && !schatpacket.func_148916_d()) {
              return;
           }
-+         p_211148_1_ = net.minecraftforge.common.ForgeHooks.onSChatPacket(schatpacket, field_147369_b);
-+         if (p_211148_1_ == null) {
-+            return;
-+         }
++         p_211148_1_ = net.minecraftforge.common.ForgeHooks.onSChatPacket(schatpacket, field_147369_b); if(p_211148_1_ == null){return;}
        }
  
        try {
-@@ -932,8 +940,9 @@
+@@ -932,8 +937,9 @@
        } catch (Throwable throwable) {
           CrashReport crashreport = CrashReport.func_85055_a(throwable, "Sending packet");
           CrashReportCategory crashreportcategory = crashreport.func_85058_a("Packet being sent");
@@ -45,7 +42,7 @@
           });
           throw new ReportedException(crashreport);
        }
-@@ -968,7 +977,9 @@
+@@ -968,7 +974,9 @@
           if (s.startsWith("/")) {
              this.func_147361_d(s);
           } else {
@@ -56,7 +53,7 @@
              this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
           }
  
-@@ -1061,6 +1072,7 @@
+@@ -1061,6 +1069,7 @@
                 this.field_147369_b.func_190775_a(entity, hand);
              } else if (p_147340_1_.func_149565_c() == CUseEntityPacket.Action.INTERACT_AT) {
                 Hand hand1 = p_147340_1_.func_186994_b();
@@ -64,7 +61,7 @@
                 ActionResultType actionresulttype = entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), hand1);
                 if (actionresulttype.func_226247_b_()) {
                    this.field_147369_b.func_226292_a_(hand1, true);
-@@ -1094,7 +1106,7 @@
+@@ -1094,7 +1103,7 @@
                 return;
              }
  
@@ -73,7 +70,7 @@
              if (this.field_147367_d.func_71199_h()) {
                 this.field_147369_b.func_71033_a(GameType.SPECTATOR);
                 this.field_147369_b.func_71121_q().func_82736_K().func_223585_a(GameRules.field_223613_p).func_223570_a(false, this.field_147367_d);
-@@ -1268,6 +1280,8 @@
+@@ -1268,6 +1277,8 @@
     }
  
     public void func_147349_a(CCustomPayloadPacket p_147349_1_) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -49,6 +49,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.model.Material;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.fluid.*;
+import net.minecraft.network.play.server.SChatPacket;
 import net.minecraft.util.CachedBlockInfo;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
@@ -122,6 +123,7 @@ import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.SChatPacketEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -972,6 +974,18 @@ public class ForgeHooks
     public static void onAdvancement(ServerPlayerEntity player, Advancement advancement)
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
+    }
+
+    @Nullable
+    public static SChatPacket onSChatPacket(SChatPacket packet, ServerPlayerEntity player)
+    {
+        SChatPacketEvent packetEvent = new SChatPacketEvent(packet, player);
+        MinecraftForge.EVENT_BUS.post(packetEvent);
+        if(packetEvent.isCanceled())
+        {
+            return null;
+        }
+        return packetEvent.getModifiedPacket();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/SChatPacketEvent.java
+++ b/src/main/java/net/minecraftforge/event/SChatPacketEvent.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * {@link #player} Contains the server player entity for the player which the packet will be sent to.<br>
  * <br>
  * This event is {@link Cancelable}. <br>
- * If this event is canceled, the chat message is never distributed to all clients.<br>
+ * If this event is canceled, the chat packet is never sent to the client.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/SChatPacketEvent.java
+++ b/src/main/java/net/minecraftforge/event/SChatPacketEvent.java
@@ -1,0 +1,61 @@
+package net.minecraftforge.event;
+
+import io.netty.util.concurrent.GenericFutureListener;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.IPacket;
+import net.minecraft.network.play.server.SChatPacket;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nullable;
+
+/**
+ * SChatPacketEvent is fired before a SChatPacket is sent from the server to a client. <br>
+ * This event is fired via {@link ForgeHooks#onSChatPacket(SChatPacket, ServerPlayerEntity)} )},
+ * which is executed by the {@link net.minecraft.network.play.ServerPlayNetHandler#sendPacket(IPacket, GenericFutureListener)} <br>
+ * <br>
+ * {@link #originalPacket} Contains the original packet that would have been sent.<br>
+ * {@link #modifiedPacket} Contains the modified packet that will be sent if the event is not cancelled.<br>
+ * {@link #player} Contains the server player entity for the player which the packet will be sent to.<br>
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If this event is canceled, the chat message is never distributed to all clients.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class SChatPacketEvent extends Event {
+    private final SChatPacket originalPacket;
+    @Nullable
+    private SChatPacket modifiedPacket;
+    private ServerPlayerEntity player;
+    public SChatPacketEvent(SChatPacket packet, ServerPlayerEntity player)
+    {
+        this.originalPacket = this.modifiedPacket = packet;
+        this.player = player;
+    }
+
+    public SChatPacket getOriginalPacket()
+    {
+        return originalPacket;
+    }
+
+    @Nullable
+    public SChatPacket getModifiedPacket()
+    {
+        return modifiedPacket;
+    }
+
+    public void setModifiedPacket(@Nullable SChatPacket modifiedPacket)
+    {
+        this.modifiedPacket = modifiedPacket;
+    }
+
+    public ServerPlayerEntity getPlayer() {
+        return player;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/chat/SChatPacketEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/SChatPacketEventTest.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.debug.chat;
+
+import net.minecraft.network.play.server.SChatPacket;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.event.SChatPacketEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("schatpacket_event_test")
+@Mod.EventBusSubscriber
+public class SChatPacketEventTest
+{
+    @SubscribeEvent
+    public static void onSChatPacket(SChatPacketEvent event)
+    {
+        if(event.getOriginalPacket().getChatComponent().getUnformattedComponentText().contains("CancelSChatPacket"))
+            event.setCanceled(true);
+        else if(event.getOriginalPacket().getChatComponent().getUnformattedComponentText().contains("ReplaceSChatPacket"))
+            event.setModifiedPacket(new SChatPacket(new StringTextComponent("Chat Packet Replaced."), event.getOriginalPacket().getType()));
+    }
+}


### PR DESCRIPTION
This event allows the monitoring, modification, and cancellation of chat packets before they get sent to the client.
An example use case for this is in a server-side chat censorship mod - *I removed this link for a reason, do not repost it* was previously needed to ensure that all chat messages, whether sent by the player or sent by some other system which the player can control, were properly censored before being sent to the client. This event addresses that.
I'm open to suggestions if anyone has any better names for anything I've added, or any other changes they'd like to be made to this event.