### PR TITLE
Add projection matrix to RenderWorldLastEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -40,7 +40,7 @@
        p_228378_4_.func_227863_a_(Vector3f.field_229181_d_.func_229187_a_(activerenderinfo.func_216778_f() + 180.0F));
        this.field_78531_r.field_71438_f.func_228426_a_(p_228378_4_, p_228378_1_, p_228378_2_, flag, activerenderinfo, this, this.field_78513_d, matrix4f);
 +      this.field_78531_r.func_213239_aq().func_219895_b("forge_render_last");
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_2_);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_2_, matrix4f);
        this.field_78531_r.func_213239_aq().func_219895_b("hand");
        if (this.field_175074_C) {
           RenderSystem.clear(256, Minecraft.field_142025_a);

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -40,7 +40,7 @@
        p_228378_4_.func_227863_a_(Vector3f.field_229181_d_.func_229187_a_(activerenderinfo.func_216778_f() + 180.0F));
        this.field_78531_r.field_71438_f.func_228426_a_(p_228378_4_, p_228378_1_, p_228378_2_, flag, activerenderinfo, this, this.field_78513_d, matrix4f);
 +      this.field_78531_r.func_213239_aq().func_219895_b("forge_render_last");
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_2_, matrix4f);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_1_, matrix4f, p_228378_2_);
        this.field_78531_r.func_213239_aq().func_219895_b("hand");
        if (this.field_175074_C) {
           RenderSystem.clear(256, Minecraft.field_142025_a);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -172,9 +172,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent(context, info, target, partialTicks, matrix, buffers));
     }
 
-    public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks)
+    public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix)
     {
-        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks));
+        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix));
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -172,6 +172,12 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent(context, info, target, partialTicks, matrix, buffers));
     }
 
+    @Deprecated // TODO: Remove in 1.16
+    public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks));
+    }
+
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -172,9 +172,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent(context, info, target, partialTicks, matrix, buffers));
     }
 
-    public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix)
+    public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
-        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix));
+        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 
+import net.minecraft.client.renderer.Matrix4f;
 import net.minecraft.client.renderer.WorldRenderer;
 
 public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
@@ -28,11 +29,13 @@ public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
     private final WorldRenderer context;
     private final MatrixStack mat;
     private final float partialTicks;
-    public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks)
+    private final Matrix4f projectionMatrix;
+    public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix)
     {
         this.context = context;
         this.mat = mat;
         this.partialTicks = partialTicks;
+        this.projectionMatrix = projectionMatrix;
     }
 
     public WorldRenderer getContext()
@@ -48,5 +51,10 @@ public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
     public float getPartialTicks()
     {
         return partialTicks;
+    }
+
+    public Matrix4f getProjectionMatrix()
+    {
+        return projectionMatrix;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -32,6 +32,16 @@ public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
     private final Matrix4f projectionMatrix;
     private final long finishTimeNano;
 
+    @Deprecated // TODO: Remove in 1.16
+    public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks)
+    {
+        this.context = context;
+        this.mat = mat;
+        this.partialTicks = partialTicks;
+        this.projectionMatrix = null;
+        this.finishTimeNano = 0;
+    }
+
     public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         this.context = context;

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -30,12 +30,15 @@ public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
     private final MatrixStack mat;
     private final float partialTicks;
     private final Matrix4f projectionMatrix;
-    public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix)
+    private final long finishTimeNano;
+
+    public RenderWorldLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         this.context = context;
         this.mat = mat;
         this.partialTicks = partialTicks;
         this.projectionMatrix = projectionMatrix;
+        this.finishTimeNano = finishTimeNano;
     }
 
     public WorldRenderer getContext()
@@ -56,5 +59,10 @@ public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
     public Matrix4f getProjectionMatrix()
     {
         return projectionMatrix;
+    }
+
+    public long getFinishTimeNano()
+    {
+        return finishTimeNano;
     }
 }


### PR DESCRIPTION
In our mod, we need to render structures during RenderWorldLastEvent. Those structures can go big (even far beyond render distance) so to reduce the load in the client thread we are aiming to mimic optimization used in vanilla code as much as possible.
This matrix is used for ClippingHelperImpl class and is passed into WorldRenderer from GameRenderer, it's a local variable and not stored anywhere.

EDIT: fixed partialTicks (finishTimeNano was passed in instead), added finishTimeNano