### PR TITLE
Modded Hill Biomes

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -41,7 +41,7 @@
                 return true;
              }
           }
-@@ -375,6 +375,12 @@
+@@ -375,6 +375,35 @@
        return this.field_185364_H;
     }
  
@@ -51,10 +51,33 @@
 +      return Biomes.field_76781_i;
 +   }
 +
++   public Biome getHill(net.minecraft.world.gen.INoiseRandom rand) {
++      if (this == Biomes.field_76769_d) return Biomes.field_76786_s;
++      if (this == Biomes.field_76767_f) return Biomes.field_76785_t;
++      if (this == Biomes.field_150583_P) return Biomes.field_150582_Q;
++      if (this == Biomes.field_150585_R) return Biomes.field_76772_c;
++      if (this == Biomes.field_76768_g) return Biomes.field_76784_u;
++      if (this == Biomes.field_150578_U) return Biomes.field_150581_V;
++      if (this == Biomes.field_150584_S) return Biomes.field_150579_T;
++      if (this == Biomes.field_76772_c) return rand.func_202696_a(3) == 0 ? Biomes.field_76785_t : Biomes.field_76767_f;
++      if (this == Biomes.field_76774_n) return Biomes.field_76775_o;
++      if (this == Biomes.field_76782_w) return Biomes.field_76792_x;
++      if (this == Biomes.field_222370_aw) return Biomes.field_222371_ax;
++      if (this == Biomes.field_76771_b) return Biomes.field_150575_M;
++      if (this == Biomes.field_203615_U) return Biomes.field_203618_X;
++      if (this == Biomes.field_203616_V) return Biomes.field_203619_Y;
++      if (this == Biomes.field_76776_l) return Biomes.field_203620_Z;
++      if (this == Biomes.field_76770_e) return Biomes.field_150580_W;
++      if (this == Biomes.field_150588_X) return Biomes.field_150587_Y;
++      if (net.minecraft.world.gen.layer.LayerUtil.func_202826_a(Registry.field_212624_m.func_148757_b(this), Registry.field_212624_m.func_148757_b(Biomes.field_150607_aa))) return Biomes.field_150589_Z;
++      if ((this == Biomes.field_150575_M || this == Biomes.field_203618_X || this == Biomes.field_203619_Y || this == Biomes.field_203620_Z) && rand.func_202696_a(3) == 0) return rand.func_202696_a(2) == 0 ? Biomes.field_76772_c : Biomes.field_76767_f;
++      return this;
++   }
++
     public static class Builder {
        @Nullable
        private ConfiguredSurfaceBuilder<?> field_205422_a;
-@@ -526,6 +532,18 @@
+@@ -526,6 +555,18 @@
        }
     }
  

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -41,7 +41,7 @@
                 return true;
              }
           }
-@@ -375,6 +375,35 @@
+@@ -375,6 +375,16 @@
        return this.field_185364_H;
     }
  
@@ -52,32 +52,13 @@
 +   }
 +
 +   public Biome getHill(net.minecraft.world.gen.INoiseRandom rand) {
-+      if (this == Biomes.field_76769_d) return Biomes.field_76786_s;
-+      if (this == Biomes.field_76767_f) return Biomes.field_76785_t;
-+      if (this == Biomes.field_150583_P) return Biomes.field_150582_Q;
-+      if (this == Biomes.field_150585_R) return Biomes.field_76772_c;
-+      if (this == Biomes.field_76768_g) return Biomes.field_76784_u;
-+      if (this == Biomes.field_150578_U) return Biomes.field_150581_V;
-+      if (this == Biomes.field_150584_S) return Biomes.field_150579_T;
-+      if (this == Biomes.field_76772_c) return rand.func_202696_a(3) == 0 ? Biomes.field_76785_t : Biomes.field_76767_f;
-+      if (this == Biomes.field_76774_n) return Biomes.field_76775_o;
-+      if (this == Biomes.field_76782_w) return Biomes.field_76792_x;
-+      if (this == Biomes.field_222370_aw) return Biomes.field_222371_ax;
-+      if (this == Biomes.field_76771_b) return Biomes.field_150575_M;
-+      if (this == Biomes.field_203615_U) return Biomes.field_203618_X;
-+      if (this == Biomes.field_203616_V) return Biomes.field_203619_Y;
-+      if (this == Biomes.field_76776_l) return Biomes.field_203620_Z;
-+      if (this == Biomes.field_76770_e) return Biomes.field_150580_W;
-+      if (this == Biomes.field_150588_X) return Biomes.field_150587_Y;
-+      if (net.minecraft.world.gen.layer.LayerUtil.func_202826_a(Registry.field_212624_m.func_148757_b(this), Registry.field_212624_m.func_148757_b(Biomes.field_150607_aa))) return Biomes.field_150589_Z;
-+      if ((this == Biomes.field_150575_M || this == Biomes.field_203618_X || this == Biomes.field_203619_Y || this == Biomes.field_203620_Z) && rand.func_202696_a(3) == 0) return rand.func_202696_a(2) == 0 ? Biomes.field_76772_c : Biomes.field_76767_f;
-+      return this;
++      return null;
 +   }
 +
     public static class Builder {
        @Nullable
        private ConfiguredSurfaceBuilder<?> field_205422_a;
-@@ -526,6 +555,18 @@
+@@ -526,6 +536,18 @@
        }
     }
  

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -41,7 +41,7 @@
                 return true;
              }
           }
