### PR TITLE
[1.15] allow different item attribute modifier based on the applied entity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -357,7 +357,7 @@
        super.func_70071_h_();
        this.func_184608_ct();
        this.func_205014_p();
-@@ -2022,7 +2064,9 @@
+@@ -2022,13 +2064,15 @@
  
              ItemStack itemstack1 = this.func_184582_a(equipmentslottype);
              if (!ItemStack.func_77989_b(itemstack1, itemstack)) {
@@ -365,8 +365,16 @@
                 ((ServerWorld)this.field_70170_p).func_72863_F().func_217218_b(this, new SEntityEquipmentPacket(this.func_145782_y(), equipmentslottype, itemstack1));
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent(this, equipmentslottype, itemstack, itemstack1));
                 if (!itemstack.func_190926_b()) {
-                   this.func_110140_aT().func_111148_a(itemstack.func_111283_C(equipmentslottype));
+-                  this.func_110140_aT().func_111148_a(itemstack.func_111283_C(equipmentslottype));
++                  this.func_110140_aT().func_111148_a(itemstack.getAttributeModifiers(equipmentslottype, this));
                 }
+ 
+                if (!itemstack1.func_190926_b()) {
+-                  this.func_110140_aT().func_111147_b(itemstack1.func_111283_C(equipmentslottype));
++                  this.func_110140_aT().func_111147_b(itemstack1.getAttributeModifiers(equipmentslottype, this));
+                }
+ 
+                switch(equipmentslottype.func_188453_a()) {
 @@ -2474,13 +2518,22 @@
  
     private void func_184608_ct() {

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -190,6 +190,15 @@
        }
     }
  
+@@ -574,7 +597,7 @@
+       }
+ 
+       for(EquipmentSlotType equipmentslottype : EquipmentSlotType.values()) {
+-         Multimap<String, AttributeModifier> multimap = this.func_111283_C(equipmentslottype);
++         Multimap<String, AttributeModifier> multimap = this.getAttributeModifiers(equipmentslottype, p_82840_1_);
+          if (!multimap.isEmpty() && (i & 2) == 0) {
+             list.add(new StringTextComponent(""));
+             list.add((new TranslationTextComponent("item.modifiers." + equipmentslottype.func_188450_d())).func_211708_a(TextFormatting.GRAY));
 @@ -652,6 +675,7 @@
           }
        }
@@ -198,16 +207,33 @@
        return list;
     }
  
-@@ -772,7 +796,7 @@
+@@ -759,6 +783,10 @@
+    }
+ 
+    public Multimap<String, AttributeModifier> func_111283_C(EquipmentSlotType p_111283_1_) {
++      return this.getAttributeModifiers(p_111283_1_, null);
++   }
++
++   public Multimap<String, AttributeModifier> getAttributeModifiers(EquipmentSlotType equipmentSlot, @Nullable LivingEntity entity) {
+       Multimap<String, AttributeModifier> multimap;
+       if (this.func_77942_o() && this.field_77990_d.func_150297_b("AttributeModifiers", 9)) {
+          multimap = HashMultimap.create();
+@@ -767,12 +795,12 @@
+          for(int i = 0; i < listnbt.size(); ++i) {
+             CompoundNBT compoundnbt = listnbt.func_150305_b(i);
+             AttributeModifier attributemodifier = SharedMonsterAttributes.func_111259_a(compoundnbt);
+-            if (attributemodifier != null && (!compoundnbt.func_150297_b("Slot", 8) || compoundnbt.func_74779_i("Slot").equals(p_111283_1_.func_188450_d())) && attributemodifier.func_111167_a().getLeastSignificantBits() != 0L && attributemodifier.func_111167_a().getMostSignificantBits() != 0L) {
++            if (attributemodifier != null && (!compoundnbt.func_150297_b("Slot", 8) || compoundnbt.func_74779_i("Slot").equals(equipmentSlot.func_188450_d())) && attributemodifier.func_111167_a().getLeastSignificantBits() != 0L && attributemodifier.func_111167_a().getMostSignificantBits() != 0L) {
+                multimap.put(compoundnbt.func_74779_i("AttributeName"), attributemodifier);
              }
           }
        } else {
 -         multimap = this.func_77973_b().func_111205_h(p_111283_1_);
-+         multimap = this.func_77973_b().getAttributeModifiers(p_111283_1_, this);
++         multimap = this.func_77973_b().getAttributeModifiers(equipmentSlot, this, entity);
        }
  
        multimap.values().forEach((p_226631_0_) -> {
-@@ -915,6 +939,35 @@
+@@ -915,6 +943,35 @@
        return this.func_77973_b().func_219971_r();
     }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -67,7 +67,7 @@ public interface IForgeItem
     /**
      * ItemStack sensitive version of getItemAttributeModifiers
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated //TODO 1.16 remove in favor of overloaded method
     default Multimap<String, AttributeModifier> getAttributeModifiers(EquipmentSlotType slot, ItemStack stack)
     {
         return getItem().getAttributeModifiers(slot);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -74,6 +74,16 @@ public interface IForgeItem
     }
 
     /**
+     * ItemStack sensitive version of getItemAttributeModifiers with additional entity parameter
+     *
+     * @param entity The entity for which the AttributeModifier are gathered. If {@code null} the entity can be assumed to be a player.
+     */
+    default Multimap<String, AttributeModifier> getAttributeModifiers(EquipmentSlotType slot, ItemStack stack, @Nullable LivingEntity entity)
+    {
+        return this.getAttributeModifiers(slot, stack);
+    }
+
+    /**
      * Called when a player drops the item into the world, returning false from this
      * will prevent the item from being removed from the players inventory and
      * spawning in the world


### PR DESCRIPTION
this allows for an custom item to override IForgeItem#getAttributeModifiers to return different attribute modifier based on the entity the modifier should be applied to.