### PR TITLE
Update mapping to match MCP date.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
         ]
     }
     MAPPING_CHANNEL = 'snapshot'
-    MAPPING_VERSION = '20190719-1.14.3'
+    MAPPING_VERSION = '20200122-1.15.1'
     MC_VERSION = '1.15.2'
     MCP_VERSION = '20200122.131323'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
         ]
     }
     MAPPING_CHANNEL = 'snapshot'
-    MAPPING_VERSION = '20200122-1.15.1'
+    MAPPING_VERSION = '20190719-1.14.3'
     MC_VERSION = '1.15.2'
     MCP_VERSION = '20200122.131323'
 }


### PR DESCRIPTION
The mapping was still pointing at 1.14 from July 2019.  I updated it to the 1.15.1 version that matched the date of the MCP_VERSION.   There are 6 newer mapping versions, but figured making them the same was best.

Version gathered from here: http://export.mcpbot.bspk.rs/snapshot/?page=1