### PR TITLE
Fix NPE on java 8u242 on 1.14.x as well

### DIFF
--- a/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
+++ b/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
@@ -28,6 +28,7 @@ import cpw.mods.modlauncher.Launcher;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.Proxy;
 import java.util.Arrays;
 import java.util.Locale;
@@ -122,9 +123,12 @@ public class LaunchTesting
         // hack the classloader now.
         try
         {
-            final Field sysPathsField = ClassLoader.class.getDeclaredField("sys_paths");
-            sysPathsField.setAccessible(true);
-            sysPathsField.set(null, null);
+            final Method initializePathMethod = ClassLoader.class.getDeclaredMethod("initializePath", String.class);
+            initializePathMethod.setAccessible(true);
+            final Object usrPathsValue = initializePathMethod.invoke(null, "java.library.path");
+            final Field usrPathsField = ClassLoader.class.getDeclaredField("usr_paths");
+            usrPathsField.setAccessible(true);
+            usrPathsField.set(null, usrPathsValue);
         }
         catch(Throwable t) {}
     }


### PR DESCRIPTION
Using @Barteks2x fix for 1.15. All credit to them, this is simply backporting it to 1.14.x. Checked on the same versions of Java they did that are available from Arch Linux x86_64.

See the original issue here: /pull/6473 - Java no longer re-initializes internal paths, so we must work around this.