### PR TITLE
[1.14.4] Automatically remove tile entities when blockstate no longer has them

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -58,7 +58,7 @@
     @Deprecated
     public void func_196243_a(BlockState p_196243_1_, World p_196243_2_, BlockPos p_196243_3_, BlockState p_196243_4_, boolean p_196243_5_) {
 -      if (this.func_149716_u() && p_196243_1_.func_177230_c() != p_196243_4_.func_177230_c()) {
-+      if (p_196243_1_.hasTileEntity() && p_196243_1_.func_177230_c() != p_196243_4_.func_177230_c()) {
++      if (p_196243_1_.hasTileEntity() && (p_196243_1_.func_177230_c() != p_196243_4_.func_177230_c() || !p_196243_4_.hasTileEntity())) {
           p_196243_2_.func_175713_t(p_196243_3_);
        }
 -

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -30,7 +30,7 @@
           if (!this.field_76637_e.field_72995_K) {
              blockstate.func_196947_b(this.field_76637_e, p_177436_1_, p_177436_2_, p_177436_3_);
 -         } else if (block1 != block && block1 instanceof ITileEntityProvider) {
-+         } else if (block1 != block && blockstate.hasTileEntity()) {
++         } else if ((block1 != block || !p_177436_2_.hasTileEntity()) && blockstate.hasTileEntity()) {
              this.field_76637_e.func_175713_t(p_177436_1_);
           }
  


### PR DESCRIPTION
Fixes #6664 
Tested using the demo mod linked in the issue.