### PR TITLE
Implement ICustomPacket directly instead of using UnsafeHacks…

### DIFF
--- a/patches/minecraft/net/minecraft/network/login/client/CCustomPayloadLoginPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/client/CCustomPayloadLoginPacket.java.patch
@@ -9,3 +9,28 @@
     private int field_209922_a;
     private PacketBuffer field_209923_b;
  
+@@ -50,4 +50,24 @@
+    public void func_148833_a(IServerLoginNetHandler p_148833_1_) {
+       p_148833_1_.func_209526_a(this);
+    }
++
++	@Override
++	public PacketBuffer getInternalData() {
++		return field_209923_b;
++	}
++
++	@Override
++	public void setData(PacketBuffer data) {
++		this.field_209923_b = data;
++	}
++
++	@Override
++	public int getIndex() {
++		return field_209922_a;
++	}
++
++	@Override
++	public void setIndex(int index) {
++		this.field_209922_a = index;
++	}
+ }

--- a/patches/minecraft/net/minecraft/network/login/client/CCustomPayloadLoginPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/client/CCustomPayloadLoginPacket.java.patch
@@ -3,34 +3,34 @@
 @@ -8,7 +8,7 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
- 
+
 -public class CCustomPayloadLoginPacket implements IPacket<IServerLoginNetHandler> {
 +public class CCustomPayloadLoginPacket implements IPacket<IServerLoginNetHandler>, net.minecraftforge.fml.network.ICustomPacket<CCustomPayloadLoginPacket> {
     private int field_209922_a;
     private PacketBuffer field_209923_b;
- 
+
 @@ -50,4 +50,24 @@
     public void func_148833_a(IServerLoginNetHandler p_148833_1_) {
        p_148833_1_.func_209526_a(this);
     }
 +
-+	@Override
-+	public PacketBuffer getInternalData() {
-+		return field_209923_b;
-+	}
++    @Override
++    public PacketBuffer getInternalData() {
++        return field_209923_b;
++    }
 +
-+	@Override
-+	public void setData(PacketBuffer data) {
-+		this.field_209923_b = data;
-+	}
++    @Override
++    public void setData(PacketBuffer data) {
++        this.field_209923_b = data;
++    }
 +
-+	@Override
-+	public int getIndex() {
-+		return field_209922_a;
-+	}
++    @Override
++    public int getIndex() {
++    return field_209922_a;
++    }
 +
-+	@Override
-+	public void setIndex(int index) {
-+		this.field_209922_a = index;
-+	}
++    @Override
++    public void setIndex(int index) {
++        this.field_209922_a = index;
++    }
  }

--- a/patches/minecraft/net/minecraft/network/login/server/SCustomPayloadLoginPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/server/SCustomPayloadLoginPacket.java.patch
@@ -3,7 +3,7 @@
 @@ -8,7 +8,7 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
- 
+
 -public class SCustomPayloadLoginPacket implements IPacket<IClientLoginNetHandler> {
 +public class SCustomPayloadLoginPacket implements IPacket<IClientLoginNetHandler>, net.minecraftforge.fml.network.ICustomPacket<SCustomPayloadLoginPacket> {
     private int field_209919_a;
@@ -14,33 +14,33 @@
        return this.field_209919_a;
     }
 +
-+	@Override
-+	public PacketBuffer getInternalData() {
-+		return field_209921_c;
-+	}
++    @Override
++    public PacketBuffer getInternalData() {
++        return field_209921_c;
++    }
 +
-+	@Override
-+	public void setData(PacketBuffer data) {
-+		this.field_209921_c = data;
-+	}
++    @Override
++    public void setData(PacketBuffer data) {
++        this.field_209921_c = data;
++    }
 +
-+	@Override
-+	public ResourceLocation getName() {
-+		return field_209920_b;
-+	}
++    @Override
++    public ResourceLocation getName() {
++        return field_209920_b;
++    }
 +
-+	@Override
-+	public void setName(ResourceLocation name) {
-+		this.field_209920_b = name;
-+	}
++    @Override
++    public void setName(ResourceLocation name) {
++        this.field_209920_b = name;
++    }
 +
-+	@Override
-+	public int getIndex() {
-+		return field_209919_a;
-+	}
++    @Override
++    public int getIndex() {
++        return field_209919_a;
++    }
 +
-+	@Override
-+	public void setIndex(int index) {
-+		this.field_209919_a = index;
-+	}
++    @Override
++    public void setIndex(int index) {
++        this.field_209919_a = index;
++    }
  }

--- a/patches/minecraft/net/minecraft/network/login/server/SCustomPayloadLoginPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/server/SCustomPayloadLoginPacket.java.patch
@@ -9,3 +9,38 @@
     private int field_209919_a;
     private ResourceLocation field_209920_b;
     private PacketBuffer field_209921_c;
+@@ -38,4 +38,34 @@
+    public int func_209918_a() {
+       return this.field_209919_a;
+    }
++
++	@Override
++	public PacketBuffer getInternalData() {
++		return field_209921_c;
++	}
++
++	@Override
++	public void setData(PacketBuffer data) {
++		this.field_209921_c = data;
++	}
++
++	@Override
++	public ResourceLocation getName() {
++		return field_209920_b;
++	}
++
++	@Override
++	public void setName(ResourceLocation name) {
++		this.field_209920_b = name;
++	}
++
++	@Override
++	public int getIndex() {
++		return field_209919_a;
++	}
++
++	@Override
++	public void setIndex(int index) {
++		this.field_209919_a = index;
++	}
+ }

