### PR TITLE
[1.14.4] Backport of patch to enable Stencil Buffer in Minecraft's Framebuffer

### DIFF
--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -4,15 +4,13 @@
           GLX.glFramebufferTexture2D(GLX.GL_FRAMEBUFFER, GLX.GL_COLOR_ATTACHMENT0, 3553, this.field_147617_g, 0);
           if (this.field_147619_e) {
              GLX.glBindRenderbuffer(GLX.GL_RENDERBUFFER, this.field_147624_h);
--            GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
--            GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
 +            if (!stencilEnabled) {
-+             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
-+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
+             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
 +            } else {
-+             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
-+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
++            GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
 +            }
           }
  
@@ -22,28 +20,28 @@
        this.func_147609_e();
     }
 +
-+ /*================================ FORGE START ================================================*/
-+ private boolean stencilEnabled = false;
-+ /**
-+ * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
-+ * Modders must call this directly to set things up.
-+ * This is to prevent the default cause where graphics cards do not support stencil bits.
-+ * <b>Make sure to call this on the main render thread!</b>
-+ */
-+ public void enableStencil()
-+ {
-+  if(stencilEnabled) return;
-+  stencilEnabled = true;
-+  this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
-+ }
-+	
-+ /**
-+ * Returns whether or not this FBO has been successfully initialised with stencil bits.
-+ * If not, and a modder wishes it to be, they must call enableStencil.
-+ */
-+ public boolean isStencilEnabled()
-+ {
-+ return this.stencilEnabled;
-+ }
-+ /*================================ FORGE END ================================================*/
++   /*================================ FORGE START ================================================*/
++   private boolean stencilEnabled = false;
++   /**
++    * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
++    * Modders must call this directly to set things up.
++    * This is to prevent the default cause where graphics cards do not support stencil bits.
++    * <b>Make sure to call this on the main render thread!</b>
++    */
++   public void enableStencil()
++   {
++       if(stencilEnabled) return;
++       stencilEnabled = true;
++       this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
++   }
++
++   /**
++    * Returns whether or not this FBO has been successfully initialised with stencil bits.
++    * If not, and a modder wishes it to be, they must call enableStencil.
++    */
++   public boolean isStencilEnabled()
++   {
++     return this.stencilEnabled;
++   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -1,0 +1,47 @@
+--- a/net/minecraft/client/shader/Framebuffer.java
++++ b/net/minecraft/client/shader/Framebuffer.java
+@@ -95,8 +95,14 @@
+          GLX.glFramebufferTexture2D(GLX.GL_FRAMEBUFFER, GLX.GL_COLOR_ATTACHMENT0, 3553, this.field_147617_g, 0);
+          if (this.field_147619_e) {
+             GLX.glBindRenderbuffer(GLX.GL_RENDERBUFFER, this.field_147624_h);
++            if (!stencilEnabled) {
+             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            } else {
++            	GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
++            	GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            	GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            }
+          }
+ 
+          this.func_147611_b();
+@@ -229,4 +235,29 @@
+       GlStateManager.clear(i, p_216493_1_);
+       this.func_147609_e();
+    }
++   
++	/*================================ FORGE START ================================================*/
++	private boolean stencilEnabled = false;
++	/**
++	 * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
++	 * Modders must call this directly to set things up.
++	 * This is to prevent the default cause where graphics cards do not support stencil bits.
++	 * <b>Make sure to call this on the main render thread!</b>
++	 */
++	public void enableStencil()
++	{
++	    if(stencilEnabled) return;
++	    stencilEnabled = true;
++	    this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
++	}
++	
++	/**
++	 * Returns whether or not this FBO has been successfully initialised with stencil bits.
++	 * If not, and a modder wishes it to be, they must call enableStencil.
++	 */
++	public boolean isStencilEnabled()
++	{
++	    return this.stencilEnabled;
++	}
++	/*================================ FORGE END   ================================================*/
+ }

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -25,11 +25,11 @@
 + /*================================ FORGE START ================================================*/
 + private boolean stencilEnabled = false;
 + /**
-+	 * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
-+	 * Modders must call this directly to set things up.
-+	 * This is to prevent the default cause where graphics cards do not support stencil bits.
-+	 * <b>Make sure to call this on the main render thread!</b>
-+	 */
++ * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
++ * Modders must call this directly to set things up.
++ * This is to prevent the default cause where graphics cards do not support stencil bits.
++ * <b>Make sure to call this on the main render thread!</b>
++ */
 + public void enableStencil()
 + {
 +  if(stencilEnabled) return;

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -1,19 +1,19 @@
 --- a/net/minecraft/client/shader/Framebuffer.java
-++ b/net/minecraft/client/shader/Framebuffer.java
++++ b/net/minecraft/client/shader/Framebuffer.java
 @@ -95,8 +95,14 @@
           GLX.glFramebufferTexture2D(GLX.GL_FRAMEBUFFER, GLX.GL_COLOR_ATTACHMENT0, 3553, this.field_147617_g, 0);
           if (this.field_147619_e) {
              GLX.glBindRenderbuffer(GLX.GL_RENDERBUFFER, this.field_147624_h);
 -            GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
 -            GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-            if (!stencilEnabled) {
-             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
-             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-            } else {
-             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
-             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-            }
++            if (!stencilEnabled) {
++             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
++             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            } else {
++             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
++             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
++            }
           }
  
           this.func_147611_b();
@@ -21,29 +21,29 @@
        GlStateManager.clear(i, p_216493_1_);
        this.func_147609_e();
     }