-@@ -375,6 +375,16 @@
+@@ -375,6 +375,17 @@
        return this.field_185364_H;
     }
  
@@ -51,6 +51,7 @@
 +      return Biomes.field_76781_i;
 +   }
 +
++   @Nullable
 +   public Biome getHill(net.minecraft.world.gen.INoiseRandom rand) {
 +      return null;
 +   }
@@ -58,7 +59,7 @@
     public static class Builder {
        @Nullable
        private ConfiguredSurfaceBuilder<?> field_205422_a;
-@@ -526,6 +536,18 @@
+@@ -526,6 +537,18 @@
        }
     }
  

--- a/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/gen/layer/HillsLayer.java
++++ b/net/minecraft/world/gen/layer/HillsLayer.java
+@@ -97,6 +97,8 @@
+             l = field_202809_p;
+          } else if ((i == LayerUtil.field_202830_a || i == LayerUtil.field_203636_g || i == LayerUtil.field_203637_i || i == LayerUtil.field_203638_j) && p_215723_1_.func_202696_a(3) == 0) {
+             l = p_215723_1_.func_202696_a(2) == 0 ? field_202812_s : field_202803_j;
++         } else {
++            l = Registry.field_212624_m.func_148757_b(Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_));
+          }
+ 
+          if (k == 0 && l != i) {

--- a/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
@@ -1,11 +1,11 @@
 --- a/net/minecraft/world/gen/layer/HillsLayer.java
 +++ b/net/minecraft/world/gen/layer/HillsLayer.java
-@@ -97,6 +97,8 @@
+@@ -97,7 +97,7 @@
              l = field_202809_p;
           } else if ((i == LayerUtil.field_202830_a || i == LayerUtil.field_203636_g || i == LayerUtil.field_203637_i || i == LayerUtil.field_203638_j) && p_215723_1_.func_202696_a(3) == 0) {
              l = p_215723_1_.func_202696_a(2) == 0 ? field_202812_s : field_202803_j;
-+         } else {
-+            l = Registry.field_212624_m.func_148757_b(Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_));
-          }
+-         }
++         } else l = Registry.field_212624_m.func_148757_b(Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_));
  
           if (k == 0 && l != i) {
+             Biome biome1 = Biome.func_185356_b(Registry.field_212624_m.func_148745_a(l));

--- a/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/world/gen/layer/HillsLayer.java
 +++ b/net/minecraft/world/gen/layer/HillsLayer.java
-@@ -97,7 +97,7 @@
-             l = field_202809_p;
-          } else if ((i == LayerUtil.field_202830_a || i == LayerUtil.field_203636_g || i == LayerUtil.field_203637_i || i == LayerUtil.field_203638_j) && p_215723_1_.func_202696_a(3) == 0) {
-             l = p_215723_1_.func_202696_a(2) == 0 ? field_202812_s : field_202803_j;
--         }
-+         } else l = Registry.field_212624_m.func_148757_b(Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_));
+@@ -59,7 +59,9 @@
  
-          if (k == 0 && l != i) {
-             Biome biome1 = Biome.func_185356_b(Registry.field_212624_m.func_148745_a(l));
+       if (p_215723_1_.func_202696_a(3) == 0 || k == 0) {
+          int l = i;
+-         if (i == field_202799_f) {
++         Biome hill = Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_);
++         if (hill != null) l = Registry.field_212624_m.func_148757_b(hill);
++         else if (i == field_202799_f) {
+             l = field_202800_g;
+          } else if (i == field_202803_j) {
+             l = field_202804_k;

--- a/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/gen/layer/HillsLayer.java
 +++ b/net/minecraft/world/gen/layer/HillsLayer.java
-@@ -59,7 +59,9 @@
+@@ -59,7 +59,10 @@
  
        if (p_215723_1_.func_202696_a(3) == 0 || k == 0) {
           int l = i;
 -         if (i == field_202799_f) {
-+         Biome hill = Registry.field_212624_m.func_148745_a(i).getHill(p_215723_1_);
++         Biome biome = Registry.field_212624_m.func_148745_a(i);
++         Biome hill = biome == null ? null : biome.getHill(p_215723_1_);
 +         if (hill != null) l = Registry.field_212624_m.func_148757_b(hill);
 +         else if (i == field_202799_f) {
              l = field_202800_g;


### PR DESCRIPTION
A few patches to minecraft which allows modders to override a `getHill` method in their custom biome class in order to specify a custom hill biome in overworld generation.

This method can be used to create more variation in biomes in the vanilla generator.

This method can also be called by modded world generators in order to add these modded custom hill biomes to their custom world generators.

I have tested the code. Please specify any changes that should be made. Thanks. :)