### PR TITLE
[1.15] Remove duplicate post of ChunkEvent.Load.

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -16,15 +16,7 @@
                 }
  
                 this.func_219229_a(p_219185_5_);
-@@ -482,6 +484,7 @@
-                if (flag) {
-                   IChunk ichunk = ChunkSerializer.func_222656_a(this.field_219255_i, this.field_219269_w, this.field_219260_n, p_223172_1_, compoundnbt);
-                   ichunk.func_177432_b(this.field_219255_i.func_82737_E());
-+                  net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Load(ichunk));
-                   return Either.left(ichunk);
-                }
- 
-@@ -594,6 +597,7 @@
+@@ -594,6 +596,7 @@
                 if (list != null) {
                    list.forEach(chunk::func_76622_b);
                 }
@@ -32,7 +24,7 @@
              }
  
              return chunk;
-@@ -679,6 +683,7 @@
+@@ -679,6 +682,7 @@
  
              this.field_219255_i.func_217381_Z().func_230035_c_("chunkSave");
              CompoundNBT compoundnbt1 = ChunkSerializer.func_222645_a(this.field_219255_i, p_219229_1_);
@@ -40,7 +32,7 @@
              this.func_219100_a(chunkpos, compoundnbt1);
              return true;
           } catch (Exception exception) {
-@@ -711,6 +716,7 @@
+@@ -711,6 +715,7 @@
  
     protected void func_219199_a(ServerPlayerEntity p_219199_1_, ChunkPos p_219199_2_, IPacket<?>[] p_219199_3_, boolean p_219199_4_, boolean p_219199_5_) {
        if (p_219199_1_.field_70170_p == this.field_219255_i) {


### PR DESCRIPTION
This call to `ChunkEvent.Load` is a duplicate, it is called _directly_ after `ChunkDataEvent.Load`, and _only_ when a chunk is loaded from disk. Whereas the other call to `ChunkEvent.Load` is fired _after_ the chunk has been marked as loaded and successfully generated or loaded from disk.  
This duplicate call was also fired for ProtoChunks in the middle of generating if generation was halted at a specific step and saved then loaded from disk.  

I wrote a [small test mod](https://gist.github.com/covers1624/3c933d05a7960d59d0165ca14e02013b) (i threw it into an existing mod of mine) to track this down, I can add this to the PR if requested. The test mod is horrible, but does well enough to demonstrate the duplicated calls to the Load event. Without this change, log output from the test mod would be similar to [this](https://gist.github.com/covers1624/c92919d0bb7508b93b7e9dd90309cf8e), and when flying around near(relative to the chunk load distance around the player) edges of generated chunks [this](https://gist.github.com/covers1624/59ffd08d569135d8331d22642066fee6).