### PR TITLE
[1.15]Fixed FluidTank.drain calling onContentsChanged when simulating

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -148,7 +148,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         if (fluid.isEmpty())
         {
             fluid = new FluidStack(resource, Math.min(capacity, resource.getAmount()));
-            onContentsChanged();
+            onContentsChanged(action);
             return fluid.getAmount();
         }
         if (!fluid.isFluidEqual(resource))
@@ -167,7 +167,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
             fluid.setAmount(capacity);
         }
         if (filled > 0)
-            onContentsChanged();
+            onContentsChanged(action);
         return filled;
     }
 
@@ -197,10 +197,16 @@ public class FluidTank implements IFluidHandler, IFluidTank {
             fluid.shrink(drained);
         }
         if (drained > 0)
-            onContentsChanged();
+            onContentsChanged(action);
         return stack;
     }
+    
+    protected void onContentsChanged(FluidAction action)
+    {
+        onContentsChanged();
+    }
 
+    @Deprecated // Use the action sensitive version.
     protected void onContentsChanged()
     {
 

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -148,7 +148,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         if (fluid.isEmpty())
         {
             fluid = new FluidStack(resource, Math.min(capacity, resource.getAmount()));
-            onContentsChanged(action);
+            onContentsChanged();
             return fluid.getAmount();
         }
         if (!fluid.isFluidEqual(resource))
@@ -167,7 +167,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
             fluid.setAmount(capacity);
         }
         if (filled > 0)
-            onContentsChanged(action);
+            onContentsChanged();
         return filled;
     }
 
@@ -195,18 +195,11 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         if (action.execute() && drained > 0)
         {
             fluid.shrink(drained);
+            onContentsChanged();
         }
-        if (drained > 0)
-            onContentsChanged(action);
         return stack;
     }
-    
-    protected void onContentsChanged(FluidAction action)
-    {
-        onContentsChanged();
-    }
 
-    @Deprecated // Use the action sensitive version.
     protected void onContentsChanged()
     {
 


### PR DESCRIPTION
onContentsChanged is currently being called for both execute and simulate.
Having it called on simulate is odd as nothing changed, ~but just in case some mod is expecting that behavior I opted to make a new method that is aware of the FluidAction, which in turn calls the original to keep binary compatibility.~