### PR TITLE
Switch model generation from Object.toString() to IProperty.getName(T)

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -119,10 +119,10 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
                 JsonObject when = new JsonObject();
                 for (Entry<IProperty<?>, Collection<Comparable<?>>> e : conditions.asMap().entrySet()) {
                     StringBuilder activeString = new StringBuilder();
-                    for (Object val : e.getValue()) {
+                    for (Comparable<?> val : e.getValue()) {
                         if (activeString.length() > 0)
                             activeString.append("|");
-                        activeString.append(val.toString());
+                        activeString.append(((IProperty) e.getKey()).getName(val));
                     }
                     when.addProperty(e.getKey().getName(), activeString.toString());
                 }

--- a/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
@@ -307,7 +307,7 @@ public class VariantBlockStateBuilder implements IGeneratedBlockstate {
                 }
                 ret.append(entry.getKey().getName())
                         .append('=')
-                        .append(entry.getValue());
+                        .append(((IProperty) entry.getKey()).getName(entry.getValue()));
             }
             return ret.toString();
         }


### PR DESCRIPTION
A simple fix for #6520 that changes the calls to toString() by calls to IProperty.getName(T).