### PR TITLE
Added doRenderWorld to RenderTickEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -151,13 +151,13 @@
        RenderSystem.enableTexture();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
-+         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickStart(this.field_71428_T.field_194147_b);
++         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickStart(this.field_71428_T.field_194147_b, p_195542_1_);
           this.field_71424_I.func_219895_b("gameRenderer");
           this.field_71460_t.func_195458_a(this.field_71445_n ? this.field_193996_ah : this.field_71428_T.field_194147_b, i, p_195542_1_);
           this.field_71424_I.func_219895_b("toasts");
           this.field_193034_aS.func_195625_a();
           this.field_71424_I.func_76319_b();
-+         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickEnd(this.field_71428_T.field_194147_b);
++         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickEnd(this.field_71428_T.field_194147_b, p_195542_1_);
        }
  
        this.field_71424_I.func_219897_b();

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -78,10 +78,12 @@ public class TickEvent extends Event
 
     public static class RenderTickEvent extends TickEvent {
         public final float renderTickTime;
-        public RenderTickEvent(Phase phase, float renderTickTime)
+        public final boolean doRenderWorld;
+        public RenderTickEvent(Phase phase, float renderTickTime, boolean doRenderWorld)
         {
             super(Type.RENDER, LogicalSide.CLIENT, phase);
             this.renderTickTime = renderTickTime;
+            this.doRenderWorld = doRenderWorld;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -68,15 +68,15 @@ public class BasicEventHooks
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.ItemSmeltedEvent(player, smelted));
     }
 
-    public static void onRenderTickStart(float timer)
+    public static void onRenderTickStart(float timer, boolean doRenderWorld)
     {
         Animation.setClientPartialTickTime(timer);
-        MinecraftForge.EVENT_BUS.post(new TickEvent.RenderTickEvent(TickEvent.Phase.START, timer));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.RenderTickEvent(TickEvent.Phase.START, timer, doRenderWorld));
     }
 
-    public static void onRenderTickEnd(float timer)
+    public static void onRenderTickEnd(float timer, boolean doRenderWorld)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.RenderTickEvent(TickEvent.Phase.END, timer));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.RenderTickEvent(TickEvent.Phase.END, timer, doRenderWorld));
     }
 
     public static void onPlayerPreTick(PlayerEntity player)


### PR DESCRIPTION
**minecraft.gameRenderer.updateCameraAndRender** has a new argument **renderWorldIn** that is used to decide whether the world should be rendered or not. It appears to be false when the world does not exist (when joining or leaving a world) or when out of memory, and true otherwise.

This commit adds **renderWorldIn** to the **RenderTickEvent** so that mods have access to the relevant arguments when calling **updateCameraAndRender**.