### PR TITLE
[1.15.2] Dynamic dimensions save/load option

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -8,12 +8,14 @@
  
     public PlayerList(MinecraftServer p_i50688_1_, int p_i50688_2_) {
        this.field_72400_f = p_i50688_1_;
-@@ -110,6 +111,14 @@
+@@ -109,7 +110,15 @@
+       String s = gameprofile1 == null ? gameprofile.getName() : gameprofile1.getName();
        playerprofilecache.func_152649_a(gameprofile);
        CompoundNBT compoundnbt = this.func_72380_a(p_72355_2_);
-       ServerWorld serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);
+-      ServerWorld serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);
 +
 +      //Forge: Make sure the dimension hasn't been deleted, if so stick them in the overworld.
++      ServerWorld serverworld = p_72355_2_.field_71093_bK != null ? this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK) : null ;
 +      if (serverworld == null) {
 +         p_72355_2_.field_71093_bK = DimensionType.field_223227_a_;
 +         serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -8,14 +8,12 @@
  
     public PlayerList(MinecraftServer p_i50688_1_, int p_i50688_2_) {
        this.field_72400_f = p_i50688_1_;
-@@ -109,7 +110,15 @@
-       String s = gameprofile1 == null ? gameprofile.getName() : gameprofile1.getName();
+@@ -110,6 +111,14 @@
        playerprofilecache.func_152649_a(gameprofile);
        CompoundNBT compoundnbt = this.func_72380_a(p_72355_2_);
--      ServerWorld serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);
+       ServerWorld serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);
 +
 +      //Forge: Make sure the dimension hasn't been deleted, if so stick them in the overworld.
