### PR TITLE
Provide matrix and buffers to MapDecoration.render

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/MapItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/MapItemRenderer.java.patch
@@ -4,7 +4,7 @@
  
           for(MapDecoration mapdecoration : this.field_148242_b.field_76203_h.values()) {
              if (!p_228089_3_ || mapdecoration.func_191180_f()) {
-+               if (mapdecoration.render(k)) { k++; continue; }
++               if (mapdecoration.render(p_228089_1_, p_228089_2_, p_228089_4_, k)) { k++; continue; }
                 p_228089_1_.func_227860_a_();
                 p_228089_1_.func_227861_a_((double)(0.0F + (float)mapdecoration.func_176112_b() / 2.0F + 64.0F), (double)(0.0F + (float)mapdecoration.func_176113_c() / 2.0F + 64.0F), (double)-0.02F);
                 p_228089_1_.func_227863_a_(Vector3f.field_229183_f_.func_229187_a_((float)(mapdecoration.func_176111_d() * 360) / 16.0F));

--- a/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
@@ -4,7 +4,7 @@
        return i;
     }
  
-+   @Deprecated // Use overload with matrix stack and buffers. TODO 1.15 remove this
++   @Deprecated // Use overload with matrix stack and buffers. TODO 1.16 remove this
 +   @OnlyIn(Dist.CLIENT)
 +   public boolean render(int index) {
 +      return false;

--- a/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
@@ -1,17 +1,23 @@
 --- a/net/minecraft/world/storage/MapDecoration.java
 +++ b/net/minecraft/world/storage/MapDecoration.java
-@@ -83,6 +83,16 @@
+@@ -83,6 +83,22 @@
        return i;
     }
  
++   @Deprecated // Use overload with matrix stack and buffers. TODO 1.15 remove this
++   @OnlyIn(Dist.CLIENT)
++   public boolean render(int index) {
++      return false;
++   }
++
 +   /**
-+    * Renders this decoration, useful for custom sprite sheets.
++    * Renders this decoration into the provided buffers.
 +    * @param index The index of this icon in the MapData's list. Used by vanilla to offset the Z-coordinate to prevent Z-fighting
 +    * @return false to run vanilla logic for this decoration, true to skip it
 +    */
 +   @OnlyIn(Dist.CLIENT)
-+   public boolean render(int index) {
-+      return false;
++   public boolean render(com.mojang.blaze3d.matrix.MatrixStack ms, net.minecraft.client.renderer.IRenderTypeBuffer buffers, int light, int index) {
++      return render(index);
 +   }
 +
     public static enum Type {


### PR DESCRIPTION
As title. Current method is useless because we're in batched mode but the matrix and buffers aren't passed.