### PR TITLE
Fix ITeleporter being ignored when teleporting from the end to the overworld

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -19,7 +19,8 @@
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_212321_1_)) return null;
        this.field_184851_cj = true;
        DimensionType dimensiontype = this.field_71093_bK;
-       if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
+-      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
++      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_ && teleporter.specialEndReturn()) {
           this.func_213319_R();
 -         this.func_71121_q().func_217434_e(this);
 +         this.func_71121_q().removePlayer(this, true); //Forge: The player entity is cloned so keep the data until after cloning calls copyFrom

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -20,7 +20,7 @@
        this.field_184851_cj = true;
        DimensionType dimensiontype = this.field_71093_bK;
 -      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
-+      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_ && teleporter.specialEndReturn()) {
++      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_ && teleporter instanceof net.minecraft.world.Teleporter) { //Forge: Fix non-vanilla teleporters triggering end credits
           this.func_213319_R();
 -         this.func_71121_q().func_217434_e(this);
 +         this.func_71121_q().removePlayer(this, true); //Forge: The player entity is cloned so keep the data until after cloning calls copyFrom

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
-import net.minecraft.world.Teleporter;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.server.ServerWorld;
 
@@ -56,19 +55,8 @@ public interface ITeleporter {
      * @param yaw              the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
      * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.dimension.DimensionType, ITeleporter)}
-     *
-     * @apiNote This method will not be called if the entity is a {@link ServerPlayerEntity} and {@link #specialEndReturn()} is true, and current world is the end, and destWorld is the overworld.
      */
     default Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
        return repositionEntity.apply(true);
-    }
-
-    /**
-     * Called to check if vanilla's special handling for teleporting a player from the end to the overworld should be used, when returning from the end.
-     *
-     * @return True to use vanilla's special handling on returning from the end, false otherwise.
-     */
-    default boolean specialEndReturn() {
-        return this instanceof Teleporter;
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -57,7 +57,7 @@ public interface ITeleporter {
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
      * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.dimension.DimensionType, ITeleporter)}
      *
-     * @apiNote This method will not be called if the entity is a {@link ServerPlayerEntity} and {@link #specialEndReturn()} is true.
+     * @apiNote This method will not be called if the entity is a {@link ServerPlayerEntity} and {@link #specialEndReturn()} is true, and current world is the end, and destWorld is the overworld.
      */
     default Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
        return repositionEntity.apply(true);

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.world.Teleporter;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.server.ServerWorld;
 
@@ -55,8 +56,19 @@ public interface ITeleporter {
      * @param yaw              the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
      * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.dimension.DimensionType, ITeleporter)}
+     *
+     * @apiNote This method will not be called if the entity is a {@link ServerPlayerEntity} and {@link #specialEndReturn()} is true.
      */
     default Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
        return repositionEntity.apply(true);
+    }
+
+    /**
+     * Called to check if vanilla's special handling for teleporting a player from the end to the overworld should be used, when returning from the end.
+     *
+     * @return True to use vanilla's special handling on returning from the end, false otherwise.
+     */
+    default boolean specialEndReturn() {
+        return this instanceof Teleporter;
     }
 }

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -56,15 +56,6 @@ public class CommandSetDimension
                 )
             );
     }
-
-    private static final ITeleporter PORTALLESS = new ITeleporter()
-    {
-        @Override
-        public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) 
-        {
-            return repositionEntity.apply(false);
-        }
-    };
     
     private static int execute(CommandSource sender, Collection<? extends Entity> entities, DimensionType dim, BlockPos pos) throws CommandSyntaxException
     {
@@ -76,7 +67,16 @@ public class CommandSetDimension
         //    throw INVALID_DIMENSION.create(dim);
 
         entities.stream().filter(e -> e.dimension == dim).forEach(e -> sender.sendFeedback(new TranslationTextComponent("commands.forge.setdim.invalid.nochange", e.getDisplayName().getFormattedText(), dim), true));
-        entities.stream().filter(e -> e.dimension != dim).forEach(e ->  e.changeDimension(dim, PORTALLESS));
+        entities.stream().filter(e -> e.dimension != dim).forEach(e ->  e.changeDimension(dim, new ITeleporter()
+        {
+            @Override
+            public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
+            {
+                Entity repositionedEntity = repositionEntity.apply(false);
+                repositionedEntity.setPositionAndUpdate(pos.getX(), pos.getY(), pos.getZ());
+                return repositionedEntity;
+            }
+        }));
 
         return 0;
     }


### PR DESCRIPTION
It seems the reimplementation of the `ITeleporter` interface in #6404 missed the case in `ServerPlayerEnttiy` where vanilla has specific code in place for teleporting from the end to the overworld. This PR adds a method similar to the one the 1.12 version of `ITeleporter` to determine if the vanilla code should be ran. Rather than calling it `isVanilla()` like it was in 1.12, I have named it `specialEndReturn()` (if anyone has a better name suggestion feel free to mention it). The reason I named it this is due to the new implementation of `ITeleporter` to allow more control/handling over how the teleportation actually happens it is only needed in this one place rather than having checks all over the place.

Additionally this PR fixes forge's `setdimension` command ignoring the position information.

Tested:
- Transitioning from the end to the overworld using vanilla's end portal
- Tested using forge's `setdimension` command going to the end from the overworld and back.