### PR TITLE
Using DeferredRegister with custom registries

### DIFF
--- a/src/main/java/net/minecraftforge/DeferredCustomRegistry.java
+++ b/src/main/java/net/minecraftforge/DeferredCustomRegistry.java
@@ -1,0 +1,149 @@
+package net.minecraftforge;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.common.util.NonNullSupplier;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class DeferredCustomRegistry<T extends IForgeRegistryEntry<T>>
+{
+   private final NonNullSupplier<IForgeRegistry<T>> typeSup;
+   private IForgeRegistry<T> type;
+   private final String modid;
+   private final Map<LazyOptionalRegistryObject<T>, Supplier<? extends T>> entries = new LinkedHashMap<>();
+   private final Set<LazyOptionalRegistryObject<T>> entriesView = Collections.unmodifiableSet(entries.keySet());
+
+   /**
+    * Custom registries are only created after the {@link DeferredRegister} constructor is called due to static init.
+    * To solve this, the {@link IForgeRegistry} and {@link RegistryObject}s must be evaluated only when registry events are fired.
+    * The passed in supplier will only be called once {@link #addEntries} is invoked.
+    * When it is invoked, it is guaranteed that the registry is created since the {@link RegistryEvent.NewRegistry} event is fired beforehand.
+    * @param supReg supplier of an IForgeRegistry of the desired type.
+    */
+   public DeferredCustomRegistry(NonNullSupplier<IForgeRegistry<T>> supReg, String modid)
+   {
+      this.typeSup = supReg;
+      this.modid = modid;
+   }
+
+   /**
+    * Adds a new supplier to the list of entries to be registered, and returns a {@link LazyOptionalRegistryObject}
+    * that will be populated with the created entry automatically and lazily.
+    *
+    * @param name The new entry's name, it will automatically have the modid prefixed.
+    * @param sup A factory for the new entry, it should return a new instance every time it is called.
+    * @return A {@link LazyOptionalRegistryObject} that will be lazily updated with when the entries in the registry change.
+    */
+   public <I extends T> LazyOptionalRegistryObject<I> lazyOptRegister(final String name, final Supplier<? extends I> sup)
+   {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(sup);
+      final ResourceLocation key = new ResourceLocation(modid, name);
+      LazyOptionalRegistryObject<I> lazyOptRet = new LazyOptionalRegistryObject<>(()->RegistryObject.of(key, this.type));
+      if(entries.putIfAbsent(lazyOptRet.cast(), ()->sup.get().setRegistryName(key)) != null) {
+         throw new IllegalArgumentException("Duplicate registration " + name);
+      }
+      return lazyOptRet;
+   }
+
+   /**
+    * Adds our event handler to the specified event bus, this MUST be called in order for this class to function.
+    * See the example usage.
+    *
+    * @param bus The Mod Specific event bus.
+    */
+   public void register(IEventBus bus)
+   {
+      bus.addListener(this::addEntries);
+   }
+
+   /**
+    * @return The unmodifiable view of registered entries. Useful for bulk operations on all values.
+    */
+   public Collection<LazyOptionalRegistryObject<T>> getEntries()
+   {
+      return entriesView;
+   }
+
+   private void addEntries(RegistryEvent.Register<?> event)
+   {
+      if (event.getGenericType() == getFromSupplier().getRegistrySuperType())
+      {
+         @SuppressWarnings("unchecked")
+         IForgeRegistry<T> reg = (IForgeRegistry<T>)event.getRegistry();
+         for (Map.Entry<LazyOptionalRegistryObject<T>, Supplier<? extends T>> e : entries.entrySet())
+         {
+            reg.register(e.getValue().get());
+            e.getKey().getRegistryObject().updateReference(reg);
+         }
+      }
+   }
+
+   /**
+    * If the IForgeRegistry is null, gets it from the supplier. This is sure to be called from a classic register event.
+    * It is even guaranteed to be called from the Register Block event, since it is the first one called.
+    * This also makes sure that the IForgeRegistry is correct when updating the RegistryObjects.
+    */
+   private IForgeRegistry<T> getFromSupplier()
+   {
+      if(type == null) {
+         type = typeSup.get();
+      }
+      return type;
+   }
+
+   /**
+    * A way of lazily evaluating registry objects but in a nicer way than using {@link LazyOptional<RegistryObject>}
+    */
+   public static class LazyOptionalRegistryObject<T extends IForgeRegistryEntry<? super T>> implements Supplier<T>
+   {
+      private final LazyOptional<RegistryObject<T>> lazyOptRet;
+
+      private LazyOptionalRegistryObject(NonNullSupplier<RegistryObject<T>> supplier)
+      {
+         if(supplier == null)
+         {
+            throw new IllegalStateException("Supplier should not be null");
+         }
+         lazyOptRet = LazyOptional.of(supplier);
+      }
+
+      /**
+       * The interest of the LazyOptional is mostly for the lazy part.
+       * This is only called in {@link #addEntries} when the IForgeRegistry is definitely assigned.
+       * The RegistryObject is created using {@link RegistryObject#of(ResourceLocation, IForgeRegistry)}
+       */
+      private RegistryObject<T> getRegistryObject()
+      {
+         return lazyOptRet.orElseThrow(()->new IllegalStateException("This deserves a better error message."));
+      }
+
+      /**
+       * Mostly for convenience, so that there is no need to do get().get(), but also to act as a Supplier just like RegistryObject
+       */
+      @Override
+      public T get()
+      {
+         return getRegistryObject().get();
+      }
+
+      /**
+       * Helper function to cast, since it is needed in {@link #lazyOptRegister} to work with
+       * objects not directly implementing the type of this registry
+       */
+      @SuppressWarnings("unchecked")
+      private  <X extends IForgeRegistryEntry<? super X>> LazyOptionalRegistryObject<X> cast()
+      {
+         return (LazyOptionalRegistryObject<X>) this;
+      }
+   }
+}

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -108,7 +108,7 @@ public class DeferredRegister<T extends IForgeRegistryEntry<T>>
     }
 
     /**
-     * Adds a new supplier to the list of entries to be registered, and returns a {@link DeferredCustomRegistry.LazyRegistryObject}
+     * Adds a new supplier to the list of entries to be registered, and returns a {@link LazyRegistryObject}
      * that will be populated with the created entry automatically and lazily.
      *
      * @param name The new entry's name, it will automatically have the modid prefixed.

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/AddonDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/AddonDeferredStuff.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.fml.common.registry.customdeferred;
+
+import net.minecraftforge.registries.DeferredRegister;
+
+public class AddonDeferredStuff
+{
+   public static void init() {}
+
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_ADDON = TestDeferredStuff.TESTS.lazyRegister("test_addon", ()->new TestRegistryObject("This test comes from the addon."));
+}

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredAddon.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredAddon.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.fml.common.registry.customdeferred;
+
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+
+@Mod(TestDeferredAddon.MOD_ID)
+public class TestDeferredAddon
+{
+   public static final String MOD_ID = "custom_deferred_addon_testing";
+
+   //This works, but probably not a good idea to static init an other mods classes...
+   // Also makes this object be the first registered.
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_ADDON2 = TestDeferredStuff.TESTS.lazyRegister("test_addon2", ()->new TestRegistryObject("This test comes from the static init addon."));
+
+   public TestDeferredAddon()
+   {
+      AddonDeferredStuff.init(); //static init.
+   }
+}

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.fml.common.registry.customdeferred;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.DeferredCustomRegistry;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(TestDeferredMod.MOD_ID)
+public class TestDeferredMod
+{
+   public static final Logger LOGGER = LogManager.getLogger();
+   public static IForgeRegistry<TestRegistryObject> testRegistry = null;
+   public static final String MOD_ID = "custom_deferred_testing";
+
+   public TestDeferredMod()
+   {
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::createRegistry);
+      TestDeferredStuff.register();
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::test);
+   }
+
+   private void createRegistry(RegistryEvent.NewRegistry event)
+   {
+      testRegistry = new RegistryBuilder<TestRegistryObject>()
+              .setType(TestRegistryObject.class)
+              .setName(new ResourceLocation(MOD_ID, "test_registry"))
+              .create();
+   }
+
+   private void test(FMLCommonSetupEvent event)
+   {
+      TestDeferredStuff.TESTS.getEntries().forEach(test->test.get().test());
+   }
+}

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
@@ -2,6 +2,7 @@ package net.minecraftforge.fml.common.registry.customdeferred;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -10,6 +11,8 @@ import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
 
 @Mod(TestDeferredMod.MOD_ID)
 public class TestDeferredMod
@@ -22,9 +25,13 @@ public class TestDeferredMod
    {
       FMLJavaModLoadingContext.get().getModEventBus().addListener(this::createRegistry);
       TestDeferredStuff.register();
-      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::test);
-      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::test2);
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
    }
+
+   //Testing that getEntries() does not crash if you call it after the registry is created but before the first register event is fired
+   // this is pretty dumb however since these objects cant do anything at that time.
+   private static Collection<RegistryObject<TestRegistryObject>> testEntries;
 
    private void createRegistry(RegistryEvent.NewRegistry event)
    {
@@ -32,17 +39,18 @@ public class TestDeferredMod
               .setType(TestRegistryObject.class)
               .setName(new ResourceLocation(MOD_ID, "test_registry"))
               .create();
+      testEntries = TestDeferredStuff.TESTS.getEntries();
    }
 
-   private void test(FMLCommonSetupEvent event)
+   private void commonSetup(FMLCommonSetupEvent event)
    {
-      TestDeferredStuff.TESTS.getEntries().forEach(test->test.get().test());
+      testEntries.forEach(test->test.get().test());
       TestDeferredStuff.TEST_2.get().test();
    }
 
-   private void test2(FMLClientSetupEvent event)
+   private void clientSetup(FMLClientSetupEvent event)
    {
-      TestDeferredStuff.TESTS.getEntries().forEach(test->test.get().test());
+      testEntries.forEach(test->test.get().test());
       TestDeferredStuff.TEST_OBJECT.get().test();
    }
 }

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredMod.java
@@ -1,9 +1,9 @@
 package net.minecraftforge.fml.common.registry.customdeferred;
 
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.DeferredCustomRegistry;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.IForgeRegistry;
@@ -23,6 +23,7 @@ public class TestDeferredMod
       FMLJavaModLoadingContext.get().getModEventBus().addListener(this::createRegistry);
       TestDeferredStuff.register();
       FMLJavaModLoadingContext.get().getModEventBus().addListener(this::test);
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(this::test2);
    }
 
    private void createRegistry(RegistryEvent.NewRegistry event)
@@ -36,5 +37,12 @@ public class TestDeferredMod
    private void test(FMLCommonSetupEvent event)
    {
       TestDeferredStuff.TESTS.getEntries().forEach(test->test.get().test());
+      TestDeferredStuff.TEST_2.get().test();
+   }
+
+   private void test2(FMLClientSetupEvent event)
+   {
+      TestDeferredStuff.TESTS.getEntries().forEach(test->test.get().test());
+      TestDeferredStuff.TEST_OBJECT.get().test();
    }
 }

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
@@ -1,14 +1,15 @@
 package net.minecraftforge.fml.common.registry.customdeferred;
 
 
-import net.minecraftforge.DeferredCustomRegistry;
+import net.minecraftforge.registries.DeferredCustomRegistry;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
 
 public class TestDeferredStuff
 {
-   public static final DeferredCustomRegistry<TestRegistryObject> TESTS = new DeferredCustomRegistry<>(()->TestDeferredMod.testRegistry, TestDeferredMod.MOD_ID);
-   public static final DeferredCustomRegistry.LazyOptionalRegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.lazyOptRegister("test_object", ()->new TestRegistryObject("It worked"));
-   public static final DeferredCustomRegistry.LazyOptionalRegistryObject<TestRegistryObject> TEST_2 = TESTS.lazyOptRegister("test_2", ()->new TestRegistryObject("It works perfectly."));
+   public static final DeferredRegister<TestRegistryObject> TESTS = new DeferredRegister<>(()->TestDeferredMod.testRegistry, TestDeferredMod.MOD_ID);
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.lazyRegister("test_object", ()->new TestRegistryObject("It worked"));
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_2 = TESTS.lazyRegister("test_2", ()->new TestRegistryObject("It works perfectly."));
 
    public static void register()
    {

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
@@ -1,14 +1,15 @@
 package net.minecraftforge.fml.common.registry.customdeferred;
 
 
+import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 
 public class TestDeferredStuff
 {
    public static final DeferredRegister<TestRegistryObject> TESTS = new DeferredRegister<>(()->TestDeferredMod.testRegistry, TestDeferredMod.MOD_ID);
-   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.lazyRegister("test_object", ()->new TestRegistryObject("It worked"));
-   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_2 = TESTS.lazyRegister("test_2", ()->new TestRegistryObject("It works perfectly."));
+   public static final RegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.register("test_object", ()->new TestRegistryObject("It worked"));
+   public static final RegistryObject<TestRegistryObject> TEST_2 = TESTS.register("test_2", ()->new TestRegistryObject("It works perfectly."));
 
    public static void register()
    {

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.fml.common.registry.customdeferred;
+
+
+import net.minecraftforge.DeferredCustomRegistry;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+public class TestDeferredStuff
+{
+   public static final DeferredCustomRegistry<TestRegistryObject> TESTS = new DeferredCustomRegistry<>(()->TestDeferredMod.testRegistry, TestDeferredMod.MOD_ID);
+   public static final DeferredCustomRegistry.LazyOptionalRegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.lazyOptRegister("test_object", ()->new TestRegistryObject("It worked"));
+   public static final DeferredCustomRegistry.LazyOptionalRegistryObject<TestRegistryObject> TEST_2 = TESTS.lazyOptRegister("test_2", ()->new TestRegistryObject("It works perfectly."));
+
+   public static void register()
+   {
+      TESTS.register(FMLJavaModLoadingContext.get().getModEventBus());
+   }
+}

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
@@ -8,8 +8,8 @@ import net.minecraftforge.registries.DeferredRegister;
 public class TestDeferredStuff
 {
    public static final DeferredRegister<TestRegistryObject> TESTS = new DeferredRegister<>(()->TestDeferredMod.testRegistry, TestDeferredMod.MOD_ID);
-   public static final RegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.register("test_object", ()->new TestRegistryObject("It worked"));
-   public static final RegistryObject<TestRegistryObject> TEST_2 = TESTS.register("test_2", ()->new TestRegistryObject("It works perfectly."));
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_OBJECT = TESTS.lazyRegister("test_object", ()->new TestRegistryObject("It worked"));
+   public static final DeferredRegister.LazyRegistryObject<TestRegistryObject> TEST_2 = TESTS.lazyRegister("test_2", ()->new TestRegistryObject("It works perfectly."));
 
    public static void register()
    {

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestDeferredStuff.java
@@ -1,7 +1,6 @@
 package net.minecraftforge.fml.common.registry.customdeferred;
 
 
-import net.minecraftforge.registries.DeferredCustomRegistry;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 

--- a/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestRegistryObject.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/customdeferred/TestRegistryObject.java
@@ -1,0 +1,18 @@
+package net.minecraftforge.fml.common.registry.customdeferred;
+
+import net.minecraftforge.registries.ForgeRegistryEntry;
+
+public class TestRegistryObject extends ForgeRegistryEntry<TestRegistryObject>
+{
+   private final String test;
+
+   public TestRegistryObject(String test)
+   {
+      this.test = test;
+   }
+
+   public void test()
+   {
+      TestDeferredMod.LOGGER.info(test);
+   }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -2,6 +2,10 @@ modLoader="javafml"
 loaderVersion="[28,)"
 
 [[mods]]
+    modId="custom_deferred_testing"
+[[mods]]
+    modId="custom_deferred_addon_testing"
+[[mods]]
 	modId="containertypetest"
 [[mods]]
     modId="potion_event_test"
@@ -15,8 +19,6 @@ loaderVersion="[28,)"
 ##    modId="fog_color_in_material_test"
 [[mods]]
     modId="neighbor_notify_event_test"
-[[mods]]
-    modId="custom_deferred_testing"
 #[[mods]]
 #    modId="block_particle_effects_test"
 [[mods]]
@@ -79,3 +81,11 @@ loaderVersion="[28,)"
     versionRange="[1,)"
     ordering="AFTER"
     side="BOTH"
+[[dependencies.custom_deferred_addon_testing]]
+    modId="custom_deferred_testing"
+    mandatory=true
+    versionRange="[0,)"
+    ordering="NONE"
+    side="BOTH"
+
+

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -15,6 +15,8 @@ loaderVersion="[28,)"
 ##    modId="fog_color_in_material_test"
 [[mods]]
     modId="neighbor_notify_event_test"
+[[mods]]
+    modId="custom_deferred_testing"
 #[[mods]]
 #    modId="block_particle_effects_test"
 [[mods]]


### PR DESCRIPTION
I do not expect this to be PR'd, I open this mostly for comments and to maybe have a place to record anything such a feature must and can't have.

At first I created a separate class (DeferredCustomRegistry), but now implemented the solution into the DeferredRegister class directly.

Unsure if everything I used is necessary or if there is a simpler way instead of LazyOptional. 
I got it to work at first using LazyOptional<RegistryObject<T>> but now put a wrapper around it to simplify access to the T value and make it a supplier of T as well. 
But there could be something else to use here.

Any comments appreciated