### PR TITLE
RFC for 1.16: make getRegistryName NonNull, add getRegistryNameNullable

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -158,7 +158,7 @@
  
     public String toString() {
 -      return "Block{" + Registry.field_212618_g.func_177774_c(this) + "}";
-+      return "Block{" + getRegistryName() + "}";
++      return "Block{" + getRegistryNameNullable() + "}";
     }
  
     @OnlyIn(Dist.CLIENT)

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -40,7 +40,7 @@
              crashreportcategory.func_189529_a("Item Type", () -> {
                 return String.valueOf((Object)p_184391_2_.func_77973_b());
              });
-+            crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_184391_2_.func_77973_b().getRegistryName()));
++            crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_184391_2_.func_77973_b().getRegistryNameNullable()));
              crashreportcategory.func_189529_a("Item Damage", () -> {
                 return String.valueOf(p_184391_2_.func_77952_i());
              });

--- a/patches/minecraft/net/minecraft/entity/player/PlayerInventory.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerInventory.java.patch
@@ -23,7 +23,7 @@
           } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.func_85055_a(throwable, "Adding item to inventory");
              CrashReportCategory crashreportcategory = crashreport.func_85058_a("Item being added");
-+            crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_191971_2_.func_77973_b().getRegistryName()));
++            crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_191971_2_.func_77973_b().getRegistryNameNullable()));
 +            crashreportcategory.func_189529_a("Item Class", () -> p_191971_2_.func_77973_b().getClass().getName());
              crashreportcategory.func_71507_a("Item ID", Item.func_150891_b(p_191971_2_.func_77973_b()));
              crashreportcategory.func_71507_a("Item data", p_191971_2_.func_77952_i());

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -134,10 +134,10 @@
              crashreportcategory.func_189529_a("Source block type", () -> {
                 try {
 -                  return String.format("ID #%s (%s // %s)", Registry.field_212618_g.func_177774_c(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
-+                  return String.format("ID #%s (%s // %s)", p_190524_2_.getRegistryName(), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
++                  return String.format("ID #%s (%s // %s)", p_190524_2_.getRegistryNameNullable(), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
                 } catch (Throwable var2) {
 -                  return "ID #" + Registry.field_212618_g.func_177774_c(p_190524_2_);
-+                  return "ID #" + p_190524_2_.getRegistryName();
++                  return "ID #" + p_190524_2_.getRegistryNameNullable();
                 }
              });
              CrashReportCategory.func_175750_a(crashreportcategory, p_190524_1_, blockstate);
@@ -203,7 +203,7 @@
 +                  net.minecraftforge.server.timings.TimeTracker.TILE_ENTITY_UPDATE.trackStart(tileentity);
                    iprofiler.func_194340_a(() -> {
 -                     return String.valueOf((Object)TileEntityType.func_200969_a(tileentity.func_200662_C()));
-+                     return String.valueOf(tileentity.func_200662_C().getRegistryName());
++                     return String.valueOf(tileentity.func_200662_C().getRegistryNameNullable());
                    });
                    if (tileentity.func_200662_C().func_223045_a(this.func_180495_p(blockpos).func_177230_c())) {
                       ((ITickableTileEntity)tileentity).func_73660_a();

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -148,7 +148,7 @@
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
 -               return Registry.field_212629_r.func_177774_c(p_217479_1_.func_200600_R()).toString();
-+               return p_217479_1_.func_200600_R().getRegistryName() == null ? p_217479_1_.func_200600_R().toString() : p_217479_1_.func_200600_R().getRegistryName().toString();
++               return p_217479_1_.func_200600_R().getRegistryNameNullable() == null ? p_217479_1_.func_200600_R().toString() : p_217479_1_.func_200600_R().getRegistryName().toString();
              });
 +            if (p_217479_1_.canUpdate())
              iprofiler.func_230035_c_("tickNonPassenger");

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -531,7 +531,7 @@ public abstract class BlockStateProvider implements IDataProvider {
     }
 
     private void saveBlockState(DirectoryCache cache, JsonObject stateJson, Block owner) {
-        ResourceLocation blockName = Preconditions.checkNotNull(owner.getRegistryName());
+        ResourceLocation blockName = owner.getRegistryName();
         Path mainOutput = generator.getOutputFolder();
         String pathSuffix = "assets/" + blockName.getNamespace() + "/blockstates/" + blockName.getPath() + ".json";
         Path outputPath = mainOutput.resolve(pathSuffix);

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -343,7 +343,7 @@ public class BiomeDictionary
         if (!hasAnyType(biome))
         {
             makeBestGuess(biome);
-            LOGGER.warn("No types have been added to Biome {}, types have been assigned on a best-effort guess: {}", biome.getRegistryName(), !getBiomeInfo(biome).types.isEmpty() ? getBiomeInfo(biome).types : "could not guess types");
+            LOGGER.warn("No types have been added to Biome {}, types have been assigned on a best-effort guess: {}", biome.getRegistryNameNullable(), !getBiomeInfo(biome).types.isEmpty() ? getBiomeInfo(biome).types : "could not guess types");
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -52,7 +52,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.registry.MutableRegistry;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.IBiomeMagnifier;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.listener.IChunkStatusListener;
 import net.minecraft.world.server.ServerMultiWorld;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -982,7 +982,7 @@ public class ForgeHooks
     public static String getDefaultCreatorModId(@Nonnull ItemStack itemStack)
     {
         Item item = itemStack.getItem();
-        ResourceLocation registryName = item.getRegistryName();
+        ResourceLocation registryName = item.getRegistryNameNullable();
         String modId = registryName == null ? null : registryName.getNamespace();
         if ("minecraft".equals(modId))
         {
@@ -1010,7 +1010,7 @@ public class ForgeHooks
             }
             else if (item instanceof SpawnEggItem)
             {
-                ResourceLocation resourceLocation = ((SpawnEggItem)item).getType(null).getRegistryName();
+                ResourceLocation resourceLocation = ((SpawnEggItem)item).getType(null).getRegistryNameNullable();
                 if (resourceLocation != null)
                 {
                     return resourceLocation.getNamespace();

--- a/src/main/java/net/minecraftforge/common/crafting/ConditionalRecipe.java
+++ b/src/main/java/net/minecraftforge/common/crafting/ConditionalRecipe.java
@@ -60,7 +60,7 @@ public class ConditionalRecipe
         }
 
         @Override
-        public ResourceLocation getRegistryName()
+        public ResourceLocation getRegistryNameNullable()
         {
             return name;
         }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
@@ -95,7 +95,7 @@ public interface IForgePacketBuffer
         IForgeRegistry<T> retrievedRegistry = RegistryManager.ACTIVE.getRegistry(regType);
         Preconditions.checkArgument(retrievedRegistry!=null,"Cannot write registry id for an unknown registry type: %s",regType.getName());
         ResourceLocation name = retrievedRegistry.getRegistryName();
-        Preconditions.checkArgument(retrievedRegistry.containsValue(entry),"Cannot find %s in %s",entry.getRegistryName()!=null?entry.getRegistryName():entry,name);
+        Preconditions.checkArgument(retrievedRegistry.containsValue(entry),"Cannot find %s in %s",entry.getRegistryNameNullable()!=null?entry.getRegistryNameNullable():entry,name);
         ForgeRegistry<T> reg = (ForgeRegistry<T>)retrievedRegistry;
         getBuffer().writeResourceLocation(name); //TODO change to writing a varInt once registries use id's
         getBuffer().writeVarInt(reg.getID(entry));

--- a/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
+++ b/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
@@ -36,8 +36,8 @@ public abstract class GlobalLootModifierSerializer<T extends IGlobalLootModifier
     private ResourceLocation registryName = null;
     
     public final GlobalLootModifierSerializer<T> setRegistryName(String name) {
-        if (getRegistryName() != null)
-            throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryName());
+        if (getRegistryNameNullable() != null)
+            throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryNameNullable());
 
         this.registryName = GameData.checkPrefix(name, true);
         return this;
@@ -50,7 +50,7 @@ public abstract class GlobalLootModifierSerializer<T extends IGlobalLootModifier
     public final GlobalLootModifierSerializer<T> setRegistryName(String modID, String name){ return setRegistryName(modID + ":" + name); }
 
     @Override
-    public final ResourceLocation getRegistryName() {
+    public final ResourceLocation getRegistryNameNullable() {
         return registryName;
     }
     

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -31,7 +31,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,7 +63,7 @@ public class FluidStack
         }
         else if (ForgeRegistries.FLUIDS.getKey(fluid) == null)
         {
-            LOGGER.fatal("Failed attempt to create a FluidStack for an unregistered Fluid {} (type {})", fluid.getRegistryName(), fluid.getClass().getName());
+            LOGGER.fatal("Failed attempt to create a FluidStack for an unregistered Fluid {} (type {})", fluid.getRegistryNameNullable(), fluid.getClass().getName());
             throw new IllegalArgumentException("Cannot create a fluidstack from an unregistered fluid");
         }
         this.fluidDelegate = fluid.delegate;

--- a/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
+++ b/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
@@ -25,14 +25,12 @@ import com.google.common.collect.Multimap;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.BlockModelShapes;
 import net.minecraft.client.renderer.model.ModelResourceLocation;
-import net.minecraft.item.Item;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import org.apache.logging.log4j.message.SimpleMessage;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 import static net.minecraftforge.client.model.ModelLoader.getInventoryVariant;
 

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -59,14 +59,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
-import net.minecraftforge.registries.IForgeRegistry.AddCallback;
-import net.minecraftforge.registries.IForgeRegistry.BakeCallback;
-import net.minecraftforge.registries.IForgeRegistry.ClearCallback;
-import net.minecraftforge.registries.IForgeRegistry.CreateCallback;
-import net.minecraftforge.registries.IForgeRegistry.DummyFactory;
-import net.minecraftforge.registries.IForgeRegistry.MissingFactory;
-import net.minecraftforge.registries.IForgeRegistry.ValidateCallback;
-
 public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRegistryInternal<V>, IForgeRegistryModifiable<V>
 {
     public static Marker REGISTRIES = MarkerManager.getMarker("REGISTRIES");

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -39,8 +39,8 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
 
     public final V setRegistryName(String name)
     {
-        if (getRegistryName() != null)
-            throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryName());
+        if (getRegistryNameNullable() != null)
+            throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryNameNullable());
 
         this.registryName = GameData.checkPrefix(name, true);
         return (V)this;
@@ -52,7 +52,7 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
     public final V setRegistryName(String modID, String name){ return setRegistryName(modID + ":" + name); }
 
     @Nullable
-    public final ResourceLocation getRegistryName()
+    public final ResourceLocation getRegistryNameNullable()
     {
         if (delegate.name() != null) return delegate.name();
         return registryName != null ? registryName : null;

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -288,16 +288,6 @@ public class GameData
         return (BiMap<String, Structure<?>>) RegistryManager.ACTIVE.getRegistry(Feature.class).getSlaveMap(STRUCTURES, BiMap.class);
     }
 
-    public static <K extends IForgeRegistryEntry<K>> K register_impl(K value)
-    {
-        Validate.notNull(value, "Attempted to register a null object");
-        Validate.notNull(value.getRegistryName(), String.format("Attempt to register object without having set a registry name %s (type %s)", value, value.getClass().getName()));
-        final IForgeRegistry<K> registry = RegistryManager.ACTIVE.getRegistry(value.getRegistryType());
-        Validate.notNull(registry, "Attempted to registry object without creating registry first: " + value.getRegistryType().getName());
-        registry.register(value);
-        return value;
-    }
-
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static void vanillaSnapshot()
     {
@@ -422,7 +412,7 @@ public class GameData
                             .collect(Collectors.joining(";"));
 
                     LOGGER.error(REGISTRIES,()-> new AdvancedLogMessageAdapter(sb-> {
-                        sb.append("Registry replacements for vanilla block '").append(block.getRegistryName()).
+                        sb.append("Registry replacements for vanilla block '").append(block.getRegistryNameNullable()).
                                 append("' must not change the number or order of blockstates.\n");
                         sb.append("\tOld: ").append(oldSequence).append('\n');
                         sb.append("\tNew: ").append(newSequence);

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistryEntry.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.registries;
 import net.minecraft.util.ResourceLocation;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface IForgeRegistryEntry<V>
@@ -41,7 +42,7 @@ public interface IForgeRegistryEntry<V>
      */
     V setRegistryName(ResourceLocation name);
 
-    /**
+     /**
      * A unique identifier for this entry, if this entry is registered already it will return it's official registry name.
      * Otherwise it will return the name set in setRegistryName().
      * If neither are valid null is returned.
@@ -49,7 +50,23 @@ public interface IForgeRegistryEntry<V>
      * @return Unique identifier or null.
      */
     @Nullable
-    ResourceLocation getRegistryName();
+    ResourceLocation getRegistryNameNullable();
+
+    /**
+     * A unique identifier for this entry, if this entry is registered already it will return it's official registry name.
+     * Otherwise it will return the name set in setRegistryName().
+     * If neither a {@link IllegalStateException} will be thrown
+     *
+     * @return Unique identifier
+     * @throws IllegalStateException when no name is available yet
+     */
+    @Nonnull
+    default ResourceLocation getRegistryName() {
+        ResourceLocation regName = getRegistryNameNullable();
+        if (regName == null)
+            throw new IllegalStateException("No registy name available!");
+        return regName;
+    }
 
     /**
      * Determines the type for this entry, used to look up the correct registry in the global registries list as there can only be one

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -53,7 +53,7 @@ class NamespacedDefaultedWrapper<T extends IForgeRegistryEntry<T>> extends Defau
             throw new IllegalStateException("Can not register to a locked registry. Modder should use Forge Register methods.");
         Validate.notNull(value);
 
-        if (value.getRegistryName() == null)
+        if (value.getRegistryNameNullable() == null)
             value.setRegistryName(key);
 
         int realId = this.delegate.add(id, value);

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -50,7 +50,7 @@ class NamespacedWrapper<T extends IForgeRegistryEntry<T>> extends SimpleRegistry
 
         Validate.notNull(value);
 
-        if (value.getRegistryName() == null)
+        if (value.getRegistryNameNullable() == null)
             value.setRegistryName(key);
 
         int realId = this.delegate.add(id, value);

--- a/src/main/java/net/minecraftforge/server/command/CommandEntity.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandEntity.java
@@ -37,7 +37,6 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
 import net.minecraft.command.ISuggestionProvider;
 import net.minecraft.command.arguments.DimensionArgument;
-import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.text.StringTextComponent;

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -40,7 +40,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.model.generators.BlockStateProvider;
 import net.minecraftforge.client.model.generators.ExistingFileHelper;
-import net.minecraftforge.client.model.generators.ItemModelProvider;
 import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.event.world.PistonEvent;
 import net.minecraftforge.event.world.PistonEvent.PistonMoveType;

--- a/src/test/java/net/minecraftforge/debug/world/ChunkWatchEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkWatchEventTest.java
@@ -74,7 +74,6 @@ public class ChunkWatchEventTest
                 watched);
     }
 
-    @Nullable
     private static ResourceLocation getDimensionName(World w) {
         return w.getDimension().getType().getRegistryName();
     }


### PR DESCRIPTION
Most of the time modders call getRegistryName, they assume that the regname is not null, as it is already in a registry, so there are pointless IDE warnings as you don't check for null, but in reality there is no way it can be null at that stage.
Open for comments.