### PR TITLE
Implement command for client side execution

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screen/ChatScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/ChatScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screen/ChatScreen.java
++++ b/net/minecraft/client/gui/screen/ChatScreen.java
+@@ -89,7 +89,7 @@
+          }
+       } else {
+          String s = this.field_146415_a.func_146179_b().trim();
+-         if (!s.isEmpty()) {
++         if (!s.isEmpty() && net.minecraftforge.client.ForgeHooksClient.sendMessage(this.field_228174_e_.field_228106_o_)) {
+             this.sendMessage(s);
+          }
+ 

--- a/patches/minecraft/net/minecraft/client/gui/screen/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/Screen.java.patch
@@ -25,7 +25,7 @@
           RenderSystem.disableRescaleNormal();
           RenderSystem.disableDepthTest();
           int i = 0;
-@@ -308,9 +315,12 @@
+@@ -308,6 +315,8 @@
     }
  
     public void sendMessage(String p_sendMessage_1_, boolean p_sendMessage_2_) {
@@ -34,11 +34,7 @@
        if (p_sendMessage_2_) {
           this.minecraft.field_71456_v.func_146158_b().func_146239_a(p_sendMessage_1_);
        }
-+      //if (net.minecraftforge.client.ClientCommandHandler.instance.executeCommand(mc.player, msg) != 0) return; //Forge: TODO Client command re-write
- 
-       this.minecraft.field_71439_g.func_71165_d(p_sendMessage_1_);
-    }
-@@ -321,10 +331,14 @@
+@@ -321,10 +330,14 @@
        this.font = p_init_1_.field_71466_p;
        this.width = p_init_2_;
        this.height = p_init_3_;
@@ -53,7 +49,7 @@
     }
  
     public void setSize(int p_setSize_1_, int p_setSize_2_) {
-@@ -352,6 +366,7 @@
+@@ -352,6 +365,7 @@
     public void renderBackground(int p_renderBackground_1_) {
        if (this.minecraft.field_71441_e != null) {
           this.fillGradient(0, 0, this.width, this.height, -1072689136, -804253680);
@@ -61,7 +57,7 @@
        } else {
           this.renderDirtBackground(p_renderBackground_1_);
        }
-@@ -370,6 +385,7 @@
+@@ -370,6 +384,7 @@
        bufferbuilder.func_225582_a_((double)this.width, 0.0D, 0.0D).func_225583_a_((float)this.width / 32.0F, (float)p_renderDirtBackground_1_).func_225586_a_(64, 64, 64, 255).func_181675_d();
        bufferbuilder.func_225582_a_(0.0D, 0.0D, 0.0D).func_225583_a_(0.0F, (float)p_renderDirtBackground_1_).func_225586_a_(64, 64, 64, 255).func_181675_d();
        tessellator.func_78381_a();
@@ -69,7 +65,7 @@
     }
  
     public boolean isPauseScreen() {
-@@ -453,4 +469,8 @@
+@@ -453,4 +468,8 @@
     public boolean isMouseOver(double p_isMouseOver_1_, double p_isMouseOver_3_) {
        return true;
     }

--- a/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
@@ -60,7 +60,15 @@
           }
  
           if (flag && this.field_147299_f.field_71462_r instanceof CommandBlockScreen) {
-@@ -1276,6 +1288,7 @@
+@@ -1255,6 +1267,7 @@
+    public void func_195511_a(SCommandListPacket p_195511_1_) {
+       PacketThreadUtil.func_218797_a(p_195511_1_, this, this.field_147299_f);
+       this.field_195517_n = new CommandDispatcher<>(p_195511_1_.func_197693_a());
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.CommandRegistryEvent(this.field_195517_n));
+    }
+ 
+    public void func_195512_a(SStopSoundPacket p_195512_1_) {
+@@ -1276,6 +1289,7 @@
        clientrecipebook.func_199644_c();
        clientrecipebook.func_199642_d().forEach(imutablesearchtree::func_217872_a);
        imutablesearchtree.func_194040_a();
@@ -68,7 +76,7 @@
     }
  
     public void func_200232_a(SPlayerLookPacket p_200232_1_) {
-@@ -1356,7 +1369,7 @@
+@@ -1356,7 +1370,7 @@
        PacketThreadUtil.func_218797_a(p_147260_1_, this, this.field_147299_f);
        Entity entity = this.field_147300_g.func_73045_a(p_147260_1_.func_149426_d());
        if (entity instanceof LivingEntity) {
@@ -77,7 +85,7 @@
           if (effect != null) {
              EffectInstance effectinstance = new EffectInstance(effect, p_147260_1_.func_180755_e(), p_147260_1_.func_149428_f(), p_147260_1_.func_186984_g(), p_147260_1_.func_179707_f(), p_147260_1_.func_205527_h());
              effectinstance.func_100012_b(p_147260_1_.func_149429_c());
-@@ -1376,6 +1389,7 @@
+@@ -1376,6 +1390,7 @@
        }
  
        this.field_147299_f.func_213253_a(SearchTreeManager.field_215360_b).func_194040_a();
@@ -85,7 +93,7 @@
     }
  
     public void func_175098_a(SCombatPacket p_175098_1_) {
-@@ -1851,10 +1865,12 @@
+@@ -1851,10 +1866,12 @@
              int l5 = packetbuffer.readInt();
              this.field_147299_f.field_184132_p.field_229018_q_.func_229022_a_(blockpos7, l3, s10, l5);
           } else {
@@ -99,7 +107,7 @@
              packetbuffer.release();
           }
  
-@@ -1994,7 +2010,7 @@
+@@ -1994,7 +2011,7 @@
              for(SEntityPropertiesPacket.Snapshot sentitypropertiespacket$snapshot : p_147290_1_.func_149441_d()) {
                 IAttributeInstance iattributeinstance = abstractattributemap.func_111152_a(sentitypropertiespacket$snapshot.func_151409_a());
                 if (iattributeinstance == null) {

--- a/patches/minecraft/net/minecraft/command/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/command/Commands.java.patch
@@ -17,3 +17,11 @@
              return lvt_4_3_;
           } catch (CommandException commandexception) {
              p_197059_1_.func_197021_a(commandexception.func_197003_a());
+@@ -269,6 +277,7 @@
+                argumentbuilder.executes((p_197053_0_) -> {
+                   return 0;
+                });
++               argumentbuilder.executes(null);// FORGE Client Commands support
+             }
+ 
+             if (argumentbuilder instanceof RequiredArgumentBuilder) {

--- a/src/main/java/net/minecraftforge/client/event/CommandRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CommandRegistryEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.ISuggestionProvider;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Fired when client {@link CommandDispatcher} has all of its commands synced from the server
+ */
+public class CommandRegistryEvent extends Event
+{
+
+    private final CommandDispatcher<ISuggestionProvider> dispatcher;
+
+    public CommandRegistryEvent(CommandDispatcher<ISuggestionProvider> dispatcher)
+    {
+        this.dispatcher = dispatcher;
+    }
+
+    /**
+     * @return The newly-updated command dispatcher that now contains all the commands that were just received.
+     */
+    public CommandDispatcher<ISuggestionProvider> getDispatcher()
+    {
+        return dispatcher;
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -11,6 +11,7 @@ public net.minecraft.client.Minecraft field_71446_o # textureManager
 public net.minecraft.client.Minecraft func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; # storeTEInStack
 public net.minecraft.client.Minecraft func_193986_ar()V # populateSearchTreeManager
 public net.minecraft.client.audio.SoundEngine field_148622_c #sndHandler
+public net.minecraft.client.gui.CommandSuggestionHelper field_228106_o_ #parseResults
 protected net.minecraft.client.gui.IngameGui *
 protected net.minecraft.client.gui.IngameGui func_194798_c()V # renderAttackIndicator
 protected net.minecraft.client.gui.IngameGui func_194802_a(Lnet/minecraft/scoreboard/ScoreObjective;)V

--- a/src/test/java/net/minecraftforge/debug/chat/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/ClientCommandTest.java
@@ -19,72 +19,44 @@
 
 package net.minecraftforge.debug.chat;
 
-import net.minecraft.command.CommandException;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.math.BlockPos;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.ISuggestionProvider;
+import net.minecraft.command.arguments.ResourceLocationArgument;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.client.event.CommandRegistryEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.GameData;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-//@Mod("client_command_test")
+@Mod("client_command_test")
 public class ClientCommandTest
 {
-    /*
-    @EventHandler
-    public void init(FMLInitializationEvent event)
+    public ClientCommandTest()
     {
-        ClientCommandHandler.instance.registerCommand(new TestCommand());
+        MinecraftForge.EVENT_BUS.addListener(this::init);
     }
 
-    private class TestCommand extends CommandBase
+    private void init(CommandRegistryEvent event)
+    {
+        LiteralArgumentBuilder<ISuggestionProvider> cmd = LiteralArgumentBuilder.literal("clientcommandtest");
+        RequiredArgumentBuilder<ISuggestionProvider, ResourceLocation> arg = RequiredArgumentBuilder.argument("block", ResourceLocationArgument.resourceLocation());
+        SuggestionProvider<ISuggestionProvider> suggestions = (c,b)->ISuggestionProvider.suggestIterable(ForgeRegistries.BLOCKS.getKeys(), b);
+        event.getDispatcher().register(cmd.requires(c->true).then(arg.suggests(suggestions).executes(new TestCommand())));
+    }
+
+    private static class TestCommand implements Command<ISuggestionProvider>
     {
         @Override
-        public String getName()
+        public int run(CommandContext<ISuggestionProvider> commandContext)
         {
-            return "clientCommandTest";
-        }
-
-        @Override
-        public String getUsage(ICommandSender sender)
-        {
-            return "clientCommandTest <block>";
-        }
-
-        @Override
-        public boolean checkPermission(MinecraftServer server, ICommandSender sender)
-        {
-            return true;
-        }
-
-        @Override
-        public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos)
-        {
-            if (args.length > 0)
-            {
-                return getListOfStringsMatchingLastWord(args, ForgeRegistries.BLOCKS.getKeys());
-            }
-
-            return Collections.emptyList();
-        }
-
-        @Override
-        public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
-        {
-            if (args.length > 0)
-            {
-                sender.sendMessage(new StringTextComponent("Input: " + Arrays.toString(args)));
-            }
-            else
-            {
-                sender.sendMessage(new StringTextComponent("No arguments."));
-            }
+            Minecraft.getInstance().player.sendMessage(new StringTextComponent("Input: " + commandContext.getArgument("block", ResourceLocation.class).toString()));
+            return 0;
         }
     }
-    */
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -29,8 +29,8 @@ loaderVersion="[28,)"
     modId="custom_slime_block_test"
 [[mods]]
     modId="client_chat_event_test"
-##[[mods]] # Client Command System doesn't exist yet
-##    modId="client_command_test"
+[[mods]]
+    modId="client_command_test"
 [[mods]]
     modId="command_event_test"
 [[mods]]


### PR DESCRIPTION
Leverage CommandDispatcher on client side
Added CommandRegistryEvent to register commands to this dispatcher
Updzted ClientCommandTest exemple mod
Patched ChatScreen to capture parsing data

Client and server commands will differ by the generics:
CommandSource for server
ISuggestionProvider for client

This means client commands need specific registration, and context must be fetched instead of provided by source.
They follow the same contract regarding tab completion and builder pattern for registration.

Server side is patched so that the suggestion packet does not contain dummy lambdas of the execution part of commands.
This simplify handling on client side to differenciate client commands registered by mods and client commands which are replicated from the server.