### PR TITLE
Fix RightClickBlock code differences between client and server implementation

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -90,7 +90,7 @@
        }
  
        return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -256,13 +264,19 @@
+@@ -256,13 +264,24 @@
           return ActionResultType.FAIL;
        } else {
           ItemStack itemstack = p_217292_1_.func_184586_b(p_217292_3_);
@@ -105,6 +105,11 @@
              return ActionResultType.SUCCESS;
           } else {
 -            boolean flag = !p_217292_1_.func_184614_ca().func_190926_b() || !p_217292_1_.func_184592_cb().func_190926_b();
++            ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
++            if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++               ActionResultType result = itemstack.onItemUseFirst(itemusecontext);
++               if (result != ActionResultType.PASS) return result;
++            }
 +            boolean flag = !p_217292_1_.func_184614_ca().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_) || !p_217292_1_.func_184592_cb().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_);
              boolean flag1 = p_217292_1_.func_226563_dT_() && flag;
 -            if (!flag1) {
@@ -112,15 +117,17 @@
                 ActionResultType actionresulttype = p_217292_2_.func_180495_p(blockpos).func_227031_a_(p_217292_2_, p_217292_1_, p_217292_3_, p_217292_4_);
                 if (actionresulttype.func_226246_a_()) {
                    this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
-@@ -271,6 +285,7 @@
+@@ -271,8 +290,8 @@
              }
  
              this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
              if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
-                ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
+-               ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
                 ActionResultType actionresulttype1;
-@@ -300,11 +315,14 @@
+                if (this.field_78779_k.func_77145_d()) {
+                   int i = itemstack.func_190916_E();
+@@ -300,11 +319,14 @@
           if (p_187101_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
              return ActionResultType.PASS;
           } else {
@@ -135,7 +142,7 @@
              }
  
              return actionresult.func_188397_a();
-@@ -329,6 +347,9 @@
+@@ -329,6 +351,9 @@
     public ActionResultType func_187097_a(PlayerEntity p_187097_1_, Entity p_187097_2_, Hand p_187097_3_) {
        this.func_78750_j();
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187097_2_, p_187097_3_));
@@ -145,7 +152,7 @@
        return this.field_78779_k == GameType.SPECTATOR ? ActionResultType.PASS : p_187097_1_.func_190775_a(p_187097_2_, p_187097_3_);
     }
  
-@@ -336,6 +357,9 @@
+@@ -336,6 +361,9 @@
        this.func_78750_j();
        Vec3d vec3d = p_187102_3_.func_216347_e().func_178786_a(p_187102_2_.func_226277_ct_(), p_187102_2_.func_226278_cu_(), p_187102_2_.func_226281_cx_());
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -122,12 +122,19 @@
           int i = p_187250_3_.func_190916_E();
           int j = p_187250_3_.func_77952_i();
           ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
-@@ -296,9 +321,16 @@
+@@ -287,6 +312,8 @@
+    public ActionResultType func_219441_a(PlayerEntity p_219441_1_, World p_219441_2_, ItemStack p_219441_3_, Hand p_219441_4_, BlockRayTraceResult p_219441_5_) {
+       BlockPos blockpos = p_219441_5_.func_216350_a();
+       BlockState blockstate = p_219441_2_.func_180495_p(blockpos);
++      net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_.func_216354_b());
++      if (event.isCanceled()) return event.getCancellationResult();
+       if (this.field_73091_c == GameType.SPECTATOR) {
+          INamedContainerProvider inamedcontainerprovider = blockstate.func_215699_b(p_219441_2_, blockpos);
+          if (inamedcontainerprovider != null) {
+@@ -296,9 +323,14 @@
              return ActionResultType.PASS;
           }
        } else {
-+         net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_.func_216354_b());
-+         if (event.isCanceled()) return event.getCancellationResult();
 +         ItemUseContext itemusecontext = new ItemUseContext(p_219441_1_, p_219441_4_, p_219441_5_);
 +         if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
 +            ActionResultType result = p_219441_3_.onItemUseFirst(itemusecontext);


### PR DESCRIPTION
There were two minor differences in the code for handling right clicking on a block between the client and the server. This caused #6448 as onItemUseFirst wasn't checked on the client causing the event to get canceled only on the server side.

I've added a check to onItemUseFirst on the client and I've moved a isCanceled check up on the server side so the RightBlockEvent is now triggered for players in spectator mode on both client and server. (previously only on client)