### PR TITLE
Add a way to create Music Discs without requiring a SoundEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -85,47 +85,29 @@
        if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p() == DimensionType.field_223229_c_) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
-@@ -1977,25 +1992,31 @@
+@@ -1977,7 +1992,12 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
--   public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_) {
--      ISound isound = this.field_147593_P.get(p_184377_2_);
 +   @Deprecated // Forge: use item aware function below
-+   public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_)
-+   {
+    public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_) {
 +      this.playRecord(p_184377_1_, p_184377_2_, p_184377_1_ == null? null : MusicDiscItem.func_185074_a(p_184377_1_));
 +   }
 +
-+   public void playRecord(@Nullable SoundEvent soundIn, BlockPos pos, @Nullable MusicDiscItem musicDiscItem) {
-+      ISound isound = this.field_147593_P.get(pos);
++   public void playRecord(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_, @Nullable MusicDiscItem musicDiscItem) {
+       ISound isound = this.field_147593_P.get(p_184377_2_);
        if (isound != null) {
           this.field_72777_q.func_147118_V().func_147683_b(isound);
--         this.field_147593_P.remove(p_184377_2_);
-+         this.field_147593_P.remove(pos);
+@@ -1985,7 +2005,7 @@
        }
  
--      if (p_184377_1_ != null) {
+       if (p_184377_1_ != null) {
 -         MusicDiscItem musicdiscitem = MusicDiscItem.func_185074_a(p_184377_1_);
-+      if (soundIn != null) {
 +         MusicDiscItem musicdiscitem = musicDiscItem;
           if (musicdiscitem != null) {
              this.field_72777_q.field_71456_v.func_73833_a(musicdiscitem.func_200299_h().func_150254_d());
           }
- 
--         ISound simplesound = SimpleSound.func_184372_a(p_184377_1_, (float)p_184377_2_.func_177958_n(), (float)p_184377_2_.func_177956_o(), (float)p_184377_2_.func_177952_p());
--         this.field_147593_P.put(p_184377_2_, simplesound);
-+         ISound simplesound = SimpleSound.func_184372_a(soundIn, (float)pos.func_177958_n(), (float)pos.func_177956_o(), (float)pos.func_177952_p());
-+         this.field_147593_P.put(pos, simplesound);
-          this.field_72777_q.func_147118_V().func_147682_a(simplesound);
-       }
- 
--      this.func_193054_a(this.field_72769_h, p_184377_2_, p_184377_1_ != null);
-+      this.func_193054_a(this.field_72769_h, pos, soundIn != null);
-    }
- 
-    private void func_193054_a(World p_193054_1_, BlockPos p_193054_2_, boolean p_193054_3_) {
-@@ -2133,7 +2154,7 @@
+@@ -2133,7 +2153,7 @@
           break;
        case 1010:
           if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
@@ -134,7 +116,7 @@
           } else {
              this.func_184377_a((SoundEvent)null, p_180439_3_);
           }
-@@ -2283,8 +2304,8 @@
+@@ -2283,8 +2303,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -145,7 +127,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2432,7 +2453,7 @@
+@@ -2432,7 +2452,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -154,7 +136,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2445,6 +2466,11 @@
+@@ -2445,6 +2465,11 @@
        return this.field_175015_z;
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -85,7 +85,56 @@
        if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p() == DimensionType.field_223229_c_) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
-@@ -2283,8 +2298,8 @@
+@@ -1977,25 +1992,31 @@
+       this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
+    }
+ 
+-   public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_) {
+-      ISound isound = this.field_147593_P.get(p_184377_2_);
++   @Deprecated // Forge: use item aware function below
++   public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_)
++   {
++      this.playRecord(p_184377_1_, p_184377_2_, p_184377_1_ == null? null : MusicDiscItem.func_185074_a(p_184377_1_));
++   }
++
++   public void playRecord(@Nullable SoundEvent soundIn, BlockPos pos, @Nullable MusicDiscItem musicDiscItem) {
++      ISound isound = this.field_147593_P.get(pos);
+       if (isound != null) {
+          this.field_72777_q.func_147118_V().func_147683_b(isound);
+-         this.field_147593_P.remove(p_184377_2_);
++         this.field_147593_P.remove(pos);
+       }
+ 
+-      if (p_184377_1_ != null) {
+-         MusicDiscItem musicdiscitem = MusicDiscItem.func_185074_a(p_184377_1_);
++      if (soundIn != null) {
++         MusicDiscItem musicdiscitem = musicDiscItem;
+          if (musicdiscitem != null) {
+             this.field_72777_q.field_71456_v.func_73833_a(musicdiscitem.func_200299_h().func_150254_d());
+          }
+ 
+-         ISound simplesound = SimpleSound.func_184372_a(p_184377_1_, (float)p_184377_2_.func_177958_n(), (float)p_184377_2_.func_177956_o(), (float)p_184377_2_.func_177952_p());
+-         this.field_147593_P.put(p_184377_2_, simplesound);
++         ISound simplesound = SimpleSound.func_184372_a(soundIn, (float)pos.func_177958_n(), (float)pos.func_177956_o(), (float)pos.func_177952_p());
++         this.field_147593_P.put(pos, simplesound);
+          this.field_72777_q.func_147118_V().func_147682_a(simplesound);
+       }
+ 
+-      this.func_193054_a(this.field_72769_h, p_184377_2_, p_184377_1_ != null);
++      this.func_193054_a(this.field_72769_h, pos, soundIn != null);
+    }
+ 
+    private void func_193054_a(World p_193054_1_, BlockPos p_193054_2_, boolean p_193054_3_) {
+@@ -2133,7 +2154,7 @@
+          break;
+       case 1010:
+          if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
+-            this.func_184377_a(((MusicDiscItem)Item.func_150899_d(p_180439_4_)).func_185075_h(), p_180439_3_);
++            this.playRecord(((MusicDiscItem)Item.func_150899_d(p_180439_4_)).func_185075_h(), p_180439_3_, (MusicDiscItem) Item.func_150899_d(p_180439_4_));
+          } else {
+             this.func_184377_a((SoundEvent)null, p_180439_3_);
+          }
+@@ -2283,8 +2304,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -96,7 +145,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2432,7 +2447,7 @@
+@@ -2432,7 +2453,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -105,7 +154,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2445,6 +2460,11 @@
+@@ -2445,6 +2466,11 @@
        return this.field_175015_z;
     }
  

