### PR TITLE
Add Fire Source Tag to add fire source block

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/fire_source.json
+++ b/src/generated/resources/data/forge/tags/blocks/fire_source.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:netherrack",
+    "minecraft:magma_block"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -111,6 +111,7 @@ public class Tags
         public static final Tag<Block> STORAGE_BLOCKS_LAPIS = tag("storage_blocks/lapis");
         public static final Tag<Block> STORAGE_BLOCKS_QUARTZ = tag("storage_blocks/quartz");
         public static final Tag<Block> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
+        public static final Tag<Block> FIRE_SOURCE = tag("fire_source");
 
         private static Tag<Block> tag(String name)
         {

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -96,6 +96,7 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
         getBuilder(STORAGE_BLOCKS_LAPIS).add(Blocks.LAPIS_BLOCK);
         getBuilder(STORAGE_BLOCKS_QUARTZ).add(Blocks.QUARTZ_BLOCK);
         getBuilder(STORAGE_BLOCKS_REDSTONE).add(Blocks.REDSTONE_BLOCK);
+        getBuilder(FIRE_SOURCE).add(Blocks.NETHERRACK, Blocks.MAGMA_BLOCK);
     }
 
     private void addColored(Consumer<Block> consumer, Tag<Block> group, String pattern)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -80,6 +80,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.ToolType;
 
 @SuppressWarnings("deprecation")
@@ -987,7 +988,7 @@ public interface IForgeBlock
     {
         if (side != Direction.UP)
             return false;
-        if (getBlock() == Blocks.NETHERRACK || getBlock() == Blocks.MAGMA_BLOCK)
+        if (Tags.Blocks.FIRE_SOURCE.contains(getBlock()))
             return true;
         if (world instanceof IWorldReader && ((IWorldReader)world).getDimension() instanceof EndDimension && getBlock() == Blocks.BEDROCK)
             return true;


### PR DESCRIPTION
This PR add a fire source tag to allow to specify the blocks like the netherrack which allows the fire to burn indefinitely.