### PR TITLE
Fixed rounding issue with entity navigation fix

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
@@ -6,7 +6,7 @@
        Vec3d vec3d1 = this.field_75514_c.func_186310_f();
 -      if (Math.abs(this.field_75515_a.field_70165_t - (vec3d1.field_72450_a + 0.5D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70161_v - (vec3d1.field_72449_c + 0.5D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70163_u - vec3d1.field_72448_b) < 1.0D) {
 +      // Forge: fix MC-94054
-+      if (Math.abs(this.field_75515_a.field_70165_t - (vec3d1.field_72450_a + (this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70161_v - (vec3d1.field_72449_c + (this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70163_u - vec3d1.field_72448_b) < 1.0D) {
++      if (Math.abs(this.field_75515_a.field_70165_t - (vec3d1.field_72450_a + (int)(this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70161_v - (vec3d1.field_72449_c + (int)(this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)this.field_188561_o && Math.abs(this.field_75515_a.field_70163_u - vec3d1.field_72448_b) < 1.0D) {
           this.field_75514_c.func_75872_c(this.field_75514_c.func_75873_e() + 1);
        }
  

--- a/patches/minecraft/net/minecraft/pathfinding/SwimmerPathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/SwimmerPathNavigator.java.patch
@@ -6,7 +6,7 @@
           Vec3d vec3d2 = this.field_75514_c.func_186310_f();
 -         if (Math.abs(this.field_75515_a.field_70165_t - (vec3d2.field_72450_a + 0.5D)) < (double)f1 && Math.abs(this.field_75515_a.field_70161_v - (vec3d2.field_72449_c + 0.5D)) < (double)f1 && Math.abs(this.field_75515_a.field_70163_u - vec3d2.field_72448_b) < (double)(f1 * 2.0F)) {
 +         // Forge: fix MC-94054
-+         if (Math.abs(this.field_75515_a.field_70165_t - (vec3d2.field_72450_a + (this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)f1 && Math.abs(this.field_75515_a.field_70161_v - (vec3d2.field_72449_c + (this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)f1 && Math.abs(this.field_75515_a.field_70163_u - vec3d2.field_72448_b) < (double)(f1 * 2.0F)) {
++         if (Math.abs(this.field_75515_a.field_70165_t - (vec3d2.field_72450_a + (int)(this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)f1 && Math.abs(this.field_75515_a.field_70161_v - (vec3d2.field_72449_c + (int)(this.field_75515_a.func_213311_cf() + 1) / 2D)) < (double)f1 && Math.abs(this.field_75515_a.field_70163_u - vec3d2.field_72448_b) < (double)(f1 * 2.0F)) {
              this.field_75514_c.func_75875_a();
           }
  


### PR DESCRIPTION
Fixed an issue from my previous entity navigation pr (#6091), where the math copied from `Path#getVectorFromIndex` was at max 0.5 blocks off due to rounding and me taking an `(int)` to be a deobf artifact. Due to it only being 0.5 blocks off, this would affect smaller entities more than larger entities.

The actual math from is `getVectorFromIndex` as follows: 
```java
(double)((int)(entityIn.getWidth() + 1.0F)) * 0.5D
```
I had it as:
```java
(entityIn.getWidth() + 1.0F) * 0.5D
```
when it should be:
```java
(int)(entityIn.getWidth() + 1.0F) * 0.5D
```

Before:
![qjTEjfsn4X](https://user-images.githubusercontent.com/15876682/72673466-d734f700-3a62-11ea-8e73-9c46d6bf4740.gif)

After:
![vP8RR0ZTI5](https://user-images.githubusercontent.com/15876682/72673340-dbf8ab80-3a60-11ea-9493-4e9e0295cea9.gif)