### PR TITLE
Patch Various Entity Classes to allow Modded Bows and Crossbows

### DIFF
--- a/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
@@ -63,16 +63,12 @@
                    this.field_70170_p.func_72960_a(playerentity, (byte)30);
                 }
              }
-@@ -1215,7 +1226,12 @@
+@@ -1214,7 +1225,7 @@
+       }
  
     }
- 
-+   @Deprecated
+-
++   public boolean isHolding(java.util.function.Predicate<Item> itemPredicate) { return itemPredicate.test(this.func_184614_ca().func_77973_b()) || itemPredicate.test(this.func_184592_cb().func_77973_b()); }
     public boolean func_213382_a(Item p_213382_1_) {
        return this.func_184614_ca().func_77973_b() == p_213382_1_ || this.func_184592_cb().func_77973_b() == p_213382_1_;
     }
-+
-+   public boolean isHolding(java.util.function.Predicate<Item> itemPredicate) {
-+      return itemPredicate.test(this.func_184614_ca().func_77973_b()) || itemPredicate.test(this.func_184592_cb().func_77973_b());
-+   }
- }

--- a/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
@@ -63,3 +63,16 @@
                    this.field_70170_p.func_72960_a(playerentity, (byte)30);
                 }
              }
+@@ -1215,7 +1226,12 @@
+ 
+    }
+ 
++   @Deprecated
+    public boolean func_213382_a(Item p_213382_1_) {
+       return this.func_184614_ca().func_77973_b() == p_213382_1_ || this.func_184592_cb().func_77973_b() == p_213382_1_;
+    }
++
++   public boolean isHolding(java.util.function.Predicate<Item> itemPredicate) {
++      return itemPredicate.test(this.func_184614_ca().func_77973_b()) || itemPredicate.test(this.func_184592_cb().func_77973_b());
++   }
+ }

--- a/patches/minecraft/net/minecraft/entity/ai/goal/RangedBowAttackGoal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/goal/RangedBowAttackGoal.java.patch
@@ -9,3 +9,12 @@
     }
  
     public boolean func_75253_b() {
+@@ -117,7 +117,7 @@
+                }
+             }
+          } else if (--this.field_188503_e <= 0 && this.field_188504_f >= -60) {
+-            this.field_188499_a.func_184598_c(ProjectileHelper.func_221274_a(this.field_188499_a, Items.field_151031_f));
++            this.field_188499_a.func_184598_c(ProjectileHelper.getHandWith(this.field_188499_a, item -> item instanceof BowItem));
+          }
+ 
+       }

--- a/patches/minecraft/net/minecraft/entity/ai/goal/RangedCrossbowAttackGoal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/goal/RangedCrossbowAttackGoal.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/entity/ai/goal/RangedCrossbowAttackGoal.java
++++ b/net/minecraft/entity/ai/goal/RangedCrossbowAttackGoal.java
+@@ -30,7 +30,7 @@
+    }
+ 
+    private boolean func_220745_g() {
+-      return this.field_220748_a.func_213382_a(Items.field_222114_py);
++      return this.field_220748_a.isHolding(item -> item instanceof CrossbowItem);
+    }
+ 
+    public boolean func_75253_b() {
+@@ -80,7 +80,7 @@
+          this.field_220748_a.func_70671_ap().func_75651_a(livingentity, 30.0F, 30.0F);
+          if (this.field_220749_b == RangedCrossbowAttackGoal.CrossbowState.UNCHARGED) {
+             if (!flag2) {
+-               this.field_220748_a.func_184598_c(ProjectileHelper.func_221274_a(this.field_220748_a, Items.field_222114_py));
++               this.field_220748_a.func_184598_c(ProjectileHelper.getHandWith(this.field_220748_a, item -> item instanceof CrossbowItem));
+                this.field_220749_b = RangedCrossbowAttackGoal.CrossbowState.CHARGING;
+                ((ICrossbowUser)this.field_220748_a).func_213671_a(true);
+             }
+@@ -104,7 +104,7 @@
+             }
+          } else if (this.field_220749_b == RangedCrossbowAttackGoal.CrossbowState.READY_TO_ATTACK && flag) {
+             ((IRangedAttackMob)this.field_220748_a).func_82196_d(livingentity, 1.0F);
+-            ItemStack itemstack1 = this.field_220748_a.func_184586_b(ProjectileHelper.func_221274_a(this.field_220748_a, Items.field_222114_py));
++            ItemStack itemstack1 = this.field_220748_a.func_184586_b(ProjectileHelper.getHandWith(this.field_220748_a, item -> item instanceof CrossbowItem));
+             CrossbowItem.func_220011_a(itemstack1, false);
+             this.field_220749_b = RangedCrossbowAttackGoal.CrossbowState.UNCHARGED;
+          }

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractSkeletonEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractSkeletonEntity.java.patch
@@ -1,17 +1,22 @@
 --- a/net/minecraft/entity/monster/AbstractSkeletonEntity.java
 +++ b/net/minecraft/entity/monster/AbstractSkeletonEntity.java
