### PR TITLE
[1.15.x] Fix Widget FG Color to allow black

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/widget/Widget.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/widget/Widget.java.patch
@@ -29,12 +29,16 @@
        this.focused = p_setFocused_1_;
     }
 +
++   public static final int UNSET_FG_COLOR = -1;
 +   protected int packedFGColor = 0;
 +   public int getFGColor() {
-+      if (packedFGColor != 0) return packedFGColor;
-+      return this.active ? 16777215 : 10526880;
++      if (packedFGColor != UNSET_FG_COLOR) return packedFGColor;
++      return this.active ? 16777215 : 10526880; // White : Light Grey
 +   }
 +   public void setFGColor(int color) {
 +      this.packedFGColor = color;
++   }
++   public void clearFGColor() {
++      this.packedFGColor = UNSET_FG_COLOR;
 +   }
  }

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiButtonExt.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiButtonExt.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fml.client.config;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.client.gui.widget.button.Button;
 
 /**
@@ -52,20 +53,10 @@ public class GuiButtonExt extends Button
             int k = this.getYImage(this.isHovered);
             GuiUtils.drawContinuousTexturedBox(WIDGETS_LOCATION, this.x, this.y, 0, 46 + k * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, this.getBlitOffset());
             this.renderBg(mc, mouseX, mouseY);
-            int color = 14737632;
+            int color = getFGColor();
 
-            if (packedFGColor != 0)
-            {
-                color = packedFGColor;
-            }
-            else if (!this.active)
-            {
-                color = 10526880;
-            }
-            else if (this.isHovered)
-            {
-                color = 16777120;
-            }
+            if (this.isHovered && this.packedFGColor == Widget.UNSET_FG_COLOR)
+                color = 0xFFFFA0; // Slightly Yellow
 
             String buttonText = this.getMessage();
             int strWidth = mc.fontRenderer.getStringWidth(buttonText);


### PR DESCRIPTION
Fixes the check of `packedFGColor != 0` to check against `-1` to allow pure black to be a valid color.
Also cleans up the code of `GuiButtonExt` makes it respect these changes and keeps the original yellow tint when hovered