### PR TITLE
Correct and clarify documentation for default density and viscosity of FluidAttributes.

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -82,7 +82,7 @@ public class FluidAttributes
      * Density of the fluid - completely arbitrary; negative density indicates that the fluid is
      * lighter than air.
      *
-     * Default value is approximately the real-life density of water in kg/m^3.
+     * Default value is approximately the real-life density of water at 20 degrees Celsius in kilograms per meter cubed (kg/m^3).
      */
     private final int density;
 
@@ -98,7 +98,7 @@ public class FluidAttributes
      * Viscosity ("thickness") of the fluid - completely arbitrary; negative values are not
      * permissible.
      *
-     * Default value is approximately the real-life density of water in m/s^2 (x10^-3).
+     * Default value is approximately the real-life dynamic viscosity at 20 degrees Celsius of water in micropascal seconds (µPa·s).
      *
      * Higher viscosity means that a fluid flows more slowly, like molasses.
      * Lower viscosity means that a fluid flows more quickly, like helium.


### PR DESCRIPTION
Source for density value (see table for value in kg/m^3):
[https://www.engineeringtoolbox.com/water-density-specific-weight-d_595.html](https://www.engineeringtoolbox.com/water-density-specific-weight-d_595.html)

Source for dynamic viscosity value (reported in mPa·s):
[https://www.engineeringtoolbox.com/water-dynamic-kinematic-viscosity-d_596.html](https://www.engineeringtoolbox.com/water-dynamic-kinematic-viscosity-d_596.html)

Conversion from mPa·s to µPa·s:
[https://www.wolframalpha.com/input/?i=mPa%C2%B7s+to+%C2%B5Pa%C2%B7s&assumption=%7B%22F%22%2C+%22UnitsConversion2%22%2C+%22fromValue%22%7D+-%3E%221%22](https://www.wolframalpha.com/input/?i=mPa%C2%B7s+to+%C2%B5Pa%C2%B7s&assumption=%7B%22F%22%2C+%22UnitsConversion2%22%2C+%22fromValue%22%7D+-%3E%221%22)