### PR TITLE
LTS back port for Trapdoor climbing support for modded ladders.

### DIFF
--- a/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
@@ -8,7 +8,7 @@
 +   public boolean isLadder(BlockState state, net.minecraft.world.IWorldReader world, BlockPos pos, net.minecraft.entity.LivingEntity entity) {
 +      if (state.func_177229_b(field_176283_b)) {
 +         BlockState down = world.func_180495_p(pos.func_177977_b());
-+         if (down.func_177230_c() == net.minecraft.block.Blocks.field_150468_ap)
++         if (down.func_177230_c() instanceof net.minecraft.block.LadderBlock)
 +            return down.func_177229_b(LadderBlock.field_176382_a) == state.func_177229_b(field_185512_D);
 +      }
 +      return false;

--- a/src/test/java/net/minecraftforge/debug/block/TrapdoorTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/TrapdoorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.LadderBlock;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+@SuppressWarnings("unused")
+@Mod(TrapdoorTest.MODID)
+public class TrapdoorTest
+{
+    public static final String MODID = "trapdoor_test";
+
+    // Represents modded ladders to be supported
+    private static class TrapdoorTestLadder extends LadderBlock
+    {
+        private TrapdoorTestLadder(Block.Properties builder)
+        { super(builder); }
+    }
+
+    private static final Block MODDED_TEST_LADDER = (new TrapdoorTestLadder(
+      // Using different block properties as the model is the vanilla ladder model.
+      Block.Properties.create(Material.WOOL)
+           .hardnessAndResistance(0.1f,0.1f)
+           .sound(SoundType.CLOTH).lightValue(15)
+      )).setRegistryName(MODID, MODID+"_ladder");
+
+    // ------------------------------------------------------------------------------------
+
+    @Mod.EventBusSubscriber(bus = Bus.MOD)
+    public static class ForgeEvents
+    {
+        @SubscribeEvent
+        public static void registerBlocks(RegistryEvent.Register<Block> event)
+        {
+            event.getRegistry().register(MODDED_TEST_LADDER);
+        }
+
+        @SubscribeEvent
+        @SuppressWarnings("all") // blocks statically defined, regnames are not null here.
+        public static void registerItems(RegistryEvent.Register<Item> event)
+        {
+            event.getRegistry().register(new BlockItem(MODDED_TEST_LADDER, new Item.Properties()).setRegistryName(MODDED_TEST_LADDER.getRegistryName()));
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -63,3 +63,5 @@ loaderVersion="[28,)"
     modId="new_model_loader_test"
 [[mods]]
     modId="global_loot_test"
+[[mods]]
+    modId="trapdoor_test"

--- a/src/test/resources/assets/trapdoor_test/blockstates/trapdoor_test_ladder.json
+++ b/src/test/resources/assets/trapdoor_test/blockstates/trapdoor_test_ladder.json
@@ -1,0 +1,8 @@
+{
+  "variants": {
+    "facing=north": { "model": "minecraft:block/ladder" },
+    "facing=east":  { "model": "minecraft:block/ladder", "y": 90 },
+    "facing=south": { "model": "minecraft:block/ladder", "y": 180 },
+    "facing=west":  { "model": "minecraft:block/ladder", "y": 270 }
+  }
+}

--- a/src/test/resources/assets/trapdoor_test/models/item/trapdoor_test_ladder.json
+++ b/src/test/resources/assets/trapdoor_test/models/item/trapdoor_test_ladder.json
@@ -1,0 +1,1 @@
+{ "parent": "minecraft:block/ladder" }


### PR DESCRIPTION
The changes and tests of this PR are identical to the 1.15.x patch in PR#6617.
- Reference check changed to type check,
- Test adds a modded ladder inherited from `LadderBlock` for verification.
