### PR TITLE
Add missing localization for attributes

### DIFF
--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -148,5 +148,6 @@
   "forge.controlsgui.alt": "ALT + %s",
 
   "forge.container.enchant.limitedEnchantability": "Limited Enchantability",
+  "attribute.name.generic.reachDistance": "Reach Distance",
   "attribute.name.forge.swimSpeed": "Swim Speed"
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -147,5 +147,6 @@
   "forge.controlsgui.control.mac": "CMD + %s",
   "forge.controlsgui.alt": "ALT + %s",
 
-  "forge.container.enchant.limitedEnchantability": "Limited Enchantability"
+  "forge.container.enchant.limitedEnchantability": "Limited Enchantability",
+  "attribute.name.forge.swimSpeed": "Swim Speed"
 }


### PR DESCRIPTION
### Issue Description
The localization for the swim speed attribute added by Forge is currently missing in the `en_us.json` file. This localization is present in the [old `en_us.lang` file](https://github.com/MinecraftForge/MinecraftForge/blob/1.14.x/src/main/resources/assets/forge/lang/en_us.lang) but didn't get moved to the new json system.

When the Swim Speed attribute is currently put on an item, this results in this:
![swim_attribute_localization_missing](https://user-images.githubusercontent.com/5775267/75222868-7c02cc80-57a5-11ea-99bd-8861ec7cf09a.png).

### Changes
This pull request simply adds this single localization to the `en_us.json` file.

### Notes
I don't know how this change will affect the translation into other languages at [crowdin](https://crowdin.com/project/minecraft-forge). Is the new line added automatically or will it require some manual intervention?
