### PR TITLE
Defer writing the server.properties file until after mods have loaded

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -172,20 +172,16 @@
  
        try {
           OptionSet optionset = optionparser.parse(p_main_0_);
-@@ -888,10 +913,11 @@
+@@ -888,7 +913,7 @@
  
           Path path = Paths.get("server.properties");
           ServerPropertiesProvider serverpropertiesprovider = new ServerPropertiesProvider(path);
 -         serverpropertiesprovider.func_219035_b();
-+         if (!Files.exists(path)) serverpropertiesprovider.func_219035_b();
++         if (optionset.has(optionspec1) || !Files.exists(path)) serverpropertiesprovider.func_219035_b();
           Path path1 = Paths.get("eula.txt");
           ServerEula servereula = new ServerEula(path1);
           if (optionset.has(optionspec1)) {
-+            serverpropertiesprovider.func_219035_b();
-             field_147145_h.info("Initialized '" + path.toAbsolutePath().toString() + "' and '" + path1.toAbsolutePath().toString() + "'");
-             return;
-          }
-@@ -910,6 +936,10 @@
+@@ -910,6 +935,10 @@
           GameProfileRepository gameprofilerepository = yggdrasilauthenticationservice.createProfileRepository();
           PlayerProfileCache playerprofilecache = new PlayerProfileCache(gameprofilerepository, new File(s, field_152367_a.getName()));
           String s1 = Optional.ofNullable(optionset.valueOf(optionspec9)).orElse(serverpropertiesprovider.func_219034_a().field_219021_o);
@@ -196,7 +192,7 @@
           final DedicatedServer dedicatedserver = new DedicatedServer(new File(s), serverpropertiesprovider, DataFixesManager.func_210901_a(), yggdrasilauthenticationservice, minecraftsessionservice, gameprofilerepository, playerprofilecache, LoggingChunkStatusListener::new, s1);
           dedicatedserver.func_71224_l(optionset.valueOf(optionspec7));
           dedicatedserver.func_71208_b(optionset.valueOf(optionspec10));
-@@ -927,6 +957,7 @@
+@@ -927,6 +956,7 @@
           Thread thread = new Thread("Server Shutdown Thread") {
              public void run() {
                 dedicatedserver.func_71263_m(true);
@@ -204,7 +200,7 @@
              }
           };
           thread.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(field_147145_h));
