### PR TITLE
[1.15.x] Extend the config system

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -33,6 +33,13 @@ import java.util.stream.Collectors;
 
 import static net.minecraftforge.fml.loading.LogMarkers.CORE;
 
+/**
+ * Modders: Do not base your config off this, use Forge's config system and base your config off Forge's Config.
+ *
+ * @see net.minecraftforge.common.ForgeConfig
+ * @see net.minecraftforge.common.ForgeConfigSpec
+ * @see net.minecraftforge.fml.config.ModConfig
+ */
 public class FMLConfig
 {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -291,7 +291,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             context.setComment(ObjectArrays.concat(context.getComment(), "Range: " + range.toString()));
             if (min.compareTo(max) > 0)
                 throw new IllegalArgumentException("Range min most be less then max.");
-            return define(path, defaultSupplier, range);
+            return define(path, defaultSupplier, range, clazz);
         }
 
         //Object > Limited Value Object

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -339,6 +339,13 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             final Supplier<Long> defaultSupplier = () -> defaultValue;
             return new LongValue(this, defineInList(path, defaultSupplier, allowedValues, Long.class).getPath(), defaultSupplier);
         }
+        //Object > Limited Value Object (Enum)
+        // Enum needs special handling otherwise it gets read as a String and a class cast exception can occur.
+        public <V extends Enum<V>> EnumValue<V> defineInList(String path, V defaultValue, Collection<V> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
+        }
+        public <V extends Enum<V>> EnumValue<V> defineInList(List<String> path, V defaultValue, Collection<V> allowedValues) {
+            return defineEnum(path, defaultValue, allowedValues);
         }
 
         //Object > List

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -771,11 +771,11 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 else return between;
             else if (clazz == Float.class)
                 if (max.equals(Float.MAX_VALUE)) return greaterThan;
-                else if (min.equals(Float.MIN_VALUE)) return lessThan;
+                else if (min.equals(-Float.MAX_VALUE)) return lessThan; // Float.MIN_VALUE stores the smallest POSITIVE value a float can have
                 else return between;
             else if (clazz == Double.class)
                 if (max.equals(Double.MAX_VALUE)) return greaterThan;
-                else if (min.equals(Double.MIN_VALUE)) return lessThan;
+                else if (min.equals(-Double.MAX_VALUE)) return lessThan; // Double.MIN_VALUE stores the smallest POSITIVE value a float can have
                 else return between;
 
             return between;

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -60,9 +60,9 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
 
-/*
- * Like {@link com.electronwill.nightconfig.core.ConfigSpec} except in builder format, and extended to accept comments, language keys,
- * and other things Forge configs would find useful.
+/**
+ * Like {@link com.electronwill.nightconfig.core.ConfigSpec} except in builder format, and extended
+ * to accept comments, language keys, and other things Forge configs would find useful.
  */
 public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfig> //TODO: Remove extends and pipe everything through getSpec/getValues?
 {
@@ -274,6 +274,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             context = new BuilderContext();
             return new ConfigValue<>(this, path, defaultSupplier);
         }
+
+        //Object > Comparable (Range)
         public <V extends Comparable<? super V>> ConfigValue<V> defineInRange(String path, V defaultValue, V min, V max, Class<V> clazz) {
             return defineInRange(split(path), defaultValue, min, max, clazz);
         }
@@ -291,6 +293,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 throw new IllegalArgumentException("Range min most be less then max.");
             return define(path, defaultSupplier, range);
         }
+
+        //Object > Limited Value Object
         public <T> ConfigValue<T> defineInList(String path, T defaultValue, Collection<? extends T> acceptableValues) {
             return defineInList(split(path), defaultValue, acceptableValues);
         }
@@ -303,6 +307,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public <T> ConfigValue<T> defineInList(List<String> path, Supplier<T> defaultSupplier, Collection<? extends T> acceptableValues) {
             return define(path, defaultSupplier, acceptableValues::contains);
         }
+
+        //Object > List
         public <T> ConfigValue<List<? extends T>> defineList(String path, List<? extends T> defaultValue, Predicate<Object> elementValidator) {
             return defineList(split(path), defaultValue, elementValidator);
         }
@@ -408,7 +414,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return new EnumValue<V>(this, define(path, new ValueSpec(defaultSupplier, validator, context), defaultSupplier).getPath(), defaultSupplier, converter, clazz);
         }
 
