### PR TITLE
Added ProjectileImpactEvent.FireworkRocket

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/FireworkRocketEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FireworkRocketEntity.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/entity/item/FireworkRocketEntity.java
++++ b/net/minecraft/entity/item/FireworkRocketEntity.java
+@@ -187,6 +187,7 @@
+    }
+ 
+    protected void func_213892_a(RayTraceResult p_213892_1_) {
++      if(p_213892_1_.func_216346_c() != RayTraceResult.Type.MISS && net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, p_213892_1_)) return;
+       if (p_213892_1_.func_216346_c() == RayTraceResult.Type.ENTITY && !this.field_70170_p.field_72995_K) {
+          this.func_213893_k();
+       } else if (this.field_70132_H) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -36,6 +36,7 @@ import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.effect.LightningBoltEntity;
+import net.minecraft.entity.item.FireworkRocketEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.monster.ZombieEntity;
 import net.minecraft.entity.passive.AnimalEntity;
@@ -628,6 +629,11 @@ public class ForgeEventFactory
     public static boolean onProjectileImpact(ThrowableEntity throwable, RayTraceResult ray)
     {
         return MinecraftForge.EVENT_BUS.post(new ProjectileImpactEvent.Throwable(throwable, ray));
+    }
+
+    public static boolean onProjectileImpact(FireworkRocketEntity fireworkRocket, RayTraceResult ray)
+    {
+        return MinecraftForge.EVENT_BUS.post(new ProjectileImpactEvent.FireworkRocket(fireworkRocket, ray));
     }
 
     public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTableManager lootTableManager)

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -106,6 +106,9 @@ public class ProjectileImpactEvent extends EntityEvent
         }
     }
 
+    /**
+     * Event is cancellable, causes firework to ignore the current hit and continue on its journey.
+     */
     @Cancelable
     public static class FireworkRocket extends ProjectileImpactEvent
     {

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event.entity;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.FireworkRocketEntity;
 import net.minecraft.entity.projectile.AbstractArrowEntity;
 import net.minecraft.entity.projectile.DamagingProjectileEntity;
 import net.minecraft.entity.projectile.ThrowableEntity;
@@ -102,6 +103,23 @@ public class ProjectileImpactEvent extends EntityEvent
         public ThrowableEntity getThrowable()
         {
             return throwable;
+        }
+    }
+
+    @Cancelable
+    public static class FireworkRocket extends ProjectileImpactEvent
+    {
+        private final FireworkRocketEntity fireworkRocket;
+
+        public FireworkRocket(FireworkRocketEntity fireworkRocket, RayTraceResult ray)
+        {
+            super(fireworkRocket, ray);
+            this.fireworkRocket = fireworkRocket;
+        }
+
+        public FireworkRocketEntity getFireworkRocket()
+        {
+            return fireworkRocket;
         }
     }
 }


### PR DESCRIPTION
Event is cancellable, causes firework to ignore the current hit and continue on its journey.
Requested by folks on the forums