### PR TITLE
Fix ownership leak in ItemStackHandler

### DIFF
--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -141,8 +141,12 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
             {
                 this.stacks.set(slot, ItemStack.EMPTY);
                 onContentsChanged(slot);
+                return existing;
             }
-            return existing;
+            else
+            {
+                return existing.copy();
+            }
         }
         else
         {


### PR DESCRIPTION
This is a simple fix to return a copied item stack when `ItemStackHandler#extractItem` is invoked with `simulate=true`m and there happen to be less items stored than desired.
The original code returns a direct reference which breaks the postcondition `The returned ItemStack can be safely modified after, so item handlers should return a new or copied stack.`

This bug also exists in the 1.14 branch, which needs to be changed separately. I won't submit another PR for it.