### PR TITLE
Allow colors of tooltip to be specified in GuiUtils tooltip methods

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -49,9 +49,9 @@ import javax.annotation.Nonnull;
  */
 public class GuiUtils
 {
-    private static final int DEFAULT_BACKGROUND_COLOR = 0xF0100010;
-    private static final int DEFAULT_BORDER_COLOR_START = 0x505000FF;
-    private static final int DEFAULT_BORDER_COLOR_END = (DEFAULT_BORDER_COLOR_START & 0xFEFEFE) >> 1 | DEFAULT_BORDER_COLOR_START & 0xFF000000;
+    public static final int DEFAULT_BACKGROUND_COLOR = 0xF0100010;
+    public static final int DEFAULT_BORDER_COLOR_START = 0x505000FF;
+    public static final int DEFAULT_BORDER_COLOR_END = (DEFAULT_BORDER_COLOR_START & 0xFEFEFE) >> 1 | DEFAULT_BORDER_COLOR_START & 0xFF000000;
     public static final String UNDO_CHAR  = "\u21B6";
     public static final String RESET_CHAR = "\u2604";
     public static final String VALID      = "\u2714";

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -49,6 +49,9 @@ import javax.annotation.Nonnull;
  */
 public class GuiUtils
 {
+    private static final int DEFAULT_BACKGROUND_COLOR = 0xF0100010;
+    private static final int DEFAULT_BORDER_COLOR_START = 0x505000FF;
+    private static final int DEFAULT_BORDER_COLOR_END = (DEFAULT_BORDER_COLOR_START & 0xFEFEFE) >> 1 | DEFAULT_BORDER_COLOR_START & 0xFF000000;
     public static final String UNDO_CHAR  = "\u21B6";
     public static final String RESET_CHAR = "\u2604";
     public static final String VALID      = "\u2714";
@@ -236,6 +239,11 @@ public class GuiUtils
         cachedTooltipStack = ItemStack.EMPTY;
     }
 
+    public static void drawHoveringText(List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    {
+        drawHoveringText(textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, DEFAULT_BACKGROUND_COLOR, DEFAULT_BORDER_COLOR_START, DEFAULT_BORDER_COLOR_END, font);
+    }
+
     /**
      *  Draws a tooltip box on the screen with text in it.
      *  Automatically positions the box relative to the mouse to match Mojang's implementation.
@@ -251,17 +259,25 @@ public class GuiUtils
      *                     Set to a negative number to have no max width.
      * @param font the font for drawing the text in the tooltip box
      */
-    public static void drawHoveringText(List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    public static void drawHoveringText(List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight,
+                                        int maxTextWidth, int backgroundColor, int borderColorStart, int borderColorEnd, FontRenderer font)
     {
-        drawHoveringText(cachedTooltipStack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, font);
+        drawHoveringText(cachedTooltipStack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, backgroundColor, borderColorStart, borderColorEnd, font);
+    }
+
+    public static void drawHoveringText(@Nonnull final ItemStack stack, List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    {
+        drawHoveringText(stack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, DEFAULT_BACKGROUND_COLOR, DEFAULT_BORDER_COLOR_START, DEFAULT_BORDER_COLOR_END, font);
     }
 
     /**
      * Use this version if calling from somewhere where ItemStack context is available.
      *
-     * @see #drawHoveringText(List, int, int, int, int, int, FontRenderer)
+     * @see #drawHoveringText(List, int, int, int, int, int, int, int, int, FontRenderer)
      */
-    public static void drawHoveringText(@Nonnull final ItemStack stack, List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    public static void drawHoveringText(@Nonnull final ItemStack stack, List<String> textLines, int mouseX, int mouseY,
+                                        int screenWidth, int screenHeight, int maxTextWidth,
+                                        int backgroundColor, int borderColorStart, int borderColorEnd, FontRenderer font)
     {
         if (!textLines.isEmpty())
         {
@@ -353,9 +369,6 @@ public class GuiUtils
                 tooltipY = screenHeight - tooltipHeight - 4;
 
             final int zLevel = 300;
-            int backgroundColor = 0xF0100010;
-            int borderColorStart = 0x505000FF;
-            int borderColorEnd = (borderColorStart & 0xFEFEFE) >> 1 | borderColorStart & 0xFF000000;
             RenderTooltipEvent.Color colorEvent = new RenderTooltipEvent.Color(stack, textLines, tooltipX, tooltipY, font, backgroundColor, borderColorStart, borderColorEnd);
             MinecraftForge.EVENT_BUS.post(colorEvent);
             backgroundColor = colorEvent.getBackground();

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -257,6 +257,10 @@ public class GuiUtils
      * @param screenHeight the available  screen height for the tooltip to drawn in
      * @param maxTextWidth the maximum width of the text in the tooltip box.
      *                     Set to a negative number to have no max width.
+     * @param backgroundColor The background color of the box
+     * @param borderColorStart The starting color of the box border
+     * @param borderColorEnd The ending color of the box border. The border color will be smoothly interpolated
+     *                       between the start and end values.
      * @param font the font for drawing the text in the tooltip box
      */
     public static void drawHoveringText(List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight,


### PR DESCRIPTION
In Vazkiis mods we have giant helper methods to draw tooltips when we could just be using Forge's, all because we need custom colors. I imagine the same for many other large mods that use tooltips with custom-colored borders.

The methods in GuiUtil already support changing the colors using an event, so it makes little sense to not allow them to take the colors as parameters too.

Added three parameters for the colors and add overloads for the old signatures for backward compatibility.