-        //boolean
+        //Boolean
         public BooleanValue define(String path, boolean defaultValue) {
             return define(split(path), defaultValue);
         }
@@ -439,7 +445,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return new DoubleValue(this, defineInRange(path, defaultSupplier, min, max, Double.class).getPath(), defaultSupplier);
         }
 
-        //Ints
+        //Int
         public IntValue defineInRange(String path, int defaultValue, int min, int max) {
             return defineInRange(split(path), defaultValue, min, max);
         }
@@ -453,7 +459,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return new IntValue(this, defineInRange(path, defaultSupplier, min, max, Integer.class).getPath(), defaultSupplier);
         }
 
-        //Longs
+        //Long
         public LongValue defineInRange(String path, long defaultValue, long min, long max) {
             return defineInRange(split(path), defaultValue, min, max);
         }
@@ -569,7 +575,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             validate(hasComment(), "Non-empty comment when empty expected");
             validate(langKey, "Non-null translation key when null expected");
             validate(range, "Non-null range when null expected");
-            validate(worldRestart, "Dangeling world restart value set to true");
+            validate(worldRestart, "Dangling world restart value set to true");
         }
 
         private void validate(Object value, String message)

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -419,7 +419,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, Supplier<V> defaultSupplier, EnumGetMethod converter, Predicate<Object> validator, Class<V> clazz) {
             context.setClazz(clazz);
             V[] allowedValues = clazz.getEnumConstants();
-            context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + Arrays.stream(allowedValues).map(Enum::name).collect(Collectors.joining(", "))));
+            context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + Arrays.stream(allowedValues).filter(validator).map(Enum::name).collect(Collectors.joining(", "))));
             return new EnumValue<V>(this, define(path, new ValueSpec(defaultSupplier, validator, context), defaultSupplier).getPath(), defaultSupplier, converter, clazz);
         }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -818,11 +818,12 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
-    private static final Joiner LINE_JOINER = Joiner.on("\n");
-    private static final Joiner DOT_JOINER = Joiner.on(".");
-    private static final Splitter DOT_SPLITTER = Splitter.on(".");
-    private static List<String> split(String path)
+    public static final Joiner LINE_JOINER = Joiner.on("\n");
+    public static final Joiner DOT_JOINER = Joiner.on(".");
+    public static final Splitter DOT_SPLITTER = Splitter.on(".");
+    public static List<String> split(String path)
     {
         return Lists.newArrayList(DOT_SPLITTER.split(path));
     }
+
 }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -321,8 +321,23 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             if (!allowedValues.contains(defaultSupplier.get()))
                 throw new IllegalArgumentException("Allowed values must contain the default value.");
             context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + allowedValues.stream().map(t -> t instanceof Enum<?>? ((Enum<?>) t).name() : t.toString()).collect(Collectors.joining(", "))));
+            if (defaultSupplier.get() instanceof Number)
+                return define(path, defaultSupplier, obj -> {
+                    if (!(obj instanceof Number))
+                        return false;
+                    return allowedValues.stream().anyMatch(n -> ((Number) n).doubleValue() == ((Number) obj).doubleValue());
+                }, clazz);
             return define(path, defaultSupplier, allowedValues::contains, clazz);
         }
+        }
+        //Object > Limited Value Object (Long)
+        // Long needs special handling otherwise it gets read as an Integer and a class cast exception can occur.
+        public LongValue defineInList(String path, long defaultValue, Collection<Long> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
+        }
+        public LongValue defineInList(List<String> path, long defaultValue, Collection<Long> allowedValues) {
+            final Supplier<Long> defaultSupplier = () -> defaultValue;
+            return new LongValue(this, defineInList(path, defaultSupplier, allowedValues, Long.class).getPath(), defaultSupplier);
         }
         }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -329,6 +329,23 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 }, clazz);
             return define(path, defaultSupplier, allowedValues::contains, clazz);
         }
