### PR TITLE
Add an AT entry to make it easier to add vanilla-like brewing recipes

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -171,3 +171,4 @@ public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGene
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 private-f net.minecraft.world.storage.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.world.storage.loot.LootPool field_186456_d # bonusRolls
+public net.minecraft.potion.PotionBrewing *() # convenient to add vanilla-like brewing recipes


### PR DESCRIPTION
I noticed that in 1.13+ Forge no longer publish methods in net.minecraft.potion.PotionBrewing (once called PotionHelper in 1.12.2) to allow modder to add vanilla-like brewing recipes easier. But I also noticed there is a patch on it to make its subclass MixPredictae follow Forge's principles. So I think its missing is due to cleanup and forgetting to re-add.
Old version at link: [https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/resources/forge_at.cfg#L297](url)