--- a/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
@@ -1,11 +1,8 @@
 --- a/net/minecraft/item/MusicDiscItem.java
 +++ b/net/minecraft/item/MusicDiscItem.java
-@@ -21,15 +21,14 @@
- import net.minecraftforge.api.distmarker.OnlyIn;
- 
+@@ -23,13 +23,12 @@
  public class MusicDiscItem extends Item {
--   private static final Map<SoundEvent, MusicDiscItem> field_150928_b = Maps.newHashMap();
-+   private static final Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> field_150928_b = Maps.newHashMap();
+    private static final Map<SoundEvent, MusicDiscItem> field_150928_b = Maps.newHashMap();
     private final int field_195977_c;
 -   private final SoundEvent field_185076_b;
 +   private SoundEvent field_185076_b;
@@ -21,7 +18,7 @@
     }
  
     public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
-@@ -71,11 +70,36 @@
+@@ -71,11 +70,38 @@
     @Nullable
     @OnlyIn(Dist.CLIENT)
     public static MusicDiscItem func_185074_a(SoundEvent p_185074_0_) {
@@ -36,6 +33,8 @@
     }
 +
 +   // FORGE START
++   private static final Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> FORGE_RECORDS = Maps.newHashMap();
++
 +   /**
 +    * For mod use, allows to create a music disc without having to create a new
 +    * SoundEvent before their registry event is fired.
@@ -51,11 +50,11 @@
 +      super(builder);
 +      this.field_195977_c = comparatorValue;
 +      this.soundName = soundName;
-+      field_150928_b.put(soundName, this.delegate);
++      getRecordsMap().put(soundName, this.delegate);
 +   }
 +
 +   public static Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> getRecordsMap()
 +   {
-+      return field_150928_b;
++      return FORGE_RECORDS;
 +   }
  }

--- a/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
@@ -1,60 +1,52 @@
 --- a/net/minecraft/item/MusicDiscItem.java
 +++ b/net/minecraft/item/MusicDiscItem.java
-@@ -23,13 +23,12 @@
+@@ -21,17 +21,41 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
  public class MusicDiscItem extends Item {
++   @Deprecated // Forge: refer to WorldRender#playRecord. Modders: there's no need to reflectively modify this map!
     private static final Map<SoundEvent, MusicDiscItem> field_150928_b = Maps.newHashMap();
     private final int field_195977_c;
--   private final SoundEvent field_185076_b;
-+   private SoundEvent field_185076_b;
-+   private final net.minecraft.util.ResourceLocation soundName;
++   @Deprecated // Forge: refer to soundSupplier
+    private final SoundEvent field_185076_b;
++   private final java.util.function.Supplier<SoundEvent> soundSupplier;
  
-+   @Deprecated // mods should use the constructor below
++   // Forge: Use the constructor that takes a supplier instead
++   @Deprecated
     protected MusicDiscItem(int p_i48475_1_, SoundEvent p_i48475_2_, Item.Properties p_i48475_3_) {
--      super(p_i48475_3_);
--      this.field_195977_c = p_i48475_1_;
--      this.field_185076_b = p_i48475_2_;
--      field_150928_b.put(this.field_185076_b, this);
-+      this(p_i48475_1_, java.util.Objects.requireNonNull(p_i48475_2_.getRegistryName()), p_i48475_3_);
+       super(p_i48475_3_);
+       this.field_195977_c = p_i48475_1_;
+       this.field_185076_b = p_i48475_2_;
+       field_150928_b.put(this.field_185076_b, this);
++      this.soundSupplier = this.field_185076_b.delegate;
     }
  
-    public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
-@@ -71,11 +70,38 @@
-    @Nullable
-    @OnlyIn(Dist.CLIENT)
-    public static MusicDiscItem func_185074_a(SoundEvent p_185074_0_) {
--      return field_150928_b.get(p_185074_0_);
-+      return getRecordsMap().get(p_185074_0_.getRegistryName()).get() instanceof MusicDiscItem ? ((MusicDiscItem) getRecordsMap().get(p_185074_0_.getRegistryName()).get()) : null;
-    }
- 
-    @OnlyIn(Dist.CLIENT)
-    public SoundEvent func_185075_h() {
-+      if (this.field_185076_b == null) this.field_185076_b = net.minecraftforge.registries.ForgeRegistries.SOUND_EVENTS.getValue(this.soundName);
-       return this.field_185076_b;
-    }
-+
-+   // FORGE START
-+   private static final Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> FORGE_RECORDS = Maps.newHashMap();
-+
 +   /**
 +    * For mod use, allows to create a music disc without having to create a new
 +    * SoundEvent before their registry event is fired.
 +    *
-+    * @param comparatorValue
-+    *       The value this music disc should output on the comparator. Must be between 0 and 15.
-+    * @param soundName
-+    *       The resource location that identifies the SoundEvent to play with this music disc.
-+    * @param builder
++    * @param comparatorValue The value this music disc should output on the comparator. Must be between 0 and 15.
++    * @param soundSupplier A supplier that provides the sound that should be played. Use a
++    *                      {@link net.minecraftforge.fml.RegistryObject}{@code <SoundEvent>} or a
++    *                      {@link net.minecraftforge.registries.IRegistryDelegate} for this parameter.
++    * @param builder A set of {@link Item.Properties} that describe this item.
 +    */
