### PR TITLE
fix test mod and add warning comment to framebuffer

### DIFF
--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -15,7 +15,7 @@
        }
  
        this.func_147611_b();
-@@ -254,4 +260,28 @@
+@@ -254,4 +260,29 @@
        GlStateManager.func_227658_a_(i, p_216493_1_);
        this.func_147609_e();
     }
@@ -26,6 +26,7 @@
 +     * Attempts to enabled 8 bits of stencil buffer on this FrameBuffer.
 +     * Modders must call this directly to set things up.
 +     * This is to prevent the default cause where graphics cards do not support stencil bits.
++     * <b>Make sure to call this on the main render thread!</b>
 +     */
 +    public void enableStencil()
 +    {

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -23,7 +23,7 @@
 +    /*================================ FORGE START ================================================*/
 +    private boolean stencilEnabled = false;
 +    /**
-+     * Attempts to enabled 8 bits of stencil buffer on this FrameBuffer.
++     * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
 +     * Modders must call this directly to set things up.
 +     * This is to prevent the default cause where graphics cards do not support stencil bits.
 +     * <b>Make sure to call this on the main render thread!</b>

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -2,6 +2,7 @@ package net.minecraftforge.debug.client.rendering;
 
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -13,6 +14,6 @@ public class StencilEnableTest {
     }
 
     private void clientSetup(FMLClientSetupEvent event) {
-        Minecraft.getInstance().getFramebuffer().enableStencil();
+        DeferredWorkQueue.runLater(() -> Minecraft.getInstance().getFramebuffer().enableStencil());
     }
 }


### PR DESCRIPTION
Quick oversight from gigaherz in test mod.
As others are likely to run into the same issue, I added a comment to the original method