--- a/patches/minecraft/net/minecraft/network/play/client/CCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CCustomPayloadPacket.java.patch
@@ -18,3 +18,28 @@
     }
  
     public void func_148833_a(IServerPlayNetHandler p_148833_1_) {
+@@ -45,4 +45,24 @@
+       }
+ 
+    }
++
++	@Override
++	public PacketBuffer getInternalData() {
++		return field_149561_c;
++	}
++
++	@Override
++	public void setData(PacketBuffer data) {
++		this.field_149561_c = data;
++	}
++
++	@Override
++	public ResourceLocation getName() {
++		return field_149562_a;
++	}
++
++	@Override
++	public void setName(ResourceLocation name) {
++		this.field_149562_a = name;
++	}
+ }

--- a/patches/minecraft/net/minecraft/network/play/client/CCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CCustomPayloadPacket.java.patch
@@ -3,43 +3,43 @@
 @@ -9,7 +9,7 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
- 
+
 -public class CCustomPayloadPacket implements IPacket<IServerPlayNetHandler> {
 +public class CCustomPayloadPacket implements IPacket<IServerPlayNetHandler>, net.minecraftforge.fml.network.ICustomPacket<CCustomPayloadPacket> {
     public static final ResourceLocation field_210344_a = new ResourceLocation("brand");
     private ResourceLocation field_149562_a;
     private PacketBuffer field_149561_c;
 @@ -35,7 +35,7 @@
- 
+
     public void func_148840_b(PacketBuffer p_148840_1_) throws IOException {
        p_148840_1_.func_192572_a(this.field_149562_a);
 -      p_148840_1_.writeBytes((ByteBuf)this.field_149561_c);
 +      p_148840_1_.writeBytes((ByteBuf)this.field_149561_c.copy()); //This may be access multiple times, from multiple threads, lets be safe like the S->C packet
     }
- 
+
     public void func_148833_a(IServerPlayNetHandler p_148833_1_) {
 @@ -45,4 +45,24 @@
        }
- 
+
     }
 +
-+	@Override
-+	public PacketBuffer getInternalData() {
-+		return field_149561_c;
++    @Override
++    public PacketBuffer getInternalData() {
++        return field_149561_c;
 +	}
 +
-+	@Override
-+	public void setData(PacketBuffer data) {
-+		this.field_149561_c = data;
-+	}
++    @Override
++    public void setData(PacketBuffer data) {
++    this.field_149561_c = data;
++    }
 +
-+	@Override
-+	public ResourceLocation getName() {
-+		return field_149562_a;
-+	}
++    @Override
++    public ResourceLocation getName() {
++        return field_149562_a;
++    }
 +
-+	@Override
-+	public void setName(ResourceLocation name) {
-+		this.field_149562_a = name;
-+	}
++    @Override
++    public void setName(ResourceLocation name) {
++        this.field_149562_a = name;
++    }
  }

--- a/patches/minecraft/net/minecraft/network/play/server/SCustomPayloadPlayPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SCustomPayloadPlayPacket.java.patch
@@ -3,7 +3,7 @@
 @@ -8,7 +8,7 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
- 
+
 -public class SCustomPayloadPlayPacket implements IPacket<IClientPlayNetHandler> {
 +public class SCustomPayloadPlayPacket implements IPacket<IClientPlayNetHandler>, net.minecraftforge.fml.network.ICustomPacket<SCustomPayloadPlayPacket> {
     public static final ResourceLocation field_209911_b = new ResourceLocation("brand");
@@ -14,23 +14,23 @@
        return new PacketBuffer(this.field_149171_b.copy());
     }
 +
-+	@Override
-+	public PacketBuffer getInternalData() {
-+		return field_149171_b;
-+	}
++    @Override
++    public PacketBuffer getInternalData() {
++        return field_149171_b;
++    }
 +
-+	@Override
-+	public void setData(PacketBuffer data) {
-+		this.field_149171_b = data;
-+	}
++    @Override
++    public void setData(PacketBuffer data) {
++        this.field_149171_b = data;
++    }
 +
-+	@Override
-+	public ResourceLocation getName() {
-+		return field_149172_a;
-+	}
++    @Override
++    public ResourceLocation getName() {
++    return field_149172_a;
++    }
 +
-+	@Override
-+	public void setName(ResourceLocation name) {
-+		this.field_149172_a = name;
-+	}
++    @Override
++    public void setName(ResourceLocation name) {
++    this.field_149172_a = name;
++    }
  }

--- a/patches/minecraft/net/minecraft/network/play/server/SCustomPayloadPlayPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SCustomPayloadPlayPacket.java.patch
@@ -9,3 +9,28 @@
     public static final ResourceLocation field_209911_b = new ResourceLocation("brand");
     public static final ResourceLocation field_209913_d = new ResourceLocation("debug/path");
     public static final ResourceLocation field_209914_e = new ResourceLocation("debug/neighbors_update");
+@@ -68,4 +68,24 @@
+    public PacketBuffer func_180735_b() {
+       return new PacketBuffer(this.field_149171_b.copy());
+    }
++
++	@Override
++	public PacketBuffer getInternalData() {
++		return field_149171_b;
++	}
++
++	@Override
++	public void setData(PacketBuffer data) {
++		this.field_149171_b = data;
++	}
++
++	@Override
++	public ResourceLocation getName() {
++		return field_149172_a;
++	}
++
++	@Override
++	public void setName(ResourceLocation name) {
++		this.field_149172_a = name;
++	}
+ }

