### PR TITLE
Reworked AnvilUpdateEvent for more flexibility and to solve existing problems

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -18,20 +18,31 @@
                    BlockState blockstate1 = AnvilBlock.func_196433_f(blockstate);
                    if (blockstate1 == null) {
                       p_216931_1_.func_217377_a(p_216931_2_, false);
-@@ -132,8 +134,11 @@
+@@ -132,8 +134,22 @@
           Map<Enchantment, Integer> map = EnchantmentHelper.func_82781_a(itemstack1);
           j = j + itemstack.func_82838_A() + (itemstack2.func_190926_b() ? 0 : itemstack2.func_82838_A());
           this.field_82856_l = 0;
 +         boolean flag = false;
-+
++         net.minecraftforge.event.AnvilUpdateEvent evt = net.minecraftforge.common.ForgeHooks.onAnvilChange(itemstack, itemstack2, this.field_82857_m, this.field_82855_n.field_71075_bZ.field_75098_d);
++         this.materialCost = evt.getMaterialCost();
++         i += evt.getCost();
++         if (evt.isCanceled()) {
++            this.field_82852_f.func_70299_a(0, evt.getOutput());
++            this.maximumCost.set(i);
++            if (!evt.getOutput().isEmpty()) this.func_75142_b();
++            return;
++         }
++         if (!evt.getOutput().isEmpty()) {
++            itemstack1 = evt.getOutput();
++            map = EnchantmentHelper.func_82781_a(evt.getOutput());
++         } else
           if (!itemstack2.func_190926_b()) {
 -            boolean flag = itemstack2.func_77973_b() == Items.field_151134_bR && !EnchantedBookItem.func_92110_g(itemstack2).isEmpty();
-+            if (!net.minecraftforge.common.ForgeHooks.onAnvilChange(this, itemstack, itemstack2, field_82852_f, field_82857_m, j)) return;
 +            flag = itemstack2.func_77973_b() == Items.field_151134_bR && !EnchantedBookItem.func_92110_g(itemstack2).isEmpty();
              if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2)) {
                 int l2 = Math.min(itemstack1.func_77952_i(), itemstack1.func_77958_k() / 4);
                 if (l2 <= 0) {
-@@ -250,6 +255,7 @@
+@@ -250,6 +266,7 @@
              i += k;
              itemstack1.func_200302_a(new StringTextComponent(this.field_82857_m));
           }
@@ -39,12 +50,3 @@
  
           this.field_82854_e.func_221494_a(j + i);
           if (i <= 0) {
-@@ -354,4 +360,8 @@
-    public int func_216976_f() {
-       return this.field_82854_e.func_221495_b();
-    }
-+
-+   public void setMaximumCost(int value) {
-+      this.field_82854_e.func_221494_a(value);
-+   }
- }

--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -23,7 +23,7 @@
           j = j + itemstack.func_82838_A() + (itemstack2.func_190926_b() ? 0 : itemstack2.func_82838_A());
           this.field_82856_l = 0;
 +         boolean flag = false;
-+         net.minecraftforge.event.AnvilUpdateEvent evt = net.minecraftforge.common.ForgeHooks.onAnvilChange(itemstack, itemstack2, this.field_82857_m, this.field_82855_n.field_71075_bZ.field_75098_d);
++         net.minecraftforge.event.AnvilUpdateEvent evt = net.minecraftforge.common.ForgeHooks.onAnvilUpdate(itemstack, itemstack2, this.field_82857_m, this.field_82855_n.field_71075_bZ.field_75098_d);
 +         this.field_82856_l = evt.getMaterialCost();
 +         i += evt.getCost();
 +         if (evt.isCanceled()) {
@@ -50,3 +50,12 @@
  
           this.field_82854_e.func_221494_a(j + i);
           if (i <= 0) {
+@@ -354,4 +371,8 @@
+    public int func_216976_f() {
+       return this.field_82854_e.func_221495_b();
+    }
++
++   public void setMaximumCost(int value) {
++      this.field_82854_e.func_221494_a(value);
++   }
+ }

--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -24,15 +24,15 @@
           this.field_82856_l = 0;
 +         boolean flag = false;
 +         net.minecraftforge.event.AnvilUpdateEvent evt = net.minecraftforge.common.ForgeHooks.onAnvilChange(itemstack, itemstack2, this.field_82857_m, this.field_82855_n.field_71075_bZ.field_75098_d);
-+         this.materialCost = evt.getMaterialCost();
++         this.field_82856_l = evt.getMaterialCost();
 +         i += evt.getCost();
 +         if (evt.isCanceled()) {
 +            this.field_82852_f.func_70299_a(0, evt.getOutput());
-+            this.maximumCost.set(i);
-+            if (!evt.getOutput().isEmpty()) this.func_75142_b();
++            this.field_82854_e.func_221494_a(i);
++            if (!evt.getOutput().func_190926_b()) this.func_75142_b();
 +            return;
 +         }
-+         if (!evt.getOutput().isEmpty()) {
++         if (!evt.getOutput().func_190926_b()) {
 +            itemstack1 = evt.getOutput();
 +            map = EnchantmentHelper.func_82781_a(evt.getOutput());
 +         } else

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -681,16 +681,11 @@ public class ForgeHooks
         return ret;
     }
 
-    public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost)
+    public static AnvilUpdateEvent onAnvilChange(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, boolean creativePlayer)
     {
-        AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, baseCost);
-        if (MinecraftForge.EVENT_BUS.post(e)) return false;
-        if (e.getOutput().isEmpty()) return true;
-
-        outputSlot.setInventorySlotContents(0, e.getOutput());
-        container.setMaximumCost(e.getCost());
-        container.materialCost = e.getMaterialCost();
-        return false;
+        AnvilUpdateEvent evt = new AnvilUpdateEvent(left, right, name, creativePlayer);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
     public static float onAnvilRepair(PlayerEntity player, @Nonnull ItemStack output, @Nonnull ItemStack left, @Nonnull ItemStack right)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -681,7 +681,19 @@ public class ForgeHooks
         return ret;
     }
 
