### PR TITLE
Added an AT to remove a restriction from entity models.

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -54,6 +54,7 @@ protected net.minecraft.client.renderer.model.ModelBakery field_177606_o # MODEL
 protected net.minecraft.client.renderer.model.ModelBakery field_177616_r # MODEL_ENTITY
 private-f net.minecraft.client.renderer.model.ModelBakery field_217853_J # field_217853_J - need to un-finalize so that we can delay initialization to after calling super() in ModelLoader
 protected net.minecraft.client.renderer.model.ModelBakery func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/model/BlockModel; # loadModel
+public net.minecraft.client.renderer.model.ModelRenderer func_228305_a_(IIFFFFFFFFFZZ)V # addBox
 private-f net.minecraft.client.renderer.tileentity.PistonTileEntityRenderer field_178462_c # blockRenderer - it's static so we need to un-finalize in case this class loads to early.
 public net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher field_147557_n # fontRenderer - needed for rendering text in TESR items before entering world
 public net.minecraft.command.arguments.EntityOptions func_202024_a(Ljava/lang/String;Lnet/minecraft/command/arguments/EntityOptions$IFilter;Ljava/util/function/Predicate;Lnet/minecraft/util/text/ITextComponent;)V # register


### PR DESCRIPTION
This tiny change should give mod creators a bit more freedom regarding their Entity Models.
By default, you cannot use 3 axis inflation while also mirroring the texture.
This behavior isn't really intuitive and there is no real reason for this method to have restricted access.
(I'd guess mojang has an overload for it but it got lost during compilation/obfuscation)
Having this change directly within Forge would be great for Modelling Tools like Blockbench,
that would otherwise be either forced to keep the old pre 1.15 limits for entity models,
or require the users to add the AT to their own mods.