--- a/src/main/java/net/minecraftforge/fml/network/ICustomPacket.java
+++ b/src/main/java/net/minecraftforge/fml/network/ICustomPacket.java
@@ -19,82 +19,30 @@
 
 package net.minecraftforge.fml.network;
 
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap;
 import net.minecraft.network.IPacket;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.network.login.client.CCustomPayloadLoginPacket;
-import net.minecraft.network.login.server.SCustomPayloadLoginPacket;
-import net.minecraft.network.play.client.CCustomPayloadPacket;
-import net.minecraft.network.play.server.SCustomPayloadPlayPacket;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.unsafe.UnsafeHacks;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public interface ICustomPacket<T extends IPacket<?>> {
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    enum Fields {
-        CPACKETCUSTOMPAYLOAD(CCustomPayloadPacket.class),
-        SPACKETCUSTOMPAYLOAD(SCustomPayloadPlayPacket.class),
-        CPACKETCUSTOMLOGIN(CCustomPayloadLoginPacket.class),
-        SPACKETCUSTOMLOGIN(SCustomPayloadLoginPacket.class),
-        ;
-
-        static final Reference2ReferenceArrayMap<Class<?>, Fields> lookup;
-        static {
-            lookup = Stream.of(values()).
-                    collect(Collectors.toMap(Fields::getClazz, Function.identity(), (m1, m2)->m1, Reference2ReferenceArrayMap::new));
-        }
-
-        private final Class<?> clazz;
-
-        final Optional<Field> data;
-        final Optional<Field> channel;
-        final Optional<Field> index;
-
-        Fields(Class<?> customPacketClass)
-        {
-            this.clazz = customPacketClass;
-            Field[] fields = customPacketClass.getDeclaredFields();
-            data = Arrays.stream(fields).filter(f-> !Modifier.isStatic(f.getModifiers()) && f.getType() == PacketBuffer.class).findFirst();
-            channel = Arrays.stream(fields).filter(f->!Modifier.isStatic(f.getModifiers()) && f.getType() == ResourceLocation.class).findFirst();
-            index = Arrays.stream(fields).filter(f->!Modifier.isStatic(f.getModifiers()) && f.getType() == int.class).findFirst();
-        }
-
-        private Class<?> getClazz()
-        {
-            return clazz;
-        }
-    }
-
     default PacketBuffer getInternalData() {
-        return Fields.lookup.get(this.getClass()).data.map(f->UnsafeHacks.<PacketBuffer>getField(f, this)).orElse(null);
+        return null;
     }
 
     default ResourceLocation getName() {
-        return Fields.lookup.get(this.getClass()).channel.map(f->UnsafeHacks.<ResourceLocation>getField(f, this)).orElse(FMLLoginWrapper.WRAPPER);
+        return FMLLoginWrapper.WRAPPER;
     }
 
     default int getIndex() {
-        return Fields.lookup.get(this.getClass()).index.map(f->UnsafeHacks.getIntField(f, this)).orElse(Integer.MIN_VALUE);
+        return Integer.MIN_VALUE;
     }
 
     default void setData(PacketBuffer buffer) {
-        Fields.lookup.get(this.getClass()).data.ifPresent(f->UnsafeHacks.setField(f, this, buffer));
     }
 
     default void setName(ResourceLocation channelName) {
-        Fields.lookup.get(this.getClass()).channel.ifPresent(f->UnsafeHacks.setField(f, this, channelName));
     }
 
     default void setIndex(int index) {
-        Fields.lookup.get(this.getClass()).index.ifPresent(f->UnsafeHacks.setIntField(f, this, index));
     }
 
     default NetworkDirection getDirection() {


### PR DESCRIPTION
...reflection.

This pull request drastically reduces the complexity of ICustomPacket by implementing the interface directly instead of using UnsafeHacks reflection. In addition to making this code easier to understand (and, in theory maintain), this PR reduces Forge's reliance on deprecated classes and reflection tactics.

I implemented the methods in the style I have seen other parts of Forge used, but if there is a new preferred style that differs from what I have please mention it in a review.
The Fields enum was removed as all of its useful additions were package-private or private, and I assumed it was an implementation detail. If someone uses this enum in their mod, I can restore it.