+        //Object > Limited Value Object (Byte)
+        // Byte needs special handling otherwise it gets read as an Integer and a class cast exception can occur.
+        public ByteValue defineInList(String path, byte defaultValue, Collection<Byte> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
+        }
+        public ByteValue defineInList(List<String> path, byte defaultValue, Collection<Byte> allowedValues) {
+            final Supplier<Byte> defaultSupplier = () -> defaultValue;
+            return new ByteValue(this, defineInList(path, defaultSupplier, allowedValues, Byte.class).getPath(), defaultSupplier);
+        }
+        //Object > Limited Value Object (Short)
+        // Short needs special handling otherwise it gets read as an Integer and a class cast exception can occur.
+        public ShortValue defineInList(String path, short defaultValue, Collection<Short> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
+        }
+        public ShortValue defineInList(List<String> path, short defaultValue, Collection<Short> allowedValues) {
+            final Supplier<Short> defaultSupplier = () -> defaultValue;
+            return new ShortValue(this, defineInList(path, defaultSupplier, allowedValues, Short.class).getPath(), defaultSupplier);
         }
         //Object > Limited Value Object (Long)
         // Long needs special handling otherwise it gets read as an Integer and a class cast exception can occur.
@@ -338,6 +355,15 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public LongValue defineInList(List<String> path, long defaultValue, Collection<Long> allowedValues) {
             final Supplier<Long> defaultSupplier = () -> defaultValue;
             return new LongValue(this, defineInList(path, defaultSupplier, allowedValues, Long.class).getPath(), defaultSupplier);
+        }
+        //Object > Limited Value Object (Float)
+        // Float needs special handling otherwise it gets read as an Double and a class cast exception can occur.
+        public FloatValue defineInList(String path, float defaultValue, Collection<Float> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
+        }
+        public FloatValue defineInList(List<String> path, float defaultValue, Collection<Float> allowedValues) {
+            final Supplier<Float> defaultSupplier = () -> defaultValue;
+            return new FloatValue(this, defineInList(path, defaultSupplier, allowedValues, Float.class).getPath(), defaultSupplier);
         }
         //Object > Limited Value Object (Enum)
         // Enum needs special handling otherwise it gets read as a String and a class cast exception can occur.
@@ -471,18 +497,32 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             }, Boolean.class).getPath(), defaultSupplier);
         }
 
