### PR TITLE
Re-implement forge.logging.noAnsi...

### DIFF
--- a/src/fmllauncher/resources/log4j2.xml
+++ b/src/fmllauncher/resources/log4j2.xml
@@ -20,10 +20,10 @@
     <Appenders>
         <TerminalConsole name="Console">
             <PatternLayout>
-                <LoggerNamePatternSelector defaultPattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [%c{2.}/%markerSimpleName]: %minecraftFormatting{%msg}%n%tEx}">
+                <LoggerNamePatternSelector defaultPattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [%c{2.}/%markerSimpleName]: %minecraftFormatting{%msg}%n%tEx}{disableAnsi=${sys:forge.logging.noAnsi:-false}}">
                     <!-- don't include the full logger name for Mojang's logs since they use full class names and it's very verbose -->
-                    <PatternMatch key="net.minecraft." pattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [minecraft/%logger{1}]: %minecraftFormatting{%msg}%n%tEx}"/>
-                    <PatternMatch key="com.mojang." pattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [mojang/%logger{1}]: %minecraftFormatting{%msg}%n%tEx}"/>
+                    <PatternMatch key="net.minecraft." pattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [minecraft/%logger{1}]: %minecraftFormatting{%msg}%n%tEx}{disableAnsi=${sys:forge.logging.noAnsi:-false}}"/>
+                    <PatternMatch key="com.mojang." pattern="%highlight{[%d{HH:mm:ss}] [%t/%level] [mojang/%logger{1}]: %minecraftFormatting{%msg}%n%tEx}{disableAnsi=${sys:forge.logging.noAnsi:-false}}"/>
                 </LoggerNamePatternSelector>
             </PatternLayout>
         </TerminalConsole>

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client.rendering;
 
 import net.minecraft.client.Minecraft;


### PR DESCRIPTION
 ...for use with consoles that do not support ANSI

Windows CMD and Powershell are detected as consoles for the purpose of enabling ANSI, despite their ANSI support being disabled by default, resulting in raw ANSI symbols being printed.

(Also includes a license fix)