### PR TITLE
Corrected typo in javadoc for RegistryEvent.NewRegistry

### DIFF
--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -41,7 +41,7 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
         super(clazz);
     }
     /**
-     * Register new registries when you receive this event, through the {@link RecipeBuilder}
+     * Register new registries when you receive this event, through the {@link RegistryBuilder}
      */
     public static class NewRegistry extends net.minecraftforge.eventbus.api.Event
     {


### PR DESCRIPTION
Referred to RecipeBuilder when it should refer to RegistryBuilder.