-
- /*================================ FORGE START ================================================*/
- private boolean stencilEnabled = false;
- /**
- * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
- * Modders must call this directly to set things up.
- * This is to prevent the default cause where graphics cards do not support stencil bits.
- * <b>Make sure to call this on the main render thread!</b>
- */
- public void enableStencil()
- {
-  if(stencilEnabled) return;
-  stencilEnabled = true;
-  this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
- }
-
- /**
- * Returns whether or not this FBO has been successfully initialised with stencil bits.
- * If not, and a modder wishes it to be, they must call enableStencil.
- */
- public boolean isStencilEnabled()
- {
- return this.stencilEnabled;
- }
- /*================================ FORGE END ================================================*/
++
++ /*================================ FORGE START ================================================*/
++ private boolean stencilEnabled = false;
++ /**
++	 * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
++	 * Modders must call this directly to set things up.
++	 * This is to prevent the default cause where graphics cards do not support stencil bits.
++	 * <b>Make sure to call this on the main render thread!</b>
++	 */
++ public void enableStencil()
++ {
++  if(stencilEnabled) return;
++  stencilEnabled = true;
++  this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
++ }
++	
++ /**
++ * Returns whether or not this FBO has been successfully initialised with stencil bits.
++ * If not, and a modder wishes it to be, they must call enableStencil.
++ */
++ public boolean isStencilEnabled()
++ {
++ return this.stencilEnabled;
++ }
++ /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -1,17 +1,19 @@
 --- a/net/minecraft/client/shader/Framebuffer.java
-+++ b/net/minecraft/client/shader/Framebuffer.java
+++ b/net/minecraft/client/shader/Framebuffer.java
 @@ -95,8 +95,14 @@
           GLX.glFramebufferTexture2D(GLX.GL_FRAMEBUFFER, GLX.GL_COLOR_ATTACHMENT0, 3553, this.field_147617_g, 0);
           if (this.field_147619_e) {
              GLX.glBindRenderbuffer(GLX.GL_RENDERBUFFER, this.field_147624_h);
-+            if (!stencilEnabled) {
+-            GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
+-            GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
+            if (!stencilEnabled) {
              GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, 33190, this.field_147622_a, this.field_147620_b);
              GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-+            } else {
-+            	GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
-+            	GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-+            	GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
-+            }
+            } else {
+             GLX.glRenderbufferStorage(GLX.GL_RENDERBUFFER, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, this.field_147622_a, this.field_147620_b);
+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, GLX.GL_DEPTH_ATTACHMENT, GLX.GL_RENDERBUFFER, this.field_147624_h);
+             GLX.glFramebufferRenderbuffer(GLX.GL_FRAMEBUFFER, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, GLX.GL_RENDERBUFFER, this.field_147624_h);
+            }
           }
  
           this.func_147611_b();
@@ -19,29 +21,29 @@
        GlStateManager.clear(i, p_216493_1_);
        this.func_147609_e();
     }