-    public static AnvilUpdateEvent onAnvilChange(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, boolean creativePlayer)
+    public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost)
+    {
+        AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, false);
+        if (MinecraftForge.EVENT_BUS.post(e)) return false;
+        if (e.getOutput().isEmpty()) return true;
+
+        outputSlot.setInventorySlotContents(0, e.getOutput());
+        container.setMaximumCost(e.getCost());
+        container.materialCost = e.getMaterialCost();
+        return false;
+    }
+
+    public static AnvilUpdateEvent onAnvilUpdate(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, boolean creativePlayer)
     {
         AnvilUpdateEvent evt = new AnvilUpdateEvent(left, right, name, creativePlayer);
         MinecraftForge.EVENT_BUS.post(evt);

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -27,32 +27,37 @@ import javax.annotation.Nonnull;
 
 /**
  * 
- * AnvilUpdateEvent is fired when a player places items in both the left and right slots of a anvil.
- * If the event is canceled, vanilla behavior will not run, and the output will be set to null.
- * If the event is not canceled, but the output is not null, it will set the output and not run vanilla behavior.
- * if the output is null, and the event is not canceled, vanilla behavior will execute.
+ * This event is fired in {@link net.minecraft.inventory.container.RepairContainer#updateRepairOutput} as long as an item stack is present in the left slot of the anvil.
+ * Maximum cost and material cost will always be set from this event, even when not canceled.
+ * 
+ * If the output stack remains empty and the event is not canceled, vanilla behavior will be executed.
+ * If the output stack is changed it will be set from this event.
+ * If the event is then canceled no vanilla behaviour will apply.
+ * If the event is not canceled vanilla logic for creating the output will be skipped, but the rest of the vanilla method will execute as normal.
  */
 @Cancelable
 public class AnvilUpdateEvent extends Event
 {
     @Nonnull
-    private final ItemStack left;  // The left side of the input
+    private final ItemStack left;               // The left side of the input
     @Nonnull
-    private final ItemStack right; // The right side of the input
-    private final String name;     // The name to set the item, if the user specified one.
+    private final ItemStack right;              // The right side of the input, can be empty
+    private final String name;                  // The name of the left item stack
+    private final boolean creativePlayer        // Whether the player is in creative mode
     @Nonnull
-    private ItemStack output;      // Set this to set the output stack
-    private int cost;              // The base cost, set this to change it if output != null
-    private int materialCost; // The number of items from the right slot to be consumed during the repair. Leave as 0 to consume the entire stack.
+    private ItemStack output;                   // Set this to set the output stack
+    private int cost;                           // The cost for this repair operation
+    private int materialCost;                   // The number of items from the right stack to be consumed during the repair, leaving as 0 will consume the entire stack
 
-    public AnvilUpdateEvent(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, int cost)
+    public AnvilUpdateEvent(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, boolean creativePlayer)
     {
         this.left = left;
         this.right = right;
-        this.output = ItemStack.EMPTY;
         this.name = name;
-        this.setCost(cost);
-        this.setMaterialCost(0);
+        this.creativePlayer = creativePlayer;
+        this.output = ItemStack.EMPTY;
+        this.cost = 0;
+        this.materialCost = 0;
     }
 
     @Nonnull
@@ -60,6 +65,7 @@ public class AnvilUpdateEvent extends Event
     @Nonnull
     public ItemStack getRight() { return right; }
     public String getName() { return name; }
+    public String isCreativePlayer() { return creativePlayer; }
     @Nonnull
     public ItemStack getOutput() { return output; }
     public void setOutput(@Nonnull ItemStack output) { this.output = output; }

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -65,7 +65,7 @@ public class AnvilUpdateEvent extends Event
     @Nonnull
     public ItemStack getRight() { return right; }
     public String getName() { return name; }
-    public String isCreativePlayer() { return creativePlayer; }
+    public boolean isCreativePlayer() { return creativePlayer; }
     @Nonnull
     public ItemStack getOutput() { return output; }
     public void setOutput(@Nonnull ItemStack output) { this.output = output; }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -117,7 +117,6 @@ public net.minecraft.entity.player.ServerPlayerEntity field_71139_cq
 public net.minecraft.entity.player.ServerPlayerEntity func_71117_bO()V
 public net.minecraft.inventory.container.ContainerType <init>(Lnet/minecraft/inventory/container/ContainerType$IFactory;)V
 public net.minecraft.inventory.container.ContainerType$IFactory
-public net.minecraft.inventory.container.RepairContainer field_82856_l #RepairContainer/stackSizeToBeUsedInRepair
 public net.minecraft.item.AxeItem <init>(Lnet/minecraft/item/IItemTier;FFLnet/minecraft/item/Item$Properties;)V
 public net.minecraft.item.Item field_185051_m # properties
 public-f net.minecraft.item.ItemGroup field_78032_a # group array

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -117,6 +117,7 @@ public net.minecraft.entity.player.ServerPlayerEntity field_71139_cq
 public net.minecraft.entity.player.ServerPlayerEntity func_71117_bO()V
 public net.minecraft.inventory.container.ContainerType <init>(Lnet/minecraft/inventory/container/ContainerType$IFactory;)V
 public net.minecraft.inventory.container.ContainerType$IFactory
+public net.minecraft.inventory.container.RepairContainer field_82856_l #RepairContainer/stackSizeToBeUsedInRepair
 public net.minecraft.item.AxeItem <init>(Lnet/minecraft/item/IItemTier;FFLnet/minecraft/item/Item$Properties;)V
 public net.minecraft.item.Item field_185051_m # properties
 public-f net.minecraft.item.ItemGroup field_78032_a # group array


### PR DESCRIPTION
So here is a reworked version of the `AnvilUpdateEvent`. Why is this necessary in the first place?

**Problems with the current implementation**
- Client desync as `RepairContainer::detectAndSendChanges` is not being called, a manual call is impossible; this causes e. g. the `Too Expensive!` text to not display when it should
- No access to whether the player is in creative mode; this is used for disabling the level cap in vanilla, modders might want to do something similar
- Modders always need to copy most of the `RepairContainer::updateRepairOutput` method, even when doing such simple things as adding / changing the output
&nbsp;

Solving all three of those problems has most notably lead to changes to `AnvilUpdateEvent` as well as `RepairContainer.java.patch`. For better understanding here is a deobfuscated version of the most relevant part of the changes to `RepairContainer.java.patch`.
```
          this.materialCost = 0;
+         boolean flag = false;
+         net.minecraftforge.event.AnvilUpdateEvent evt = net.minecraftforge.common.ForgeHooks.onAnvilUpdate(itemstack, itemstack2, this.repairedItemName, this.player.abilities.isCreativeMode);
+         this.materialCost = evt.getMaterialCost();
+         i += evt.getCost();
+         if (evt.isCanceled()) {
+            this.outputSlot.setInventorySlotContents(0, evt.getOutput());
+            this.maximumCost.set(i);
+            if (!evt.getOutput().isEmpty()) this.detectAndSendChanges();
+            return;
+         }
+         if (!evt.getOutput().isEmpty()) {
+            itemstack1 = evt.getOutput();
+            map = EnchantmentHelper.getEnchantments(evt.getOutput());
+         } else
          if (!itemstack2.isEmpty()) {
```

**Three ways of using the new implementation**
- Cancel the event
**Behaviour:** output slot remains empty
**Possible before?** Yes
**Changes:** `outputSlot` and `maximumCost` are properly reset
- Cancel the event and set your own output
**Behaviour:** no vanilla logic runs, modder has full control
**Possible before?** Yes
**Changes:** `RepairContainer::detectAndSendChanges` is called as intended and there's access to whether the player is in creative mode
- Change the output without canceling the event
**Behaviour:** vanilla code for setting the output will be skipped, but the rest of `RepairContainer::updateRepairOutput` executes as usual (renaming, calculating cost, checking level cap, etc.)
**Possible before?** No
&nbsp;

Some questions that might arise.

**Why has the call to this event moved outside of the `if (!itemstack2.isEmpty())`-block?**
A bunch of mods use this event for removing the vanilla level cap. Previously that type of removal would only apply when combing two items. Now it always applies, even when renaming an item.

**Why is the event now solely handled in the vanilla class and not in `ForgeHooks`?**
Access to multiple local variables is required (itemstack1 = output, i = maximum cost, map = enchantments, needed later).