### PR TITLE
[1.15.x] Change IExtensibleEnum documentation to avoid name clashes

### DIFF
--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -29,7 +29,7 @@ package net.minecraftforge.common;
  * require the method:
  * 
  * <pre>
- * public static MyEnum create(String name, Object foo)
+ * public static MyEnum create(String enumName, Object foo)
  * {
  *     throw new IllegalStateException("Enum not extended");
  * }


### PR DESCRIPTION
Many enums accept a parameter called `name` in their constructor. This results in a parameter name conflict if the recommended name is used. This is usually not an issue as the name conflict will be noticed by the person extending the enum. However, when dealing with Minecraft's code the enum may be made extensible before its fully mapped leading to a name conflict occurring when the parameter is mapped. This can be seen in #6462.