### PR TITLE
Supply matrixstack to IRenderHandler where possible. Closes #6439

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -73,19 +73,39 @@
              IVertexBuilder ivertexbuilder2 = irendertypebuffer$impl.getBuffer(RenderType.func_228659_m_());
              this.func_228429_a_(p_228426_1_, ivertexbuilder2, p_228426_6_.func_216773_g(), d0, d1, d2, blockpos, blockstate);
           }
-@@ -1380,6 +1390,11 @@
+@@ -1380,6 +1390,15 @@
     }
  
     public void func_228424_a_(MatrixStack p_228424_1_, float p_228424_2_) {
 +      net.minecraftforge.client.IRenderHandler renderer = this.field_72769_h.func_201675_m().getSkyRenderer();
 +      if (renderer != null) {
-+         renderer.render(this.field_72773_u, p_228424_2_, this.field_72769_h, this.field_72777_q);
++         if (renderer instanceof net.minecraftforge.client.SkyRenderHandler) {
++            ((net.minecraftforge.client.SkyRenderHandler) renderer).render(this.field_72773_u, p_228424_2_, p_228424_1_, this.field_72769_h, this.field_72777_q);
++         } else {
++            renderer.render(this.field_72773_u, p_228424_2_, this.field_72769_h, this.field_72777_q);
++         }
 +         return;
 +      }
        if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p() == DimensionType.field_223229_c_) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
-@@ -1977,7 +1992,12 @@
+@@ -1508,6 +1527,15 @@
+    }
+ 
+    public void func_228425_a_(MatrixStack p_228425_1_, float p_228425_2_, double p_228425_3_, double p_228425_5_, double p_228425_7_) {
++      net.minecraftforge.client.IRenderHandler renderer = this.field_72769_h.func_201675_m().getCloudRenderer();
++      if (renderer != null) {
++         if (renderer instanceof net.minecraftforge.client.CloudRenderHandler) {
++            ((net.minecraftforge.client.CloudRenderHandler) renderer).render(this.field_72773_u, p_228425_2_, p_228425_1_, this.field_72769_h, this.field_72777_q);
++         } else {
++            renderer.render(this.field_72773_u, p_228425_2_, this.field_72769_h, this.field_72777_q);
++         }
++         return;
++      }
+       if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
+          RenderSystem.disableCull();
+          RenderSystem.enableBlend();
+@@ -1977,7 +2005,12 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
@@ -98,7 +118,7 @@
        ISound isound = this.field_147593_P.get(p_184377_2_);
        if (isound != null) {
           this.field_72777_q.func_147118_V().func_147683_b(isound);
-@@ -1985,7 +2005,7 @@
+@@ -1985,7 +2018,7 @@
        }
  
        if (p_184377_1_ != null) {
@@ -107,7 +127,7 @@
           if (musicdiscitem != null) {
              this.field_72777_q.field_71456_v.func_73833_a(musicdiscitem.func_200299_h().func_150254_d());
           }
-@@ -2133,7 +2153,7 @@
+@@ -2133,7 +2166,7 @@
           break;
        case 1010:
           if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
@@ -116,7 +136,7 @@
           } else {
              this.func_184377_a((SoundEvent)null, p_180439_3_);
           }
-@@ -2283,8 +2303,8 @@
+@@ -2283,8 +2316,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -127,7 +147,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2432,7 +2452,7 @@
+@@ -2432,7 +2465,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -136,7 +156,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2445,6 +2465,11 @@
+@@ -2445,6 +2478,11 @@
        return this.field_175015_z;
     }
  

--- a/src/main/java/net/minecraftforge/client/CloudRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/CloudRenderHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.world.ClientWorld;
+
+/**
+ * Call {@link net.minecraft.world.dimension.Dimension#setCloudRenderer} with an implementation of this
+ * to override all cloud rendering with your own.
+ */
+public interface CloudRenderHandler extends IRenderHandler {
+	@Override
+	default void render(int ticks, float partialTicks, ClientWorld world, Minecraft mc) {}
+
+	void render(int ticks, float partialTicks, MatrixStack matrixStack, ClientWorld world, Minecraft mc);
+}

--- a/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.world.ClientWorld;
+
+/**
+ * Call {@link net.minecraft.world.dimension.Dimension#setSkyRenderer} with an implementation of this
+ * to override all sky rendering with your own. This includes the sun, moon, stars, and sky-coloring.
+ */
+public interface SkyRenderHandler extends IRenderHandler {
+	@Override
+	default void render(int ticks, float partialTicks, ClientWorld world, Minecraft mc) {}
+
+	void render(int ticks, float partialTicks, MatrixStack matrixStack, ClientWorld world, Minecraft mc);
+
+}

--- a/src/main/java/net/minecraftforge/client/WeatherRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/WeatherRenderHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+/**
+ * Call {@link net.minecraft.world.dimension.Dimension#setWeatherRenderer} with an implementation of this
+ * to override all weather rendering with your own. This includes rain and snow.
+ */
+public interface WeatherRenderHandler extends IRenderHandler {
+}


### PR DESCRIPTION
Sky renderhandlers are completely useless currently because you don't have the matrix stack representing the current transform.

This isn't very clean and I'd rather just blow up irenderhandler and split it up, but an RB has already been released, so hacks it is.