### PR TITLE
[1.15.x] Add Coal Tag

### DIFF
--- a/src/generated/resources/data/forge/tags/items/gems.json
+++ b/src/generated/resources/data/forge/tags/items/gems.json
@@ -5,6 +5,7 @@
     "#forge:gems/emerald",
     "#forge:gems/lapis",
     "#forge:gems/prismarine",
-    "#forge:gems/quartz"
+    "#forge:gems/quartz",
+    "#forge:gems/coal"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/gems/coal.json
+++ b/src/generated/resources/data/forge/tags/items/gems/coal.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:coal",
+    "minecraft:charcoal"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -173,6 +173,7 @@ public class Tags
         public static final Tag<Item> GEMS_LAPIS = tag("gems/lapis");
         public static final Tag<Item> GEMS_PRISMARINE = tag("gems/prismarine");
         public static final Tag<Item> GEMS_QUARTZ = tag("gems/quartz");
+        public static final Tag<Item> GEMS_COAL = tag("gems/coal");
 
         public static final Tag<Item> GLASS = tag("glass");
         public static final Tag<Item> GLASS_BLACK = tag("glass/black");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -80,12 +80,14 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.FENCES, Tags.Items.FENCES);
         copy(Tags.Blocks.FENCES_NETHER_BRICK, Tags.Items.FENCES_NETHER_BRICK);
         copy(Tags.Blocks.FENCES_WOODEN, Tags.Items.FENCES_WOODEN);
-        getBuilder(Tags.Items.GEMS).add(Tags.Items.GEMS_DIAMOND, Tags.Items.GEMS_EMERALD, Tags.Items.GEMS_LAPIS, Tags.Items.GEMS_PRISMARINE, Tags.Items.GEMS_QUARTZ);
+        getBuilder(Tags.Items.GEMS).add(Tags.Items.GEMS_DIAMOND, Tags.Items.GEMS_EMERALD, Tags.Items.GEMS_LAPIS, Tags.Items.GEMS_PRISMARINE, Tags.Items.GEMS_QUARTZ, Tags.Items.GEMS_COAL);
         getBuilder(Tags.Items.GEMS_DIAMOND).add(Items.DIAMOND);
         getBuilder(Tags.Items.GEMS_EMERALD).add(Items.EMERALD);
         getBuilder(Tags.Items.GEMS_LAPIS).add(Items.LAPIS_LAZULI);
         getBuilder(Tags.Items.GEMS_PRISMARINE).add(Items.PRISMARINE_CRYSTALS);
         getBuilder(Tags.Items.GEMS_QUARTZ).add(Items.QUARTZ);
+        getBuilder(Tags.Items.GEMS_COAL).add(Items.COAL);
+        getBuilder(Tags.Items.GEMS_COAL).add(Items.CHARCOAL);
         copy(Tags.Blocks.GLASS, Tags.Items.GLASS);
         copyColored(Tags.Blocks.GLASS, Tags.Items.GLASS);
         copy(Tags.Blocks.GLASS_PANES, Tags.Items.GLASS_PANES);


### PR DESCRIPTION
I'm missing Coal tag, which would group all kinds of Coal like regular coal, charcoal and other mod coals. So I think this would be a good to add.