### PR TITLE
Un-hardcoding milk bucket being universal effect cure

### DIFF
--- a/patches/minecraft/net/minecraft/item/MilkBucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MilkBucketItem.java.patch
@@ -9,7 +9,18 @@
        if (p_77654_3_ instanceof ServerPlayerEntity) {
           ServerPlayerEntity serverplayerentity = (ServerPlayerEntity)p_77654_3_;
           CriteriaTriggers.field_193138_y.func_193148_a(serverplayerentity, p_77654_1_);
-@@ -44,4 +46,9 @@
+@@ -25,10 +27,6 @@
+          p_77654_1_.func_190918_g(1);
+       }
+ 
+-      if (!p_77654_2_.field_72995_K) {
+-         p_77654_3_.func_195061_cb();
+-      }
+-
+       return p_77654_1_.func_190926_b() ? new ItemStack(Items.field_151133_ar) : p_77654_1_;
+    }
+ 
+@@ -44,4 +42,9 @@
        p_77659_2_.func_184598_c(p_77659_3_);
        return ActionResult.func_226248_a_(p_77659_2_.func_184586_b(p_77659_3_));
     }


### PR DESCRIPTION
- The Vanilla Effect class implements the Forge IForgeEffect interface
- IForgeEffect interface has a method "getCurativeItems" which returns a list of item stacks which cure the effect
- This has a default implementation containing only the milk bucket
- The MilkBucketItem class then appropriately calls the method which checks if it cures each effect by going through the curable items list and then removes the effect only if the item matches
- So far so good
- Now here is the problem: Just a few lines below it also calls a method which removes all potion effects regardless, kinda negating everything from above

Basically everything was in place already but I believe the vanilla implementation was just forgotten about. First pull request so pls be patient with me.