### PR TITLE
Fix incorrectly ported patch for restoreBlurMipmap

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -41,7 +41,7 @@
        this.func_174967_a(p_228426_3_ + l1);
        iprofiler.func_219895_b("terrain");
        this.func_228441_a_(RenderType.func_228639_c_(), p_228426_1_, d0, d1, d2);
-+      this.field_72777_q.func_209506_al().func_229356_a_(AtlasTexture.field_110575_b).func_174937_a(false, this.field_72777_q.field_71474_y.field_151442_I > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
++      this.field_72777_q.func_209506_al().func_229356_a_(AtlasTexture.field_110575_b).setBlurMipmap(false, this.field_72777_q.field_71474_y.field_151442_I > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
        this.func_228441_a_(RenderType.func_228641_d_(), p_228426_1_, d0, d1, d2);
 +      this.field_72777_q.func_209506_al().func_229356_a_(AtlasTexture.field_110575_b).restoreLastBlurMipmap();
        this.func_228441_a_(RenderType.func_228643_e_(), p_228426_1_, d0, d1, d2);

--- a/patches/minecraft/net/minecraft/client/renderer/texture/Texture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/Texture.java.patch
@@ -1,12 +1,21 @@
 --- a/net/minecraft/client/renderer/texture/Texture.java
 +++ b/net/minecraft/client/renderer/texture/Texture.java
-@@ -33,6 +33,11 @@
+@@ -33,6 +33,20 @@
        GlStateManager.func_227677_b_(3553, 10240, j);
     }
  
 +   // FORGE: This seems to have been stripped out, but we need it
++   boolean lastBlur;
++   boolean lastMipmap;
++
++   public void setBlurMipmap(boolean blur, boolean mipmap) {
++      this.lastBlur = this.field_174940_b;
++      this.lastMipmap = this.field_174941_c;
++      func_174937_a(blur, mipmap);
++   }
++
 +   public void restoreLastBlurMipmap() {
-+      func_174937_a(this.field_174940_b, this.field_174941_c);
++      func_174937_a(this.lastBlur, this.lastMipmap);
 +   }
 +
     public int func_110552_b() {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/Texture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/Texture.java.patch
@@ -5,8 +5,8 @@
     }
  
 +   // FORGE: This seems to have been stripped out, but we need it
-+   boolean lastBlur;
-+   boolean lastMipmap;
++   private boolean lastBlur;
++   private boolean lastMipmap;
 +
 +   public void setBlurMipmap(boolean blur, boolean mipmap) {
 +      this.lastBlur = this.field_174940_b;


### PR DESCRIPTION
In past versions, there was setBlurMipmapDirect, setBlurMipmap, and restoreBlurMipmap. The first did the GL change directly while the latter two allowed you to "remember" the prior setting and restore it.

restoreBlurMipmap disappeared in 1.15 and a patch was added to bring it back, except it didn't bring back the `last` variables accompanying it, it would just call setBlurMipmapDirect with the current state variables, which just does nothing.

Fix the patch to match older versions and update the one call to restoreBlurMipmap to use the right setup call.