### PR TITLE
Serialize capabilities when sending ItemStacks to the client

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -145,7 +145,7 @@ public interface IForgeItem
     @Nullable
     default CompoundNBT getShareTag(ItemStack stack)
     {
-        return stack.getTag();
+        return stack.serializeNBT();
     }
 
     /**
@@ -157,7 +157,7 @@ public interface IForgeItem
      */
     default void readShareTag(ItemStack stack, @Nullable CompoundNBT nbt)
     {
-        stack.setTag(nbt);
+        stack.deserializeNBT(nbt);
     }
 
     /**


### PR DESCRIPTION
Currently, when `ItemStack`s are sent to the client (e.g. sending the contents of a `Container`) , capability NBT data is not sent which leads to strange behaviour where capability NBT data is out of sync between the client and server. This pull request resolves the issue by simply modifying the method the PacketBuffer uses to serialize and deserialize `ItemStack`s.