-@@ -154,7 +154,7 @@
+@@ -153,8 +153,8 @@
+       if (this.field_70170_p != null && !this.field_70170_p.field_72995_K) {
           this.field_70714_bg.func_85156_a(this.field_85038_e);
           this.field_70714_bg.func_85156_a(this.field_85037_d);
-          ItemStack itemstack = this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f));
+-         ItemStack itemstack = this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f));
 -         if (itemstack.func_77973_b() == Items.field_151031_f) {
++         ItemStack itemstack = this.func_184586_b(ProjectileHelper.getHandWith(this, item -> item instanceof net.minecraft.item.BowItem));
 +         if (itemstack.func_77973_b() instanceof net.minecraft.item.BowItem) {
              int i = 20;
              if (this.field_70170_p.func_175659_aa() != Difficulty.HARD) {
                 i = 40;
-@@ -172,6 +172,8 @@
+@@ -170,8 +170,10 @@
+    }
+ 
     public void func_82196_d(LivingEntity p_82196_1_, float p_82196_2_) {
-       ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f)));
+-      ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f)));
++      ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.getHandWith(this, item -> item instanceof net.minecraft.item.BowItem)));
        AbstractArrowEntity abstractarrowentity = this.func_213624_b(itemstack, p_82196_2_);
 +      if (this.func_184614_ca().func_77973_b() instanceof net.minecraft.item.BowItem)
 +         abstractarrowentity = ((net.minecraft.item.BowItem)this.func_184614_ca().func_77973_b()).customeArrow(abstractarrowentity);

--- a/patches/minecraft/net/minecraft/entity/monster/IllusionerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/IllusionerEntity.java.patch
@@ -1,8 +1,11 @@
 --- a/net/minecraft/entity/monster/IllusionerEntity.java
 +++ b/net/minecraft/entity/monster/IllusionerEntity.java
-@@ -185,6 +185,8 @@
+@@ -183,8 +183,10 @@
+    }
+ 
     public void func_82196_d(LivingEntity p_82196_1_, float p_82196_2_) {
-       ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f)));
+-      ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.func_221274_a(this, Items.field_151031_f)));
++      ItemStack itemstack = this.func_213356_f(this.func_184586_b(ProjectileHelper.getHandWith(this, item -> item instanceof net.minecraft.item.BowItem)));
        AbstractArrowEntity abstractarrowentity = ProjectileHelper.func_221272_a(this, itemstack, p_82196_2_);
 +      if (this.func_184614_ca().func_77973_b() instanceof net.minecraft.item.BowItem)
 +         abstractarrowentity = ((net.minecraft.item.BowItem)this.func_184614_ca().func_77973_b()).customeArrow(abstractarrowentity);

