### PR TITLE
Fix interaction of transforms with variant transforms

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -249,7 +249,7 @@ public class ModelLoaderRegistry
         IModelGeometry<?> customModel = blockModel.customData.getCustomGeometry();
         IModelTransform customModelState = blockModel.customData.getCustomModelState();
         if (customModelState != null)
-            modelTransform = new ModelTransformComposition(customModelState, modelTransform, modelTransform.isUvLock());
+            modelTransform = new ModelTransformComposition(modelTransform, customModelState, modelTransform.isUvLock());
 
         if (customModel != null)
             model = customModel.bake(blockModel.customData, modelBakery, spriteGetter, modelTransform, blockModel.getOverrides(modelBakery, otherModel, spriteGetter), modelLocation);


### PR DESCRIPTION
This relates to https://github.com/MinecraftForge/MinecraftForge/issues/6603 .

When using model transforms and variant transformations at the same time, the transformations are applied in reverse order. This PR fixes that.

**Example**:
Assume the following composite model:
```json
{
  "loader": "forge:composite",
  "parts": {
    "wideanvil": {
      "parent": "minecraft:block/anvil",
      "transform": {
        "scale": [2, 1, 1]
      }
    }
  }
}
```
This is supposed to produce a single anvil submodel with double the width (over the X axis).
When combined with a blockstate containing `"y": 90` (a 90 degree rotation over the Y axis), this produces unexpected results:
![scale-without-patch](https://user-images.githubusercontent.com/1949124/80283832-a959f100-86e8-11ea-95a3-f33871c30122.png)

The anvil at the top of the image has the rotation in the blockstate and the one to the right does not.
I would expect both anvils to be the same, but rotated.
The reason this is not working as expected is that the order of transformations is reversed (first the variant blockstate is applied, then the submodel transformation). As a result, the block is first rotated, then stretched, leading to this effect.

This PR changes that order, leading to the correct result:
![scale-with-patch](https://user-images.githubusercontent.com/1949124/80283973-73693c80-86e9-11ea-98c2-5dd95cfd2e6f.png)

**Impact**:
This is clearly a breaking change.
However, I think it is important to make it because there is no good way to work around this issue within the system. The only true workaround I see is to make completely separate models for all rotations.