### PR TITLE
Add ability to create custom (client-side only) chat commands

### DIFF
--- a/patches/minecraft/net/minecraft/command/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/command/Commands.java.patch
@@ -1,6 +1,23 @@
 --- a/net/minecraft/command/Commands.java
 +++ b/net/minecraft/command/Commands.java
-@@ -194,7 +194,15 @@
+@@ -94,6 +94,7 @@
+ import net.minecraft.util.text.TranslationTextComponent;
+ import net.minecraft.util.text.event.ClickEvent;
+ import net.minecraft.util.text.event.HoverEvent;
++import net.minecraftforge.command.ForgeCommands;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+@@ -176,6 +177,8 @@
+          WhitelistCommand.func_198873_a(this.field_197062_b);
+       }
+ 
++      ForgeCommands.register(this.field_197062_b, p_i49161_1_);
++
+       this.field_197062_b.findAmbiguities((p_201302_1_, p_201302_2_, p_201302_3_, p_201302_4_) -> {
+          field_197061_a.warn("Ambiguity between arguments {} and {} with inputs: {}", this.field_197062_b.getPath(p_201302_2_), this.field_197062_b.getPath(p_201302_3_), p_201302_4_);
+       });
+@@ -194,7 +197,15 @@
  
        try {
           try {

--- a/src/main/java/net/minecraftforge/command/ForgeCommands.java
+++ b/src/main/java/net/minecraftforge/command/ForgeCommands.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ForgeCommands {
+
+	private static List<ModCommand> COMMANDS = new ArrayList<>();
+
+	public static void addCommand(ModCommand command) {
+		COMMANDS.add(command);
+	}
+
+	public static void register(CommandDispatcher<CommandSource> dispatcher, boolean isDedicatedServer) {
+		// TODO register commands here
+		// 	ideas:
+		// 		- look through all classes annotated with @ModCommand and execute the register method
+		//  	- create a list of ModCommands and have the user add their command to it
+
+		System.err.println("Registering commands");
+		for (ModCommand command : COMMANDS) {
+			command.register(dispatcher, isDedicatedServer);
+		}
+	}
+}

--- a/src/main/java/net/minecraftforge/command/ForgeCommands.java
+++ b/src/main/java/net/minecraftforge/command/ForgeCommands.java
@@ -19,11 +19,6 @@ public class ForgeCommands {
 	}
 
 	public static void register(CommandDispatcher<CommandSource> dispatcher, boolean isDedicatedServer) {
-		// TODO register commands here
-		// 	ideas:
-		// 		- look through all classes annotated with @ModCommand and execute the register method
-		//  	- create a list of ModCommands and have the user add their command to it
-
 		LOGGER.info("Registering commands");
 		for (ModCommand command : COMMANDS) {
 			command.register(dispatcher, isDedicatedServer);

--- a/src/main/java/net/minecraftforge/command/ForgeCommands.java
+++ b/src/main/java/net/minecraftforge/command/ForgeCommands.java
@@ -2,11 +2,15 @@ package net.minecraftforge.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.command.CommandSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ForgeCommands {
+
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	private static List<ModCommand> COMMANDS = new ArrayList<>();
 
@@ -20,9 +24,10 @@ public class ForgeCommands {
 		// 		- look through all classes annotated with @ModCommand and execute the register method
 		//  	- create a list of ModCommands and have the user add their command to it
 
-		System.err.println("Registering commands");
+		LOGGER.info("Registering commands");
 		for (ModCommand command : COMMANDS) {
 			command.register(dispatcher, isDedicatedServer);
+			LOGGER.info("Registered command " + command.getClass());
 		}
 	}
 }

--- a/src/main/java/net/minecraftforge/command/ModCommand.java
+++ b/src/main/java/net/minecraftforge/command/ModCommand.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+
+public interface ModCommand {
+	void register(CommandDispatcher<CommandSource> dispatcher, boolean isDedicatedServer);
+}

--- a/src/main/java/net/minecraftforge/command/ModCommand.java
+++ b/src/main/java/net/minecraftforge/command/ModCommand.java
@@ -3,6 +3,7 @@ package net.minecraftforge.command;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.command.CommandSource;
 
+@FunctionalInterface
 public interface ModCommand {
 	void register(CommandDispatcher<CommandSource> dispatcher, boolean isDedicatedServer);
 }

--- a/src/test/java/net/minecraftforge/debug/CommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/CommandTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.debug;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraftforge.command.ForgeCommands;
+import net.minecraftforge.command.ModCommand;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("command_test")
+@Mod.EventBusSubscriber
+public class CommandTest implements ModCommand {
+
+	public CommandTest() {
+		ForgeCommands.addCommand(this);
+	}
+
+	@Override
+	public void register(CommandDispatcher<CommandSource> dispatcher, boolean isDedicatedServer) {
+		dispatcher.register(
+				Commands.literal("test_command")
+						.executes((context) -> {
+							System.err.println("Hello World");
+							return 0;
+						}));
+	}
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -61,3 +61,5 @@ loaderVersion="[28,)"
     modId="nameplate_render_test"
 [[mods]]
     modId="global_loot_test"
+[[mods]]
+    modId="command_test"


### PR DESCRIPTION
I was looking for a way to create custom chat commands.
I think this simple fix would enable people to add custom chat commands to their mods.

All this patch does, is hook into the standard way Minecraft registers chat commands and make it expandable.
This is done by using a static list of commands that should be registered.
A mod simple adds their commands to this list during the initialization and they'll be added to the game.

Another way of doing it would be by creating an annotation and scanning the classes of the mod for this annotation and add the custom commands that way.
This would be a lot more convenient for the mod creator, but also much more complicated to implement.