### PR TITLE
Add src/generated/.cache/ to mdk .gitignore

### DIFF
--- a/mdk/gitignore.txt
+++ b/mdk/gitignore.txt
@@ -23,3 +23,4 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+src/generated/.cache/


### PR DESCRIPTION
This Pull Request adds the `src/generated/.cache/` directory to the gitignore file.  
Even though the file is not present at first, it is generated during the first startup of the game.  
Ignoring it by default should prevent confusion about it's inclusion into git.  

This Forum Post prompted my submisson of this Pull Request:  
https://www.minecraftforge.net/forum/topic/80638-srcgenerated-folder-and-git  

