### PR TITLE
Provide extra context to RightClickBlock, create OnItemUse

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -95,7 +95,7 @@
        } else {
           ItemStack itemstack = p_217292_1_.func_184586_b(p_217292_3_);
 +         net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
-+                 .onRightClickBlock(p_217292_1_, p_217292_3_, blockpos, p_217292_4_.func_216354_b());
++                 .onRightClickBlock(p_217292_1_, p_217292_3_, blockpos, p_217292_4_);
 +         if (event.isCanceled()) {
 +            this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
 +            return event.getCancellationResult();
@@ -120,17 +120,19 @@
                 ActionResultType actionresulttype = p_217292_2_.func_180495_p(blockpos).func_227031_a_(p_217292_2_, p_217292_1_, p_217292_3_, p_217292_4_);
                 if (actionresulttype.func_226246_a_()) {
                    this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
-@@ -271,8 +293,8 @@
+@@ -271,8 +293,10 @@
              }
  
              this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
              if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
 -               ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
++               net.minecraftforge.event.entity.player.PlayerInteractEvent.OnItemUse event2 = net.minecraftforge.common.ForgeHooks.onItemUse(p_217292_1_, p_217292_3_, blockpos, p_217292_4_);
++               if (event2.isCanceled()) return event2.getCancellationResult();
                 ActionResultType actionresulttype1;
                 if (this.field_78779_k.func_77145_d()) {
                    int i = itemstack.func_190916_E();
-@@ -300,11 +322,14 @@
+@@ -300,11 +324,14 @@
           if (p_187101_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
              return ActionResultType.PASS;
           } else {
@@ -145,7 +147,7 @@
              }
  
              return actionresult.func_188397_a();
-@@ -329,6 +354,9 @@
+@@ -329,6 +356,9 @@
     public ActionResultType func_187097_a(PlayerEntity p_187097_1_, Entity p_187097_2_, Hand p_187097_3_) {
        this.func_78750_j();
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187097_2_, p_187097_3_));
@@ -155,7 +157,7 @@
        return this.field_78779_k == GameType.SPECTATOR ? ActionResultType.PASS : p_187097_1_.func_190775_a(p_187097_2_, p_187097_3_);
     }
  
-@@ -336,6 +364,9 @@
+@@ -336,6 +366,9 @@
        this.func_78750_j();
        Vec3d vec3d = p_187102_3_.func_216347_e().func_178786_a(p_187102_2_.func_226277_ct_(), p_187102_2_.func_226278_cu_(), p_187102_2_.func_226281_cx_());
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -126,7 +126,7 @@
     public ActionResultType func_219441_a(PlayerEntity p_219441_1_, World p_219441_2_, ItemStack p_219441_3_, Hand p_219441_4_, BlockRayTraceResult p_219441_5_) {
        BlockPos blockpos = p_219441_5_.func_216350_a();
        BlockState blockstate = p_219441_2_.func_180495_p(blockpos);
-+      net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_.func_216354_b());
++      net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_);
 +      if (event.isCanceled()) return event.getCancellationResult();
        if (this.field_73091_c == GameType.SPECTATOR) {
           INamedContainerProvider inamedcontainerprovider = blockstate.func_215699_b(p_219441_2_, blockpos);
@@ -148,12 +148,14 @@
              ActionResultType actionresulttype = blockstate.func_227031_a_(p_219441_2_, p_219441_1_, p_219441_4_, p_219441_5_);
              if (actionresulttype.func_226246_a_()) {
                 return actionresulttype;
-@@ -306,7 +338,7 @@
+@@ -306,7 +338,9 @@
           }
  
           if (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
 -            ItemUseContext itemusecontext = new ItemUseContext(p_219441_1_, p_219441_4_, p_219441_5_);
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.OnItemUse event2 = net.minecraftforge.common.ForgeHooks.onItemUse(p_219441_1_, p_219441_4_, blockpos, p_219441_5_);
++            if (event2.isCanceled()) return event2.getCancellationResult();
              if (this.func_73083_d()) {
                 int i = p_219441_3_.func_190916_E();
                 ActionResultType actionresulttype1 = p_219441_3_.func_196084_a(itemusecontext);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -779,9 +779,24 @@ public class ForgeHooks
         return evt;
     }
 
+    @Deprecated //TODO Remove, superseded by BlockRayTraceResult version.
     public static PlayerInteractEvent.RightClickBlock onRightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, Direction face)
     {
         PlayerInteractEvent.RightClickBlock evt = new PlayerInteractEvent.RightClickBlock(player, hand, pos, face);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
+    }
+
+    public static PlayerInteractEvent.RightClickBlock onRightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult res)
+    {
+        PlayerInteractEvent.RightClickBlock evt = new PlayerInteractEvent.RightClickBlock(player, hand, pos, res);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
+    }
+
+    public static PlayerInteractEvent.OnItemUse onItemUse(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult res)
+    {
+        PlayerInteractEvent.OnItemUse evt = new PlayerInteractEvent.OnItemUse(player, hand, pos, res);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -239,7 +239,6 @@ public class PlayerInteractEvent extends PlayerEvent
          * @return The ray trace result from clicking on this block.  May be null, if called from mod code using the old constructor.
          * Mods should be phasing away from the old constructor, and the nullable annotation will be removed in a future version.
          */
-        @Nullable
         public BlockRayTraceResult getRayTraceResult()
         {
             return res;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -236,8 +236,7 @@ public class PlayerInteractEvent extends PlayerEvent
         }
 
         /**
-         * @return The ray trace result from clicking on this block.  May be null, if called from mod code using the old constructor.
-         * Mods should be phasing away from the old constructor, and the nullable annotation will be removed in a future version.
+         * @return The ray trace result to the block the item was used on.
          */
         public BlockRayTraceResult getRayTraceResult()
         {


### PR DESCRIPTION
This PR Re-Adds the proper ray trace result context to PlayerInteractEvent.RightClickBlock that was lost in the 1.13 update (previously we had access to the Vec3d hitvec).

It also adds a new event that is fired when onItemUse would normally be called.  This event is useful for when you want to add additional right click behaviors to arbitrary items, but do not want to manaully recreate all of the logic for handling the block being clicked, as is currently required (and impossible, without the first half of this PR).