--- a/patches/minecraft/net/minecraft/entity/monster/PillagerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/PillagerEntity.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/entity/monster/PillagerEntity.java
++++ b/net/minecraft/entity/monster/PillagerEntity.java
+@@ -122,7 +122,7 @@
+    public AbstractIllagerEntity.ArmPose func_193077_p() {
+       if (this.func_213675_dX()) {
+          return AbstractIllagerEntity.ArmPose.CROSSBOW_CHARGE;
+-      } else if (this.func_213382_a(Items.field_222114_py)) {
++      } else if (this.isHolding(item -> item instanceof CrossbowItem)) {
+          return AbstractIllagerEntity.ArmPose.CROSSBOW_HOLD;
+       } else {
+          return this.func_213398_dR() ? AbstractIllagerEntity.ArmPose.ATTACKING : AbstractIllagerEntity.ArmPose.NEUTRAL;
+@@ -193,9 +193,9 @@
+    }
+ 
+    public void func_82196_d(LivingEntity p_82196_1_, float p_82196_2_) {
+-      Hand hand = ProjectileHelper.func_221274_a(this, Items.field_222114_py);
++      Hand hand = ProjectileHelper.getHandWith(this, item -> item instanceof CrossbowItem);
+       ItemStack itemstack = this.func_184586_b(hand);
+-      if (this.func_213382_a(Items.field_222114_py)) {
++      if (this.isHolding(item -> item instanceof CrossbowItem)) {
+          CrossbowItem.func_220014_a(this.field_70170_p, this, hand, itemstack, 1.6F, (float)(14 - this.field_70170_p.func_175659_aa().func_151525_a() * 4));
+       }
+ 

--- a/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
@@ -9,19 +9,12 @@
                    if (d0 == 0.0D) {
                       entity = entity1;
                       vec3d = vec3d1;
-@@ -153,10 +153,15 @@
-       p_188803_0_.field_70177_z = MathHelper.func_219799_g(p_188803_1_, p_188803_0_.field_70126_B, p_188803_0_.field_70177_z);
-    }
- 
-+   @Deprecated
+@@ -156,7 +156,7 @@
     public static Hand func_221274_a(LivingEntity p_221274_0_, Item p_221274_1_) {
        return p_221274_0_.func_184614_ca().func_77973_b() == p_221274_1_ ? Hand.MAIN_HAND : Hand.OFF_HAND;
     }
- 
-+   public static Hand getHandWith(LivingEntity living, Predicate<Item> itemPredicate) {
-+      return itemPredicate.test(living.func_184614_ca().func_77973_b()) ? Hand.MAIN_HAND : Hand.OFF_HAND;
-+   }
-+
+-
++   public static Hand getHandWith(LivingEntity living, Predicate<Item> itemPredicate) { return itemPredicate.test(living.func_184614_ca().func_77973_b()) ? Hand.MAIN_HAND : Hand.OFF_HAND; }
     public static AbstractArrowEntity func_221272_a(LivingEntity p_221272_0_, ItemStack p_221272_1_, float p_221272_2_) {
        ArrowItem arrowitem = (ArrowItem)(p_221272_1_.func_77973_b() instanceof ArrowItem ? p_221272_1_.func_77973_b() : Items.field_151032_g);
        AbstractArrowEntity abstractarrowentity = arrowitem.func_200887_a(p_221272_0_.field_70170_p, p_221272_1_, p_221272_0_);

--- a/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/ProjectileHelper.java.patch
@@ -9,3 +9,19 @@
                    if (d0 == 0.0D) {
                       entity = entity1;
                       vec3d = vec3d1;
+@@ -153,10 +153,15 @@
+       p_188803_0_.field_70177_z = MathHelper.func_219799_g(p_188803_1_, p_188803_0_.field_70126_B, p_188803_0_.field_70177_z);
+    }
+ 
++   @Deprecated
+    public static Hand func_221274_a(LivingEntity p_221274_0_, Item p_221274_1_) {
+       return p_221274_0_.func_184614_ca().func_77973_b() == p_221274_1_ ? Hand.MAIN_HAND : Hand.OFF_HAND;
+    }
+ 
++   public static Hand getHandWith(LivingEntity living, Predicate<Item> itemPredicate) {
++      return itemPredicate.test(living.func_184614_ca().func_77973_b()) ? Hand.MAIN_HAND : Hand.OFF_HAND;
++   }
++
+    public static AbstractArrowEntity func_221272_a(LivingEntity p_221272_0_, ItemStack p_221272_1_, float p_221272_2_) {
+       ArrowItem arrowitem = (ArrowItem)(p_221272_1_.func_77973_b() instanceof ArrowItem ? p_221272_1_.func_77973_b() : Items.field_151032_g);
+       AbstractArrowEntity abstractarrowentity = arrowitem.func_200887_a(p_221272_0_.field_70170_p, p_221272_1_, p_221272_0_);

--- a/src/test/java/net/minecraftforge/debug/item/GetHandWithTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/GetHandWithTest.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.item.BowItem;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(GetHandWithTest.MODID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class GetHandWithTest {
+
+    //Testing if the new alternative for ProjectileHelper.getHandWith works
+    //Skeletons and Illusioners should be able to use the modded bow;
+    //and Pillagers should be able to use the modded crossbow.
+
+    static final String MODID = "get_hand_with_test";
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        event.getRegistry().register(new BowItem(new Item.Properties().group(ItemGroup.COMBAT).maxDamage(256)).setRegistryName(MODID, "modded_bow"));
+        event.getRegistry().register(new CrossbowItem(new Item.Properties().group(ItemGroup.COMBAT).maxDamage(326)).setRegistryName(MODID, "modded_crossbow"));
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -61,3 +61,5 @@ loaderVersion="[28,)"
     modId="nameplate_render_test"
 [[mods]]
     modId="global_loot_test"
+[[mods]]
+    modId="get_hand_with_test"


### PR DESCRIPTION
There are now new versions of ProjectileHelper.getHandWith and MobEntity#isHolding. These take a Predicate<Item> instead of an Item; this lets the vanilla calling classes use instanceof to check for modded bows and crossbows instead of just vanilla ones.

A test mod (get_hand_with_test) that adds a BowItem and CrossbowItem is included. When a modded bow is given to a Skeleton, Wither Skeleton, Stray, or Illusioner, it properly uses it; when a modded crossbow is given to a pillager it properly uses it as well.