### PR TITLE
Fix NullPointerException on java 8u242 in dev environment.

### DIFF
--- a/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
+++ b/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
@@ -28,6 +28,7 @@ import cpw.mods.modlauncher.Launcher;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.Proxy;
 import java.util.Arrays;
 import java.util.Locale;
@@ -122,9 +123,12 @@ public class LaunchTesting
         // hack the classloader now.
         try
         {
-            final Field sysPathsField = ClassLoader.class.getDeclaredField("sys_paths");
-            sysPathsField.setAccessible(true);
-            sysPathsField.set(null, null);
+            final Method initializePathMethod = ClassLoader.class.getDeclaredMethod("initializePath", String.class);
+            initializePathMethod.setAccessible(true);
+            final Object usrPathsValue = initializePathMethod.invoke(null, "java.library.path");
+            final Field usrPathsField = ClassLoader.class.getDeclaredField("usr_paths");
+            usrPathsField.setAccessible(true);
+            usrPathsField.set(null, usrPathsValue);
         }
         catch(Throwable t) {}
     }


### PR DESCRIPTION
Java 8u242 no longer re-initializes internal `sys_paths` and `usr_paths` fields in `loadLibrary` when they are null, so the value can't be set to null.

Can also submit for 1.14.x if needed.