-+   public MusicDiscItem(int comparatorValue, net.minecraft.util.ResourceLocation soundName, Item.Properties builder)
++   public MusicDiscItem(int comparatorValue, java.util.function.Supplier<SoundEvent> soundSupplier, Item.Properties builder)
 +   {
 +      super(builder);
 +      this.field_195977_c = comparatorValue;
-+      this.soundName = soundName;
-+      getRecordsMap().put(soundName, this.delegate);
++      this.field_185076_b = null;
++      this.soundSupplier = soundSupplier;
 +   }
 +
-+   public static Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> getRecordsMap()
-+   {
-+      return FORGE_RECORDS;
-+   }
+    public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
+       World world = p_195939_1_.func_195991_k();
+       BlockPos blockpos = p_195939_1_.func_195995_a();
+@@ -76,6 +100,6 @@
+ 
+    @OnlyIn(Dist.CLIENT)
+    public SoundEvent func_185075_h() {
+-      return this.field_185076_b;
++      return this.soundSupplier.get();
+    }
  }

--- a/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
@@ -1,0 +1,61 @@
+--- a/net/minecraft/item/MusicDiscItem.java
++++ b/net/minecraft/item/MusicDiscItem.java
+@@ -21,15 +21,14 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ public class MusicDiscItem extends Item {
+-   private static final Map<SoundEvent, MusicDiscItem> field_150928_b = Maps.newHashMap();
++   private static final Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> field_150928_b = Maps.newHashMap();
+    private final int field_195977_c;
+-   private final SoundEvent field_185076_b;
++   private SoundEvent field_185076_b;
++   private final net.minecraft.util.ResourceLocation soundName;
+ 
++   @Deprecated // mods should use the constructor below
+    protected MusicDiscItem(int p_i48475_1_, SoundEvent p_i48475_2_, Item.Properties p_i48475_3_) {
+-      super(p_i48475_3_);
+-      this.field_195977_c = p_i48475_1_;
+-      this.field_185076_b = p_i48475_2_;
+-      field_150928_b.put(this.field_185076_b, this);
++      this(p_i48475_1_, java.util.Objects.requireNonNull(p_i48475_2_.getRegistryName()), p_i48475_3_);
+    }
+ 
+    public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
+@@ -71,11 +70,36 @@
+    @Nullable
+    @OnlyIn(Dist.CLIENT)
+    public static MusicDiscItem func_185074_a(SoundEvent p_185074_0_) {
+-      return field_150928_b.get(p_185074_0_);
++      return getRecordsMap().get(p_185074_0_.getRegistryName()).get() instanceof MusicDiscItem ? ((MusicDiscItem) getRecordsMap().get(p_185074_0_.getRegistryName()).get()) : null;
+    }
+ 
+    @OnlyIn(Dist.CLIENT)
+    public SoundEvent func_185075_h() {
++      if (this.field_185076_b == null) this.field_185076_b = net.minecraftforge.registries.ForgeRegistries.SOUND_EVENTS.getValue(this.soundName);
+       return this.field_185076_b;
+    }
++
++   // FORGE START
++   /**
++    * For mod use, allows to create a music disc without having to create a new
++    * SoundEvent before their registry event is fired.
++    *
++    * @param comparatorValue
++    *       The value this music disc should output on the comparator. Must be between 0 and 15.
++    * @param soundName
++    *       The resource location that identifies the SoundEvent to play with this music disc.
++    * @param builder
++    */
++   public MusicDiscItem(int comparatorValue, net.minecraft.util.ResourceLocation soundName, Item.Properties builder)
++   {
++      super(builder);
++      this.field_195977_c = comparatorValue;
++      this.soundName = soundName;
++      field_150928_b.put(soundName, this.delegate);
++   }
++
++   public static Map<net.minecraft.util.ResourceLocation, net.minecraftforge.registries.IRegistryDelegate<Item>> getRecordsMap()
++   {
++      return field_150928_b;
++   }
+ }

