### PR TITLE
IBlockState -> BlockState in Javadocs, plus minor improvements/update…

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractRailBlock.java.patch
@@ -2,15 +2,15 @@
 +++ b/net/minecraft/block/AbstractRailBlock.java
 @@ -36,7 +36,7 @@
     }
- 
+
     public VoxelShape func_220053_a(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_, ISelectionContext p_220053_4_) {
 -      RailShape railshape = p_220053_1_.func_177230_c() == this ? p_220053_1_.func_177229_b(this.func_176560_l()) : null;
 +      RailShape railshape = p_220053_1_.func_177230_c() == this ? getRailDirection(p_220053_1_, p_220053_2_, p_220053_3_, null) : null;
        return railshape != null && railshape.func_208092_c() ? field_190959_b : field_185590_a;
     }
- 
+
 @@ -56,7 +56,7 @@
- 
+
     public void func_220069_a(BlockState p_220069_1_, World p_220069_2_, BlockPos p_220069_3_, Block p_220069_4_, BlockPos p_220069_5_, boolean p_220069_6_) {
        if (!p_220069_2_.field_72995_K) {
 -         RailShape railshape = p_220069_1_.func_177229_b(this.func_176560_l());
@@ -26,12 +26,12 @@
 +         if (getRailDirection(p_196243_1_, p_196243_2_, p_196243_3_, null).func_208092_c()) {
              p_196243_2_.func_195593_d(p_196243_3_.func_177984_a(), this);
           }
- 
+
 @@ -134,5 +134,66 @@
        return blockstate.func_206870_a(this.func_176560_l(), flag ? RailShape.EAST_WEST : RailShape.NORTH_SOUTH);
     }
- 
-+   //Forge: Use getRailDirection(IBlockAccess, BlockPos, IBlockState, EntityMinecart) for enhanced ability
+
++   //Forge: Use getRailDirection(BlockState, IBlockReader, BlockPos, net.minecraft.entity.item.minecart.AbstractMinecartEntity) for enhanced ability
     public abstract IProperty<RailShape> func_176560_l();
 +
 +   /* ======================================== FORGE START =====================================*/

--- a/patches/minecraft/net/minecraft/client/renderer/model/IBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/IBakedModel.java.patch
@@ -2,27 +2,27 @@
 +++ b/net/minecraft/client/renderer/model/IBakedModel.java
 @@ -10,7 +10,9 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
- 
+
  @OnlyIn(Dist.CLIENT)
 -public interface IBakedModel {
 +public interface IBakedModel extends net.minecraftforge.client.extensions.IForgeBakedModel {
-+   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getQuads(IBlockState, EnumFacing, Random, net.minecraftforge.client.model.data.IModelData)}*/
++   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getQuads(BlockState, Direction, Random, net.minecraftforge.client.model.data.IModelData)}*/
 +   @Deprecated
     List<BakedQuad> func_200117_a(@Nullable BlockState p_200117_1_, @Nullable Direction p_200117_2_, Random p_200117_3_);
- 
+
     boolean func_177555_b();
 @@ -21,9 +23,13 @@
- 
+
     boolean func_188618_c();
- 
+
 +   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getParticleTexture(net.minecraftforge.client.model.data.IModelData)}*/
 +   @Deprecated
     TextureAtlasSprite func_177554_e();
- 
+
 -   ItemCameraTransforms func_177552_f();
 +   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective(net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType, com.mojang.blaze3d.matrix.MatrixStack)} instead */
 +   @Deprecated
 +   default ItemCameraTransforms func_177552_f() { return ItemCameraTransforms.field_178357_a; }
- 
+
     ItemOverrideList func_188617_f();
  }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -57,7 +57,7 @@ public interface IForgeBakedModel
      */
     default boolean doesHandlePerspectives() { return false; }
 
-    /*
+    /**
      * Returns the pair of the model for the given perspective, and the matrix that
      * should be applied to the GL state before rendering it (matrix may be null).
      */

