### PR TITLE
Don't resolve symbolic links in ModDirTransformerDiscoverer

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -53,7 +53,7 @@ public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService
     }
 
     private static void scan(final Path gameDirectory) {
-        final Path modsDir = gameDirectory.resolve(FMLPaths.MODSDIR.relative());
+        final Path modsDir = gameDirectory.resolve(FMLPaths.MODSDIR.relative()).toAbsolutePath().normalize();
         transformers = new ArrayList<>();
         locators = new ArrayList<>();
         if (!Files.exists(modsDir)) {
@@ -74,9 +74,9 @@ public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService
         if (LamdbaExceptionUtils.uncheck(() -> Files.size(path)) == 0) return;
         try (ZipFile zf = new ZipFile(new File(path.toUri()))) {
             if (zf.getEntry("META-INF/services/cpw.mods.modlauncher.api.ITransformationService") != null) {
-                transformers.add(path.toRealPath());
+                transformers.add(path);
             } else if (zf.getEntry("META-INF/services/net.minecraftforge.forgespi.locating.IModLocator") != null) {
-                locators.add(path.toRealPath());
+                locators.add(path);
             }
         } catch (IOException ioe) {
             LogManager.getLogger().error("Zip Error when loading jar file {}", path, ioe);


### PR DESCRIPTION
This PR fixes an issue that occurs when the Game Directory is located behind a symbolic link.

The [ModDirTransformerDiscoverer](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java) scans jar files checking if they contain ITransformationService or IModLocator services, If the jar does contain any of these services the path is added to a list, This list is later used by the [ModsFolderLocator](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java) which will exclude any jars in this list from being loaded as a Mod.

The issue is when resolving the path to the jar file the [ModDirTransformerDiscoverer](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java) calls `toRealPath` but the [ModsFolderLocator](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java) uses `toAbsolutePath` as seen in [FMLPaths](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLPaths.java), The difference here is that `toRealPath` will resolve symbolic links where `toAbsolutePath` doesn't, This causes jars that were excluded to get loaded anyway due to the list containing the incorrect path.

The changes I've made remove the call to `toRealPath` and instead make the `modsDir` variable store an absolute path instead of a relative one using the same method as [FMLPaths#L73](https://github.com/MinecraftForge/MinecraftForge/blob/0d2a0deef396a46ceadd8cdaeb0deca36770188f/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLPaths.java#L73) to resolve the path.

Related Issues:
- https://github.com/gorilla-devs/GDLauncher-Next-Issues/issues/15
- https://github.com/LXGaming/MixinBootstrap/issues/10