### PR TITLE
Add API for item models to draw using a different RenderType from default.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -9,7 +9,7 @@
  
        for(Item item : Registry.field_212630_s) {
           if (!field_195411_c.contains(item)) {
-@@ -91,7 +91,7 @@
+@@ -91,10 +91,10 @@
              p_229111_8_ = this.field_175059_m.func_178083_a().func_174953_a(new ModelResourceLocation("minecraft:trident#inventory"));
           }
  
@@ -17,7 +17,11 @@
 +         p_229111_8_ = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(p_229111_4_, p_229111_8_, p_229111_2_, p_229111_3_);
           p_229111_4_.func_227861_a_(-0.5D, -0.5D, -0.5D);
           if (!p_229111_8_.func_188618_c() && (p_229111_1_.func_77973_b() != Items.field_203184_eO || flag1)) {
-             RenderType rendertype = RenderTypeLookup.func_228389_a_(p_229111_1_);
+-            RenderType rendertype = RenderTypeLookup.func_228389_a_(p_229111_1_);
++            RenderType rendertype = p_229111_8_.getRenderType(p_229111_1_);
+             RenderType rendertype1;
+             if (flag && Objects.equals(rendertype, Atlases.func_228784_i_())) {
+                rendertype1 = Atlases.func_228785_j_();
 @@ -105,7 +105,7 @@
              IVertexBuilder ivertexbuilder = func_229113_a_(p_229111_5_, rendertype1, true, p_229111_1_.func_77962_s());
              this.func_229114_a_(p_229111_8_, p_229111_1_, p_229111_6_, p_229111_7_, p_229111_4_, ivertexbuilder);

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -1,0 +1,49 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+import net.minecraft.client.renderer.RenderState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.util.ResourceLocation;
+
+public class ForgeRenderTypes extends RenderType
+{
+    private ForgeRenderTypes(String p_i225992_1_, VertexFormat p_i225992_2_, int p_i225992_3_, int p_i225992_4_, boolean p_i225992_5_, boolean p_i225992_6_, Runnable p_i225992_7_, Runnable p_i225992_8_)
+    {
+        super(p_i225992_1_, p_i225992_2_, p_i225992_3_, p_i225992_4_, p_i225992_5_, p_i225992_6_, p_i225992_7_, p_i225992_8_);
+        throw new IllegalStateException("This class must not be instantiated");
+    }
+
+    public static RenderType unsortedTranslucent(ResourceLocation textureLocation, boolean outline) {
+        RenderType.State rendertype$state = RenderType.State.func_228694_a_().func_228724_a_(new RenderState.TextureState(textureLocation, false, false))
+                .func_228726_a_(field_228515_g_).func_228716_a_(field_228532_x_).func_228713_a_(field_228517_i_).func_228714_a_(field_228491_A_)
+                .func_228719_a_(field_228528_t_).func_228722_a_(field_228530_v_).func_228728_a_(outline);
+        return func_228633_a_("entity_unsorted_translucent", DefaultVertexFormats.field_227849_i_, 7, 256, true, false /* disable sorting*/, rendertype$state);
+    }
+    public static RenderType unsortedTranslucent(ResourceLocation p_230168_0_)
+    {
+        return unsortedTranslucent(p_230168_0_, true);
+    }
+
+    public static RenderType UNSORTED_TRANSLUCENT = unsortedTranslucent(AtlasTexture.LOCATION_BLOCKS_TEXTURE, true);
+}

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -28,10 +28,13 @@ import javax.annotation.Nullable;
 import com.mojang.blaze3d.matrix.MatrixStack;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypeLookup;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ILightReader;
@@ -74,5 +77,10 @@ public interface IForgeBakedModel
     default TextureAtlasSprite getParticleTexture(@Nonnull IModelData data)
     {
         return getBakedModel().getParticleTexture();
+    }
+
+    default RenderType getRenderType(ItemStack itemStack)
+    {
+        return RenderTypeLookup.func_228389_a_(itemStack);
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
+++ b/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
@@ -320,7 +320,7 @@ public final class DynamicBucketModel implements IModelGeometry<DynamicBucketMod
         @Override
         public RenderType getRenderType(ItemStack itemStack)
         {
-            return ForgeRenderTypes.UNSORTED_TRANSLUCENT;
+            return ForgeRenderTypes.ITEM_UNSORTED_TRANSLUCENT.get();
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
+++ b/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.TransformationMatrix;
 import net.minecraft.client.renderer.model.*;
 import net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType;
@@ -41,6 +42,7 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.ForgeRenderTypes;
 import net.minecraftforge.client.model.geometry.IModelGeometry;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -313,6 +315,12 @@ public final class DynamicBucketModel implements IModelGeometry<DynamicBucketMod
             this.cache = cache;
             this.originalTransform = originalTransform;
             this.isSideLit = isSideLit;
+        }
+
+        @Override
+        public RenderType getRenderType(ItemStack itemStack)
+        {
+            return ForgeRenderTypes.UNSORTED_TRANSLUCENT;
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
@@ -50,8 +50,8 @@ public class NewFluidTest
 {
     public static final String MODID = "new_fluid_test";
 
-    public static final ResourceLocation FLUID_STILL = new ResourceLocation("minecraft:block/brown_mushroom_block");
-    public static final ResourceLocation FLUID_FLOWING = new ResourceLocation("minecraft:block/mushroom_stem");
+    public static final ResourceLocation FLUID_STILL = new ResourceLocation("minecraft:block/water_still");
+    public static final ResourceLocation FLUID_FLOWING = new ResourceLocation("minecraft:block/water_flow");
     public static final ResourceLocation FLUID_OVERLAY = new ResourceLocation("minecraft:block/obsidian");
 
     public static final DeferredRegister<Block> BLOCKS = new DeferredRegister<>(ForgeRegistries.BLOCKS, MODID);


### PR DESCRIPTION
Add API for item models to draw using a different RenderType from default.

Concerns to be resolved:

- [ ] Do we want an API to allow modders to specify the render type for items, without requiring a custom model loader? I'd argue we **need** it. Something similar to RenderTypeLookup.setRenderLayer but for items, perhaps?
- [ ] Do we want to support multi-layer items? Eg. `#getItemLayers()` + `#canRenderInLayer(ItemStack)`
- [ ] Do we want to also add a similar method for blocks? Eg. `#canRenderInLayer(BlockState)` (no getBlockLayers because the set of layers a block can draw to, is fixed).