### PR TITLE
Fix issue with providing a null ItemStack to onPlayerDestroyItem

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -606,7 +606,7 @@ public class ForgeHooks
         if (!(itemstack.getItem() instanceof BucketItem)) // if not bucket
             world.captureBlockSnapshots = true;
 
-        ItemStack copy = itemstack.isDamageable() ? itemstack.copy() : null;
+        ItemStack copy = itemstack.copy();
         ActionResultType ret = itemstack.getItem().onItemUse(context);
         if (itemstack.isEmpty())
             ForgeEventFactory.onPlayerDestroyItem(player, copy, context.getHand());


### PR DESCRIPTION
This PR fixes an issue where when the last block in a stack is placed into the world the resulting PlayerDestroyItemEvent contains a null ItemStack for the original stack.

I believe the original intent was to clone the original ItemStack if the item is NOT damageable, rather than when it is damageable, then not send the event if the copy is null. This PR makes the "safer" change to just always clone in I missed a case where this would be called for damageable items.