### PR TITLE
Fix precheck for if an ItemHandler is full

### DIFF
--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -225,7 +225,7 @@ public class VanillaInventoryCodeHooks
         for (int slot = 0; slot < itemHandler.getSlots(); slot++)
         {
             ItemStack stackInSlot = itemHandler.getStackInSlot(slot);
-            if (stackInSlot.isEmpty() || stackInSlot.getCount() != stackInSlot.getMaxStackSize())
+            if (stackInSlot.isEmpty() || stackInSlot.getCount() < itemHandler.getSlotLimit(slot))
             {
                 return false;
             }

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -194,15 +194,13 @@ public class VanillaInventoryCodeHooks
                     if (!destinationHopper.mayTransfer())
                     {
                         int k = 0;
-/* TODO TileEntityHopper patches
-                        if (source instanceof TileEntityHopper)
+                        if (source instanceof HopperTileEntity)
                         {
-                            if (destinationHopper.getLastUpdateTime() >= ((TileEntityHopper) source).getLastUpdateTime())
+                            if (destinationHopper.getLastUpdateTime() >= ((HopperTileEntity) source).getLastUpdateTime())
                             {
                                 k = 1;
                             }
                         }
-*/
                         destinationHopper.setTransferCooldown(8 - k);
                     }
                 }


### PR DESCRIPTION
This PR fixes the precheck that is based on Vanilla's hopper implementation for if an inventory is full.

Currently the hopper's IItemHandler integration considers a slot full if it is at the stacks max size. This is a problem for any slots that want to allow past a stack's max stack size to be inserted (for example Mekanism's bins). I am changing this to checking to only consider it as full if it is at the slot's limit. This change does not break any logic due to the fact that it is a precheck, so simulation still happens to ensure the destination can actually accept a stack, but does allow for this simulation and insertion to take place if a container can accept past the max stack size in a slot.

I tested to ensure this does not break any vanilla interactions, including ensuring that it doesn't try to stack items past their max stack size and it continues to properly work as intended. I also tested and this fix does work as intended, allowing for ItemHandler implementations that allow for items stacking past their max stack size to be inserted.