### PR TITLE
Another attempt at multi-layer item rendering.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -9,7 +9,7 @@
  
        for(Item item : Registry.field_212630_s) {
           if (!field_195411_c.contains(item)) {
-@@ -91,7 +91,7 @@
+@@ -91,9 +91,11 @@
              p_229111_8_ = this.field_175059_m.func_178083_a().func_174953_a(new ModelResourceLocation("minecraft:trident#inventory"));
           }
  
@@ -17,17 +17,23 @@
 +         p_229111_8_ = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(p_229111_4_, p_229111_8_, p_229111_2_, p_229111_3_);
           p_229111_4_.func_227861_a_(-0.5D, -0.5D, -0.5D);
           if (!p_229111_8_.func_188618_c() && (p_229111_1_.func_77973_b() != Items.field_203184_eO || flag1)) {
++            if (p_229111_8_.isLayered()) { net.minecraftforge.client.ForgeHooksClient.drawItemLayered(this, p_229111_8_, p_229111_1_, p_229111_4_, p_229111_5_, p_229111_6_, p_229111_7_); }
++            else {
              RenderType rendertype = RenderTypeLookup.func_228389_a_(p_229111_1_);
-@@ -105,7 +105,7 @@
+             RenderType rendertype1;
+             if (flag && Objects.equals(rendertype, Atlases.func_228784_i_())) {
+@@ -104,8 +106,9 @@
+ 
              IVertexBuilder ivertexbuilder = func_229113_a_(p_229111_5_, rendertype1, true, p_229111_1_.func_77962_s());
              this.func_229114_a_(p_229111_8_, p_229111_1_, p_229111_6_, p_229111_7_, p_229111_4_, ivertexbuilder);
++            }
           } else {
 -            ItemStackTileEntityRenderer.field_147719_a.func_228364_a_(p_229111_1_, p_229111_4_, p_229111_5_, p_229111_6_, p_229111_7_);
 +            p_229111_1_.func_77973_b().getItemStackTileEntityRenderer().func_228364_a_(p_229111_1_, p_229111_4_, p_229111_5_, p_229111_6_, p_229111_7_);
           }
  
           p_229111_4_.func_227865_b_();
-@@ -129,7 +129,7 @@
+@@ -129,7 +132,7 @@
           float f = (float)(i >> 16 & 255) / 255.0F;
           float f1 = (float)(i >> 8 & 255) / 255.0F;
           float f2 = (float)(i & 255) / 255.0F;
@@ -36,7 +42,7 @@
        }
  
     }
-@@ -215,6 +215,7 @@
+@@ -215,6 +218,7 @@
              crashreportcategory.func_189529_a("Item Type", () -> {
                 return String.valueOf((Object)p_184391_2_.func_77973_b());
              });
@@ -44,7 +50,7 @@
              crashreportcategory.func_189529_a("Item Damage", () -> {
                 return String.valueOf(p_184391_2_.func_77952_i());
              });
-@@ -246,18 +247,16 @@
+@@ -246,18 +250,16 @@
              irendertypebuffer$impl.func_228461_a_();
           }
  
@@ -67,7 +73,7 @@
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
              RenderSystem.enableBlend();
