### PR TITLE
[1.15.1] Fix name clash in EntityClassification patch

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -14,7 +14,7 @@
        return this.field_82707_i;
     }
 +
-+   public static EntityClassification create(String name, String p_i50381_3_, int p_i50381_4_, boolean p_i50381_5_, boolean p_i50381_6_) {
++   public static EntityClassification create(String enumName, String p_i50381_3_, int p_i50381_4_, boolean p_i50381_5_, boolean p_i50381_6_) {
 +      throw new IllegalStateException("Enum not extended");
 +   }
  }


### PR DESCRIPTION
The parameter name "name" of the added `create` method clashes with the mapped name of "p_i50381_3_" ("name")