### PR TITLE
Add EndermanAttack Event

### DIFF
--- a/patches/minecraft/net/minecraft/block/BushBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BushBlock.java.patch
@@ -1,15 +1,25 @@
 --- a/net/minecraft/block/BushBlock.java
 +++ b/net/minecraft/block/BushBlock.java
-@@ -7,7 +7,7 @@
+@@ -6,15 +6,16 @@
+ import net.minecraft.world.IBlockReader;
  import net.minecraft.world.IWorld;
  import net.minecraft.world.IWorldReader;
++import net.minecraftforge.common.Tags;
  
 -public class BushBlock extends Block {
 +public class BushBlock extends Block implements net.minecraftforge.common.IPlantable {
     protected BushBlock(Block.Properties p_i48437_1_) {
        super(p_i48437_1_);
     }
-@@ -23,6 +23,8 @@
+ 
+    protected boolean func_200014_a_(BlockState p_200014_1_, IBlockReader p_200014_2_, BlockPos p_200014_3_) {
+       Block block = p_200014_1_.func_177230_c();
+-      return block == Blocks.field_196658_i || block == Blocks.field_150346_d || block == Blocks.field_196660_k || block == Blocks.field_196661_l || block == Blocks.field_150458_ak;
++      return Tags.Blocks.BUSH_FLOOR.func_199685_a_(block);
+    }
+ 
+    public BlockState func_196271_a(BlockState p_196271_1_, Direction p_196271_2_, BlockState p_196271_3_, IWorld p_196271_4_, BlockPos p_196271_5_, BlockPos p_196271_6_) {
+@@ -23,6 +24,8 @@
  
     public boolean func_196260_a(BlockState p_196260_1_, IWorldReader p_196260_2_, BlockPos p_196260_3_) {
        BlockPos blockpos = p_196260_3_.func_177977_b();
@@ -18,7 +28,7 @@
        return this.func_200014_a_(p_196260_2_.func_180495_p(blockpos), p_196260_2_, blockpos);
     }
  
-@@ -33,4 +35,11 @@
+@@ -33,4 +36,11 @@
     public boolean func_196266_a(BlockState p_196266_1_, IBlockReader p_196266_2_, BlockPos p_196266_3_, PathType p_196266_4_) {
        return p_196266_4_ == PathType.AIR && !this.field_196274_w ? true : super.func_196266_a(p_196266_1_, p_196266_2_, p_196266_3_, p_196266_4_);
     }

--- a/patches/minecraft/net/minecraft/block/MushroomBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/MushroomBlock.java.patch
@@ -1,10 +1,20 @@
 --- a/net/minecraft/block/MushroomBlock.java
 +++ b/net/minecraft/block/MushroomBlock.java
-@@ -64,7 +64,7 @@
+@@ -12,6 +12,7 @@
+ import net.minecraft.world.gen.feature.ConfiguredFeature;
+ import net.minecraft.world.gen.feature.Feature;
+ import net.minecraft.world.server.ServerWorld;
++import net.minecraftforge.common.Tags;
+ 
+ public class MushroomBlock extends BushBlock implements IGrowable {
+    protected static final VoxelShape field_196385_a = Block.func_208617_a(5.0D, 0.0D, 5.0D, 11.0D, 6.0D, 11.0D);
+@@ -63,8 +64,8 @@
+       BlockPos blockpos = p_196260_3_.func_177977_b();
        BlockState blockstate = p_196260_2_.func_180495_p(blockpos);
        Block block = blockstate.func_177230_c();
-       if (block != Blocks.field_150391_bh && block != Blocks.field_196661_l) {
+-      if (block != Blocks.field_150391_bh && block != Blocks.field_196661_l) {
 -         return p_196260_2_.func_226659_b_(p_196260_3_, 0) < 13 && this.func_200014_a_(blockstate, p_196260_2_, blockpos);
++      if (!Tags.Blocks.MUSHROMM_FLOOR.func_199685_a_(block)) {
 +         return p_196260_2_.func_226659_b_(p_196260_3_, 0) < 13 && blockstate.canSustainPlant(p_196260_2_, blockpos, net.minecraft.util.Direction.UP, this);
        } else {
           return true;

--- a/patches/minecraft/net/minecraft/block/MushroomBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/MushroomBlock.java.patch
@@ -14,7 +14,7 @@
        Block block = blockstate.func_177230_c();
 -      if (block != Blocks.field_150391_bh && block != Blocks.field_196661_l) {
 -         return p_196260_2_.func_226659_b_(p_196260_3_, 0) < 13 && this.func_200014_a_(blockstate, p_196260_2_, blockpos);
-+      if (!Tags.Blocks.MUSHROMM_FLOOR.func_199685_a_(block)) {
++      if (!Tags.Blocks.MUSHROOM_FLOOR.func_199685_a_(block)) {
 +         return p_196260_2_.func_226659_b_(p_196260_3_, 0) < 13 && blockstate.canSustainPlant(p_196260_2_, blockpos, net.minecraft.util.Direction.UP, this);
        } else {
           return true;

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/entity/monster/EndermanEntity.java
 +++ b/net/minecraft/entity/monster/EndermanEntity.java
-@@ -93,7 +93,6 @@
+@@ -51,6 +51,7 @@
+ import net.minecraft.world.IWorld;
+ import net.minecraft.world.IWorldReader;
+ import net.minecraft.world.World;
++import net.minecraftforge.event.entity.EndermanAttackEvent;
+ 
+ public class EndermanEntity extends MonsterEntity {
+    private static final UUID field_110192_bp = UUID.fromString("020E0DFB-87AE-4653-9556-831010E291A0");
+@@ -93,7 +94,6 @@
     }
  
     public void func_70624_b(@Nullable LivingEntity p_70624_1_) {
@@ -8,7 +16,7 @@
        IAttributeInstance iattributeinstance = this.func_110148_a(SharedMonsterAttributes.field_111263_d);
        if (p_70624_1_ == null) {
           this.field_184721_by = 0;
-@@ -108,6 +107,7 @@
+@@ -108,6 +108,7 @@
           }
        }
  
@@ -16,7 +24,17 @@
     }
  
     protected void func_70088_a() {
-@@ -234,7 +234,9 @@
+@@ -167,7 +168,8 @@
+          double d0 = vec3d1.func_72433_c();
+          vec3d1 = vec3d1.func_72432_b();
+          double d1 = vec3d.func_72430_b(vec3d1);
+-         return d1 > 1.0D - 0.025D / d0 ? p_70821_1_.func_70685_l(this) : false;
++         net.minecraftforge.event.entity.EndermanAttackEvent event = new net.minecraftforge.event.entity.EndermanAttackEvent(this, p_70821_1_);
++         return d1 > 1.0D - 0.025D / d0 && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event) ? p_70821_1_.func_70685_l(this) : false;
+       }
+    }
+ 
+@@ -234,7 +236,9 @@
        boolean flag = blockstate.func_185904_a().func_76230_c();
        boolean flag1 = blockstate.func_204520_s().func_206884_a(FluidTags.field_206959_a);
        if (flag && !flag1) {
@@ -27,7 +45,7 @@
           if (flag2) {
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70169_q, this.field_70167_r, this.field_70166_s, SoundEvents.field_187534_aX, this.func_184176_by(), 1.0F, 1.0F);
              this.func_184185_a(SoundEvents.field_187534_aX, 1.0F, 1.0F);
-@@ -390,7 +392,7 @@
+@@ -390,7 +394,7 @@
        public boolean func_75250_a() {
           if (this.field_179475_a.func_195405_dq() == null) {
              return false;
@@ -36,7 +54,7 @@
              return false;
           } else {
              return this.field_179475_a.func_70681_au().nextInt(2000) == 0;
-@@ -408,7 +410,7 @@
+@@ -408,7 +412,7 @@
           BlockPos blockpos1 = blockpos.func_177977_b();
           BlockState blockstate1 = iworld.func_180495_p(blockpos1);
           BlockState blockstate2 = this.field_179475_a.func_195405_dq();
@@ -45,7 +63,7 @@
              iworld.func_180501_a(blockpos, blockstate2, 3);
              this.field_179475_a.func_195406_b((BlockState)null);
           }
-@@ -416,7 +418,7 @@
+@@ -416,7 +420,7 @@
        }
  
        private boolean func_220836_a(IWorldReader p_220836_1_, BlockPos p_220836_2_, BlockState p_220836_3_, BlockState p_220836_4_, BlockState p_220836_5_, BlockPos p_220836_6_) {
@@ -54,7 +72,7 @@
        }
     }
  
-@@ -458,7 +460,7 @@
+@@ -458,7 +462,7 @@
        public boolean func_75250_a() {
           if (this.field_179473_a.func_195405_dq() != null) {
              return false;

--- a/src/generated/resources/data/forge/tags/blocks/bush_floor.json
+++ b/src/generated/resources/data/forge/tags/blocks/bush_floor.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:grass_block",
+    "minecraft:dirt",
+    "minecraft:coarse_dirt",
+    "minecraft:podzol",
+    "minecraft:farmland"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/mushroom_floor.json
+++ b/src/generated/resources/data/forge/tags/blocks/mushroom_floor.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:mycelium",
+    "minecraft:podzol"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -42,6 +42,7 @@ public class Tags
         public static final Tag<Block> FENCES = tag("fences");
         public static final Tag<Block> FENCES_NETHER_BRICK = tag("fences/nether_brick");
         public static final Tag<Block> FENCES_WOODEN = tag("fences/wooden");
+        public static final Tag<Block> MUSHROMM_FLOOR = tag("mushroom_floor");
 
         public static final Tag<Block> GLASS = tag("glass");
         public static final Tag<Block> GLASS_BLACK = tag("glass/black");

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -42,7 +42,8 @@ public class Tags
         public static final Tag<Block> FENCES = tag("fences");
         public static final Tag<Block> FENCES_NETHER_BRICK = tag("fences/nether_brick");
         public static final Tag<Block> FENCES_WOODEN = tag("fences/wooden");
-        public static final Tag<Block> MUSHROMM_FLOOR = tag("mushroom_floor");
+        public static final Tag<Block> MUSHROOM_FLOOR = tag("mushroom_floor");
+        public static final Tag<Block> BUSH_FLOOR = tag("bush_floor");
 
         public static final Tag<Block> GLASS = tag("glass");
         public static final Tag<Block> GLASS_BLACK = tag("glass/black");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -58,6 +58,7 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
         getBuilder(CHESTS_WOODEN).add(Blocks.CHEST, Blocks.TRAPPED_CHEST);
         getBuilder(COBBLESTONE).add(Blocks.COBBLESTONE, Blocks.INFESTED_COBBLESTONE, Blocks.MOSSY_COBBLESTONE);
         getBuilder(DIRT).add(Blocks.DIRT, Blocks.GRASS_BLOCK, Blocks.COARSE_DIRT, Blocks.PODZOL, Blocks.MYCELIUM);
+        getBuilder(MUSHROMM_FLOOR).add(Blocks.MYCELIUM, Blocks.PODZOL);
         getBuilder(END_STONES).add(Blocks.END_STONE);
         getBuilder(FENCE_GATES).add(FENCE_GATES_WOODEN);
         getBuilder(FENCE_GATES_WOODEN).add(Blocks.OAK_FENCE_GATE, Blocks.SPRUCE_FENCE_GATE, Blocks.BIRCH_FENCE_GATE, Blocks.JUNGLE_FENCE_GATE, Blocks.ACACIA_FENCE_GATE, Blocks.DARK_OAK_FENCE_GATE);

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -58,7 +58,8 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
         getBuilder(CHESTS_WOODEN).add(Blocks.CHEST, Blocks.TRAPPED_CHEST);
         getBuilder(COBBLESTONE).add(Blocks.COBBLESTONE, Blocks.INFESTED_COBBLESTONE, Blocks.MOSSY_COBBLESTONE);
         getBuilder(DIRT).add(Blocks.DIRT, Blocks.GRASS_BLOCK, Blocks.COARSE_DIRT, Blocks.PODZOL, Blocks.MYCELIUM);
-        getBuilder(MUSHROMM_FLOOR).add(Blocks.MYCELIUM, Blocks.PODZOL);
+        getBuilder(MUSHROOM_FLOOR).add(Blocks.MYCELIUM, Blocks.PODZOL);
+        getBuilder(BUSH_FLOOR).add(Blocks.GRASS_BLOCK, Blocks.DIRT,Blocks.COARSE_DIRT,Blocks.PODZOL,Blocks.FARMLAND);
         getBuilder(END_STONES).add(Blocks.END_STONE);
         getBuilder(FENCE_GATES).add(FENCE_GATES_WOODEN);
         getBuilder(FENCE_GATES_WOODEN).add(Blocks.OAK_FENCE_GATE, Blocks.SPRUCE_FENCE_GATE, Blocks.BIRCH_FENCE_GATE, Blocks.JUNGLE_FENCE_GATE, Blocks.ACACIA_FENCE_GATE, Blocks.DARK_OAK_FENCE_GATE);

--- a/src/main/java/net/minecraftforge/event/entity/EndermanAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EndermanAttackEvent.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.monster.EndermanEntity;
+import net.minecraft.entity.monster.ZombieEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+@net.minecraftforge.eventbus.api.Cancelable
+public class EndermanAttackEvent extends EntityEvent {
+
+    private final PlayerEntity player;
+
+    public EndermanAttackEvent(EndermanEntity entity, PlayerEntity player)
+    {
+        super(entity);
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer() {
+        return player;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/entity/EntityTestEvent.java
+++ b/src/test/java/net/minecraftforge/debug/entity/EntityTestEvent.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.debug.entity;
+
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.Items;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.debug.PotionEventTest;
+import net.minecraftforge.debug.block.PistonEventTest;
+import net.minecraftforge.event.entity.EndermanAttackEvent;
+import net.minecraftforge.event.world.PistonEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod.EventBusSubscriber(modid = "entity_event_test")
+@Mod(value = "entity_event_test")
+public class EntityTestEvent {
+
+    public static final String MODID = "entity_event_test";
+
+    @SubscribeEvent
+    public static void endermanAttack(EndermanAttackEvent event)
+    {
+
+        if(event.getPlayer().getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.DIAMOND_HELMET){
+
+            event.setCanceled(true);
+
+        }
+
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -57,6 +57,8 @@ loaderVersion="[28,)"
     modId="music_disc_test"
 [[mods]]
     modId="stencil_enable_test"
+[[mods]]
+    modId="entity_event_test"
 [[dependencies.global_loot_test]]
     modId="forge"
     mandatory=true


### PR DESCRIPTION
This RP adds an event that is called when a player looks an enderman in the eye.

This event could be used for example to add conditions so that the enderman does not attack the player.