### PR TITLE
[1.15.x] DataGenerator for LootTable, replacing shears item to shears tag

### DIFF
--- a/src/generated/resources/data/forge/tags/items/shears.json
+++ b/src/generated/resources/data/forge/tags/items/shears.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:shears"
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/acacia_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/acacia_leaves.json
@@ -1,0 +1,128 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:acacia_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:acacia_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/birch_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/birch_leaves.json
@@ -1,0 +1,128 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:birch_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:birch_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/cobweb.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/cobweb.json
@@ -1,0 +1,54 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:cobweb"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/dark_oak_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/dark_oak_leaves.json
@@ -1,0 +1,182 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:dark_oak_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:dark_oak_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.005,
+                0.0055555557,
+                0.00625,
+                0.008333334,
+                0.025
+              ]
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/dead_bush.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/dead_bush.json
@@ -1,0 +1,44 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "tag": "forge:shears"
+                  }
+                }
+              ],
+              "name": "minecraft:dead_bush"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": {
+                    "min": 0.0,
+                    "max": 2.0,
+                    "type": "minecraft:uniform"
+                  }
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "minecraft:stick"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/fern.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/fern.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "tag": "forge:shears"
+                  }
+                }
+              ],
+              "name": "minecraft:fern"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.125
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:uniform_bonus_count",
+                  "parameters": {
+                    "bonusMultiplier": 2
+                  }
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "minecraft:wheat_seeds"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/grass.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/grass.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "tag": "forge:shears"
+                  }
+                }
+              ],
+              "name": "minecraft:grass"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.125
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:uniform_bonus_count",
+                  "parameters": {
+                    "bonusMultiplier": 2
+                  }
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "minecraft:wheat_seeds"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/jungle_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/jungle_leaves.json
@@ -1,0 +1,129 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:jungle_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.025,
+                    0.027777778,
+                    0.03125,
+                    0.041666668,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:jungle_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/large_fern.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/large_fern.json
@@ -1,0 +1,47 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "tag": "forge:shears"
+                  }
+                }
+              ],
+              "name": "minecraft:fern"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:block_state_property",
+                  "block": "minecraft:large_fern",
+                  "properties": {
+                    "half": "lower"
+                  }
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.125
+                }
+              ],
+              "name": "minecraft:wheat_seeds"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/oak_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/oak_leaves.json
@@ -1,0 +1,182 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:oak_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:oak_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.005,
+                0.0055555557,
+                0.00625,
+                0.008333334,
+                0.025
+              ]
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/seagrass.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/seagrass.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:seagrass"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "tag": "forge:shears"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/spruce_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/spruce_leaves.json
@@ -1,0 +1,128 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "tag": "forge:shears"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:spruce_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "minecraft:spruce_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "tag": "forge:shears"
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/tall_grass.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/tall_grass.json
@@ -1,0 +1,47 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "tag": "forge:shears"
+                  }
+                }
+              ],
+              "name": "minecraft:grass"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:block_state_property",
+                  "block": "minecraft:tall_grass",
+                  "properties": {
+                    "half": "lower"
+                  }
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.125
+                }
+              ],
+              "name": "minecraft:wheat_seeds"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/tall_seagrass.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/tall_seagrass.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:seagrass"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "tag": "forge:shears"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/minecraft/loot_tables/blocks/vine.json
+++ b/src/generated/resources/data/minecraft/loot_tables/blocks/vine.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:vine"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "tag": "forge:shears"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -61,6 +61,7 @@ import net.minecraftforge.common.crafting.conditions.TagEmptyCondition;
 import net.minecraftforge.common.crafting.conditions.TrueCondition;
 import net.minecraftforge.common.data.ForgeBlockTagsProvider;
 import net.minecraftforge.common.data.ForgeItemTagsProvider;
+import net.minecraftforge.common.data.ForgeLootTableProvider;
 import net.minecraftforge.common.data.ForgeRecipeProvider;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.energy.CapabilityEnergy;
@@ -179,6 +180,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
             gen.addProvider(new ForgeBlockTagsProvider(gen));
             gen.addProvider(new ForgeItemTagsProvider(gen));
             gen.addProvider(new ForgeRecipeProvider(gen));
+            gen.addProvider(new ForgeLootTableProvider(gen));
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -252,6 +252,7 @@ public class Tags
         public static final Tag<Item> SEEDS_MELON = tag("seeds/melon");
         public static final Tag<Item> SEEDS_PUMPKIN = tag("seeds/pumpkin");
         public static final Tag<Item> SEEDS_WHEAT = tag("seeds/wheat");
