### PR TITLE
Make Minecarts work with modded powered/activator rails.

### DIFF
--- a/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
@@ -4,17 +4,17 @@
  public class PoweredRailBlock extends AbstractRailBlock {
     public static final EnumProperty<RailShape> field_176568_b = BlockStateProperties.field_208166_S;
     public static final BooleanProperty field_176569_M = BlockStateProperties.field_208194_u;
-+   private final boolean isActivator;
++   private final boolean isActivator;  // TRUE for an Activator Rail, FALSE for Powered Rail
  
     protected PoweredRailBlock(Block.Properties p_i48349_1_) {
 -      super(true, p_i48349_1_);
 +      this(p_i48349_1_, false);
 +   }
 +
-+   protected PoweredRailBlock(Block.Properties builder, boolean isActivator) {
++   protected PoweredRailBlock(Block.Properties builder, boolean isPoweredRail) {
 +      super(true, builder);
        this.func_180632_j(this.field_176227_L.func_177621_b().func_206870_a(field_176568_b, RailShape.NORTH_SOUTH).func_206870_a(field_176569_M, Boolean.valueOf(false)));
-+      this.isActivator = isActivator;
++      this.isActivator = !isPoweredRail;
     }
  
     protected boolean func_176566_a(World p_176566_1_, BlockPos p_176566_2_, BlockState p_176566_3_, boolean p_176566_4_, int p_176566_5_) {
@@ -35,3 +35,12 @@
                    return p_208071_1_.func_175640_z(p_208071_2_) ? true : this.func_176566_a(p_208071_1_, p_208071_2_, blockstate, p_208071_3_, p_208071_4_ + 1);
                 } else {
                    return false;
+@@ -255,4 +261,8 @@
+    protected void func_206840_a(StateContainer.Builder<Block, BlockState> p_206840_1_) {
+       p_206840_1_.func_206894_a(field_176568_b, field_176569_M);
+    }
++
++   public boolean isActivatorRail() {
++      return isActivator;
++   }
+ }

--- a/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
@@ -31,15 +31,18 @@
     }
  
     public double func_70042_X() {
-@@ -239,7 +241,7 @@
+@@ -239,9 +241,9 @@
  
           BlockPos blockpos = new BlockPos(i, j, k);
           BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
 -         if (blockstate.func_203425_a(BlockTags.field_203437_y)) {
 +         if (canUseRail() && blockstate.func_203425_a(BlockTags.field_203437_y)) {
              this.func_180460_a(blockpos, blockstate);
-             if (blockstate.func_177230_c() == Blocks.field_150408_cc) {
+-            if (blockstate.func_177230_c() == Blocks.field_150408_cc) {
++            if (blockstate.func_177230_c() instanceof PoweredRailBlock && ((PoweredRailBlock) blockstate.func_177230_c()).isActivatorRail()) {
                 this.func_96095_a(i, j, k, blockstate.func_177229_b(PoweredRailBlock.field_176569_M));
+             }
+          } else {
 @@ -266,8 +268,11 @@
           }
  
@@ -98,7 +101,13 @@
        }
  
     }
-@@ -327,24 +341,23 @@
+@@ -322,29 +336,28 @@
+       boolean flag = false;
+       boolean flag1 = false;
+       AbstractRailBlock abstractrailblock = (AbstractRailBlock)p_180460_2_.func_177230_c();
+-      if (abstractrailblock == Blocks.field_196552_aC) {
++      if (abstractrailblock instanceof PoweredRailBlock && !((PoweredRailBlock) abstractrailblock).isActivatorRail()) {
+          flag = p_180460_2_.func_177229_b(PoweredRailBlock.field_176569_M);
           flag1 = !flag;
        }
  
@@ -238,7 +247,7 @@
 +   public void moveMinecartOnRail(BlockPos pos) { //Non-default because getMaximumSpeed is protected
 +      AbstractMinecartEntity mc = getMinecart();
 +      double d24 = mc.func_184207_aI() ? 0.75D : 1.0D;
-+      double d25 = mc.func_174898_m();
++      double d25 = mc.getMaxSpeedWithRail();
 +      Vec3d vec3d1 = mc.func_213322_ci();
 +      mc.func_213315_a(MoverType.SELF, new Vec3d(MathHelper.func_151237_a(d24 * vec3d1.field_72450_a, -d25, d25), 0.0D, MathHelper.func_151237_a(d24 * vec3d1.field_72449_c, -d25, d25)));
 +   }


### PR DESCRIPTION
Re-adds functionality for rails to have different maximum speeds.

This is a manual cherry pick of https://github.com/MinecraftForge/MinecraftForge/commit/d28cd0352b6b0fe86e062f29e681c3b14572c6d5 (which in combination with #6485, gets the 1.15 branch at feature parity with the 1.14 branch). For more detail about what this PR does see the original 1.14 PR #6354 

Note: I did not test this with modded Minecarts or rails as I do not have any use for this and just wanted to get 1.15 at feature parity with 1.14, but I did test and made sure that no vanilla functionality was broken by this change.