### PR TITLE
Capability share tags

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -243,3 +243,16 @@
     public SoundEvent func_226629_F_() {
        return this.func_77973_b().func_225520_U__();
     }
+@@ -922,4 +975,12 @@
+    public SoundEvent func_226630_G_() {
+       return this.func_77973_b().func_225519_S__();
+    }
++
++   public CompoundNBT serializeShareTag() {
++      return this.serializeShareTags();
++   }
++
++   public void deserializeShareTag(CompoundNBT nbt) {
++	  this.deserializeShareTags(nbt);
++   }
+ }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -96,6 +96,25 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
             disp.deserializeNBT(tag);
         }
     }
+    
+    protected final CompoundNBT serializeShareTags() 
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        if (disp != null)
+        {
+            return disp.serializeShareTag();
+        }
+        return null;
+    }
+
+    protected final void deserializeShareTags(CompoundNBT nbt) 
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        if (disp != null)
+        {
+            disp.deserializeShareTag(nbt);
+        }
+    }
 
     protected void invalidateCaps()
     {

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityShareTag.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityShareTag.java
@@ -1,0 +1,28 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import net.minecraft.nbt.INBT;
+
+public interface ICapabilityShareTag<T extends INBT>
+{
+    T serializeShareTag();
+    void deserializeShareTag(T nbt);
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -145,7 +145,7 @@ public interface IForgeItem
     @Nullable
     default CompoundNBT getShareTag(ItemStack stack)
     {
-        return stack.getTag();
+        return stack.serializeNBT();
     }
 
     /**
@@ -157,7 +157,7 @@ public interface IForgeItem
      */
     default void readShareTag(ItemStack stack, @Nullable CompoundNBT nbt)
     {
-        stack.setTag(nbt);
+        stack.deserializeNBT(nbt);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -145,7 +145,7 @@ public interface IForgeItem
     @Nullable
     default CompoundNBT getShareTag(ItemStack stack)
     {
-        return stack.serializeNBT();
+        return stack.getTag();
     }
 
     /**
@@ -157,7 +157,7 @@ public interface IForgeItem
      */
     default void readShareTag(ItemStack stack, @Nullable CompoundNBT nbt)
     {
-        stack.deserializeNBT(nbt);
+        stack.setTag(nbt);
     }
 
     /**


### PR DESCRIPTION
This is a reimplementation of #5009 and follow up to #6667. It allows capabilities to specify a custom share tag to be sent when synchronization occurs between server and client via the newly implemented `ICapabilityShareTag`. The tag is appended to the existing vanilla share tag (`ItemStack::getTag`) so is fully compatible with vanilla clients. The majority of the logic is agnostic to the type of object, and could be used to add sync support to `TileEntity`s and various other capability providers.