-@@ -971,7 +1002,7 @@
+@@ -971,7 +1001,7 @@
     }
  
     public ServerWorld func_71218_a(DimensionType p_71218_1_) {
@@ -213,7 +209,7 @@
     }
  
     public Iterable<ServerWorld> func_212370_w() {
-@@ -1010,7 +1041,7 @@
+@@ -1010,7 +1040,7 @@
     }
  
     public String getServerModName() {
@@ -222,7 +218,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -1396,6 +1427,10 @@
+@@ -1396,6 +1426,10 @@
     public FunctionManager func_193030_aL() {
        return this.field_200258_al;
     }
@@ -233,7 +229,7 @@
  
     public void func_193031_aM() {
        if (!this.func_213162_bc()) {
-@@ -1567,6 +1602,31 @@
+@@ -1567,6 +1601,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -172,11 +172,12 @@
  
        try {
           OptionSet optionset = optionparser.parse(p_main_0_);
-@@ -888,15 +913,16 @@
+@@ -888,10 +913,11 @@
  
           Path path = Paths.get("server.properties");
           ServerPropertiesProvider serverpropertiesprovider = new ServerPropertiesProvider(path);
 -         serverpropertiesprovider.func_219035_b();
++         if (!Files.exists(path)) serverpropertiesprovider.func_219035_b();
           Path path1 = Paths.get("eula.txt");
           ServerEula servereula = new ServerEula(path1);
           if (optionset.has(optionspec1)) {
@@ -184,25 +185,18 @@
              field_147145_h.info("Initialized '" + path.toAbsolutePath().toString() + "' and '" + path1.toAbsolutePath().toString() + "'");
              return;
           }
- 
-          if (!servereula.func_154346_a()) {
-+            serverpropertiesprovider.func_219035_b();
-             field_147145_h.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
-             return;
-          }
-@@ -910,6 +936,11 @@
+@@ -910,6 +936,10 @@
           GameProfileRepository gameprofilerepository = yggdrasilauthenticationservice.createProfileRepository();
           PlayerProfileCache playerprofilecache = new PlayerProfileCache(gameprofilerepository, new File(s, field_152367_a.getName()));
           String s1 = Optional.ofNullable(optionset.valueOf(optionspec9)).orElse(serverpropertiesprovider.func_219034_a().field_219021_o);
 +         if (s1 == null || s1.isEmpty() || new File(s, s1).getAbsolutePath().equals(new File(s).getAbsolutePath())) {
-+            serverpropertiesprovider.func_219035_b();
 +            field_147145_h.error("Invalid world directory specified, must not be null, empty or the same directory as your universe! " + s1);
 +            return;
 +         }
           final DedicatedServer dedicatedserver = new DedicatedServer(new File(s), serverpropertiesprovider, DataFixesManager.func_210901_a(), yggdrasilauthenticationservice, minecraftsessionservice, gameprofilerepository, playerprofilecache, LoggingChunkStatusListener::new, s1);
           dedicatedserver.func_71224_l(optionset.valueOf(optionspec7));
           dedicatedserver.func_71208_b(optionset.valueOf(optionspec10));
-@@ -927,6 +958,7 @@
+@@ -927,6 +957,7 @@
           Thread thread = new Thread("Server Shutdown Thread") {
              public void run() {
                 dedicatedserver.func_71263_m(true);
@@ -210,7 +204,7 @@
              }
           };
           thread.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(field_147145_h));
-@@ -971,7 +1003,7 @@
+@@ -971,7 +1002,7 @@
     }
  
     public ServerWorld func_71218_a(DimensionType p_71218_1_) {
@@ -219,7 +213,7 @@
     }
  
     public Iterable<ServerWorld> func_212370_w() {
-@@ -1010,7 +1042,7 @@
+@@ -1010,7 +1041,7 @@
     }
  
     public String getServerModName() {
@@ -228,7 +222,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -1396,6 +1428,10 @@
+@@ -1396,6 +1427,10 @@
     public FunctionManager func_193030_aL() {
        return this.field_200258_al;
     }
@@ -239,7 +233,7 @@
  
     public void func_193031_aM() {
        if (!this.func_213162_bc()) {
-@@ -1567,6 +1603,31 @@
+@@ -1567,6 +1602,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -172,7 +172,25 @@
  
        try {
           OptionSet optionset = optionparser.parse(p_main_0_);
-@@ -910,6 +935,10 @@
+@@ -888,15 +913,16 @@
+ 
+          Path path = Paths.get("server.properties");
+          ServerPropertiesProvider serverpropertiesprovider = new ServerPropertiesProvider(path);
+-         serverpropertiesprovider.func_219035_b();
+          Path path1 = Paths.get("eula.txt");
+          ServerEula servereula = new ServerEula(path1);
+          if (optionset.has(optionspec1)) {
++            serverpropertiesprovider.func_219035_b();
+             field_147145_h.info("Initialized '" + path.toAbsolutePath().toString() + "' and '" + path1.toAbsolutePath().toString() + "'");
+             return;
+          }
+ 
+          if (!servereula.func_154346_a()) {
++            serverpropertiesprovider.func_219035_b();
+             field_147145_h.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
+             return;
+          }
+@@ -910,6 +936,10 @@
           GameProfileRepository gameprofilerepository = yggdrasilauthenticationservice.createProfileRepository();
           PlayerProfileCache playerprofilecache = new PlayerProfileCache(gameprofilerepository, new File(s, field_152367_a.getName()));
           String s1 = Optional.ofNullable(optionset.valueOf(optionspec9)).orElse(serverpropertiesprovider.func_219034_a().field_219021_o);
@@ -183,7 +201,7 @@
           final DedicatedServer dedicatedserver = new DedicatedServer(new File(s), serverpropertiesprovider, DataFixesManager.func_210901_a(), yggdrasilauthenticationservice, minecraftsessionservice, gameprofilerepository, playerprofilecache, LoggingChunkStatusListener::new, s1);
           dedicatedserver.func_71224_l(optionset.valueOf(optionspec7));
           dedicatedserver.func_71208_b(optionset.valueOf(optionspec10));
-@@ -927,6 +956,7 @@
+@@ -927,6 +957,7 @@
           Thread thread = new Thread("Server Shutdown Thread") {
              public void run() {
                 dedicatedserver.func_71263_m(true);
@@ -191,7 +209,7 @@
              }
           };
           thread.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(field_147145_h));
-@@ -971,7 +1001,7 @@
+@@ -971,7 +1002,7 @@
     }
  
     public ServerWorld func_71218_a(DimensionType p_71218_1_) {
@@ -200,7 +218,7 @@
     }
  
     public Iterable<ServerWorld> func_212370_w() {
-@@ -1010,7 +1040,7 @@
+@@ -1010,7 +1041,7 @@
     }
  
     public String getServerModName() {
@@ -209,7 +227,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -1396,6 +1426,10 @@
+@@ -1396,6 +1427,10 @@
     public FunctionManager func_193030_aL() {
        return this.field_200258_al;
     }
@@ -220,7 +238,7 @@
  
     public void func_193031_aM() {
        if (!this.func_213162_bc()) {
-@@ -1567,6 +1601,31 @@
+@@ -1567,6 +1602,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -190,18 +190,19 @@
              field_147145_h.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
              return;
           }
-@@ -910,6 +936,10 @@
+@@ -910,6 +936,11 @@
           GameProfileRepository gameprofilerepository = yggdrasilauthenticationservice.createProfileRepository();
           PlayerProfileCache playerprofilecache = new PlayerProfileCache(gameprofilerepository, new File(s, field_152367_a.getName()));
           String s1 = Optional.ofNullable(optionset.valueOf(optionspec9)).orElse(serverpropertiesprovider.func_219034_a().field_219021_o);
 +         if (s1 == null || s1.isEmpty() || new File(s, s1).getAbsolutePath().equals(new File(s).getAbsolutePath())) {
++            serverpropertiesprovider.func_219035_b();
 +            field_147145_h.error("Invalid world directory specified, must not be null, empty or the same directory as your universe! " + s1);
 +            return;
 +         }
           final DedicatedServer dedicatedserver = new DedicatedServer(new File(s), serverpropertiesprovider, DataFixesManager.func_210901_a(), yggdrasilauthenticationservice, minecraftsessionservice, gameprofilerepository, playerprofilecache, LoggingChunkStatusListener::new, s1);
           dedicatedserver.func_71224_l(optionset.valueOf(optionspec7));
           dedicatedserver.func_71208_b(optionset.valueOf(optionspec10));
-@@ -927,6 +957,7 @@
+@@ -927,6 +958,7 @@
           Thread thread = new Thread("Server Shutdown Thread") {
              public void run() {
                 dedicatedserver.func_71263_m(true);
@@ -209,7 +210,7 @@
              }
           };
           thread.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(field_147145_h));
-@@ -971,7 +1002,7 @@
+@@ -971,7 +1003,7 @@
     }
  
     public ServerWorld func_71218_a(DimensionType p_71218_1_) {
@@ -218,7 +219,7 @@
     }
  
     public Iterable<ServerWorld> func_212370_w() {
-@@ -1010,7 +1041,7 @@
+@@ -1010,7 +1042,7 @@
     }
  
     public String getServerModName() {
@@ -227,7 +228,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -1396,6 +1427,10 @@
+@@ -1396,6 +1428,10 @@
     public FunctionManager func_193030_aL() {
        return this.field_200258_al;
     }
@@ -238,7 +239,7 @@
  
     public void func_193031_aM() {
        if (!this.func_213162_bc()) {
-@@ -1567,6 +1602,31 @@
+@@ -1567,6 +1603,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -1,14 +1,6 @@
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -15,6 +15,7 @@
- import java.net.InetAddress;
- import java.net.Proxy;
- import java.nio.charset.StandardCharsets;
-+import java.nio.file.Paths;
- import java.util.Collections;
- import java.util.List;
- import java.util.Locale;
-@@ -97,6 +98,7 @@
+@@ -97,6 +97,7 @@
     public boolean func_71197_b() throws IOException {
        Thread thread = new Thread("Server console handler") {
           public void run() {
@@ -16,17 +8,17 @@
              BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
  
              String s3;
-@@ -118,7 +120,9 @@
+@@ -118,7 +119,9 @@
           field_155771_h.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
        }
  
 +      net.minecraftforge.fml.server.ServerModLoader.begin(this);
        field_155771_h.info("Loading properties");
-+      this.field_71340_o.func_219033_a(properties -> ServerProperties.func_218985_a(Paths.get("server.properties")));
++      this.field_71340_o.func_219033_a(properties -> ServerProperties.func_218985_a(java.nio.file.Paths.get("server.properties")));
        ServerProperties serverproperties = this.field_71340_o.func_219034_a();
        if (this.func_71264_H()) {
           this.func_71189_e("127.0.0.1");
-@@ -175,6 +179,7 @@
+@@ -175,6 +178,7 @@
        if (!PreYggdrasilConverter.func_219587_e(this)) {
           return false;
        } else {
@@ -34,7 +26,7 @@
           this.func_184105_a(new DedicatedPlayerList(this));
           long i = Util.func_211178_c();
           String s = serverproperties.field_219022_p;
-@@ -196,6 +201,7 @@
+@@ -196,6 +200,7 @@
           SkullTileEntity.func_184293_a(this.func_152358_ax());
           SkullTileEntity.func_184294_a(this.func_147130_as());
           PlayerProfileCache.func_187320_a(this.func_71266_T());
@@ -42,7 +34,7 @@
           field_155771_h.info("Preparing level \"{}\"", (Object)this.func_71270_I());
           JsonObject jsonobject = new JsonObject();
           if (worldtype == WorldType.field_77138_c) {
-@@ -208,6 +214,7 @@
+@@ -208,6 +213,7 @@
           long l = Util.func_211178_c() - i;
           String s2 = String.format(Locale.ROOT, "%.3fs", (double)l / 1.0E9D);
           field_155771_h.info("Done ({})! For help, type \"help\"", (Object)s2);
@@ -50,7 +42,7 @@
           if (serverproperties.field_219027_u != null) {
              this.func_200252_aR().func_223585_a(GameRules.field_223620_w).func_223570_a(serverproperties.field_219027_u, this);
           }
-@@ -233,7 +240,8 @@
+@@ -233,7 +239,8 @@
           }
  
           Items.field_190931_a.func_150895_a(ItemGroup.field_78027_g, NonNullList.func_191196_a());
@@ -60,7 +52,7 @@
        }
     }
  
-@@ -547,4 +555,9 @@
+@@ -547,4 +554,9 @@
     public boolean func_213199_b(GameProfile p_213199_1_) {
        return false;
     }

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -97,6 +97,7 @@
+@@ -15,6 +15,7 @@
+ import java.net.InetAddress;
+ import java.net.Proxy;
+ import java.nio.charset.StandardCharsets;
++import java.nio.file.Paths;
+ import java.util.Collections;
+ import java.util.List;
+ import java.util.Locale;
+@@ -97,6 +98,7 @@
     public boolean func_71197_b() throws IOException {
        Thread thread = new Thread("Server console handler") {
           public void run() {
@@ -8,15 +16,17 @@
              BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
  
              String s3;
-@@ -118,6 +119,7 @@
+@@ -118,7 +120,9 @@
           field_155771_h.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
        }
  
 +      net.minecraftforge.fml.server.ServerModLoader.begin(this);
        field_155771_h.info("Loading properties");
++      this.field_71340_o.func_219033_a(properties -> ServerProperties.func_218985_a(Paths.get("server.properties")));
        ServerProperties serverproperties = this.field_71340_o.func_219034_a();
        if (this.func_71264_H()) {
-@@ -175,6 +177,7 @@
+          this.func_71189_e("127.0.0.1");
+@@ -175,6 +179,7 @@
        if (!PreYggdrasilConverter.func_219587_e(this)) {
           return false;
        } else {
@@ -24,7 +34,7 @@
           this.func_184105_a(new DedicatedPlayerList(this));
           long i = Util.func_211178_c();
           String s = serverproperties.field_219022_p;
-@@ -196,6 +199,7 @@
+@@ -196,6 +201,7 @@
           SkullTileEntity.func_184293_a(this.func_152358_ax());
           SkullTileEntity.func_184294_a(this.func_147130_as());
           PlayerProfileCache.func_187320_a(this.func_71266_T());
@@ -32,7 +42,7 @@
           field_155771_h.info("Preparing level \"{}\"", (Object)this.func_71270_I());
           JsonObject jsonobject = new JsonObject();
           if (worldtype == WorldType.field_77138_c) {
-@@ -208,6 +212,7 @@
+@@ -208,6 +214,7 @@
           long l = Util.func_211178_c() - i;
           String s2 = String.format(Locale.ROOT, "%.3fs", (double)l / 1.0E9D);
           field_155771_h.info("Done ({})! For help, type \"help\"", (Object)s2);
@@ -40,7 +50,7 @@
           if (serverproperties.field_219027_u != null) {
              this.func_200252_aR().func_223585_a(GameRules.field_223620_w).func_223570_a(serverproperties.field_219027_u, this);
           }
-@@ -233,7 +238,8 @@
+@@ -233,7 +240,8 @@
           }
  
           Items.field_190931_a.func_150895_a(ItemGroup.field_78027_g, NonNullList.func_191196_a());
@@ -50,7 +60,7 @@
        }
     }
  
-@@ -547,4 +553,9 @@
+@@ -547,4 +555,9 @@
     public boolean func_213199_b(GameProfile p_213199_1_) {
        return false;
     }


### PR DESCRIPTION
Proposed fix for #6189 

This prevents the server from overwriting the server.properties file until after mods have loaded, allowing their world-types etc to be used in it.

It simply re-reads the properties file after mod-loading and updates the server's copy. The call to `ServerPropertiesProvider.func_219033_a(..)` also performs a save, ensuring the file is created and contains valid values.

This also maintains the vanilla behaviour of creating the settings file when the server stops early due to the eula not being accepted, the initSettings flag being present, or an invalid world being specified.

Hope this is ok!