### PR TITLE
Allows custom blocks to use the fluid overlay texture

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/FluidBlockRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/FluidBlockRenderer.java.patch
@@ -51,20 +51,21 @@
              flag7 = true;
           }
  
-@@ -222,10 +223,10 @@
+@@ -222,10 +223,9 @@
                 flag7 = true;
                 BlockPos blockpos = p_228796_2_.func_177972_a(direction);
                 TextureAtlasSprite textureatlassprite2 = atextureatlassprite[1];
 -               if (!flag) {
-+               if (atextureatlassprite[2] != null) {
-                   Block block = p_228796_1_.func_180495_p(blockpos).func_177230_c();
-                   if (block == Blocks.field_150359_w || block instanceof StainedGlassBlock) {
+-                  Block block = p_228796_1_.func_180495_p(blockpos).func_177230_c();
+-                  if (block == Blocks.field_150359_w || block instanceof StainedGlassBlock) {
 -                     textureatlassprite2 = this.field_187501_d;
++               if (atextureatlassprite[2] != null) {
++                  if (p_228796_1_.func_180495_p(blockpos).shouldDisplayFluidOverlay(p_228796_1_, blockpos, p_228796_4_)) {
 +                     textureatlassprite2 = atextureatlassprite[2];
                    }
                 }
  
-@@ -239,15 +240,15 @@
+@@ -239,15 +239,15 @@
                 float f31 = 1.0F * f30 * f;
                 float f32 = 1.0F * f30 * f1;
                 float f33 = 1.0F * f30 * f2;
@@ -89,7 +90,7 @@
                 }
              }
           }
-@@ -256,10 +257,15 @@
+@@ -256,10 +256,15 @@
        }
     }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IBeaconBeamColorProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.SoundType;
+import net.minecraft.block.StainedGlassBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.particle.ParticleManager;
@@ -1053,5 +1054,19 @@ public interface IForgeBlock
     default boolean collisionExtendsVertically(BlockState state, IBlockReader world, BlockPos pos, Entity collidingEntity)
     {
         return getBlock().isIn(BlockTags.FENCES) || getBlock().isIn(BlockTags.WALLS) || getBlock() instanceof FenceGateBlock;
+    }
+
+    /**
+     * Called to determine whether this block should use the fluid overlay texture or flowing texture when it is placed under the fluid.
+     *
+     * @param state The current state
+     * @param world The world
+     * @param pos Block position in world
+     * @param fluidState The state of the fluid
+     * @return Whether the fluid overlay texture should be used
+     */
+    default boolean shouldDisplayFluidOverlay(BlockState state, ILightReader world, BlockPos pos, IFluidState fluidState)
+    {
+        return state.getBlock() == Blocks.GLASS || state.getBlock() instanceof StainedGlassBlock;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -898,4 +898,17 @@ public interface IForgeBlockState
     {
         return getBlockState().getBlock().collisionExtendsVertically(getBlockState(), world, pos, collidingEntity);
     }
+
+    /**
+     * Called to determine whether this block should use the fluid overlay texture or flowing texture when it is placed under the fluid.
+     *
+     * @param world The world
+     * @param pos Block position in world
+     * @param fluidState The state of the fluid
+     * @return Whether the fluid overlay texture should be used
+     */
+    default boolean shouldDisplayFluidOverlay(ILightReader world, BlockPos pos, IFluidState fluidState)
+    {
+        return getBlockState().getBlock().shouldDisplayFluidOverlay(getBlockState(), world, pos, fluidState);
+    }
 }


### PR DESCRIPTION
Currently in `FluidBlockRenderer` the check for if the fluid overlay should be used is hardcoded to glass and stained glass. This PR moves it to a method that can be overridden so as to allow for mods with custom glass blocks (or blocks of a similar concept), to be able to use the fluid overlay texture when in the fluid instead of using the flowing texture.