--- a/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/item/MusicDiscItem.java
 +++ b/net/minecraft/item/MusicDiscItem.java
-@@ -21,17 +21,41 @@
+@@ -21,17 +21,40 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  
  public class MusicDiscItem extends Item {
@@ -11,8 +11,7 @@
     private final SoundEvent field_185076_b;
 +   private final java.util.function.Supplier<SoundEvent> soundSupplier;
  
-+   // Forge: Use the constructor that takes a supplier instead
-+   @Deprecated
++   @Deprecated // Forge: Use the constructor that takes a supplier instead
     protected MusicDiscItem(int p_i48475_1_, SoundEvent p_i48475_2_, Item.Properties p_i48475_3_) {
        super(p_i48475_3_);
        this.field_195977_c = p_i48475_1_;
@@ -42,7 +41,7 @@
     public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
        World world = p_195939_1_.func_195991_k();
        BlockPos blockpos = p_195939_1_.func_195995_a();
-@@ -76,6 +100,6 @@
+@@ -76,6 +99,6 @@
  
     @OnlyIn(Dist.CLIENT)
     public SoundEvent func_185075_h() {

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -120,10 +120,3 @@ net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/s
 net/minecraft/world/storage/loot/LootEntryItem.<init>(Lnet/minecraft/item/Item;II[Lnet/minecraft/world/storage/loot/functions/LootFunction;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46644_1_,p_i46644_2_,p_i46644_3_,p_i46644_4_,p_i46644_5_,entryName
 net/minecraft/world/storage/loot/LootEntryTable.<init>(Lnet/minecraft/util/ResourceLocation;II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46639_1_,p_i46639_2_,p_i46639_3_,p_i46639_4_,entryName
 net/minecraft/world/storage/loot/LootPool.<init>([Lnet/minecraft/world/storage/loot/LootEntry;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Lnet/minecraft/world/storage/loot/RandomValueRange;Lnet/minecraft/world/storage/loot/RandomValueRange;Ljava/lang/String;)V=|p_i46643_1_,p_i46643_2_,p_i46643_3_,p_i46643_4_
-<<<<<<< HEAD
-=======
-
-net/minecraft/util/math/shapes/EntitySelectionContext.<init>(Lnet/minecraft/entity/Entity;ZDLnet/minecraft/item/Item;)V=|entityIn,p_i51181_1_,p_i51181_2_,p_i51181_4_
-
-net/minecraft/item/BoneMealItem.applyBonemeal(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)Z=|p_195966_0_,p_195966_1_,p_195966_2_,player
->>>>>>> 39c10b66b... Reduced patch size

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -23,6 +23,8 @@ net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkRender$SortTransp
 
 net/minecraft/client/renderer/entity/layers/ArmorLayer.renderArmor(Lcom/mojang/blaze3d/matrix/MatrixStack;Lnet/minecraft/client/renderer/IRenderTypeBuffer;IZLnet/minecraft/client/renderer/entity/model/BipedModel;FFFLnet/minecraft/util/ResourceLocation;)V=|p_229128_1_,p_229128_2_,p_229128_3_,p_229128_5_,p_229128_6_,p_229128_8_,p_229128_9_,p_229128_10_,armorResource
 
+net/minecraft/client/renderer/WorldRenderer.playRecord(Lnet/minecraft/util/SoundEvent;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/item/MusicDiscItem;)V=|p_184377_1_,p_184377_2_,musicDiscItem
+
 net/minecraft/client/renderer/model/BakedQuad.<init>([IILnet/minecraft/util/Direction;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;Z)V=|p_i46574_1_,p_i46574_2_,p_i46574_3_,p_i46574_4_,applyDiffuseLighting
 net/minecraft/client/renderer/model/BlockModel.bake(Lnet/minecraft/client/renderer/model/ModelBakery;Lnet/minecraft/client/renderer/model/BlockModel;Ljava/util/function/Function;Lnet/minecraft/client/renderer/texture/IModelTransform;Lnet/minecraft/client/renderer/vertex/VertexFormat;)Lnet/minecraft/client/renderer/model/IBakedModel;=|p_217644_1_,p_217644_2_,p_217644_3_,p_217644_4_,format
 net/minecraft/client/renderer/model/BlockModel.bakeVanilla(Lnet/minecraft/client/renderer/model/ModelBakery;Lnet/minecraft/client/renderer/model/BlockModel;Ljava/util/function/Function;Lnet/minecraft/client/renderer/model/IModelTransform;Lnet/minecraft/util/ResourceLocation;Z)Lnet/minecraft/client/renderer/model/IBakedModel;=|p_228813_1_,p_228813_2_,p_228813_3_,p_228813_4_,p_228813_5_,p_228813_6_
@@ -118,3 +120,10 @@ net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/s
 net/minecraft/world/storage/loot/LootEntryItem.<init>(Lnet/minecraft/item/Item;II[Lnet/minecraft/world/storage/loot/functions/LootFunction;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46644_1_,p_i46644_2_,p_i46644_3_,p_i46644_4_,p_i46644_5_,entryName
 net/minecraft/world/storage/loot/LootEntryTable.<init>(Lnet/minecraft/util/ResourceLocation;II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46639_1_,p_i46639_2_,p_i46639_3_,p_i46639_4_,entryName
 net/minecraft/world/storage/loot/LootPool.<init>([Lnet/minecraft/world/storage/loot/LootEntry;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Lnet/minecraft/world/storage/loot/RandomValueRange;Lnet/minecraft/world/storage/loot/RandomValueRange;Ljava/lang/String;)V=|p_i46643_1_,p_i46643_2_,p_i46643_3_,p_i46643_4_
+<<<<<<< HEAD
+=======
+
+net/minecraft/util/math/shapes/EntitySelectionContext.<init>(Lnet/minecraft/entity/Entity;ZDLnet/minecraft/item/Item;)V=|entityIn,p_i51181_1_,p_i51181_2_,p_i51181_4_
+
+net/minecraft/item/BoneMealItem.applyBonemeal(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)Z=|p_195966_0_,p_195966_1_,p_195966_2_,player
+>>>>>>> 39c10b66b... Reduced patch size

--- a/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.item.Item;

--- a/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
@@ -21,16 +21,16 @@ public class MusicDiscTest
     private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MOD_ID);
     private static final DeferredRegister<SoundEvent> SOUND_EVENTS = new DeferredRegister<>(ForgeRegistries.SOUND_EVENTS, MOD_ID);
 
+    private static final RegistryObject<SoundEvent> TEST_SOUND_EVENT = SOUND_EVENTS.register("test_sound_event",
+            () -> new SoundEvent(new ResourceLocation(MOD_ID, "test_sound_event")));
+
+    private static final RegistryObject<Item> TEST_MUSIC_DISC = ITEMS.register("test_music_disc",
+            () -> new MusicDiscItem(1, TEST_SOUND_EVENT, new Item.Properties().maxStackSize(1).rarity(Rarity.EPIC)));
+
     public MusicDiscTest()
     {
         final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
         ITEMS.register(modBus);
         SOUND_EVENTS.register(modBus);
-    }
-
-    static
-    {
-        final RegistryObject<SoundEvent> testEvent = SOUND_EVENTS.register("test_sound_event", () -> new SoundEvent(new ResourceLocation(MOD_ID, "test_sound_event")));
-        ITEMS.register("test_music_disc", () -> new MusicDiscItem(1, testEvent, new Item.Properties().maxStackSize(1).rarity(Rarity.EPIC)));
     }
 }

--- a/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.MusicDiscItem;
+import net.minecraft.item.Rarity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod(MusicDiscTest.MOD_ID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = MusicDiscTest.MOD_ID)
+public class MusicDiscTest
+{
+    static final String MOD_ID = "music_disc_test";
+
+    private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MOD_ID);
+    private static final DeferredRegister<SoundEvent> SOUND_EVENTS = new DeferredRegister<>(ForgeRegistries.SOUND_EVENTS, MOD_ID);
+
+    static {
+        ITEMS.register("test_music_disc", () -> new MusicDiscItem(1, new ResourceLocation(MOD_ID, "test_sound_event"), new Item.Properties().maxStackSize(1).rarity(Rarity.EPIC)));
+        SOUND_EVENTS.register("test_sound_event", () -> new SoundEvent(new ResourceLocation(MOD_ID, "test_sound_event")));
+    }
+
+    public MusicDiscTest() {
+        final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ITEMS.register(modBus);
+        SOUND_EVENTS.register(modBus);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
@@ -6,6 +6,7 @@ import net.minecraft.item.Rarity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
@@ -20,14 +21,16 @@ public class MusicDiscTest
     private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MOD_ID);
     private static final DeferredRegister<SoundEvent> SOUND_EVENTS = new DeferredRegister<>(ForgeRegistries.SOUND_EVENTS, MOD_ID);
 
-    static {
-        ITEMS.register("test_music_disc", () -> new MusicDiscItem(1, new ResourceLocation(MOD_ID, "test_sound_event"), new Item.Properties().maxStackSize(1).rarity(Rarity.EPIC)));
-        SOUND_EVENTS.register("test_sound_event", () -> new SoundEvent(new ResourceLocation(MOD_ID, "test_sound_event")));
-    }
-
-    public MusicDiscTest() {
+    public MusicDiscTest()
+    {
         final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
         ITEMS.register(modBus);
         SOUND_EVENTS.register(modBus);
+    }
+
+    static
+    {
+        final RegistryObject<SoundEvent> testEvent = SOUND_EVENTS.register("test_sound_event", () -> new SoundEvent(new ResourceLocation(MOD_ID, "test_sound_event")));
+        ITEMS.register("test_music_disc", () -> new MusicDiscItem(1, testEvent, new Item.Properties().maxStackSize(1).rarity(Rarity.EPIC)));
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -65,6 +65,8 @@ loaderVersion="[28,)"
     modId="custom_plant_type_test"
 [[mods]]
     modId="chunk_data_event_save_null_world_test"
+[[mods]]
+    modId="music_disc_test"
 [[dependencies.global_loot_test]]
     modId="forge"
     mandatory=true

--- a/src/test/resources/assets/music_disc_test/lang/en_us.json
+++ b/src/test/resources/assets/music_disc_test/lang/en_us.json
@@ -1,4 +1,4 @@
 {
   "item.music_disc_test.test_music_disc": "Music Disc",
-  "item.music_disc_test.test_music_disc.desc": "Kevin MacLeod - The Ice Giants (first 10 seconds)"
+  "item.music_disc_test.test_music_disc.desc": "Nuance 2 Ambient Music"
 }

--- a/src/test/resources/assets/music_disc_test/lang/en_us.json
+++ b/src/test/resources/assets/music_disc_test/lang/en_us.json
@@ -1,4 +1,4 @@
 {
   "item.music_disc_test.test_music_disc": "Music Disc",
-  "item.music_disc_test.test_music_disc.desc": "The Ice Giants - Kevin MacLeod (first 10 seconds)"
+  "item.music_disc_test.test_music_disc.desc": "Kevin MacLeod - The Ice Giants (first 10 seconds)"
 }

--- a/src/test/resources/assets/music_disc_test/lang/en_us.json
+++ b/src/test/resources/assets/music_disc_test/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "item.music_disc_test.test_music_disc": "Music Disc",
+  "item.music_disc_test.test_music_disc.desc": "The Ice Giants - Kevin MacLeod (first 10 seconds)"
+}

--- a/src/test/resources/assets/music_disc_test/models/item/test_music_disc.json
+++ b/src/test/resources/assets/music_disc_test/models/item/test_music_disc.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "item/music_disc_13"
+  }
+}

--- a/src/test/resources/assets/music_disc_test/sounds.json
+++ b/src/test/resources/assets/music_disc_test/sounds.json
@@ -2,11 +2,8 @@
   "test_sound_event": {
     "sounds": [
       {
-        "name": "music_disc_test:example_ogg",
-        "stream": true,
-        "__content": "First 10 seconds of 'The Ice Giants' by Kevin MacLeod",
-        "__link": "https://incompetech.filmmusic.io/song/5745-the-ice-giants",
-        "__license": "http://creativecommons.org/licenses/by/4.0/"
+        "name": "minecraft:music/game/nuance2",
+        "stream": true
       }
     ]
   }

--- a/src/test/resources/assets/music_disc_test/sounds.json
+++ b/src/test/resources/assets/music_disc_test/sounds.json
@@ -1,0 +1,13 @@
+{
+  "test_sound_event": {
+    "sounds": [
+      {
+        "name": "music_disc_test:example_ogg",
+        "stream": true,
+        "__content": "First 10 seconds of 'The Ice Giants' by Kevin MacLeod",
+        "__link": "https://incompetech.filmmusic.io/song/5745-the-ice-giants",
+        "__license": "http://creativecommons.org/licenses/by/4.0/"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Abstract
Creating a `MusicDiscItem` requires the user to supply a `SoundEvent`, which is a `ForgeRegistryEntry`. For this reason, these entries should only be created and registered in their `RegistryEvent.Register`. In this case, though, the registry event for `SoundEvent`s fires after the one for `Item`s, making it effectively impossible to create a `MusicDiscItem`.

### The Changes
What this PR does is change this requirement so that the user can use a `Supplier<SoundEvent>`, so that the actual `SoundEvent` can be retrieved and loaded as needed. Vanilla has also been patched to account for this behavior.
Additionally, `WorldRenderer` has been patched not to be stupid, rendering the `RECORDS` map effectively useless, since the look up is now performed only if the two-parameter version of `playRecord` is called with a non-`null` `SoundEvent`, which vanilla doesn't call anymore. In fact, the `MusicDiscItem` that vanilla retrieves from `playEvent` isn't discarded anymore, but it's passed to Forge's three-parameter version.
This PR also provides a test mod that demonstrates the usage of the newly added hook.