-@@ -295,4 +294,9 @@
+@@ -295,4 +297,9 @@
     public void func_195410_a(IResourceManager p_195410_1_) {
        this.field_175059_m.func_178085_b();
     }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -815,4 +815,17 @@ public class ForgeHooksClient
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
+
+    public static void drawItemLayered(ItemRenderer renderer, IBakedModel modelIn, ItemStack itemStackIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int combinedLightIn, int combinedOverlayIn)
+    {
+        for(com.mojang.datafixers.util.Pair<IBakedModel,RenderType> layerModel : modelIn.getLayerModels(itemStackIn)) {
+            modelIn = layerModel.getFirst();
+            RenderType rendertype = layerModel.getSecond();
+            net.minecraftforge.client.ForgeHooksClient.setRenderLayer(rendertype); // neded for compatibility with MultiLayerModels
+
+            IVertexBuilder ivertexbuilder = ItemRenderer.getBuffer(bufferIn, rendertype, true, itemStackIn.hasEffect());
+            renderer.renderModel(modelIn, itemStackIn, combinedLightIn, combinedOverlayIn, matrixStackIn, ivertexbuilder);
+        }
+        net.minecraftforge.client.ForgeHooksClient.setRenderLayer(null);
+    }
 }

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -1,0 +1,142 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+import net.minecraft.client.renderer.RenderState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.NonNullLazy;
+import net.minecraftforge.common.util.NonNullSupplier;
+import org.lwjgl.opengl.GL11;
+
+public enum ForgeRenderTypes
+{
+    /**
+     * A cached copy of {@link ForgeRenderTypes#getUnsortedTranslucent(ResourceLocation)}
+     * for use in item models and TileEntityRenderers that use the block/item atlas.
+     */
+    ITEM_UNSORTED_TRANSLUCENT(()-> getUnsortedTranslucent(AtlasTexture.LOCATION_BLOCKS_TEXTURE)),
+    ITEM_UNLIT_TRANSLUCENT(()-> getUnlitTranslucent(AtlasTexture.LOCATION_BLOCKS_TEXTURE)),
+    ITEM_UNSORTED_UNLIT_TRANSLUCENT(()-> getUnlitTranslucent(AtlasTexture.LOCATION_BLOCKS_TEXTURE, false));
+
+    /**
+     * @return A RenderType fit for translucent item/entity rendering, but with depth sorting disabled.
+     */
+    public static RenderType getUnsortedTranslucent(ResourceLocation textureLocation)
+    {
+        return Internal.unsortedTranslucent(textureLocation);
+    }
+
+    /**
+     * @return A RenderType fit for translucent item/entity rendering, but with diffuse lighting disabled
+     * so that fullbright quads look correct.
+     */
+    public static RenderType getUnlitTranslucent(ResourceLocation textureLocation)
+    {
+        return getUnlitTranslucent(textureLocation, true);
+    }
+
+    /**
+     * @return A RenderType fit for translucent item/entity rendering, but with diffuse lighting disabled
+     * so that fullbright quads look correct.
+     * @param sortingEnabled If false, depth sorting will not be performed.
+     */
+    public static RenderType getUnlitTranslucent(ResourceLocation textureLocation, boolean sortingEnabled)
+    {
+        return Internal.unlitTranslucent(textureLocation, sortingEnabled);
+    }
+
+    /**
+     * @return Same as {@link RenderType#getEntityCutout(ResourceLocation)}, but with mipmapping enabled.
+     */
+    public static RenderType getEntityCutoutMipped(ResourceLocation textureLocation)
+    {
+        return Internal.entityCutoutMipped(textureLocation);
+    }
+
+    // ----------------------------------------
+    //  Implementation details below this line
+    // ----------------------------------------
+
+    private final NonNullSupplier<RenderType> renderTypeSupplier;
+
+    ForgeRenderTypes(NonNullSupplier<RenderType> renderTypeSupplier)
+    {
+        // Wrap in a Lazy<> to avoid running the supplier more than once.
+        this.renderTypeSupplier = NonNullLazy.of(renderTypeSupplier);
+    }
+
+    public RenderType get()
+    {
+        return renderTypeSupplier.get();
+    }
+
+    private static class Internal extends RenderType
+    {
+        private Internal(String name, VertexFormat fmt, int glMode, int size, boolean doCrumbling, boolean depthSorting, Runnable onEnable, Runnable onDisable)
+        {
+            super(name, fmt, glMode, size, doCrumbling, depthSorting, onEnable, onDisable);
+            throw new IllegalStateException("This class must not be instantiated");
+        }
+
+        public static RenderType unsortedTranslucent(ResourceLocation textureLocation)
+        {
+            final boolean sortingEnabled = false;
+            State renderState = State.getBuilder()
+                    .texture(new TextureState(textureLocation, false, false))
+                    .transparency(TRANSLUCENT_TRANSPARENCY)
+                    .diffuseLighting(DIFFUSE_LIGHTING_ENABLED)
+                    .alpha(DEFAULT_ALPHA)
+                    .cull(CULL_DISABLED)
+                    .lightmap(LIGHTMAP_ENABLED)
+                    .overlay(OVERLAY_ENABLED)
+                    .build(true);
+            return makeType("entity_unsorted_translucent", DefaultVertexFormats.ENTITY, GL11.GL_QUADS, 256, true, sortingEnabled, renderState);
+        }
+
+        public static RenderType unlitTranslucent(ResourceLocation textureLocation, boolean sortingEnabled)
+        {
+            State renderState = State.getBuilder()
+                    .texture(new TextureState(textureLocation, false, false))
+                    .transparency(TRANSLUCENT_TRANSPARENCY)
+                    .alpha(DEFAULT_ALPHA)
+                    .cull(CULL_DISABLED)
+                    .lightmap(LIGHTMAP_ENABLED)
+                    .overlay(OVERLAY_ENABLED)
+                    .build(true);
+            return makeType("entity_unlit_translucent", DefaultVertexFormats.ENTITY, GL11.GL_QUADS, 256, true, sortingEnabled, renderState);
+        }
+
+        public static RenderType entityCutoutMipped(ResourceLocation locationIn) {
+            RenderType.State rendertype$state = RenderType.State.getBuilder()
+                    .texture(new RenderState.TextureState(locationIn, false, true))
+                    .transparency(NO_TRANSPARENCY)
+                    .diffuseLighting(DIFFUSE_LIGHTING_ENABLED)
+                    .alpha(DEFAULT_ALPHA)
+                    .lightmap(LIGHTMAP_ENABLED)
+                    .overlay(OVERLAY_ENABLED)
+                    .build(true);
+            return makeType("entity_cutout_mipped", DefaultVertexFormats.ENTITY, 7, 256, true, false, rendertype$state);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -19,19 +19,25 @@
 
 package net.minecraftforge.client.extensions;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypeLookup;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ILightReader;
@@ -74,5 +80,21 @@ public interface IForgeBakedModel
     default TextureAtlasSprite getParticleTexture(@Nonnull IModelData data)
     {
         return getBakedModel().getParticleTexture();
+    }
+
+    /**
+     * Override to true, to tell forge to call the getLayerModels method below.
+     */
+    default boolean isLayered()
+    {
+        return false;
+    }
+
+    /**
+     * If {@see isLayered()} returns true, this is called to get the list of layers to draw.
+     */
+    default List<Pair<IBakedModel, RenderType>> getLayerModels(ItemStack itemStack)
+    {
+        return Collections.singletonList(Pair.of(getBakedModel(), RenderTypeLookup.getRenderType(itemStack)));
     }
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
@@ -42,17 +42,17 @@ public interface IForgeVertexBuilder
 {
     default IVertexBuilder getVertexBuilder() { return (IVertexBuilder)this; }
 
-    // Copy of func_227889_a_, but enables tinting
+    // Copy of addQuad, but enables tinting and per-vertex alpha
     default void addVertexData(MatrixStack.Entry matrixStack, BakedQuad bakedQuad, float red, float green, float blue, int lightmapCoord, int overlayColor, boolean readExistingColor) {
-        getVertexBuilder().addQuad(matrixStack, bakedQuad, new float[]{1.0F, 1.0F, 1.0F, 1.0F}, red, green, blue, new int[]{lightmapCoord, lightmapCoord, lightmapCoord, lightmapCoord}, overlayColor, readExistingColor);
+        addVertexData(matrixStack, bakedQuad, red, green, blue, 1.0f, lightmapCoord, overlayColor, readExistingColor);
     }
 
-    // Copy of func_227889_a_ with alpha support
+    // Copy of addQuad with alpha support
     default void addVertexData(MatrixStack.Entry matrixEntry, BakedQuad bakedQuad, float red, float green, float blue, float alpha, int lightmapCoord, int overlayColor) {
         addVertexData(matrixEntry, bakedQuad, new float[]{1.0F, 1.0F, 1.0F, 1.0F}, red, green, blue, alpha, new int[]{lightmapCoord, lightmapCoord, lightmapCoord, lightmapCoord}, overlayColor, false);
     }
 
-    // Copy of func_227889_a_ with alpha support
+    // Copy of addQuad with alpha support
     default void addVertexData(MatrixStack.Entry matrixEntry, BakedQuad bakedQuad, float red, float green, float blue, float alpha, int lightmapCoord, int overlayColor, boolean readExistingColor) {
         addVertexData(matrixEntry, bakedQuad, new float[]{1.0F, 1.0F, 1.0F, 1.0F}, red, green, blue, alpha, new int[]{lightmapCoord, lightmapCoord, lightmapCoord, lightmapCoord}, overlayColor, readExistingColor);
     }

--- a/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
+++ b/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
@@ -39,6 +39,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.model.geometry.IModelGeometry;
+import net.minecraftforge.common.model.TransformationHelper;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.resource.IResourceType;
@@ -112,7 +113,9 @@ public final class DynamicBucketModel implements IModelGeometry<DynamicBucketMod
         // if the fluid is lighter than air, will manipulate the initial state to be rotated 180deg to turn it upside down
         if (flipGas && fluid != Fluids.EMPTY && fluid.getAttributes().isLighterThanAir())
         {
-            modelTransform = new ModelTransformComposition(modelTransform, new SimpleModelTransform(new TransformationMatrix(null, new Quaternion(0, 0, 1, 0), null, null)));
+            modelTransform = new SimpleModelTransform(
+                    modelTransform.getRotation().blockCornerToCenter().composeVanilla(
+                            new TransformationMatrix(null, new Quaternion(0, 0, 1, 0), null, null)).blockCenterToCorner());
         }
 
         TransformationMatrix transform = modelTransform.getRotation();

--- a/src/main/java/net/minecraftforge/client/model/ItemMultiLayerBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemMultiLayerBakedModel.java
@@ -1,0 +1,134 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.TransformationMatrix;
+import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.model.ItemOverrideList;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+import net.minecraftforge.client.model.data.EmptyModelData;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Random;
+
+public class ItemMultiLayerBakedModel implements IBakedModel
+{
+    private final boolean smoothLighting;
+    private final boolean shadedInGui;
+    private final boolean sideLit;
+    private final TextureAtlasSprite particle;
+    private final ItemOverrideList overrides;
+    private final ImmutableList<Pair<IBakedModel, RenderType>> layerModels;
+    private final ImmutableMap<ItemCameraTransforms.TransformType, TransformationMatrix> cameraTransforms;
+
+    public ItemMultiLayerBakedModel(boolean smoothLighting, boolean shadedInGui, boolean sideLit,
+                                    TextureAtlasSprite particle, ItemOverrideList overrides,
+                                    ImmutableMap<ItemCameraTransforms.TransformType, TransformationMatrix> cameraTransforms,
+                                    ImmutableList<Pair<IBakedModel, RenderType>> layerModels)
+    {
+        this.smoothLighting = smoothLighting;
+        this.shadedInGui = shadedInGui;
+        this.sideLit = sideLit;
+        this.particle = particle;
+        this.overrides = overrides;
+        this.layerModels = layerModels;
+        this.cameraTransforms = cameraTransforms;
+    }
+
+    @Override
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand)
+    {
+        List<BakedQuad> quads = Lists.newArrayList();
+        layerModels.forEach(lm -> quads.addAll(lm.getFirst().getQuads(state, side, rand, EmptyModelData.INSTANCE)));
+        return quads;
+    }
+
+    @Override
+    public boolean isAmbientOcclusion()
+    {
+        return smoothLighting;
+    }
+
+    @Override
+    public boolean isGui3d()
+    {
+        return shadedInGui;
+    }
+
+    @Override
+    public boolean func_230044_c_()
+    {
+        return sideLit;
+    }
+
+    @Override
+    public boolean isBuiltInRenderer()
+    {
+        return false;
+    }
+
+    @Override
+    public TextureAtlasSprite getParticleTexture()
+    {
+        return particle;
+    }
+
+    @Override
+    public ItemOverrideList getOverrides()
+    {
+        return overrides;
+    }
+
+    @Override
+    public boolean doesHandlePerspectives()
+    {
+        return true;
+    }
+
+    @Override
+    public IBakedModel handlePerspective(ItemCameraTransforms.TransformType cameraTransformType, MatrixStack mat)
+    {
+        return PerspectiveMapWrapper.handlePerspective(this, cameraTransforms, cameraTransformType, mat);
+    }
+
+    @Override
+    public boolean isLayered()
+    {
+        return true;
+    }
+
+    @Override
+    public List<Pair<IBakedModel, RenderType>> getLayerModels(ItemStack itemStack)
+    {
+        return layerModels;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -19,12 +19,17 @@
 
 package net.minecraftforge.client.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.TransformationMatrix;
 import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.Direction;
 import net.minecraftforge.client.model.pipeline.BakedQuadBuilder;
 import net.minecraftforge.client.model.pipeline.IVertexConsumer;
@@ -47,15 +52,18 @@ public final class ItemTextureQuadConverter
      * The resulting list of quads is the texture represented as a list of horizontal OR vertical quads,
      * depending on which creates less quads. If the amount of quads is equal, horizontal is preferred.
      *
-     * @param format
      * @param template The input texture to convert
      * @param sprite   The texture whose UVs shall be used
      * @return The generated quads.
      */
     public static List<BakedQuad> convertTexture(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint)
     {
-        List<BakedQuad> horizontal = convertTextureHorizontal(transform, template, sprite, z, facing, color, tint);
-        List<BakedQuad> vertical = convertTextureVertical(transform, template, sprite, z, facing, color, tint);
+        return convertTexture(transform, template, sprite, z, facing, color, tint, 0);
+    }
+    public static List<BakedQuad> convertTexture(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint, int luminosity)
+    {
+        List<BakedQuad> horizontal = convertTextureHorizontal(transform, template, sprite, z, facing, color, tint, luminosity);
+        List<BakedQuad> vertical = convertTextureVertical(transform, template, sprite, z, facing, color, tint, luminosity);
 
         return horizontal.size() <= vertical.size() ? horizontal : vertical;
     }
@@ -65,6 +73,10 @@ public final class ItemTextureQuadConverter
      * The height of the strips is as big as possible.
      */
     public static List<BakedQuad> convertTextureHorizontal(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint)
+    {
+        return convertTextureHorizontal(transform, template, sprite, z, facing, color, tint, 0);
+    }
+    public static List<BakedQuad> convertTextureHorizontal(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint, int luminosity)
     {
         int w = template.getWidth();
         int h = template.getHeight();
@@ -115,7 +127,7 @@ public final class ItemTextureQuadConverter
                                       (float)y * hScale,
                                       (float)x * wScale,
                                       (float)endY * hScale,
-                                      z, sprite, facing, color, tint));
+                                      z, sprite, facing, color, tint, luminosity));
 
                     // update Y if all the rows match. no need to rescan
                     if (endY - y > 1)
@@ -136,6 +148,10 @@ public final class ItemTextureQuadConverter
      * The width of the strips is as big as possible.
      */
     public static List<BakedQuad> convertTextureVertical(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint)
+    {
+        return convertTextureVertical(transform, template, sprite, z, facing, color, tint, 0);
+    }
+    public static List<BakedQuad> convertTextureVertical(TransformationMatrix transform, TextureAtlasSprite template, TextureAtlasSprite sprite, float z, Direction facing, int color, int tint, int luminosity)
     {
         int w = template.getWidth();
         int h = template.getHeight();
@@ -186,7 +202,7 @@ public final class ItemTextureQuadConverter
                                       (float)start * hScale,
                                       (float)endX * wScale,
                                       (float)y * hScale,
-                                      z, sprite, facing, color, tint));
+                                      z, sprite, facing, color, tint, luminosity));
 
                     // update X if all the columns match. no need to rescan
                     if (endX - x > 1)
