### PR TITLE
Add renderer to RenderNameplateEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -6,7 +6,7 @@
     public void func_225623_a_(T p_225623_1_, float p_225623_2_, float p_225623_3_, MatrixStack p_225623_4_, IRenderTypeBuffer p_225623_5_, int p_225623_6_) {
 -      if (this.func_177070_b(p_225623_1_)) {
 -         this.func_225629_a_(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), p_225623_4_, p_225623_5_, p_225623_6_);
-+      net.minecraftforge.client.event.RenderNameplateEvent renderNameplateEvent = new net.minecraftforge.client.event.RenderNameplateEvent(p_225623_1_,p_225623_1_.func_145748_c_().func_150254_d(), p_225623_4_, p_225623_5_);
++      net.minecraftforge.client.event.RenderNameplateEvent<T> renderNameplateEvent = new net.minecraftforge.client.event.RenderNameplateEvent<T>(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), this, p_225623_4_, p_225623_5_, p_225623_6_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(renderNameplateEvent);
 +      if (renderNameplateEvent.getResult() != net.minecraftforge.eventbus.api.Event.Result.DENY && (renderNameplateEvent.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || this.func_177070_b(p_225623_1_))) {
 +         this.func_225629_a_(p_225623_1_, renderNameplateEvent.getContent(), p_225623_4_, p_225623_5_, p_225623_6_);

--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -6,7 +6,7 @@
     public void func_225623_a_(T p_225623_1_, float p_225623_2_, float p_225623_3_, MatrixStack p_225623_4_, IRenderTypeBuffer p_225623_5_, int p_225623_6_) {
 -      if (this.func_177070_b(p_225623_1_)) {
 -         this.func_225629_a_(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), p_225623_4_, p_225623_5_, p_225623_6_);
-+      net.minecraftforge.client.event.RenderNameplateEvent<T> renderNameplateEvent = new net.minecraftforge.client.event.RenderNameplateEvent<T>(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), this, p_225623_4_, p_225623_5_, p_225623_6_);
++      net.minecraftforge.client.event.RenderNameplateEvent renderNameplateEvent = new net.minecraftforge.client.event.RenderNameplateEvent(p_225623_1_, p_225623_1_.func_145748_c_().func_150254_d(), this, p_225623_4_, p_225623_5_, p_225623_6_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(renderNameplateEvent);
 +      if (renderNameplateEvent.getResult() != net.minecraftforge.eventbus.api.Event.Result.DENY && (renderNameplateEvent.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || this.func_177070_b(p_225623_1_))) {
 +         this.func_225629_a_(p_225623_1_, renderNameplateEvent.getContent(), p_225623_4_, p_225623_5_, p_225623_6_);

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -60,7 +60,7 @@ public class RenderNameplateEvent extends EntityEvent
     private final IRenderTypeBuffer renderTypeBuffer;
     private final int packedLight;
 
-    @Deprecated
+    @Deprecated //TODO 1.16: upon removal, also remove @Nullable on getEntityRenderer(), and update its javadoc
     public RenderNameplateEvent(Entity entity, String content, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer)
     {
         this(entity, content, null, matrixStack, renderTypeBuffer, 0);

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityEvent;
@@ -32,33 +33,41 @@ import net.minecraftforge.eventbus.api.Event;
  * {@link #nameplateContent} contains the content being rendered on the name plate/tag. This can be changed by mods.<br>
  * {@link #originalContent} contains the original content being rendered on the name plate/tag. This cannot be
  * changed by mods.<br>
+ * {@link #entityRenderer} contains the entity renderer instance that renders the name plate/tag. This cannot be
+ * changed by mods.<br>
  * {@link #matrixStack} contains the matrix stack instance involved in rendering the name plate/tag. This cannot
  * be changed by mods.<br>
  * {@link #renderTypeBuffer} contains the render type buffer instance involved in rendering the name plate/tag.
  * This cannot be changed by mods.<br>
+ * {@link #packedLight} contains the sky and block light values used in rendering the name plate/tag.<br>
  * <br>
  * This event has a result. {@link HasResult}. <br>
  * ALLOW will force-render name plate/tag, DEFAULT will ignore the hook and continue using the vanilla check
  * & DENY will prevent name plate/tag from rendering<br>
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ * @param <T> the entity type of the renderer
  **/
 @Event.HasResult
-public class RenderNameplateEvent extends EntityEvent
+public class RenderNameplateEvent<T extends Entity> extends EntityEvent
 {
 
     private String nameplateContent;
     private final String originalContent;
+    private final EntityRenderer<T> entityRenderer;
     private final MatrixStack matrixStack;
     private final IRenderTypeBuffer renderTypeBuffer;
+    private final int packedLight;
 
-    public RenderNameplateEvent(Entity entity, String content, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer)
+    public RenderNameplateEvent(Entity entity, String content, EntityRenderer<T> entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)
     {
         super(entity);
         this.originalContent = content;
         this.setContent(this.originalContent);
+        this.entityRenderer = entityRenderer;
         this.matrixStack = matrixStack;
         this.renderTypeBuffer = renderTypeBuffer;
+        this.packedLight = packedLight;
     }
 
     /**
@@ -86,6 +95,14 @@ public class RenderNameplateEvent extends EntityEvent
     }
 
     /**
+     * The entity renderer that renders the name plate/tag
+     */
+    public EntityRenderer<T> getEntityRenderer()
+    {
+        return this.entityRenderer;
+    }
+
+    /**
      * The matrix stack used during the rendering of the name plate/tag
      */
     public MatrixStack getMatrixStack()
@@ -99,5 +116,13 @@ public class RenderNameplateEvent extends EntityEvent
     public IRenderTypeBuffer getRenderTypeBuffer()
     {
         return this.renderTypeBuffer;
+    }
+
+    /**
+     * The packed values of sky and block light used during the rendering of the name plate/tag
+     */
+    public int getPackedLight()
+    {
+        return this.packedLight;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.client.event;
 
+import javax.annotation.Nullable;
+
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.EntityRenderer;
@@ -46,20 +48,31 @@ import net.minecraftforge.eventbus.api.Event;
  * & DENY will prevent name plate/tag from rendering<br>
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
- * @param <T> the entity type of the renderer
  **/
+@SuppressWarnings("rawtypes")
 @Event.HasResult
-public class RenderNameplateEvent<T extends Entity> extends EntityEvent
+public class RenderNameplateEvent extends EntityEvent
 {
 
     private String nameplateContent;
     private final String originalContent;
-    private final EntityRenderer<T> entityRenderer;
+    private final EntityRenderer entityRenderer;
     private final MatrixStack matrixStack;
     private final IRenderTypeBuffer renderTypeBuffer;
     private final int packedLight;
 
-    public RenderNameplateEvent(Entity entity, String content, EntityRenderer<T> entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)
+    public RenderNameplateEvent(Entity entity, String content, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer)
+    {
+        super(entity);
+        this.originalContent = content;
+        this.setContent(this.originalContent);
+        this.entityRenderer = null;
+        this.matrixStack = matrixStack;
+        this.renderTypeBuffer = renderTypeBuffer;
+        this.packedLight = 0;
+    }
+
+    public RenderNameplateEvent(Entity entity, String content, EntityRenderer entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)
     {
         super(entity);
         this.originalContent = content;
@@ -95,9 +108,10 @@ public class RenderNameplateEvent<T extends Entity> extends EntityEvent
     }
 
     /**
-     * The entity renderer that renders the name plate/tag
+     * The entity renderer that renders the name plate/tag, if it was provided
      */
-    public EntityRenderer<T> getEntityRenderer()
+    @Nullable
+    public EntityRenderer getEntityRenderer()
     {
         return this.entityRenderer;
     }

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -49,14 +49,13 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@SuppressWarnings("rawtypes")
 @Event.HasResult
 public class RenderNameplateEvent extends EntityEvent
 {
 
     private String nameplateContent;
     private final String originalContent;
-    private final EntityRenderer entityRenderer;
+    private final EntityRenderer<?> entityRenderer;
     private final MatrixStack matrixStack;
     private final IRenderTypeBuffer renderTypeBuffer;
     private final int packedLight;
@@ -67,7 +66,7 @@ public class RenderNameplateEvent extends EntityEvent
         this(entity, content, null, matrixStack, renderTypeBuffer, 0);
     }
 
-    public RenderNameplateEvent(Entity entity, String content, EntityRenderer entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)
+    public RenderNameplateEvent(Entity entity, String content, EntityRenderer<?> entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)
     {
         super(entity);
         this.originalContent = content;
@@ -106,7 +105,7 @@ public class RenderNameplateEvent extends EntityEvent
      * The entity renderer that renders the name plate/tag, if it was provided
      */
     @Nullable
-    public EntityRenderer getEntityRenderer()
+    public EntityRenderer<?> getEntityRenderer()
     {
         return this.entityRenderer;
     }

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -61,6 +61,7 @@ public class RenderNameplateEvent extends EntityEvent
     private final IRenderTypeBuffer renderTypeBuffer;
     private final int packedLight;
 
+    @Deprecated
     public RenderNameplateEvent(Entity entity, String content, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer)
     {
         this(entity, content, null, matrixStack, renderTypeBuffer, 0);

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -63,13 +63,7 @@ public class RenderNameplateEvent extends EntityEvent
 
     public RenderNameplateEvent(Entity entity, String content, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer)
     {
-        super(entity);
-        this.originalContent = content;
-        this.setContent(this.originalContent);
-        this.entityRenderer = null;
-        this.matrixStack = matrixStack;
-        this.renderTypeBuffer = renderTypeBuffer;
-        this.packedLight = 0;
+        this(entity, content, null, matrixStack, renderTypeBuffer, 0);
     }
 
     public RenderNameplateEvent(Entity entity, String content, EntityRenderer entityRenderer, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int packedLight)

--- a/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
@@ -35,7 +35,7 @@ public class NameplateRenderingEventTest
     static final boolean ENABLED = false;
 
     @SubscribeEvent
-    public static void onNameplateRender(RenderNameplateEvent<Entity> event)
+    public static void onNameplateRender(RenderNameplateEvent event)
     {
 
         if(!ENABLED)

--- a/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
@@ -35,7 +35,7 @@ public class NameplateRenderingEventTest
     static final boolean ENABLED = false;
 
     @SubscribeEvent
-    public static void onNameplateRender(RenderNameplateEvent event)
+    public static void onNameplateRender(RenderNameplateEvent<Entity> event)
     {
 
         if(!ENABLED)


### PR DESCRIPTION
Adds renderer access previously provided by RenderLivingEvent.Specials.Pre, and includes packedLight to the same end: for mods to cancel/deny the event and render their own nameplate.

[forum thread](https://www.minecraftforge.net/forum/topic/81771-1152-rendernameplateevent-has-no-renderer/)