### PR TITLE
Clear server config after server is shut down

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -81,7 +81,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
     public void setConfig(CommentedConfig config) {
         this.childConfig = config;
-        if (!isCorrect(config)) {
+        if (config != null && !isCorrect(config)) {
             String configName = config instanceof FileConfig ? ((FileConfig) config).getNioPath().toString() : config.toString();
             LogManager.getLogger().warn(CORE, "Configuration file {} is not correct. Correcting", configName);
             correct(config, (action, path, incorrectValue, correctedValue) ->

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -40,30 +40,26 @@ public class ConfigFileTypeHandler {
     static ConfigFileTypeHandler TOML = new ConfigFileTypeHandler();
     private static final Path defaultConfigPath = FMLPaths.GAMEDIR.get().resolve(FMLConfig.defaultConfigPath());
 
-    @Deprecated //TODO remove in 1.16
     public Function<ModConfig, CommentedFileConfig> reader(Path configBasePath) {
-        return (c) -> readConfig(configBasePath, c);
-    }
-
-    public CommentedFileConfig readConfig(Path configBasePath, ModConfig config) {
-        final Path configPath = configBasePath.resolve(config.getFileName());
-        final CommentedFileConfig configData = CommentedFileConfig.builder(configPath).sync().
-                preserveInsertionOrder().
-                autosave().
-                onFileNotFound((newfile, configFormat) -> setupConfigFile(config, newfile, configFormat)).
-                writingMode(WritingMode.REPLACE).
-                build();
-        LOGGER.debug(CONFIG, "Built TOML config for {}", configPath.toString());
-        configData.load();
-        LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath.toString());
-        try {
-            FileWatcher.defaultInstance().addWatch(configPath, new ConfigWatcher(config, configData, Thread.currentThread().getContextClassLoader()));
-
-            LOGGER.debug(CONFIG, "Watching TOML config file {} for changes", configPath.toString());
-        } catch (IOException e) {
-            throw new RuntimeException("Couldn't watch config file", e);
-        }
-        return configData;
+        return (c) -> {
+            final Path configPath = configBasePath.resolve(c.getFileName());
+            final CommentedFileConfig configData = CommentedFileConfig.builder(configPath).sync().
+                    preserveInsertionOrder().
+                    autosave().
+                    onFileNotFound((newfile, configFormat)-> setupConfigFile(c, newfile, configFormat)).
+                    writingMode(WritingMode.REPLACE).
+                    build();
+            LOGGER.debug(CONFIG, "Built TOML config for {}", configPath.toString());
+            configData.load();
+            LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath.toString());
+            try {
+                FileWatcher.defaultInstance().addWatch(configPath, new ConfigWatcher(c, configData, Thread.currentThread().getContextClassLoader()));
+                LOGGER.debug(CONFIG, "Watching TOML config file {} for changes", configPath.toString());
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't watch config file", e);
+            }
+            return configData;
+        };
     }
 
     public void unload(Path configBasePath, ModConfig config) {

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -42,10 +42,10 @@ public class ConfigFileTypeHandler {
 
     @Deprecated //TODO remove in 1.16
     public Function<ModConfig, CommentedFileConfig> reader(Path configBasePath) {
-        return (c) -> reader(configBasePath, c);
+        return (c) -> readConfig(configBasePath, c);
     }
 
-    public CommentedFileConfig reader(Path configBasePath, ModConfig config) {
+    public CommentedFileConfig readConfig(Path configBasePath, ModConfig config) {
         final Path configPath = configBasePath.resolve(config.getFileName());
         final CommentedFileConfig configData = CommentedFileConfig.builder(configPath).sync().
                 preserveInsertionOrder().

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -67,7 +67,12 @@ public class ConfigFileTypeHandler {
     }
 
     public void unload(Path configBasePath, ModConfig config) {
-        FileWatcher.defaultInstance().removeWatch(configBasePath.resolve(config.getFileName()));
+        Path configPath = configBasePath.resolve(config.getFileName());
+        try {
+            FileWatcher.defaultInstance().removeWatch(configBasePath.resolve(config.getFileName()));
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to remove config {} from tracker!", configPath.toString(), e);
+        }
     }
 
     private boolean setupConfigFile(final ModConfig modConfig, final Path file, final ConfigFormat<?> conf) throws IOException {

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -108,10 +108,12 @@ public class ConfigTracker {
     }
 
     private void closeConfig(final ModConfig config, final Path configBasePath) {
-        LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
-        config.save();
-        config.getHandler().unload(configBasePath, config);
-        config.setConfigData(null);
+        if (config.getConfigData() != null) {
+            LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
+            config.save();
+            config.getHandler().unload(configBasePath, config);
+            config.setConfigData(null);
+        }
     }
 
     public void receiveSyncedConfig(final FMLHandshakeMessages.S2CConfigData s2CConfigData, final Supplier<NetworkEvent.Context> contextSupplier) {

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -101,7 +101,7 @@ public class ConfigTracker {
 
     private void openConfig(final ModConfig config, final Path configBasePath) {
         LOGGER.trace(CONFIG, "Loading config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
-        final CommentedFileConfig configData = config.getHandler().reader(configBasePath, config);
+        final CommentedFileConfig configData = config.getHandler().readConfig(configBasePath, config);
         config.setConfigData(configData);
         config.fireEvent(new ModConfig.Loading(config));
         config.save();

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -101,7 +101,7 @@ public class ConfigTracker {
 
     private void openConfig(final ModConfig config, final Path configBasePath) {
         LOGGER.trace(CONFIG, "Loading config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
-        final CommentedFileConfig configData = config.getHandler().readConfig(configBasePath, config);
+        final CommentedFileConfig configData = config.getHandler().reader(configBasePath).apply(config);
         config.setConfigData(configData);
         config.fireEvent(new ModConfig.Loading(config));
         config.save();


### PR DESCRIPTION
Previously, the config tracker for server-specific config would not get removed once a server has been shutdown. This lead to errors when trying to delete a world that has been opened before, as a file in the directory was still being used
This PR fixes this by removing the server configs from the tracker once the server shuts down, and also nulls out the config if it should no longer be present.
Also cleans up `ConfigFileTypeHandler.reader`, which for some reason returned a function instead of accepting two arguments