### PR TITLE
Fix "overlayMessage" rendering in ForgeIngameGui being different than vanilla

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -675,17 +675,18 @@ public class ForgeIngameGui extends IngameGui
         {
             mc.getProfiler().startSection("overlayMessage");
             float hue = (float)overlayMessageTime - partialTicks;
-            int opacity = (int)(hue * 256.0F / 20.0F);
+            int opacity = (int)(hue * 255.0F / 20.0F);
             if (opacity > 255) opacity = 255;
 
-            if (opacity > 0)
+            if (opacity > 8)
             {
                 RenderSystem.pushMatrix();
                 RenderSystem.translatef((float)(width / 2), (float)(height - 68), 0.0F);
                 RenderSystem.enableBlend();
                 RenderSystem.defaultBlendFunc();
                 int color = (animateOverlayMessageColor ? MathHelper.hsvToRGB(hue / 50.0F, 0.7F, 0.6F) & WHITE : WHITE);
-                fontrenderer.drawStringWithShadow(overlayMessage, -fontrenderer.getStringWidth(overlayMessage) / 2, -4, color | (opacity << 24));
+                renderTextBackground(fontrenderer, -4, fontrenderer.getStringWidth(overlayMessage));
+                fontrenderer.drawString(overlayMessage, -fontrenderer.getStringWidth(overlayMessage) / 2, -4, color | (opacity << 24));
                 RenderSystem.disableBlend();
                 RenderSystem.popMatrix();
             }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -180,3 +180,4 @@ public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGene
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 private-f net.minecraft.world.storage.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.world.storage.loot.LootPool field_186456_d # bonusRolls
+protected net.minecraft.client.gui.IngameGui func_212909_a(Lnet/minecraft/client/gui/FontRenderer;II)V # renderTextBackground

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -17,6 +17,7 @@ protected net.minecraft.client.gui.IngameGui func_194802_a(Lnet/minecraft/scoreb
 protected net.minecraft.client.gui.IngameGui func_194805_e(F)V
 protected net.minecraft.client.gui.IngameGui func_194808_p()V
 protected net.minecraft.client.gui.IngameGui func_212303_b(Lnet/minecraft/entity/Entity;)V
+protected net.minecraft.client.gui.IngameGui func_212909_a(Lnet/minecraft/client/gui/FontRenderer;II)V # renderTextBackground
 public net.minecraft.client.gui.ScreenManager func_216911_a(Lnet/minecraft/inventory/container/ContainerType;Lnet/minecraft/client/gui/ScreenManager$IScreenFactory;)V # registerFactory
 public net.minecraft.client.gui.ScreenManager$IScreenFactory
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211537_g # rayTraceBlock
@@ -180,4 +181,3 @@ public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGene
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 private-f net.minecraft.world.storage.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.world.storage.loot.LootPool field_186456_d # bonusRolls
-protected net.minecraft.client.gui.IngameGui func_212909_a(Lnet/minecraft/client/gui/FontRenderer;II)V # renderTextBackground


### PR DESCRIPTION
Was [reported on the forums](https://www.minecraftforge.net/forum/topic/86526-actionbar-text-has-background-it-shouldnt/).

Vanilla:
![image](https://user-images.githubusercontent.com/1915984/83965337-45177900-a8b3-11ea-8822-0505139bca3a.png)
Forge:
![image](https://user-images.githubusercontent.com/1915984/83965342-49dc2d00-a8b3-11ea-9335-aeb8836287a1.png)