-+      ServerWorld serverworld = p_72355_2_.field_71093_bK != null ? this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK) : null ;
 +      if (serverworld == null) {
 +         p_72355_2_.field_71093_bK = DimensionType.field_223227_a_;
 +         serverworld = this.field_72400_f.func_71218_a(p_72355_2_.field_71093_bK);

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -346,11 +346,16 @@ public class DimensionManager
     {
         data.putInt("version", 1);
         List<SavedEntry> list = new ArrayList<>();
-        for (DimensionType type : REGISTRY) {
-            if (type.getModType() == null) {
+        for (DimensionType type : REGISTRY)
+        {
+            if (type.getModType() == null)
+            {
                 list.add(new SavedEntry(type));
-            } else {
-                if (type.getModType().saveToLevelDat()) {
+            }
+            else
+            {
+                if (type.getModType().persistToLevelDat())
+                {
                     list.add(new SavedEntry(type));
                 }
             }
@@ -413,8 +418,10 @@ public class DimensionManager
                     continue;
                 }
 
-                if (mod.loadFromLevelDat()) registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-
+                if (mod.persistToLevelDat())
+                {
+                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
+                }
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -413,9 +413,7 @@ public class DimensionManager
                     continue;
                 }
 
-                if (mod.loadFromLevelDat()) {
-                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-                }
+                if (mod.loadFromLevelDat()) registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -413,7 +413,9 @@ public class DimensionManager
                     continue;
                 }
 
-                if (mod.loadFromLevelDat()) registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
+                if (mod.loadFromLevelDat()) {
+                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
+                }
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -347,10 +347,14 @@ public class DimensionManager
         data.putInt("version", 1);
         List<SavedEntry> list = new ArrayList<>();
         for (DimensionType type : REGISTRY) {
+
             if (type.getModType() == null){
+
                 list.add(new SavedEntry(type));
             }else{
+
                 if (type.getModType().saveToLevelDat()) {
+
                     list.add(new SavedEntry(type));
                 }
             }
@@ -412,10 +416,8 @@ public class DimensionManager
                     savedEntries.put(entry.name, entry);
                     continue;
                 }
-                if (mod.loadFromLevelDat()) {
-                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(
-                            Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-                }
+
+                if (mod.loadFromLevelDat()) registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -415,7 +415,8 @@ public class DimensionManager
                 if (mod.loadFromLevelDat()) {
                     registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(
                             Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-                } }
+                }
+            }
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -347,14 +347,10 @@ public class DimensionManager
         data.putInt("version", 1);
         List<SavedEntry> list = new ArrayList<>();
         for (DimensionType type : REGISTRY) {
-
-            if (type.getModType() == null){
-
+            if (type.getModType() == null) {
                 list.add(new SavedEntry(type));
-            }else{
-
+            } else {
                 if (type.getModType().saveToLevelDat()) {
-
                     list.add(new SavedEntry(type));
                 }
             }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -346,8 +346,15 @@ public class DimensionManager
     {
         data.putInt("version", 1);
         List<SavedEntry> list = new ArrayList<>();
-        for (DimensionType type : REGISTRY)
-            list.add(new SavedEntry(type));
+        for (DimensionType type : REGISTRY) {
+            if (type.getModType() == null){
+                list.add(new SavedEntry(type));
+            }else{
+                if (type.getModType().saveToLevelDat()) {
+                    list.add(new SavedEntry(type));
+                }
+            }
+        }
         savedEntries.values().forEach(list::add);
 
         Collections.sort(list, (a, b) -> a.id - b.id);
@@ -405,8 +412,10 @@ public class DimensionManager
                     savedEntries.put(entry.name, entry);
                     continue;
                 }
-                registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-            }
+                if (mod.loadFromLevelDat()) {
+                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(
+                            Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
+                } }
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -413,9 +413,8 @@ public class DimensionManager
                     continue;
                 }
 
-                if (mod.loadFromLevelDat()) {
-                    registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
-                }
+                if (mod.loadFromLevelDat()) registerDimensionInternal(entry.id, entry.name, mod, entry.data == null ? null : new PacketBuffer(Unpooled.wrappedBuffer(entry.data)), entry.skyLight());
+
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -41,7 +41,7 @@ public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
      * Stops the dimension from being saved to level.dat file.
      * Can be overridden for dynamic dimensions
      */
-    public boolean saveToLevelDat(){
+    public boolean saveToLevelDat() {
         return true;
     }
 
@@ -51,7 +51,7 @@ public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
      * Override for dynamic dimensions, if you don't want them loaded back from level.dat file
      * on every server restart.
      */
-    public boolean loadFromLevelDat(){
+    public boolean loadFromLevelDat() {
         return true;
     }
 

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -38,20 +38,11 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
 public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
 {
     /**
-     * Whether this dimension should be saved to the level.dat.
-     * If true, Forge will save the DimensionType and ModDimension to level.dat.
+     * Whether this dimension should be saved and loaded from the level.dat.
+     * If true, Forge will save the DimensionType and ModDimension to level.dat, then on next server boot, use that data to register it again.
      * For persistent dimensions, keep this true, but if you don't want the dimension to exist on next server boot, set to false.
      */
-    public boolean saveToLevelDat() {
-        return true;
-    }
-
-    /**
-     * Whether this dimension should be loaded from the level.dat.
-     * If true, Forge will automatically try to register this dimension from the level.dat on server boot.
-     * For persistent dimensions, keep this true, but if you don't want the dimension to exist on next server boot, set to false.
-     */
-    public boolean loadFromLevelDat() {
+    public boolean persistToLevelDat() {
         return true;
     }
 

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -38,23 +38,22 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
 public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
 {
     /**
-     * Stops the dimension from being saved to level.dat file.
-     * Can be overridden for dynamic dimensions
+     * Whether this dimension should be saved to the level.dat.
+     * If true, Forge will save the DimensionType and ModDimension to level.dat.
+     * For persistent dimensions, keep this true, but if you don't want the dimension to exist on next server boot, set to false.
      */
     public boolean saveToLevelDat() {
         return true;
     }
 
-
     /**
-     * Stops the dimension from being loaded from level.dat file.
-     * Override for dynamic dimensions, if you don't want them loaded back from level.dat file
-     * on every server restart.
+     * Whether this dimension should be loaded from the level.dat.
+     * If true, Forge will automatically try to register this dimension from the level.dat on server boot.
+     * For persistent dimensions, keep this true, but if you don't want the dimension to exist on next server boot, set to false.
      */
     public boolean loadFromLevelDat() {
         return true;
     }
-
 
     public abstract BiFunction<World, DimensionType, ? extends Dimension> getFactory();
 

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -37,6 +37,21 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
  */
 public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
 {
+    /**
+     * Stops the dimension from being saved to level.dat file.
+     * Can be overridden for dynamic dimensions
+     */
+    public boolean saveToLevelDat(){return true;}
+
+
+    /**
+     * Stops the dimension from being loaded from level.dat file.
+     * Override for dynamic dimensions, if you don't want them loaded back from level.dat file
+     * on every server restart.
+     */
+    public boolean loadFromLevelDat(){return true;}
+
+
     public abstract BiFunction<World, DimensionType, ? extends Dimension> getFactory();
 
     /**

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -41,7 +41,9 @@ public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
      * Stops the dimension from being saved to level.dat file.
      * Can be overridden for dynamic dimensions
      */
-    public boolean saveToLevelDat(){return true;}
+    public boolean saveToLevelDat(){
+        return true;
+    }
 
 
     /**
@@ -49,7 +51,9 @@ public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
      * Override for dynamic dimensions, if you don't want them loaded back from level.dat file
      * on every server restart.
      */
-    public boolean loadFromLevelDat(){return true;}
+    public boolean loadFromLevelDat(){
+        return true;
+    }
 
 
     public abstract BiFunction<World, DimensionType, ? extends Dimension> getFactory();


### PR DESCRIPTION
Gives option for ModDimensions whether to save themselves to disk and if they will be used to register Dimensions on server load. Fixes #6498

Edit: my bad, i didn't know pushing a commit will get it synced to this PR. That was supposed to be another PR.