@@ -213,6 +229,10 @@ public final class ItemTextureQuadConverter
      */
     public static BakedQuad genQuad(TransformationMatrix transform, float x1, float y1, float x2, float y2, float z, TextureAtlasSprite sprite, Direction facing, int color, int tint)
     {
+        return genQuad(transform, x1, y1, x2, y2, z, sprite, facing, color, tint, 0);
+    }
+    public static BakedQuad genQuad(TransformationMatrix transform, float x1, float y1, float x2, float y2, float z, TextureAtlasSprite sprite, Direction facing, int color, int tint, int luminosity)
+    {
         float u1 = sprite.getInterpolatedU(x1);
         float v1 = sprite.getInterpolatedV(y1);
         float u2 = sprite.getInterpolatedU(x2);
@@ -227,17 +247,18 @@ public final class ItemTextureQuadConverter
         y1 = 1f - y2;
         y2 = 1f - tmp;
 
-        return putQuad(transform, facing, sprite, color, tint, x1, y1, x2, y2, z, u1, v1, u2, v2);
+        return putQuad(transform, facing, sprite, color, tint, x1, y1, x2, y2, z, u1, v1, u2, v2, luminosity);
     }
 
     private static BakedQuad putQuad(TransformationMatrix transform, Direction side, TextureAtlasSprite sprite, int color, int tint,
                                              float x1, float y1, float x2, float y2, float z,
-                                             float u1, float v1, float u2, float v2)
+                                             float u1, float v1, float u2, float v2, int luminosity)
     {
         BakedQuadBuilder builder = new BakedQuadBuilder(sprite);
 
         builder.setQuadTint(tint);
         builder.setQuadOrientation(side);
+        builder.setApplyDiffuseLighting(luminosity == 0);
 
         // only apply the transform if it's not identity
         boolean hasTransform = !transform.isIdentity();
@@ -245,28 +266,29 @@ public final class ItemTextureQuadConverter
 
         if (side == Direction.SOUTH)
         {
-            putVertex(consumer, side, x1, y1, z, u1, v2, color);
-            putVertex(consumer, side, x2, y1, z, u2, v2, color);
-            putVertex(consumer, side, x2, y2, z, u2, v1, color);
-            putVertex(consumer, side, x1, y2, z, u1, v1, color);
+            putVertex(consumer, side, x1, y1, z, u1, v2, color, luminosity);
+            putVertex(consumer, side, x2, y1, z, u2, v2, color, luminosity);
+            putVertex(consumer, side, x2, y2, z, u2, v1, color, luminosity);
+            putVertex(consumer, side, x1, y2, z, u1, v1, color, luminosity);
         }
         else
         {
-            putVertex(consumer, side, x1, y1, z, u1, v2, color);
-            putVertex(consumer, side, x1, y2, z, u1, v1, color);
-            putVertex(consumer, side, x2, y2, z, u2, v1, color);
-            putVertex(consumer, side, x2, y1, z, u2, v2, color);
+            putVertex(consumer, side, x1, y1, z, u1, v2, color, luminosity);
+            putVertex(consumer, side, x1, y2, z, u1, v1, color, luminosity);
+            putVertex(consumer, side, x2, y2, z, u2, v1, color, luminosity);
+            putVertex(consumer, side, x2, y1, z, u2, v2, color, luminosity);
         }
         return builder.build();
     }
 
     private static void putVertex(IVertexConsumer consumer, Direction side,
-                                  float x, float y, float z, float u, float v, int color)
+                                  float x, float y, float z, float u, float v, int color, int luminosity)
     {
         VertexFormat format = consumer.getVertexFormat();
         for (int e = 0; e < format.getElements().size(); e++)
         {
-            switch (format.getElements().get(e).getUsage())
+            VertexFormatElement element = format.getElements().get(e);
+            switch (element.getUsage())
             {
                 case POSITION:
                     consumer.put(e, x, y, z, 1f);
@@ -285,9 +307,14 @@ public final class ItemTextureQuadConverter
                     consumer.put(e, offX, offY, offZ, 0f);
                     break;
                 case UV:
-                    if (format.getElements().get(e).getIndex() == 0)
+                    if (element.getIndex() == 0)
                     {
                         consumer.put(e, u, v, 0f, 1f);
+                        break;
+                    }
+                    else if (element.getIndex() == 2)
+                    {
+                        consumer.put(e, (luminosity<<4)/32768.0f, (luminosity<<4)/32768.0f, 0f, 1f);
                         break;
                     }
                     // else fallthrough to default

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -24,7 +24,7 @@ import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import com.mojang.blaze3d.matrix.MatrixStack;
@@ -34,11 +34,14 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.TransformationMatrix;
 import net.minecraft.client.renderer.model.*;
 import net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType;
+import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.item.ItemStack;
 import net.minecraft.resources.IResourceManager;
 import net.minecraft.util.Direction;
 import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.ForgeRenderTypes;
 import net.minecraftforge.client.MinecraftForgeClient;
 
 import net.minecraftforge.client.model.data.EmptyModelData;
@@ -48,9 +51,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.function.Function;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.stream.Collectors;
 
 /**
  * A model that can be rendered in multiple {@link RenderType}.
@@ -92,11 +93,12 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
         IUnbakedModel missing = ModelLoader.instance().getMissingModel();
 
         return new MultiLayerBakedModel(
-                owner.useSmoothLighting(), owner.isShadedInGui(),
-                owner.isSideLit(), spriteGetter.apply(owner.resolveTexture("particle")), overrides,
-                buildModels(models, modelTransform, bakery, spriteGetter, modelLocation),
+                owner.useSmoothLighting(), owner.isShadedInGui(), owner.isSideLit(),
+                spriteGetter.apply(owner.resolveTexture("particle")), overrides, true,
                 missing.bakeModel(bakery, spriteGetter, modelTransform, modelLocation),
-                PerspectiveMapWrapper.getTransforms(new ModelTransformComposition(owner.getCombinedTransform(), modelTransform)));
+                buildModels(models, modelTransform, bakery, spriteGetter, modelLocation),
+                PerspectiveMapWrapper.getTransforms(new ModelTransformComposition(owner.getCombinedTransform(), modelTransform))
+        );
     }
 
     private static final class MultiLayerBakedModel implements IBakedModel
@@ -109,10 +111,13 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
         protected final TextureAtlasSprite particle;
         protected final ItemOverrideList overrides;
         private final IBakedModel missing;
+        private final boolean convertRenderTypes;
+        private final List<Pair<IBakedModel, RenderType>> itemLayers;
 
         public MultiLayerBakedModel(
                 boolean ambientOcclusion, boolean isGui3d, boolean isSideLit, TextureAtlasSprite particle, ItemOverrideList overrides,
-                ImmutableMap<RenderType, IBakedModel> models, IBakedModel missing, ImmutableMap<TransformType, TransformationMatrix> cameraTransforms)
+                boolean convertRenderTypes, IBakedModel missing, ImmutableMap<RenderType, IBakedModel> models,
+                ImmutableMap<TransformType, TransformationMatrix> cameraTransforms)
         {
             this.isSideLit = isSideLit;
             this.models = models;
@@ -122,6 +127,12 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
             this.gui3d = isGui3d;
             this.particle = particle;
             this.overrides = overrides;
+            this.convertRenderTypes = convertRenderTypes;
+            this.itemLayers = models.entrySet().stream().map(kv -> {
+                RenderType rt = kv.getKey();
+                if (convertRenderTypes) rt = ITEM_RENDER_TYPE_MAPPING.getOrDefault(rt, rt);
+                return Pair.of(kv.getValue(), rt);
+            }).collect(Collectors.toList());
         }
 
         @Override
@@ -144,6 +155,9 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
                 }
                 return builder.build();
             }
+            // support for item layer rendering
+            if (state == null && convertRenderTypes)
+                layer = ITEM_RENDER_TYPE_MAPPING.inverse().getOrDefault(layer, layer);
             // assumes that child model will handle this state properly. FIXME?
             return models.getOrDefault(layer, missing).getQuads(state, side, rand, extraData);
         }
@@ -200,6 +214,26 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
         public ItemOverrideList getOverrides()
         {
             return ItemOverrideList.EMPTY;
+        }
+
+        @Override
+        public boolean isLayered()
+        {
+            return true;
+        }
+
+        @Override
+        public List<Pair<IBakedModel, RenderType>> getLayerModels(ItemStack itemStack)
+        {
+            return itemLayers;
+        }
+
+        public static BiMap<RenderType, RenderType> ITEM_RENDER_TYPE_MAPPING = HashBiMap.create();
+        static {
+            ITEM_RENDER_TYPE_MAPPING.put(RenderType.getSolid(), RenderType.getEntitySolid(AtlasTexture.LOCATION_BLOCKS_TEXTURE));
+            ITEM_RENDER_TYPE_MAPPING.put(RenderType.getCutout(), RenderType.getEntityCutout(AtlasTexture.LOCATION_BLOCKS_TEXTURE));
+            ITEM_RENDER_TYPE_MAPPING.put(RenderType.getCutoutMipped(), ForgeRenderTypes.getEntityCutoutMipped(AtlasTexture.LOCATION_BLOCKS_TEXTURE));
+            ITEM_RENDER_TYPE_MAPPING.put(RenderType.getTranslucent(), RenderType.getEntityTranslucent(AtlasTexture.LOCATION_BLOCKS_TEXTURE));
         }
     }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -28,6 +28,7 @@ public net.minecraft.client.particle.ParticleManager$IParticleMetaFactory
 public net.minecraft.client.renderer.GameRenderer func_175069_a(Lnet/minecraft/util/ResourceLocation;)V #loadShader
 private net.minecraft.client.renderer.ItemModelMesher field_199313_a
 public net.minecraft.client.renderer.ItemRenderer func_229112_a_(Lcom/mojang/blaze3d/matrix/MatrixStack;Lcom/mojang/blaze3d/vertex/IVertexBuilder;Ljava/util/List;Lnet/minecraft/item/ItemStack;II)V # renderQuads
+public net.minecraft.client.renderer.ItemRenderer func_229114_a_(Lnet/minecraft/client/renderer/model/IBakedModel;Lnet/minecraft/item/ItemStack;IILcom/mojang/blaze3d/matrix/MatrixStack;Lcom/mojang/blaze3d/vertex/IVertexBuilder;)V # renderModel
 public net.minecraft.client.renderer.entity.EntityRendererManager field_78729_o #renderers
 public net.minecraft.client.renderer.entity.EntityRendererManager func_229087_a_(Lnet/minecraft/entity/EntityType;Lnet/minecraft/client/renderer/entity/EntityRenderer;)V # addRenderer
 protected net.minecraft.client.renderer.entity.ItemRenderer func_177078_a(Lnet/minecraft/item/ItemStack;)I # getMiniItemCount

--- a/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
@@ -63,7 +63,7 @@ public class NewFluidTest
     private static ForgeFlowingFluid.Properties makeProperties()
     {
         return new ForgeFlowingFluid.Properties(test_fluid, test_fluid_flowing,
-                FluidAttributes.builder(FLUID_STILL, FLUID_FLOWING).overlay(FLUID_OVERLAY).color(0x3F1080FF))
+                FluidAttributes.builder(FLUID_STILL, FLUID_FLOWING).overlay(FLUID_OVERLAY).color(0x3F1080FF).density(-1).gaseous())
                 .bucket(test_fluid_bucket).block(test_fluid_block);
     }
 

--- a/src/test/resources/assets/forgedebugmultilayermodel/models/block/test_layer_block.json
+++ b/src/test/resources/assets/forgedebugmultilayermodel/models/block/test_layer_block.json
@@ -5,7 +5,7 @@
     "solid": {
       "parent": "block/cube_all",
       "textures": { "all": "block/slime_block" },
-      "transform": { "scale": 0.5, "translation": [-0.25,-0.25,-0.25] }
+      "transform": { "origin":"center", "scale": 0.625 }
     },
     "translucent": {
       "parent": "block/cube_all",

--- a/src/test/resources/assets/minecraft/models/item/lava_bucket.json
+++ b/src/test/resources/assets/minecraft/models/item/lava_bucket.json
@@ -1,0 +1,5 @@
+{
+  "parent": "forge:item/bucket_drip",
+  "loader": "forge:bucket",
+  "fluid": "minecraft:lava"
+}

--- a/src/test/resources/assets/new_fluid_test/models/item/test_fluid_bucket.json
+++ b/src/test/resources/assets/new_fluid_test/models/item/test_fluid_bucket.json
@@ -1,5 +1,6 @@
 {
   "parent": "forge:item/bucket_drip",
   "loader": "forge:bucket",
-  "fluid": "new_fluid_test:test_fluid"
+  "fluid": "new_fluid_test:test_fluid",
+  "flipGas": true
 }


### PR DESCRIPTION
This is the third internal redesign, but the first one I feel comfortable showing.

## Intended use cases

1. Drawing multi-layer BlockItems in an equivalent way to the placed blocks.
2. Improving the fullbright item support by allowing fullbright quads to be drawn using an unlit render type.
3. Improving custom model support (eg. dynamic bucket models) by allowing models to be drawn without transparency sorting.

## What these use cases require

1. The ability to draw quads in multiple render types. (multi-layer blocks, custom models)
2. The ability to repeat render types in a well-defined order. (layered items)

## The solution

By returning a `List<Pair<IBakedModel, RenderType>>`, the code allows both use cases of the same model being drawn with multiple render types (needed by the existing multi-layer block system), and other models being drawn with a specific render type (needed by layered items with mixed fullbright quads).
