### PR TITLE
Fix a wrong RenderState name

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
@@ -5,7 +5,7 @@
  
        public LineState(OptionalDouble p_i225982_1_) {
 -         super("alpha", () -> {
-+         super("line", () -> { // FORGE: fix MC-167447
++         super("line_width", () -> { // FORGE: fix MC-167447
              if (!Objects.equals(p_i225982_1_, OptionalDouble.of(1.0D))) {
                 if (p_i225982_1_.isPresent()) {
                    RenderSystem.lineWidth((float)p_i225982_1_.getAsDouble());

--- a/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
@@ -5,7 +5,7 @@
  
        public LineState(OptionalDouble p_i225982_1_) {
 -         super("alpha", () -> {
-+         super("line", () -> {
++         super("line", () -> { // FORGE: fix MC-167447
              if (!Objects.equals(p_i225982_1_, OptionalDouble.of(1.0D))) {
                 if (p_i225982_1_.isPresent()) {
                    RenderSystem.lineWidth((float)p_i225982_1_.getAsDouble());

--- a/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderState.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/RenderState.java
++++ b/net/minecraft/client/renderer/RenderState.java
+@@ -360,7 +360,7 @@
+       private final OptionalDouble field_228587_Q_;
+ 
+       public LineState(OptionalDouble p_i225982_1_) {
+-         super("alpha", () -> {
++         super("line", () -> {
+             if (!Objects.equals(p_i225982_1_, OptionalDouble.of(1.0D))) {
+                if (p_i225982_1_.isPresent()) {
+                   RenderSystem.lineWidth((float)p_i225982_1_.getAsDouble());


### PR DESCRIPTION
Hello,

This PR fixes a Mojang wrong copy-paste in RenderState.LineState from RenderState.AlphaState : [MC-167447](https://bugs.mojang.com/browse/MC-167447)

This wrong name can be a problem for modders, especially if someone decides to create a rendering library, since the hashcode() and equals() methods will be wrong for that subclass (they both their super method which is based on that name).

In particular, collections using RenderState (e.g `List<RenderState>`) can be wrongly detecting two instances of LineState and AlphaState as being the same.

I don't know if you want it fixed in Forge, but I thought it would still be good to ask.

Have a nice day,
Rigner