### PR TITLE
Fix Minecraft screens escape key not matching done button behavior

### DIFF
--- a/patches/minecraft/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java.patch
+++ b/patches/minecraft/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java.patch
@@ -1,0 +1,18 @@
+--- a/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java
++++ b/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java
+@@ -64,6 +64,15 @@
+       super.tick();
+    }
+ 
++   @Override
++   public boolean keyPressed(int key, int scanCode, int modifiers) {
++      if (key == org.lwjgl.glfw.GLFW.GLFW_KEY_ESCAPE) {
++         Realms.setScreen(this.field_224228_a);
++         return true;
++      }
++      return super.keyPressed(key, scanCode, modifiers);
++   }
++
+    public void render(int p_render_1_, int p_render_2_, float p_render_3_) {
+       this.renderBackground();
+       this.drawCenteredString(this.field_224229_b, this.width() / 2, 80, 16777215);

--- a/patches/minecraft/net/minecraft/client/gui/screen/MultiplayerScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/MultiplayerScreen.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/client/gui/screen/MultiplayerScreen.java
++++ b/net/minecraft/client/gui/screen/MultiplayerScreen.java
+@@ -241,6 +241,11 @@
+ 
+    }
+ 
++   @Override
++   public void onClose() {
++      this.minecraft.func_147108_a(this.field_146798_g);
++   }
++
+    public ServerPinger func_146789_i() {
+       return this.field_146797_f;
+    }

--- a/patches/minecraft/net/minecraft/client/gui/screen/OptionsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/OptionsScreen.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/client/gui/screen/OptionsScreen.java
++++ b/net/minecraft/client/gui/screen/OptionsScreen.java
+@@ -118,4 +118,12 @@
+       this.drawCenteredString(this.font, this.title.func_150254_d(), this.width / 2, 15, 16777215);
+       super.render(p_render_1_, p_render_2_, p_render_3_);
+    }
++
++   @Override
++   public void onClose() {
++      // We need to consider 2 potential parent screens here:
++      // 1. From the main menu, in which case display the main menu
++      // 2. From the pause menu, in which case exit back to game
++      this.minecraft.func_147108_a(this.field_146441_g instanceof IngameMenuScreen ? null : this.field_146441_g);
++   }
+ }


### PR DESCRIPTION
This is an extension of GH-6679, to fix behaviour in Minecraft.

Other than no longer resetting the main menu animation, this has the benefit of allowing modders to use these screens in other parent screens (such as a redesigned main menu with nested levels perhaps).