-        //Double
-        public DoubleValue defineInRange(String path, double defaultValue, double min, double max) {
+        //Byte
+        public ByteValue defineInRange(String path, byte defaultValue, byte min, byte max) {
             return defineInRange(split(path), defaultValue, min, max);
         }
-        public DoubleValue defineInRange(List<String> path, double defaultValue, double min, double max) {
-            return defineInRange(path, (Supplier<Double>)() -> defaultValue, min, max);
+        public ByteValue defineInRange(List<String> path, byte defaultValue, byte min, byte max) {
+            return defineInRange(path, (Supplier<Byte>)() -> defaultValue, min, max);
         }
-        public DoubleValue defineInRange(String path, Supplier<Double> defaultSupplier, double min, double max) {
+        public ByteValue defineInRange(String path, Supplier<Byte> defaultSupplier, byte min, byte max) {
             return defineInRange(split(path), defaultSupplier, min, max);
         }
-        public DoubleValue defineInRange(List<String> path, Supplier<Double> defaultSupplier, double min, double max) {
-            return new DoubleValue(this, defineInRange(path, defaultSupplier, min, max, Double.class).getPath(), defaultSupplier);
+        public ByteValue defineInRange(List<String> path, Supplier<Byte> defaultSupplier, byte min, byte max) {
+            return new ByteValue(this, defineInRange(path, defaultSupplier, min, max, Byte.class).getPath(), defaultSupplier);
+        }
+
+        //Short
+        public ShortValue defineInRange(String path, short defaultValue, short min, short max) {
+            return defineInRange(split(path), defaultValue, min, max);
+        }
+        public ShortValue defineInRange(List<String> path, short defaultValue, short min, short max) {
+            return defineInRange(path, (Supplier<Short>)() -> defaultValue, min, max);
+        }
+        public ShortValue defineInRange(String path, Supplier<Short> defaultSupplier, short min, short max) {
+            return defineInRange(split(path), defaultSupplier, min, max);
+        }
+        public ShortValue defineInRange(List<String> path, Supplier<Short> defaultSupplier, short min, short max) {
+            return new ShortValue(this, defineInRange(path, defaultSupplier, min, max, Short.class).getPath(), defaultSupplier);
         }
 
         //Int
@@ -511,6 +551,34 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
         public LongValue defineInRange(List<String> path, Supplier<Long> defaultSupplier, long min, long max) {
             return new LongValue(this, defineInRange(path, defaultSupplier, min, max, Long.class).getPath(), defaultSupplier);
+        }
+
+        //Float
+        public FloatValue defineInRange(String path, float defaultValue, float min, float max) {
+            return defineInRange(split(path), defaultValue, min, max);
+        }
+        public FloatValue defineInRange(List<String> path, float defaultValue, float min, float max) {
+            return defineInRange(path, (Supplier<Float>)() -> defaultValue, min, max);
+        }
+        public FloatValue defineInRange(String path, Supplier<Float> defaultSupplier, float min, float max) {
+            return defineInRange(split(path), defaultSupplier, min, max);
+        }
+        public FloatValue defineInRange(List<String> path, Supplier<Float> defaultSupplier, float min, float max) {
+            return new FloatValue(this, defineInRange(path, defaultSupplier, min, max, Float.class).getPath(), defaultSupplier);
+        }
+
+        //Double
+        public DoubleValue defineInRange(String path, double defaultValue, double min, double max) {
+            return defineInRange(split(path), defaultValue, min, max);
+        }
+        public DoubleValue defineInRange(List<String> path, double defaultValue, double min, double max) {
+            return defineInRange(path, (Supplier<Double>)() -> defaultValue, min, max);
+        }
+        public DoubleValue defineInRange(String path, Supplier<Double> defaultSupplier, double min, double max) {
+            return defineInRange(split(path), defaultSupplier, min, max);
+        }
+        public DoubleValue defineInRange(List<String> path, Supplier<Double> defaultSupplier, double min, double max) {
+            return new DoubleValue(this, defineInRange(path, defaultSupplier, min, max, Double.class).getPath(), defaultSupplier);
         }
 
         public Builder comment(String comment)
@@ -796,6 +864,34 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
+    public static class ByteValue extends ConfigValue<Byte>
+    {
+        ByteValue(Builder parent, List<String> path, Supplier<Byte> defaultSupplier)
+        {
+            super(parent, path, defaultSupplier);
+        }
+
+        @Override
+        protected Byte getRaw(Config config, List<String> path, Supplier<Byte> defaultSupplier)
+        {
+            return config.getByteOrElse(path, defaultSupplier.get());
+        }
+    }
+
+    public static class ShortValue extends ConfigValue<Short>
+    {
+        ShortValue(Builder parent, List<String> path, Supplier<Short> defaultSupplier)
+        {
+            super(parent, path, defaultSupplier);
+        }
+
+        @Override
+        protected Short getRaw(Config config, List<String> path, Supplier<Short> defaultSupplier)
+        {
+            return config.getShortOrElse(path, defaultSupplier.get());
+        }
+    }
+
     public static class IntValue extends ConfigValue<Integer>
     {
         IntValue(Builder parent, List<String> path, Supplier<Integer> defaultSupplier)
@@ -821,6 +917,26 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         protected Long getRaw(Config config, List<String> path, Supplier<Long> defaultSupplier)
         {
             return config.getLongOrElse(path, () -> defaultSupplier.get());
+        }
+    }
+
+    public static class FloatValue extends ConfigValue<Float>
+    {
+        FloatValue(Builder parent, List<String> path, Supplier<Float> defaultSupplier)
+        {
+            super(parent, path, defaultSupplier);
+        }
+
+        @Override
+        public Float get() {
+            return super.get();
+        }
+
+        @Override
+        protected Float getRaw(Config config, List<String> path, Supplier<Float> defaultSupplier)
+        {
+            Number n = config.<Number>get(path);
+            return n == null ? defaultSupplier.get() : n.floatValue();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -749,14 +749,36 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         @Override
         public String toString()
         {
-            if (clazz == Integer.class) {
-                if (max.equals(Integer.MAX_VALUE)) {
-                    return "> " + min;
-                } else if (min.equals(Integer.MIN_VALUE)) {
-                    return "< " + max;
-                }
-            } // TODO add more special cases?
-            return min + " ~ " + max;
+            final String greaterThan = "> " + min;
+            final String lessThan = "< " + max;
+            final String between = min + " ~ " + max;
+
+            if (clazz == Byte.class)
+                if (max.equals(Byte.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Byte.MIN_VALUE)) return lessThan;
+                else return between;
+            if (clazz == Short.class)
+                if (max.equals(Short.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Short.MIN_VALUE)) return lessThan;
+                else return between;
+            if (clazz == Integer.class)
+                if (max.equals(Integer.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Integer.MIN_VALUE)) return lessThan;
+                else return between;
+            if (clazz == Long.class)
+                if (max.equals(Long.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Long.MIN_VALUE)) return lessThan;
+                else return between;
+            else if (clazz == Float.class)
+                if (max.equals(Float.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Float.MIN_VALUE)) return lessThan;
+                else return between;
+            else if (clazz == Double.class)
+                if (max.equals(Double.MAX_VALUE)) return greaterThan;
+                else if (min.equals(Double.MIN_VALUE)) return lessThan;
+                else return between;
+
+            return between;
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -775,7 +775,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 else return between;
             else if (clazz == Double.class)
                 if (max.equals(Double.MAX_VALUE)) return greaterThan;
-                else if (min.equals(-Double.MAX_VALUE)) return lessThan; // Double.MIN_VALUE stores the smallest POSITIVE value a float can have
+                else if (min.equals(-Double.MAX_VALUE)) return lessThan; // Double.MIN_VALUE stores the smallest POSITIVE value a double can have
                 else return between;
 
             return between;

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -303,17 +303,18 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
 
         //Object > Limited Value Object
-        public <T> ConfigValue<T> defineInList(String path, T defaultValue, Collection<? extends T> acceptableValues) {
-            return defineInList(split(path), defaultValue, acceptableValues);
+        public <T> ConfigValue<T> defineInList(String path, T defaultValue, Collection<? extends T> allowedValues) {
+            return defineInList(split(path), defaultValue, allowedValues);
         }
-        public <T> ConfigValue<T> defineInList(String path, Supplier<T> defaultSupplier, Collection<? extends T> acceptableValues) {
-            return defineInList(split(path), defaultSupplier, acceptableValues);
+        public <T> ConfigValue<T> defineInList(String path, Supplier<T> defaultSupplier, Collection<? extends T> allowedValues) {
+            return defineInList(split(path), defaultSupplier, allowedValues);
         }
-        public <T> ConfigValue<T> defineInList(List<String> path, T defaultValue, Collection<? extends T> acceptableValues) {
-            return defineInList(path, () -> defaultValue, acceptableValues);
+        public <T> ConfigValue<T> defineInList(List<String> path, T defaultValue, Collection<? extends T> allowedValues) {
+            return defineInList(path, () -> defaultValue, allowedValues);
         }
-        public <T> ConfigValue<T> defineInList(List<String> path, Supplier<T> defaultSupplier, Collection<? extends T> acceptableValues) {
-            return define(path, defaultSupplier, acceptableValues::contains);
+        public <T> ConfigValue<T> defineInList(List<String> path, Supplier<T> defaultSupplier, Collection<? extends T> allowedValues) {
+            return define(path, defaultSupplier, allowedValues::contains);
+        }
         }
 
         //Object > List
@@ -357,38 +358,38 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter) {
             return defineEnum(path, defaultValue, converter, defaultValue.getDeclaringClass().getEnumConstants());
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, @SuppressWarnings("unchecked") V... acceptableValues) {
-            return defineEnum(split(path), defaultValue, acceptableValues);
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, @SuppressWarnings("unchecked") V... allowedValues) {
+            return defineEnum(split(path), defaultValue, allowedValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... acceptableValues) {
-            return defineEnum(split(path), defaultValue, converter, acceptableValues);
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... allowedValues) {
+            return defineEnum(split(path), defaultValue, converter, allowedValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, @SuppressWarnings("unchecked") V... acceptableValues) {
-            return defineEnum(path, defaultValue, (Collection<V>) Arrays.asList(acceptableValues));
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, @SuppressWarnings("unchecked") V... allowedValues) {
+            return defineEnum(path, defaultValue, (Collection<V>) Arrays.asList(allowedValues));
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... acceptableValues) {
-            return defineEnum(path, defaultValue, converter, Arrays.asList(acceptableValues));
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... allowedValues) {
+            return defineEnum(path, defaultValue, converter, Arrays.asList(allowedValues));
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, Collection<V> acceptableValues) {
-            return defineEnum(split(path), defaultValue, acceptableValues);
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, Collection<V> allowedValues) {
+            return defineEnum(split(path), defaultValue, allowedValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, Collection<V> acceptableValues) {
-            return defineEnum(split(path), defaultValue, converter, acceptableValues);
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, Collection<V> allowedValues) {
+            return defineEnum(split(path), defaultValue, converter, allowedValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, Collection<V> acceptableValues) {
-            return defineEnum(path, defaultValue, EnumGetMethod.NAME_IGNORECASE, acceptableValues);
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, Collection<V> allowedValues) {
+            return defineEnum(path, defaultValue, EnumGetMethod.NAME_IGNORECASE, allowedValues);
         }
         @SuppressWarnings("unchecked")
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, Collection<V> acceptableValues) {
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, Collection<V> allowedValues) {
             return defineEnum(path, defaultValue, converter, obj -> {
                 if (obj instanceof Enum) {
-                    return acceptableValues.contains(obj);
+                    return allowedValues.contains(obj);
                 }
                 if (obj == null) {
                     return false;
                 }
                 try {
-                    return acceptableValues.contains(converter.get(obj, defaultValue.getClass()));
+                    return allowedValues.contains(converter.get(obj, defaultValue.getClass()));
                 } catch (IllegalArgumentException | ClassCastException e) {
                     return false;
                 }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -313,7 +313,16 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return defineInList(path, () -> defaultValue, allowedValues);
         }
         public <T> ConfigValue<T> defineInList(List<String> path, Supplier<T> defaultSupplier, Collection<? extends T> allowedValues) {
-            return define(path, defaultSupplier, allowedValues::contains);
+            return defineInList(path, defaultSupplier, allowedValues, Object.class);
+        }
+        public <T> ConfigValue<T> defineInList(List<String> path, Supplier<T> defaultSupplier, Collection<? extends T> allowedValues, Class<?> clazz) {
+            if (allowedValues.isEmpty())
+                throw new IllegalArgumentException("Must have allowed values.");
+            if (!allowedValues.contains(defaultSupplier.get()))
+                throw new IllegalArgumentException("Allowed values must contain the default value.");
+            context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + allowedValues.stream().map(t -> t instanceof Enum<?>? ((Enum<?>) t).name() : t.toString()).collect(Collectors.joining(", "))));
+            return define(path, defaultSupplier, allowedValues::contains, clazz);
+        }
         }
         }
 

--- a/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -24,6 +24,7 @@ import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.loading.StringUtils;
 
 import java.nio.file.Path;
@@ -99,32 +100,45 @@ public class ModConfig
 
     public enum Type {
         /**
-         * Common mod config for configuration that needs to be loaded on both environments.
-         * Loaded on both servers and clients.
+         * Common config is for configuration that needs to be loaded on both environments.
+         * Loaded on both server and client environments during startup (after registry events and before setup events).
          * Stored in the global config directory.
          * Not synced.
          * Suffix is "-common" by default.
+         * Examples of config entries that would use this:
+         * - Whether to enable an update checker (FML has this)
+         * - What paths to load extra mod assets from (plugin/addon files)
          */
         COMMON,
         /**
          * Client config is for configuration affecting the ONLY client state such as graphical options.
-         * Only loaded on the client side.
+         * Loaded on the client environment during startup (after registry events and before setup events).
          * Stored in the global config directory.
          * Not synced.
          * Suffix is "-client" by default.
+         * Examples of config entries that would use this:
+         * - If certain info should be rendered in a GUI/HUD
+         * - The color of something that will be rendered in a GUI/HUD
+         * - Options that change how you interact with things
+         * - Controls/Accessibility options (For changing the effects of keybinds/mouse clicks/mouse movement)
          */
         CLIENT,
 //        /**
 //         * Player type config is configuration that is associated with a player.
 //         * Preferences around machine states, for example.
+//         * Not Implemented (yet).
 //         */
 //        PLAYER,
         /**
-         * Server type config is configuration that is associated with a server instance.
-         * Only loaded during server startup.
+         * Server config is for configuration that is associated with a logical server instance.
+         * Loaded during server startup (right before the {@link FMLServerAboutToStartEvent} is fired).
          * Stored in a server/save specific "serverconfig" directory.
          * Synced to clients during connection.
          * Suffix is "-server" by default.
+         * Examples of config entries that would use this:
+         * - The amount of energy a machine uses/produces
+         * - World/Ore gen configuration
+         * - Entity spawning configuration
          */
         SERVER;
 


### PR DESCRIPTION
- Fixes and standardises the comments in `ForgeConfigSpec`
- Makes `ForgeConfigSpec`'s utility methods public (in prep for the Config GUI PR)
- Fixes various small issues in `ForgeConfigSpec`
- Adds support for Bytes, Shorts and Floats (`ForgeConfigSpec`)
- Adds info to `FMLConfig` telling Modders to use Forge's system and not base their config of FML's
- Improves the documentation on `ModConfig.Type`