### PR TITLE
Add "type" field to global loot modifier jsons and fix tests.

### DIFF
--- a/src/main/java/net/minecraftforge/common/data/IOptionalTagEntry.java
+++ b/src/main/java/net/minecraftforge/common/data/IOptionalTagEntry.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.data;
 
 import net.minecraft.tags.Tag.ITagEntry;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagBuilder.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.extensions;
 
 import java.util.Arrays;

--- a/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
+++ b/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/net/minecraftforge/common/loot/IGlobalLootModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/IGlobalLootModifier.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot;
 
 import java.util.List;

--- a/src/main/java/net/minecraftforge/common/loot/LootModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifier.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot;
 
 import java.util.List;

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot;
 
 import java.io.BufferedReader;

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -108,7 +108,12 @@ public class LootModifierManager extends JsonReloadListener {
 
     private IGlobalLootModifier deserializeModifier(ResourceLocation location, JsonObject object) {
         ILootCondition[] ailootcondition = GSON_INSTANCE.fromJson(object.get("conditions"), ILootCondition[].class);
-        return ForgeRegistries.LOOT_MODIFIER_SERIALIZERS.getValue(location).read(location, object, ailootcondition);
+        ResourceLocation serializer = location;
+        if (object.has("type"))
+        {
+            serializer = new ResourceLocation(JSONUtils.getString(object, "type"));
+        }
+        return ForgeRegistries.LOOT_MODIFIER_SERIALIZERS.getValue(serializer).read(location, object, ailootcondition);
     }
 
     public static GlobalLootModifierSerializer<?> getSerializerForName(ResourceLocation resourcelocation) {

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -126,13 +126,17 @@ public class LootModifierManager extends JsonReloadListener {
     }
 
     private IGlobalLootModifier deserializeModifier(ResourceLocation location, JsonObject object) {
-        ILootCondition[] ailootcondition = GSON_INSTANCE.fromJson(object.get("conditions"), ILootCondition[].class);
+        ILootCondition[] lootConditions = GSON_INSTANCE.fromJson(object.get("conditions"), ILootCondition[].class);
+
+        // For backward compatibility with the initial implementation, fall back to using the location as the type.
+        // TODO: Remove fallback in 1.16
         ResourceLocation serializer = location;
         if (object.has("type"))
         {
             serializer = new ResourceLocation(JSONUtils.getString(object, "type"));
         }
-        return ForgeRegistries.LOOT_MODIFIER_SERIALIZERS.getValue(serializer).read(location, object, ailootcondition);
+
+        return ForgeRegistries.LOOT_MODIFIER_SERIALIZERS.getValue(serializer).read(location, object, lootConditions);
     }
 
     public static GlobalLootModifierSerializer<?> getSerializerForName(ResourceLocation resourcelocation) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.gameplay.loot;
 
 import java.util.ArrayList;

--- a/src/test/resources/data/global_loot_test/loot_modifiers/silk_touch_bamboo.json
+++ b/src/test/resources/data/global_loot_test/loot_modifiers/silk_touch_bamboo.json
@@ -1,4 +1,5 @@
 {
+  "type": "global_loot_test:silk_touch_bamboo",
   "conditions": [
     {
       "condition": "minecraft:match_tool",
@@ -6,6 +7,5 @@
         "item": "minecraft:bamboo"
       }
     }
-  ],
-  "function": "global_loot_test:silk_touch_bamboo"
+  ]
 }

--- a/src/test/resources/data/global_loot_test/loot_modifiers/smelting.json
+++ b/src/test/resources/data/global_loot_test/loot_modifiers/smelting.json
@@ -1,4 +1,5 @@
 {
+  "type": "global_loot_test:smelting",
   "conditions": [
     {
       "condition": "minecraft:match_tool",
@@ -13,6 +14,5 @@
         ]
       }
     }
-  ],
-  "function": "global_loot_test:smelting"
+  ]
 }

--- a/src/test/resources/data/global_loot_test/loot_modifiers/wheat_harvest.json
+++ b/src/test/resources/data/global_loot_test/loot_modifiers/wheat_harvest.json
@@ -1,4 +1,5 @@
 {
+  "type": "global_loot_test:wheat_harvest",
   "conditions": [
     {
       "condition": "minecraft:match_tool",
@@ -11,7 +12,6 @@
       "block":"minecraft:wheat"
     }
   ],
-  "function": "global_loot_test:wheat_seeds_test",
   "seedItem": "minecraft:wheat_seeds",
   "numSeeds": 3,
   "replacement": "minecraft:wheat"


### PR DESCRIPTION
To avoid binary breaking, "type" defaults to be the same as the filename.
Still sick so I'm going to need a sanity check on this. :P