### PR TITLE
Add new methods for doing synchronous work in parallel events

### DIFF
--- a/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -53,7 +53,13 @@ import net.minecraftforge.forgespi.language.IModInfo;
  * Exceptions from tasks will be handled gracefully, causing a mod loading
  * error. Tasks that take egregiously long times to run will be logged.
  *
- * This is being deprecated in favour of a new interface on loading events, to remove confusion about how it operates. #TODO
+ * <br>
+ * This is being deprecated in favour of a new interface on loading events, to remove confusion about how it operates.
+ * Use the following methods supplied by the event instead: <br>
+ * {@link net.minecraftforge.fml.event.lifecycle.ModLifecycleEvent#enqueueSynchronousWork(Runnable)}
+ * {@link net.minecraftforge.fml.event.lifecycle.ModLifecycleEvent#enqueueSynchronousWork(CheckedRunnable)}
+ * {@link net.minecraftforge.fml.event.lifecycle.ModLifecycleEvent#enqueueSynchronousWork(Supplier)}
+ * {@link net.minecraftforge.fml.event.lifecycle.ModLifecycleEvent#enqueueSynchronousWork(Callable)}
  */
 @Deprecated
 public class DeferredWorkQueue
@@ -167,13 +173,13 @@ public class DeferredWorkQueue
      * variant allows the task to throw a checked exception.
      * <p>
      * If the task does not throw a checked exception, use
-     * {@link #getLater(Callable)}.
+     * {@link #getLater(Supplier)}.
      * <p>
      * If the task does not have a result, use {@link #runLater(Runnable)} or
      * {@link #runLaterChecked(CheckedRunnable)}.
      *
      * @param               <T> The result type of the task
-     * @param workToEnqueue A {@link Supplier} to execute later, on the loading
+     * @param workToEnqueue A {@link Callable} to execute later, on the loading
      *                      thread
      * @return A {@link CompletableFuture} that completes at said time
      */


### PR DESCRIPTION
The DeferredWorkQueue has been deprecated since September last year, with cpw stating that a new API on parallel events will come soon (see 07bcff5067c90e4fd6476187fa07d7eafa1adec1)

As this API is not here yet, and everybody seems to be annoyed/confused by the deprecation warning, I figured I'll might as well take a shot on the issue as well.
This adds method to enqueue synchronous work on the base class of the parallel events, so that you can enqueue work using the event object (this is what I think cpw intended)
Feedback welcome.