### PR TITLE
Allow mods to override ModFileInfo

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -47,7 +47,7 @@ public class ModFileInfo implements IModFileInfo
     private final List<IModInfo> mods;
     private final Map<String,Object> properties;
 
-    ModFileInfo(final ModFile modFile, final UnmodifiableConfig config)
+    public ModFileInfo(final ModFile modFile, final UnmodifiableConfig config)
     {
         this.modFile = modFile;
         this.config = config;


### PR DESCRIPTION
This exists as a stop-gap solution (somewhat) to GH-6756 by allowing
services to override the one hold-out that cannot be overriden.

This is only a solution to a symptom, and not a solution to the actual
issue though - GH-6756 is still absolutely valid.