### PR TITLE
Fix StartupQuery not working more than once on the client

### DIFF
--- a/src/main/java/net/minecraftforge/fml/StartupQuery.java
+++ b/src/main/java/net/minecraftforge/fml/StartupQuery.java
@@ -66,7 +66,6 @@ public class StartupQuery {
         MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
         if (server != null) server.initiateShutdown(false);
 
-        aborted = true; // to abort loading and go back to the main menu
         throw new AbortedException(); // to halt the server
     }
 
@@ -76,7 +75,6 @@ public class StartupQuery {
     public static void reset()
     {
         pending = null;
-        aborted = false;
     }
 
     public static boolean check()
@@ -104,7 +102,7 @@ public class StartupQuery {
             pending = null;
         }
 
-        return !aborted;
+        return true;
     }
 
     private void throwException() throws InterruptedException
@@ -113,7 +111,6 @@ public class StartupQuery {
     }
 
     private static volatile StartupQuery pending;
-    private static volatile boolean aborted = false;
 
 
     private StartupQuery(String text, @Nullable AtomicBoolean result)


### PR DESCRIPTION
The `aborted` flag was used / intended to make the client return to the main menu. But it already does that when the server ends, which is what aborting the query does.
What now happened is that the client would abort the query, it would reset itself and then it would abort. This causes `abort` to stay `true`, causing further queries to always immediately "pseudo-abort", where the client thinks the query is done, but the server keeps waiting anyways.

Since the flag is not needed anyways (the clue is that the server stopped), this fixes it.