-+   
-+	/*================================ FORGE START ================================================*/
-+	private boolean stencilEnabled = false;
-+	/**
-+	 * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
-+	 * Modders must call this directly to set things up.
-+	 * This is to prevent the default cause where graphics cards do not support stencil bits.
-+	 * <b>Make sure to call this on the main render thread!</b>
-+	 */
-+	public void enableStencil()
-+	{
-+	    if(stencilEnabled) return;
-+	    stencilEnabled = true;
-+	    this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
-+	}
-+	
-+	/**
-+	 * Returns whether or not this FBO has been successfully initialised with stencil bits.
-+	 * If not, and a modder wishes it to be, they must call enableStencil.
-+	 */
-+	public boolean isStencilEnabled()
-+	{
-+	    return this.stencilEnabled;
-+	}
-+	/*================================ FORGE END   ================================================*/
+
+ /*================================ FORGE START ================================================*/
+ private boolean stencilEnabled = false;
+ /**
+ * Attempts to enable 8 bits of stencil buffer on this FrameBuffer.
+ * Modders must call this directly to set things up.
+ * This is to prevent the default cause where graphics cards do not support stencil bits.
+ * <b>Make sure to call this on the main render thread!</b>
+ */
+ public void enableStencil()
+ {
+  if(stencilEnabled) return;
+  stencilEnabled = true;
+  this.func_216491_a(field_147621_c, field_147618_d, net.minecraft.client.Minecraft.field_142025_a);
+ }
+
+ /**
+ * Returns whether or not this FBO has been successfully initialised with stencil bits.
+ * If not, and a modder wishes it to be, they must call enableStencil.
+ */
+ public boolean isStencilEnabled()
+ {
+ return this.stencilEnabled;
+ }
+ /*================================ FORGE END ================================================*/
  }

--- a/src/test/java/net/minecraftforge/testmods/StencilTest.java
+++ b/src/test/java/net/minecraftforge/testmods/StencilTest.java
@@ -29,16 +29,15 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 @SuppressWarnings("deprecation")
 @Mod(StencilTest.MODID)
 public class StencilTest {
-	
-	public static final String MODID = "stencil_backport_test";
-	
-	public StencilTest() {
-		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-		modEventBus.addListener(this::clientSetup);
-	}
-	
-	private void clientSetup(FMLClientSetupEvent event) {
-		DeferredWorkQueue.runLater(() -> Minecraft.getInstance().getFramebuffer().enableStencil());
+
+    public static final String MODID = "stencil_backport_test";
+
+    public StencilTest() {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        modEventBus.addListener(this::clientSetup);
     }
-	
+
+    private void clientSetup(FMLClientSetupEvent event) {
+        DeferredWorkQueue.runLater(() -> Minecraft.getInstance().getFramebuffer().enableStencil());
+    }
 }

--- a/src/test/java/net/minecraftforge/testmods/StencilTest.java
+++ b/src/test/java/net/minecraftforge/testmods/StencilTest.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.testmods;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DeferredWorkQueue;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+@SuppressWarnings("deprecation")
+@Mod(StencilTest.MODID)
+public class StencilTest {
+	
+	public static final String MODID = "stencil_backport_test";
+	
+	public StencilTest() {
+		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		modEventBus.addListener(this::clientSetup);
+	}
+	
+	private void clientSetup(FMLClientSetupEvent event) {
+		DeferredWorkQueue.runLater(() -> Minecraft.getInstance().getFramebuffer().enableStencil());
+    }
+	
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -69,3 +69,5 @@ loaderVersion="[28,)"
     modId="custom_plant_type_test"
 [[mods]]
     modId="forgedebugmultilayermodel"
+[[mods]]
+    modId="stencil_backport_test"


### PR DESCRIPTION
**Need**
The ability to enable the Stencil Buffer in Minecraft's Framebuffer has been added to 1.15.2 Forge, but this is still missing in the 1.14.4 version. 

**Proposal**
Allow for the backporting of an existing patch that enables Stencil Buffers.

The enabling of the Stencil Buffer would allow for advanced render culling in a wide range of applications and reduce incentives for modders to pursue coremodding.

**Intended Use Cases**
Some specific examples include:
- Rendering the contents of other worlds within a designated area, similar to the Immersive Portals Mod. 
  - An example of a mod succesfully using stencils buffer provided by older versions of Forge is in the attached video link. https://www.youtube.com/watch?v=4A-5vUIAjS8
  - Similar results are also possible in the current versions of 1.14.4 Forge, but they are limited in scope and features due to a lack of stencils. https://www.youtube.com/watch?v=tJxtsh7rMIU

- Manipulation of advanced GUI elements such as uses cases outlined in #6489.

**Requirements of Use Cases**
- Ability to cull certain aspects of a render.

**Solution**
This patch backports the existing Stencil Buffer patch added in #6543 from 1.15.x to 1.14.x branch, which follows the Forge LTS guidelines. 

This patch is identical in functionality to the existing patch in 1.15.x.
I have also included a simple test mod that verifies these changes are working.

Could you please check and advise? Many thanks.