### PR TITLE
Fix entities pathing through lava

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/pathfinding/WalkNodeProcessor.java
 +++ b/net/minecraft/pathfinding/WalkNodeProcessor.java
-@@ -383,16 +383,9 @@
+@@ -383,15 +383,11 @@
              for(int j = -1; j <= 1; ++j) {
                 for(int k = -1; k <= 1; ++k) {
                    if (i != 0 || k != 0) {
@@ -12,15 +12,15 @@
 -                           p_193578_4_ = PathNodeType.DANGER_OTHER;
 -                        }
 -                     } else {
--                        p_193578_4_ = PathNodeType.DANGER_FIRE;
--                     }
-+                     PathNodeType type = func_189553_b(p_193578_0_, p_193578_1_, p_193578_2_, p_193578_3_);
-+                     if (type == PathNodeType.DANGER_CACTUS || type == PathNodeType.DANGER_FIRE || type == PathNodeType.DANGER_OTHER)
++                     PathNodeType type = func_189553_b(p_193578_0_, i + p_193578_1_, j + p_193578_2_, k + p_193578_3_);
++                     if (type == PathNodeType.LAVA) { // Forge: Match vanilla behaviour #6755
+                         p_193578_4_ = PathNodeType.DANGER_FIRE;
++                     } else if (type == PathNodeType.DANGER_CACTUS || type == PathNodeType.DANGER_FIRE || type == PathNodeType.DANGER_OTHER) {
 +                        p_193578_4_ = type;
+                      }
                    }
                 }
-             }
-@@ -405,9 +398,11 @@
+@@ -405,9 +401,11 @@
     protected static PathNodeType func_189553_b(IBlockReader p_189553_0_, int p_189553_1_, int p_189553_2_, int p_189553_3_) {
        BlockPos blockpos = new BlockPos(p_189553_1_, p_189553_2_, p_189553_3_);
        BlockState blockstate = p_189553_0_.func_180495_p(blockpos);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -882,7 +882,7 @@ public interface IForgeBlock
     @Nullable
     default PathNodeType getAiPathNodeType(BlockState state, IBlockReader world, BlockPos pos, @Nullable MobEntity entity)
     {
-        return state.isBurning(world, pos) ? PathNodeType.DANGER_FIRE : null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Related Issue: https://github.com/MinecraftForge/MinecraftForge/issues/6755

In vanilla, for a lava block, `func_189553_b/getPathNodeTypeRaw` returns `PathNodeType.LAVA` whereas in Forge the default implementation in `IForgeBlock#getAiPathNodeType` causes it returns `PathNodeType.DANGER_FIRE`.

`PathNodeType.DANGER_FIRE` only increases the cost of the path where as `PathNodeType.LAVA` classes the path as untraveled, hence why in forge entities will try to cross lava and vanilla not.

I have changed `IForgeBlock#getAiPathNodeType` to always return null by default so that vanilla logic takes over for fire and lava. This doesn't change the behaviour of fire but does fix lava.

The fix in `func_193578_a/checkNeighborBlocks` is because this method only wants to know if there are dangers nearby not if the blocks nearby are impassable. This change from `PathNodeType.LAVA` to `PathNodeType.DANGER_FIRE` makes this patch match vanilla for lava fluids.

A side note: `IForgeBlock#getAiPathNodeType` should possibly have an extra boolean param (`isNeighbour`) so that the returned `PathNodeType` can be dependent on if it is being check as a neighbouring block or the actual block. A use case would be for lava which wants to return `PathNodeType.LAVA` normally and `PathNodeType.DANGER_FIRE` when a neighbouring block.