### PR TITLE
Fix incorrect generation of render coords and texture UVs for side BakedQuads created by ItemLayerModel

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -326,7 +326,7 @@ public final class ItemLayerModel implements IModelGeometry<ItemLayerModel>
         int height = sprite.getHeight();
 
         float x0 = (float) u / width;
-        float y0 = (float) v / height;
+        float y0 = 1f - (float) v / height;
         float x1 = x0, y1 = y0;
         float z0 = 7.5f / 16f, z1 = 8.5f / 16f;
 
@@ -336,7 +336,7 @@ public final class ItemLayerModel implements IModelGeometry<ItemLayerModel>
             z0 = 8.5f / 16f;
             z1 = 7.5f / 16f;
         case EAST:
-            y1 = (float) (v + size) / height;
+            y1 = 1f - (float) (v + size) / height;
             break;
         case DOWN:
             z0 = 8.5f / 16f;
@@ -353,15 +353,15 @@ public final class ItemLayerModel implements IModelGeometry<ItemLayerModel>
 
         float u0 = 16f * (x0 - dx);
         float u1 = 16f * (x1 - dx);
-        float v0 = 16f * (1f - y0 - dy);
-        float v1 = 16f * (1f - y1 - dy);
+        float v0 = 16f * (1f - (y0 - dy));
+        float v1 = 16f * (1f - (y1 - dy));
 
         return buildQuad(
             transform, remap(side), sprite, tint,
-            x0, y0, z0, sprite.getInterpolatedU(u0), sprite.getInterpolatedV(v0),
-            x1, y1, z0, sprite.getInterpolatedU(u1), sprite.getInterpolatedV(v1),
+            x0, y0, z1, sprite.getInterpolatedU(u0), sprite.getInterpolatedV(v0),
             x1, y1, z1, sprite.getInterpolatedU(u1), sprite.getInterpolatedV(v1),
-            x0, y0, z1, sprite.getInterpolatedU(u0), sprite.getInterpolatedV(v0)
+            x1, y1, z0, sprite.getInterpolatedU(u1), sprite.getInterpolatedV(v1),
+            x0, y0, z0, sprite.getInterpolatedU(u0), sprite.getInterpolatedV(v0)
         );
     }
 


### PR DESCRIPTION
The side baked quads generated by getQuadsForSprite had the wrong texture coords and UVs causing the sides to render improperly like so:

![image](https://user-images.githubusercontent.com/2298444/83356022-ce9be800-a395-11ea-8ce7-6b1c32d3f8cd.png)
![image](https://user-images.githubusercontent.com/2298444/83356023-d3609c00-a395-11ea-879c-3b5cf43338ce.png)
![image](https://user-images.githubusercontent.com/2298444/83356032-e4111200-a395-11ea-9f4f-09f98ab2ac30.png)
![image](https://user-images.githubusercontent.com/2298444/83356036-e7a49900-a395-11ea-84e1-fba247dea5a8.png)

These changes fixes that:
![image](https://user-images.githubusercontent.com/2298444/83356049-fdb25980-a395-11ea-9af3-1bd09e8368b2.png)
![image](https://user-images.githubusercontent.com/2298444/83356053-00ad4a00-a396-11ea-855e-2d3ca0c572e5.png)
![image](https://user-images.githubusercontent.com/2298444/83356057-03a83a80-a396-11ea-9f18-05bf32d4aa90.png)
![image](https://user-images.githubusercontent.com/2298444/83356059-0571fe00-a396-11ea-8f40-4226a20ca213.png)
