### PR TITLE
Fixed debug.log not being generated in dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,9 @@ project(':forge') {
                 environment 'FORGE_SPEC', SPEC_VERSION
                 environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1).toString()
                 environment 'LAUNCHER_VERSION', SPEC_VERSION
+
                 property 'org.lwjgl.system.SharedLibraryExtractDirectory', 'lwjgl_dll'
+                property 'log4j.configurationFile', "${rootProject.projectDir.path}\\src\\fmllauncher\\resources\\log4j2.xml"
 
                 ideaModule "${rootProject.name}.${project.name}.userdev"
 
@@ -297,6 +299,8 @@ project(':forge') {
                 environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1).toString()
                 environment 'LAUNCHER_VERSION', SPEC_VERSION
 
+                property 'log4j.configurationFile', "${rootProject.projectDir.path}\\src\\fmllauncher\\resources\\log4j2.xml"
+
                 ideaModule "${rootProject.name}.${project.name}.userdev"
 
                 source sourceSets.main
@@ -330,6 +334,8 @@ project(':forge') {
                 environment 'FORGE_SPEC', SPEC_VERSION
                 environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1).toString()
                 environment 'LAUNCHER_VERSION', SPEC_VERSION
+
+                property 'log4j.configurationFile', "${rootProject.projectDir.path}\\src\\fmllauncher\\resources\\log4j2.xml"
 
                 ideaModule "${rootProject.name}.${project.name}.userdev"
 


### PR DESCRIPTION
Not 100% sure why the debug.log doesn't generate during dev, but I would assume it has to do with the xml not being loaded or not being loaded soon enough, as manually specifying it as a property fixes the issue.