### PR TITLE
[1.14.x] Make MultiModel pass its extra model data down to its parts

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -196,11 +196,11 @@ public final class MultiModel implements IUnbakedModel
             ImmutableList.Builder<BakedQuad> quads = ImmutableList.builder();
             if (base != null)
             {
-                quads.addAll(base.getQuads(state, side, rand));
+                quads.addAll(base.getQuads(state, side, rand, extraData));
             }
             for (IBakedModel bakedPart : parts.values())
             {
-                quads.addAll(bakedPart.getQuads(state, side, rand));
+                quads.addAll(bakedPart.getQuads(state, side, rand, extraData));
             }
             return quads.build();
         }

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -42,6 +42,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.client.model.data.EmptyModelData;
+import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 
@@ -52,7 +54,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 // TODO: Switch to vanilla class, or to something similar
@@ -187,6 +188,11 @@ public final class MultiModel implements IUnbakedModel
         @Override
         public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand)
         {
+            return getQuads(state, side, rand, EmptyModelData.INSTANCE);
+        }
+
+        @Override
+        public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, IModelData extraData) {
             ImmutableList.Builder<BakedQuad> quads = ImmutableList.builder();
             if (base != null)
             {


### PR DESCRIPTION
This was implemented in several other model loaders, but never this one, even though it is still in use in 1.14.

My use case is a composite model with a dynamic model part that uses model data.

[Comparable change in `MultiLayerModel`](https://github.com/MinecraftForge/MinecraftForge/commit/fc189c9aafd9b9db7ebd19d348b58b7d8eaaaca5#diff-67d7802b8bffc62b50cd0d1808413ed1L150-L165)