+        public static final Tag<Item> SHEARS = tag("shears");
         public static final Tag<Item> SLIMEBALLS = tag("slimeballs");
         public static final Tag<Item> STAINED_GLASS = tag("stained_glass");
         public static final Tag<Item> STAINED_GLASS_PANES = tag("stained_glass_panes");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -128,6 +128,7 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         getBuilder(Tags.Items.SEEDS_MELON).add(Items.MELON_SEEDS);
         getBuilder(Tags.Items.SEEDS_PUMPKIN).add(Items.PUMPKIN_SEEDS);
         getBuilder(Tags.Items.SEEDS_WHEAT).add(Items.WHEAT_SEEDS);
+        getBuilder(Tags.Items.SHEARS).add(Items.SHEARS);
         getBuilder(Tags.Items.SLIMEBALLS).add(Items.SLIME_BALL);
         copy(Tags.Blocks.STAINED_GLASS, Tags.Items.STAINED_GLASS);
         copy(Tags.Blocks.STAINED_GLASS_PANES, Tags.Items.STAINED_GLASS_PANES);

--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -1,0 +1,178 @@
+package net.minecraftforge.common.data;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.advancements.criterion.ItemPredicate;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.LootTableProvider;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.tags.Tag;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.conditions.Alternative;
+import net.minecraft.world.storage.loot.conditions.ILootCondition;
+import net.minecraft.world.storage.loot.conditions.Inverted;
+import net.minecraft.world.storage.loot.conditions.MatchTool;
+import net.minecraftforge.common.Tags;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class ForgeLootTableProvider extends LootTableProvider {
+
+    public ForgeLootTableProvider(DataGenerator gen) {
+        super(gen);
+    }
+
+    @Override
+    protected void validate(Map<ResourceLocation, LootTable> map, ValidationTracker validationtracker) {
+        // do not validate against all registered loot tables
+    }
+
+    @Override
+    protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootParameterSet>> getTables() {
+        return super.getTables().stream().map(pair -> {
+            // provides new consumer with filtering only changed loot tables and replacing condition item to condition tag
+            return new Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootParameterSet>(() -> replaceAndFilterChangesOnly(pair.getFirst().get()), pair.getSecond());
+        }).collect(Collectors.toList());
+    }
+
+    private Consumer<BiConsumer<ResourceLocation, LootTable.Builder>> replaceAndFilterChangesOnly(Consumer<BiConsumer<ResourceLocation, LootTable.Builder>> consumer) {
+        return (newConsumer) -> consumer.accept((resourceLocation, builder) -> {
+            if (findAndReplaceInLootTableBuilder(builder, Items.SHEARS, Tags.Items.SHEARS)) {
+                newConsumer.accept(resourceLocation, builder);
+            }
+        });
+    }
+
+    private boolean findAndReplaceInLootTableBuilder(LootTable.Builder builder, Item from, Tag<Item> to) {
+        List<LootPool> lootPools = getField(LootTable.Builder.class, builder, 0);
+        boolean found = false;
+
+        for (LootPool lootPool : lootPools) {
+            if (findAndReplaceInLootPool(lootPool, from, to)) {
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private boolean findAndReplaceInLootPool(LootPool lootPool, Item from, Tag<Item> to) {
+        List<LootEntry> lootEntries = getField(LootPool.class, lootPool, 1);
+        List<ILootCondition> lootConditions = getField(LootPool.class, lootPool, 2);
+        boolean found = false;
+
+        for (LootEntry lootEntry : lootEntries) {
+            if (lootEntry instanceof ParentedLootEntry) {
+                if (findAndReplaceInParentedLootEntry((ParentedLootEntry) lootEntry, from, to)) {
+                    found = true;
+                }
+            }
+        }
+
+        for (int i = 0; i < lootConditions.size(); i++) {
+            ILootCondition lootCondition = lootConditions.get(i);
+            if (lootCondition instanceof MatchTool && checkMatchTool((MatchTool) lootCondition, from)) {
+                lootConditions.set(i, MatchTool.builder(ItemPredicate.Builder.create().tag(to)).build());
+                found = true;
+            } else if (lootCondition instanceof Inverted && findAndReplaceInInverted((Inverted) lootCondition, from, to)) {
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private boolean findAndReplaceInParentedLootEntry(ParentedLootEntry entry, Item from, Tag<Item> to) {
+        LootEntry[] lootEntries = getField(ParentedLootEntry.class, entry, 0);
+        boolean found = false;
+
+        for (LootEntry lootEntry : lootEntries) {
+            if (findAndReplaceInLootEntry(lootEntry, from, to)) {
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private boolean findAndReplaceInLootEntry(LootEntry entry, Item from, Tag<Item> to) {
+        ILootCondition[] lootConditions = getField(LootEntry.class, entry, 0);
+        boolean found = false;
+
+        for (int i = 0; i < lootConditions.length; i++) {
+            if (lootConditions[i] instanceof Alternative && findAndReplaceInAlternative((Alternative) lootConditions[i], from, to)) {
+                found = true;
+            } else if (lootConditions[i] instanceof MatchTool && checkMatchTool((MatchTool) lootConditions[i], from)) {
+                lootConditions[i] = MatchTool.builder(ItemPredicate.Builder.create().tag(to)).build();
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private boolean findAndReplaceInAlternative(Alternative alternative, Item from, Tag<Item> to) {
+        ILootCondition[] lootConditions = getField(Alternative.class, alternative, 0);
+        boolean found = false;
+
+        for (int i = 0; i < lootConditions.length; i++) {
+            if (lootConditions[i] instanceof MatchTool && checkMatchTool((MatchTool) lootConditions[i], from)) {
+                lootConditions[i] = MatchTool.builder(ItemPredicate.Builder.create().tag(to)).build();
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private boolean findAndReplaceInInverted(Inverted inverted, Item from, Tag<Item> to) {
+        ILootCondition lootCondition = getField(Inverted.class, inverted, 0);
+
+        if (lootCondition instanceof MatchTool && checkMatchTool((MatchTool) lootCondition, from)) {
+            setField(Inverted.class, inverted, 0, MatchTool.builder(ItemPredicate.Builder.create().tag(to)).build());
+            return true;
+        } else if (lootCondition instanceof Alternative && findAndReplaceInAlternative((Alternative) lootCondition, from, to)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean checkMatchTool(MatchTool lootCondition, Item expected) {
+        ItemPredicate predicate = getField(MatchTool.class, lootCondition, 0);
+        Item item = getField(ItemPredicate.class, predicate, 4);
+        return item != null && item.equals(expected);
+    }
+
+    private <T, R> void setField(Class<T> clz, T inst, int index, R value) {
+        Field fld = clz.getDeclaredFields()[index];
+        fld.setAccessible(true);
+        try {
+            fld.set(inst, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, R> R getField(Class<T> clz, T inst, int index)
+    {
+        Field fld = clz.getDeclaredFields()[index];
+        fld.setAccessible(true);
+        try
+        {
+            return (R)fld.get(inst);
+        }
+        catch (IllegalArgumentException | IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -14,8 +14,8 @@ import net.minecraft.world.storage.loot.conditions.ILootCondition;
 import net.minecraft.world.storage.loot.conditions.Inverted;
 import net.minecraft.world.storage.loot.conditions.MatchTool;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -23,6 +23,9 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+/**
+ * Currently used only for replacing shears item to shears tag
+ */
 public class ForgeLootTableProvider extends LootTableProvider {
 
     public ForgeLootTableProvider(DataGenerator gen) {
@@ -51,8 +54,12 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootTableBuilder(LootTable.Builder builder, Item from, Tag<Item> to) {
-        List<LootPool> lootPools = getField(LootTable.Builder.class, builder, 0);
+        List<LootPool> lootPools = ObfuscationReflectionHelper.getPrivateValue(LootTable.Builder.class, builder, "field_216041_a");
         boolean found = false;
+
+        if (lootPools == null) {
+            throw new IllegalStateException(LootTable.Builder.class.getName() + " is missing field field_216041_a");
+        }
 
         for (LootPool lootPool : lootPools) {
             if (findAndReplaceInLootPool(lootPool, from, to)) {
@@ -64,9 +71,13 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootPool(LootPool lootPool, Item from, Tag<Item> to) {
-        List<LootEntry> lootEntries = getField(LootPool.class, lootPool, 1);
-        List<ILootCondition> lootConditions = getField(LootPool.class, lootPool, 2);
+        List<LootEntry> lootEntries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "field_186453_a");
+        List<ILootCondition> lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "field_186454_b");
         boolean found = false;
+
+        if (lootEntries == null) {
+            throw new IllegalStateException(LootPool.class.getName() + " is missing field field_186453_a");
+        }
 
         for (LootEntry lootEntry : lootEntries) {
             if (lootEntry instanceof ParentedLootEntry) {
@@ -76,13 +87,17 @@ public class ForgeLootTableProvider extends LootTableProvider {
             }
         }
 
+        if (lootConditions == null) {
+            throw new IllegalStateException(LootPool.class.getName() + " is missing field field_186454_b");
+        }
+
         for (int i = 0; i < lootConditions.size(); i++) {
             ILootCondition lootCondition = lootConditions.get(i);
             if (lootCondition instanceof MatchTool && checkMatchTool((MatchTool) lootCondition, from)) {
                 lootConditions.set(i, MatchTool.builder(ItemPredicate.Builder.create().tag(to)).build());
                 found = true;
             } else if (lootCondition instanceof Inverted) {
-                ILootCondition invLootCondition = getField(Inverted.class, (Inverted) lootCondition, 0);
+                ILootCondition invLootCondition = ObfuscationReflectionHelper.getPrivateValue(Inverted.class, (Inverted) lootCondition, "field_215981_a");
 
                 if (invLootCondition instanceof MatchTool && checkMatchTool((MatchTool) invLootCondition, from)) {
                     lootConditions.set(i, Inverted.builder(MatchTool.builder(ItemPredicate.Builder.create().tag(to))).build());
@@ -97,8 +112,12 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInParentedLootEntry(ParentedLootEntry entry, Item from, Tag<Item> to) {
-        LootEntry[] lootEntries = getField(ParentedLootEntry.class, entry, 0);
+        LootEntry[] lootEntries = ObfuscationReflectionHelper.getPrivateValue(ParentedLootEntry.class, entry, "field_216147_c");
         boolean found = false;
+
+        if (lootEntries == null) {
+            throw new IllegalStateException(ParentedLootEntry.class.getName() + " is missing field field_216147_c");
+        }
 
         for (LootEntry lootEntry : lootEntries) {
             if (findAndReplaceInLootEntry(lootEntry, from, to)) {
@@ -110,8 +129,12 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootEntry(LootEntry entry, Item from, Tag<Item> to) {
-        ILootCondition[] lootConditions = getField(LootEntry.class, entry, 0);
+        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootEntry.class, entry, "field_216144_d");
         boolean found = false;
+
+        if (lootConditions == null) {
+            throw new IllegalStateException(LootEntry.class.getName() + " is missing field field_216144_d");
+        }
 
         for (int i = 0; i < lootConditions.length; i++) {
             if (lootConditions[i] instanceof Alternative && findAndReplaceInAlternative((Alternative) lootConditions[i], from, to)) {
@@ -126,8 +149,12 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInAlternative(Alternative alternative, Item from, Tag<Item> to) {
-        ILootCondition[] lootConditions = getField(Alternative.class, alternative, 0);
+        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(Alternative.class, alternative, "field_215962_a");
         boolean found = false;
+
+        if (lootConditions == null) {
+            throw new IllegalStateException(Alternative.class.getName() + " is missing field field_215962_a");
+        }
 
         for (int i = 0; i < lootConditions.length; i++) {
             if (lootConditions[i] instanceof MatchTool && checkMatchTool((MatchTool) lootConditions[i], from)) {
@@ -140,23 +167,8 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean checkMatchTool(MatchTool lootCondition, Item expected) {
-        ItemPredicate predicate = getField(MatchTool.class, lootCondition, 0);
-        Item item = getField(ItemPredicate.class, predicate, 4);
+        ItemPredicate predicate = ObfuscationReflectionHelper.getPrivateValue(MatchTool.class, lootCondition, "field_216014_a");
+        Item item = ObfuscationReflectionHelper.getPrivateValue(ItemPredicate.class, predicate, "field_192496_b");
         return item != null && item.equals(expected);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T, R> R getField(Class<T> clz, T inst, int index)
-    {
-        Field fld = clz.getDeclaredFields()[index];
-        fld.setAccessible(true);
-        try
-        {
-            return (R)fld.get(inst);
-        }
-        catch (IllegalArgumentException | IllegalAccessException e)
-        {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION
Created ForgeLootTableProvider that replace matching item to tag. Flexible solution with possibility to extend.

Referenced in #6514, #6624