### PR TITLE
GH-6330 Don't log query commands

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
@@ -47,7 +47,7 @@ public class CommandDimensions
                 }
 
                 types.keySet().stream().sorted().forEach(key -> {
-                    ctx.getSource().sendFeedback(new StringTextComponent(key + ": " + types.get(key).stream().sorted().collect(Collectors.joining(", "))), true);
+                    ctx.getSource().sendFeedback(new StringTextComponent(key + ": " + types.get(key).stream().sorted().collect(Collectors.joining(", "))), false);
                 });
                 return 0;
             });

--- a/src/main/java/net/minecraftforge/server/command/CommandEntity.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandEntity.java
@@ -68,7 +68,7 @@ class CommandEntity
             return Commands.literal("list")
                 .requires(cs->cs.hasPermissionLevel(2)) //permission
                 .then(Commands.argument("filter", StringArgumentType.string())
-                    .suggests((ctx, builder) -> ISuggestionProvider.suggest(ForgeRegistries.ENTITIES.getKeys().stream().map(id -> id.toString()), builder))
+                    .suggests((ctx, builder) -> ISuggestionProvider.suggest(ForgeRegistries.ENTITIES.getKeys().stream().map(ResourceLocation::toString), builder))
                     .then(Commands.argument("dim", DimensionArgument.getDimension())
                         .executes(ctx -> execute(ctx.getSource(), StringArgumentType.getString(ctx, "filter"), DimensionArgument.getDimensionArgument(ctx, "dim")))
                     )
@@ -105,7 +105,7 @@ class CommandEntity
                 if (info == null)
                     throw NO_ENTITIES.create();
 
-                sender.sendFeedback(new TranslationTextComponent("commands.forge.entity.list.single.header", name, info.getLeft()), true);
+                sender.sendFeedback(new TranslationTextComponent("commands.forge.entity.list.single.header", name, info.getLeft()), false);
                 List<Map.Entry<ChunkPos, Integer>> toSort = new ArrayList<>();
                 toSort.addAll(info.getRight().entrySet());
                 toSort.sort((a, b) -> {
@@ -119,7 +119,7 @@ class CommandEntity
                 for (Map.Entry<ChunkPos, Integer> e : toSort)
                 {
                     if (limit-- == 0) break;
-                    sender.sendFeedback(new StringTextComponent("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z), true);
+                    sender.sendFeedback(new StringTextComponent("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z), false);
                 }
                 return toSort.size();
             }
@@ -145,8 +145,8 @@ class CommandEntity
                     throw NO_ENTITIES.create();
 
                 int count = info.stream().mapToInt(Pair::getRight).sum();
-                sender.sendFeedback(new TranslationTextComponent("commands.forge.entity.list.multiple.header", count), true);
-                info.forEach(e -> sender.sendFeedback(new StringTextComponent("  " + e.getValue() + ": " + e.getKey()), true));
+                sender.sendFeedback(new TranslationTextComponent("commands.forge.entity.list.multiple.header", count), false);
+                info.forEach(e -> sender.sendFeedback(new StringTextComponent("  " + e.getValue() + ": " + e.getKey()), false));
                 return info.size();
             }
         }

--- a/src/main/java/net/minecraftforge/server/command/CommandModList.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandModList.java
@@ -45,7 +45,7 @@ public class CommandModList {
                                                     modFile.getModInfos().get(0).getVersion(),
                                                     modFile.getModInfos().size())).
                                         collect(Collectors.joining("\n• ","• ", ""))),
-                                    true);
+                                    false);
                             return 0;
                         }
                 );

--- a/src/main/java/net/minecraftforge/server/command/CommandTps.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandTps.java
@@ -46,7 +46,7 @@ class CommandTps
 
                 double meanTickTime = mean(ctx.getSource().getServer().tickTimeArray) * 1.0E-6D;
                 double meanTPS = Math.min(1000.0/meanTickTime, 20);
-                ctx.getSource().sendFeedback(new TranslationTextComponent("commands.forge.tps.summary.all", TIME_FORMATTER.format(meanTickTime), TIME_FORMATTER.format(meanTPS)), true);
+                ctx.getSource().sendFeedback(new TranslationTextComponent("commands.forge.tps.summary.all", TIME_FORMATTER.format(meanTickTime), TIME_FORMATTER.format(meanTPS)), false);
 
                 return 0;
             }
@@ -57,12 +57,12 @@ class CommandTps
     {
         long[] times = cs.getServer().getTickTime(dim);
 
-        if (times == null) /// Null means the world is unloaded. Not invalid. That's taken car of by DimensionArgument itself.
+        if (times == null) // Null means the world is unloaded. Not invalid. That's taken car of by DimensionArgument itself.
             times = UNLOADED;
 
         double worldTickTime = mean(times) * 1.0E-6D;
         double worldTPS = Math.min(1000.0 / worldTickTime, 20);
-        cs.sendFeedback(new TranslationTextComponent("commands.forge.tps.summary.named", dim.getId(), DimensionType.getKey(dim), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), true);
+        cs.sendFeedback(new TranslationTextComponent("commands.forge.tps.summary.named", dim.getId(), DimensionType.getKey(dim), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), false);
 
         return 1;
     }


### PR DESCRIPTION
CommandSource#sendFeedback(ITextComponent, bool) will send feedback to
the console and logged-in ops if the bool flag is set. Looking at
Minecraft, it seems Mojang draw the line between commands that query
state and those that change it - this patch makes an equivalent change
to Forge.

Specifically the following commands no longer log feedback:
- /forge dimensions
- /forge entity list
- /forge mods
- /forge tps