--- a/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
@@ -31,7 +31,7 @@ import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.util.Direction;
 
 /**
- * Convenience interface with default implementation of {@link IBakedModel#getQuads(net.minecraft.block.state.IBlockState, net.minecraft.util.EnumFacing, java.util.Random)}.
+ * Convenience interface with default implementation of {@link IBakedModel#getQuads(BlockState, Direction, Random)}.
  */
 public interface IDynamicBakedModel extends IBakedModel
 {
@@ -40,7 +40,7 @@ public interface IDynamicBakedModel extends IBakedModel
     {
         return getQuads(state, side, rand, EmptyModelData.INSTANCE);
     }
-    
+
     // Force this to be overriden otherwise this introduces a default cycle between the two overloads.
     @Override
     @Nonnull

--- a/src/main/java/net/minecraftforge/common/PlantType.java
+++ b/src/main/java/net/minecraftforge/common/PlantType.java
@@ -39,7 +39,7 @@ public enum PlantType implements IExtensibleEnum
      *
      * <p>If your new plant grows on blocks like any one of them above, never create a new {@link PlantType}.
      * This enumeration is only functioning in
-     * {@link net.minecraft.block.Block#canSustainPlant(IBlockState, IWorldReader, BlockPos, EnumFacing, IPlantable)},
+     * {@link net.minecraft.block.Block#canSustainPlant(net.minecraft.block.BlockState, IWorldReader, BlockPos, net.minecraft.util.Direction, net.minecraftforge.common.IPlantable)},
      * which you are supposed to override this function in your new block and create a new plant type to grow on that block.
      *
      * <p>You can create an instance of your plant type in your API and let your/others mods access it. It will be faster than calling this method.
@@ -51,4 +51,3 @@ public enum PlantType implements IExtensibleEnum
         throw new IllegalStateException("Enum not extended");
     }
 }
-

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -843,7 +843,7 @@ public interface IForgeBlock
     }
 
     /** //TODO: Re-Evaluate
-     * Gets the {@link IBlockState} to place
+     * Gets the {@link BlockState} to place
      * @param world The world the block is being placed in
      * @param pos The position the block is being placed at
      * @param facing The side the block is being placed on
@@ -1025,7 +1025,7 @@ public interface IForgeBlock
      * @param pos Block position in world
      * @param start The start vector
      * @param end The end vector
-     * @param original The original result from {@link Block#collisionRayTrace(IBlockState, World, BlockPos, Vec3d, Vec3d)}
+     * @param original The original result from {@link Block#collisionRayTrace(BlockState, World, BlockPos, Vec3d, Vec3d)}
      * @return A result that suits your block
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -694,7 +694,7 @@ public interface IForgeBlockState
     }
 
     /** //TODO: Re-Evaluate
-     * Gets the {@link IBlockState} to place
+     * Gets the {@link BlockState} to place
      * @param world The world the block is being placed in
      * @param pos The position the block is being placed at
      * @param facing The side the block is being placed on

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -541,7 +541,7 @@ public interface IForgeItem
     }
 
     /**
-     * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
+     * ItemStack sensitive version of {@link PlayerEntity#canHarvestBlock(BlockState)}
      *
      * @param stack The itemstack used to harvest the block
      * @param state The block trying to harvest

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(IBlockState, IBlockAccess, BlockPos, Entity)}<br>
+ * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door.<br>
  * <br>
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
  * If this event is canceled, the block will not be destroyed.<br>
@@ -42,7 +42,7 @@ public class LivingDestroyBlockEvent extends LivingEvent
 {
     private final BlockPos pos;
     private final BlockState state;
-    
+
     public LivingDestroyBlockEvent(LivingEntity entity, BlockPos pos, BlockState state)
     {
         super(entity);
@@ -54,7 +54,7 @@ public class LivingDestroyBlockEvent extends LivingEvent
     {
         return state;
     }
-    
+
     public BlockPos getPos()
     {
         return pos;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -60,11 +60,11 @@ public class PlayerEvent extends LivingEvent
     /**
      * HarvestCheck is fired when a player attempts to harvest a block.<br>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link EntityPlayer#canHarvestBlock(IBlockState)}.<br>
+     * {@link EntityPlayer#canHarvestBlock(BlockState)}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#doPlayerHarvestCheck(EntityPlayer, IBlockState, boolean)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#doPlayerHarvestCheck(EntityPlayer, BlockState, boolean)}.<br>
      * <br>
-     * {@link #state} contains the {@link IBlockState} that is being checked for harvesting. <br>
+     * {@link #state} contains the {@link BlockState} that is being checked for harvesting. <br>
      * {@link #success} contains the boolean value for whether the Block will be successfully harvested. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
@@ -93,9 +93,9 @@ public class PlayerEvent extends LivingEvent
     /**
      * BreakSpeed is fired when a player attempts to harvest a block.<br>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link EntityPlayer#canHarvestBlock(IBlockState)}.<br>
+     * {@link EntityPlayer#canHarvestBlock(BlockState)}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#getBreakSpeed(EntityPlayer, IBlockState, float, BlockPos)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#getBreakSpeed(EntityPlayer, BlockState, float, BlockPos)}.<br>
      * <br>
      * {@link #state} contains the block being broken. <br>
      * {@link #originalSpeed} contains the original speed at which the player broke the block. <br>

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -33,7 +33,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event has a result. {@link HasResult}<br>
  *
  * setResult(ALLOW) informs game that player is still "in bed"<br>
- * setResult(DEFAULT) causes game to check {@link Block#isBed(IBlockState, net.minecraft.world.IWorldReader, BlockPos, Entity)} instead
+ * setResult(DEFAULT) causes game to check {@link Block#isBed(BlockState, net.minecraft.world.IWorldReader, BlockPos, Entity)} instead
  */
 @HasResult
 public class SleepingLocationCheckEvent extends LivingEvent

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -287,7 +287,7 @@ public class BlockEvent extends Event
     }
 
     /**
-     * Fired when a liquid places a block. Use {@link #setNewState(IBlockState)} to change the result of
+     * Fired when a liquid places a block. Use {@link #setNewState(BlockState)} to change the result of
      * a cobblestone generator or add variants of obsidian. Alternatively, you  could execute
      * arbitrary code when lava sets blocks on fire, even preventing it.
      *

--- a/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
@@ -30,7 +30,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
 /**
  * SaplingGrowTreeEvent is fired when a sapling grows into a tree.<br>
  * This event is fired during sapling growth in
- * {@link BlockSapling#generateTree(World, BlockPos, IBlockState, Random)}.<br>
+ * {@link SaplingBlock#func_226942_a_(World, BlockPos, BlockState, Random)}.<br>
  * <br>
  * {@link #pos} contains the coordinates of the growing sapling. <br>
  * {@link #rand} contains an instance of Random for use. <br>


### PR DESCRIPTION
…s/fixes to related Javadocs

While I was updating my mod, I saw IBlockState referenced in a Javadoc, so I became pretty confused. This pull request will update some of the documentation.

A few things I ran into while making this PR that aren't resolved:
* The main Javadoc for SleepingLocationCheckEvent appears to be outdated, since there is no isBed method (and no very obvious replacement for it)
* func_226942_a_ is the current function name of "generateTree" under the current MCP mappings for whatever reason, unless my mappings are broken which is possible.
* The JavaDoc for IForgeBlock#getRayTraceResult appears to be outdated, since there is no collisionRayTrace method (and no very obvious replacement for it)