### PR TITLE
[1.15.2] Added a new event called "RenderWorldPreTranslucentEvent"

### DIFF
--- a/patches/minecraft/net/minecraft/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/StemBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/block/StemBlock.java
 +++ b/net/minecraft/block/StemBlock.java
-@@ -38,22 +38,24 @@
+@@ -40,22 +40,24 @@
  
     public void func_225534_a_(BlockState p_225534_1_, ServerWorld p_225534_2_, BlockPos p_225534_3_, Random p_225534_4_) {
        super.func_225534_a_(p_225534_1_, p_225534_2_, p_225534_3_, p_225534_4_);
@@ -30,7 +30,7 @@
           }
  
        }
-@@ -98,4 +100,10 @@
+@@ -101,4 +103,10 @@
     public StemGrownBlock func_208486_d() {
        return this.field_149877_a;
     }

--- a/patches/minecraft/net/minecraft/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/StemBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/block/StemBlock.java
 +++ b/net/minecraft/block/StemBlock.java
-@@ -40,22 +40,24 @@
+@@ -38,22 +38,24 @@
  
     public void func_225534_a_(BlockState p_225534_1_, ServerWorld p_225534_2_, BlockPos p_225534_3_, Random p_225534_4_) {
        super.func_225534_a_(p_225534_1_, p_225534_2_, p_225534_3_, p_225534_4_);
@@ -30,7 +30,7 @@
           }
  
        }
-@@ -101,4 +103,10 @@
+@@ -98,4 +100,10 @@
     public StemGrownBlock func_208486_d() {
        return this.field_149877_a;
     }

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -78,7 +78,7 @@
        irendertypebuffer$impl.func_228462_a_(RenderType.func_228659_m_());
        irendertypebuffer$impl.func_228461_a_();
 +      iprofiler.func_219895_b("forge_render_pre_translucent");
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderPreTranslucent(this.field_72777_q.field_71438_f, p_228426_1_, p_228426_2_, matrix4f, p_228426_3_);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderPreTranslucent(this.field_72777_q.field_71438_f, p_228426_1_, irendertypebuffer$impl, p_228426_2_, matrix4f, p_228426_3_);
        iprofiler.func_219895_b("translucent");
        this.func_228441_a_(RenderType.func_228645_f_(), p_228426_1_, d0, d1, d2);
        iprofiler.func_219895_b("particles");

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -73,7 +73,16 @@
              IVertexBuilder ivertexbuilder2 = irendertypebuffer$impl.getBuffer(RenderType.func_228659_m_());
              this.func_228429_a_(p_228426_1_, ivertexbuilder2, p_228426_6_.func_216773_g(), d0, d1, d2, blockpos, blockstate);
           }
-@@ -1380,6 +1390,15 @@
+@@ -1046,6 +1056,8 @@
+       this.field_228415_m_.func_228489_c_().func_228461_a_();
+       irendertypebuffer$impl.func_228462_a_(RenderType.func_228659_m_());
+       irendertypebuffer$impl.func_228461_a_();
++      iprofiler.func_219895_b("forge_render_pre_translucent");
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderPreTranslucent(this.field_72777_q.field_71438_f, p_228426_1_, p_228426_2_, matrix4f, p_228426_3_);
+       iprofiler.func_219895_b("translucent");
+       this.func_228441_a_(RenderType.func_228645_f_(), p_228426_1_, d0, d1, d2);
+       iprofiler.func_219895_b("particles");
+@@ -1380,6 +1392,15 @@
     }
  
     public void func_228424_a_(MatrixStack p_228424_1_, float p_228424_2_) {
@@ -89,7 +98,7 @@
        if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p() == DimensionType.field_223229_c_) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
-@@ -1508,6 +1527,15 @@
+@@ -1508,6 +1529,15 @@
     }
  
     public void func_228425_a_(MatrixStack p_228425_1_, float p_228425_2_, double p_228425_3_, double p_228425_5_, double p_228425_7_) {
@@ -105,7 +114,7 @@
        if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d()) {
           RenderSystem.disableCull();
           RenderSystem.enableBlend();
-@@ -1977,7 +2005,12 @@
+@@ -1977,7 +2007,12 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
@@ -118,7 +127,7 @@
        ISound isound = this.field_147593_P.get(p_184377_2_);
        if (isound != null) {
           this.field_72777_q.func_147118_V().func_147683_b(isound);
-@@ -1985,7 +2018,7 @@
+@@ -1985,7 +2020,7 @@
        }
  
        if (p_184377_1_ != null) {
@@ -127,7 +136,7 @@
           if (musicdiscitem != null) {
              this.field_72777_q.field_71456_v.func_73833_a(musicdiscitem.func_200299_h().func_150254_d());
           }
-@@ -2133,7 +2166,7 @@
+@@ -2133,7 +2168,7 @@
           break;
        case 1010:
           if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
@@ -136,7 +145,7 @@
           } else {
              this.func_184377_a((SoundEvent)null, p_180439_3_);
           }
-@@ -2283,8 +2316,8 @@
+@@ -2283,8 +2318,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -147,7 +156,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2432,7 +2465,7 @@
+@@ -2432,7 +2467,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -156,7 +165,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2445,6 +2478,11 @@
+@@ -2445,6 +2480,11 @@
        return this.field_175015_z;
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -78,7 +78,7 @@
        irendertypebuffer$impl.func_228462_a_(RenderType.func_228659_m_());
        irendertypebuffer$impl.func_228461_a_();
 +      iprofiler.func_219895_b("forge_render_pre_translucent");
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderPreTranslucent(this.field_72777_q.field_71438_f, p_228426_1_, irendertypebuffer$impl, p_228426_2_, matrix4f, p_228426_3_);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderPreTranslucent(this.field_72777_q.field_71438_f, p_228426_6_, p_228426_1_, irendertypebuffer$impl, p_228426_2_, matrix4f, p_228426_3_);
        iprofiler.func_219895_b("translucent");
        this.func_228441_a_(RenderType.func_228645_f_(), p_228426_1_, d0, d1, d2);
        iprofiler.func_219895_b("particles");

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -70,6 +70,7 @@ import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.FogRenderer.FogType;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.IRenderTypeBuffer.Impl;
 import net.minecraft.client.renderer.Matrix4f;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.TransformationMatrix;
@@ -178,9 +179,9 @@ public class ForgeHooksClient
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
     }
     
-    public static void dispatchRenderPreTranslucent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    public static void dispatchRenderPreTranslucent(WorldRenderer context, MatrixStack mat, Impl buffers, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
-        MinecraftForge.EVENT_BUS.post(new RenderWorldPreTranslucentEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
+        MinecraftForge.EVENT_BUS.post(new RenderWorldPreTranslucentEvent(context, mat, buffers, partialTicks, projectionMatrix, finishTimeNano));
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -29,7 +29,6 @@ import static org.lwjgl.opengl.GL11.GL_VERTEX_ARRAY;
 import static org.lwjgl.opengl.GL11.glColorPointer;
 import static org.lwjgl.opengl.GL11.glDisableClientState;
 import static org.lwjgl.opengl.GL11.glEnableClientState;
-import static org.lwjgl.opengl.GL11.glMultMatrixf;
 import static org.lwjgl.opengl.GL11.glNormalPointer;
 import static org.lwjgl.opengl.GL11.glTexCoordPointer;
 import static org.lwjgl.opengl.GL11.glVertexPointer;
@@ -41,21 +40,13 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.client.renderer.*;
-import net.minecraft.client.settings.KeyBinding;
-import net.minecraftforge.client.event.RenderHandEvent;
-import net.minecraftforge.client.model.pipeline.LightUtil;
-import net.minecraftforge.fml.loading.progress.StartupMessageManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.async.ThreadNameCachingStrategy;
@@ -64,9 +55,6 @@ import org.lwjgl.opengl.GL13;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.IVertexBuilder;
 
 import net.minecraft.client.GameSettings;
 import net.minecraft.client.MainWindow;
@@ -78,26 +66,30 @@ import net.minecraft.client.gui.ClientBossInfo;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.FogRenderer.FogType;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Matrix4f;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.TransformationMatrix;
+import net.minecraft.client.renderer.Vector3f;
+import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.client.renderer.entity.model.BipedModel;
-import net.minecraft.client.renderer.model.BakedQuad;
-import net.minecraft.client.renderer.model.BlockFaceUV;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
-import net.minecraft.client.renderer.model.ItemTransformVec3f;
 import net.minecraft.client.renderer.model.Material;
 import net.minecraft.client.renderer.model.ModelManager;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.client.renderer.texture.NativeImage;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.client.renderer.vertex.VertexFormatElement.Usage;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -129,20 +121,21 @@ import net.minecraftforge.client.event.InputUpdateEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.client.event.RenderWorldPreTranslucentEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.animation.Animation;
-import net.minecraftforge.client.model.data.EmptyModelData;
-import net.minecraftforge.client.model.pipeline.QuadGatheringTransformer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.model.TransformationHelper;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.loading.progress.StartupMessageManager;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.resource.ReloadRequirements;
 import net.minecraftforge.resource.SelectiveReloadStateHandler;
@@ -183,6 +176,11 @@ public class ForgeHooksClient
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
+    }
+    
+    public static void dispatchRenderPreTranslucent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderWorldPreTranslucentEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
@@ -21,8 +21,10 @@ package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 
+import net.minecraft.client.renderer.IRenderTypeBuffer.Impl;
 import net.minecraft.client.renderer.Matrix4f;
 import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraftforge.eventbus.api.Event;
 
 /**
  * This event is called immediately before translucent blocks are rendered in the WorldRenderer class.
@@ -33,18 +35,20 @@ import net.minecraft.client.renderer.WorldRenderer;
  * will be invisible behind anything translucent rendered from this event.
  */
 
-public class RenderWorldPreTranslucentEvent extends net.minecraftforge.eventbus.api.Event
+public class RenderWorldPreTranslucentEvent extends Event
 {
     private final WorldRenderer context;
     private final MatrixStack mat;
+    private final Impl buffers;
     private final float partialTicks;
     private final Matrix4f projectionMatrix;
     private final long finishTimeNano;
 
-    public RenderWorldPreTranslucentEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    public RenderWorldPreTranslucentEvent(WorldRenderer context, MatrixStack mat, Impl buffers, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         this.context = context;
         this.mat = mat;
+        this.buffers = buffers;
         this.partialTicks = partialTicks;
         this.projectionMatrix = projectionMatrix;
         this.finishTimeNano = finishTimeNano;
@@ -58,6 +62,11 @@ public class RenderWorldPreTranslucentEvent extends net.minecraftforge.eventbus.
     public MatrixStack getMatrixStack()
     {
         return mat;
+    }
+    
+    public Impl getRenderTypeBuffers()
+    {
+        return buffers;
     }
 
     public float getPartialTicks()

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+import net.minecraft.client.renderer.Matrix4f;
+import net.minecraft.client.renderer.WorldRenderer;
+
+/**
+ * This event is called immediately before translucent blocks are rendered in the WorldRenderer class.
+ * 
+ * It is useful for rendering in a similar manner to RenderWorldLastEvent without the result being
+ * invisible behind translucent blocks such as stained glass or water.
+ * However, due to the nature of translucent block rendering, translucent blocks in the world
+ * will be invisible behind anything translucent rendered from this event.
+ */
+
+public class RenderWorldPreTranslucentEvent extends net.minecraftforge.eventbus.api.Event
+{
+    private final WorldRenderer context;
+    private final MatrixStack mat;
+    private final float partialTicks;
+    private final Matrix4f projectionMatrix;
+    private final long finishTimeNano;
+
+    public RenderWorldPreTranslucentEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    {
+        this.context = context;
+        this.mat = mat;
+        this.partialTicks = partialTicks;
+        this.projectionMatrix = projectionMatrix;
+        this.finishTimeNano = finishTimeNano;
+    }
+
+    public WorldRenderer getContext()
+    {
+        return context;
+    }
+
+    public MatrixStack getMatrixStack()
+    {
+        return mat;
+    }
+
+    public float getPartialTicks()
+    {
+        return partialTicks;
+    }
+
+    public Matrix4f getProjectionMatrix()
+    {
+        return projectionMatrix;
+    }
+
+    public long getFinishTimeNano()
+    {
+        return finishTimeNano;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldPreTranslucentEvent.java
@@ -21,7 +21,8 @@ package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 
-import net.minecraft.client.renderer.IRenderTypeBuffer.Impl;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.Matrix4f;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraftforge.eventbus.api.Event;
@@ -38,15 +39,17 @@ import net.minecraftforge.eventbus.api.Event;
 public class RenderWorldPreTranslucentEvent extends Event
 {
     private final WorldRenderer context;
+    private final ActiveRenderInfo info;
     private final MatrixStack mat;
-    private final Impl buffers;
+    private final IRenderTypeBuffer.Impl buffers;
     private final float partialTicks;
     private final Matrix4f projectionMatrix;
     private final long finishTimeNano;
 
-    public RenderWorldPreTranslucentEvent(WorldRenderer context, MatrixStack mat, Impl buffers, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    public RenderWorldPreTranslucentEvent(WorldRenderer context, ActiveRenderInfo info, MatrixStack mat, IRenderTypeBuffer.Impl buffers, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         this.context = context;
+        this.info = info;
         this.mat = mat;
         this.buffers = buffers;
         this.partialTicks = partialTicks;
@@ -58,13 +61,18 @@ public class RenderWorldPreTranslucentEvent extends Event
     {
         return context;
     }
+    
+    public ActiveRenderInfo getActiveRenderInfo()
+    {
+        return info;
+    }
 
     public MatrixStack getMatrixStack()
     {
         return mat;
     }
     
-    public Impl getRenderTypeBuffers()
+    public IRenderTypeBuffer.Impl getRenderTypeBuffers()
     {
         return buffers;
     }

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
@@ -8,11 +8,9 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
-import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.IRenderTypeBuffer.Impl;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.RenderTypeLookup;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
@@ -48,10 +46,9 @@ public class RenderWorldPreTranslucentEventTest
         World world = DimensionManager.getWorld(server, DimensionType.OVERWORLD, false, true);
         MatrixStack matrixStack = event.getMatrixStack();
         Impl renderTypeBuffers = event.getRenderTypeBuffers();
-
+        
         // Get the projected view coordinates.
-        @SuppressWarnings("resource")
-        Vec3d projectedView = Minecraft.getInstance().gameRenderer.getActiveRenderInfo().getProjectedView();
+        Vec3d projectedView = event.getActiveRenderInfo().getProjectedView();
 
         // Choose diamond ore as the arbitrary block.
         BlockState blockState = Blocks.DIAMOND_ORE.getDefaultState();

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
@@ -1,0 +1,84 @@
+package net.minecraftforge.debug.client.rendering;
+
+import java.util.Random;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BlockRendererDispatcher;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.IRenderTypeBuffer.Impl;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypeLookup;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderWorldPreTranslucentEvent;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * A simple mod to test the RenderWorldPreTranslucentEvent.
+ * For this test, a diamond ore "block" is rendered at the coordinates (0, 128, 0).
+ */
+
+@Mod(RenderWorldPreTranslucentEventTest.MODID)
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class RenderWorldPreTranslucentEventTest
+{
+    public static final String MODID = "pre_translucent_render_test";
+    static final boolean ENABLED = true;
+
+    @SubscribeEvent
+    public static void onWorldRenderPreTranslucent(RenderWorldPreTranslucentEvent event)
+    {
+        if(!ENABLED)
+            return;
+        
+        // Get instances of the classes required for a block render.
+        MinecraftServer server = Minecraft.getInstance().getIntegratedServer();
+        World world = DimensionManager.getWorld(server, DimensionType.OVERWORLD, false, true);
+        MatrixStack matrixStack = event.getMatrixStack();
+
+        // Get the projected view coordinates.
+        @SuppressWarnings("resource")
+		Vec3d projectedView = Minecraft.getInstance().gameRenderer.getActiveRenderInfo().getProjectedView();
+
+        // Choose diamond ore as the arbitrary block.
+        BlockState blockState = Blocks.DIAMOND_ORE.getDefaultState();
+
+        // Get an IRenderTypeBuffer instance.	
+        Impl renderTypeBuffer = IRenderTypeBuffer.getImpl(Tessellator.getInstance().getBuffer());
+        
+        // Render the block at the coordinates (0, 128, 0).
+        renderBlock(matrixStack, renderTypeBuffer, world, blockState, new BlockPos(0, 128, 0), projectedView, new Vec3d(0.0, 128.0, 0.0));
+
+        renderTypeBuffer.finish();
+    }
+    
+    @SuppressWarnings("deprecation")
+	public static void renderBlock(MatrixStack matrixStack, Impl renderTypeBuffer, World world, BlockState blockState, BlockPos logicPos, Vec3d projectedView, Vec3d renderCoordinates)
+	{
+		BlockRendererDispatcher blockRendererDispatcher = Minecraft.getInstance().getBlockRendererDispatcher();
+		int i = OverlayTexture.NO_OVERLAY;
+		
+		matrixStack.push();
+		matrixStack.translate(-projectedView.x + renderCoordinates.x, -projectedView.y + renderCoordinates.y, -projectedView.z + renderCoordinates.z);
+		
+		for(RenderType renderType : RenderType.getBlockRenderTypes())
+		{
+            if(RenderTypeLookup.canRenderInLayer(blockState, renderType))
+            	blockRendererDispatcher.getBlockModelRenderer().renderModel(world, blockRendererDispatcher.getModelForState(blockState), blockState, logicPos, matrixStack, renderTypeBuffer.getBuffer(renderType), true, new Random(), blockState.getPositionRandom(logicPos), i);
+		}
+		
+		matrixStack.pop();
+	}
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldPreTranslucentEventTest.java
@@ -26,8 +26,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 /**
- * A simple mod to test the RenderWorldPreTranslucentEvent.
- * For this test, a diamond ore "block" is rendered at the coordinates (0, 128, 0).
+ * A simple mod to test the RenderWorldPreTranslucentEvent. For this test, a
+ * diamond ore "block" is rendered at the coordinates (0, 128, 0).
  */
 
 @Mod(RenderWorldPreTranslucentEventTest.MODID)
@@ -35,50 +35,48 @@ import net.minecraftforge.fml.common.Mod;
 public class RenderWorldPreTranslucentEventTest
 {
     public static final String MODID = "pre_translucent_render_test";
-    static final boolean ENABLED = true;
+    static final boolean ENABLED = false;
 
     @SubscribeEvent
     public static void onWorldRenderPreTranslucent(RenderWorldPreTranslucentEvent event)
     {
         if(!ENABLED)
             return;
-        
+
         // Get instances of the classes required for a block render.
         MinecraftServer server = Minecraft.getInstance().getIntegratedServer();
         World world = DimensionManager.getWorld(server, DimensionType.OVERWORLD, false, true);
         MatrixStack matrixStack = event.getMatrixStack();
+        Impl renderTypeBuffers = event.getRenderTypeBuffers();
 
         // Get the projected view coordinates.
         @SuppressWarnings("resource")
-		Vec3d projectedView = Minecraft.getInstance().gameRenderer.getActiveRenderInfo().getProjectedView();
+        Vec3d projectedView = Minecraft.getInstance().gameRenderer.getActiveRenderInfo().getProjectedView();
 
         // Choose diamond ore as the arbitrary block.
         BlockState blockState = Blocks.DIAMOND_ORE.getDefaultState();
 
-        // Get an IRenderTypeBuffer instance.	
-        Impl renderTypeBuffer = IRenderTypeBuffer.getImpl(Tessellator.getInstance().getBuffer());
-        
         // Render the block at the coordinates (0, 128, 0).
-        renderBlock(matrixStack, renderTypeBuffer, world, blockState, new BlockPos(0, 128, 0), projectedView, new Vec3d(0.0, 128.0, 0.0));
+        renderBlock(matrixStack, renderTypeBuffers, world, blockState, new BlockPos(0, 128, 0), projectedView, new Vec3d(0.0, 128.0, 0.0));
 
-        renderTypeBuffer.finish();
+        renderTypeBuffers.finish();
     }
-    
+
     @SuppressWarnings("deprecation")
-	public static void renderBlock(MatrixStack matrixStack, Impl renderTypeBuffer, World world, BlockState blockState, BlockPos logicPos, Vec3d projectedView, Vec3d renderCoordinates)
-	{
-		BlockRendererDispatcher blockRendererDispatcher = Minecraft.getInstance().getBlockRendererDispatcher();
-		int i = OverlayTexture.NO_OVERLAY;
-		
-		matrixStack.push();
-		matrixStack.translate(-projectedView.x + renderCoordinates.x, -projectedView.y + renderCoordinates.y, -projectedView.z + renderCoordinates.z);
-		
-		for(RenderType renderType : RenderType.getBlockRenderTypes())
-		{
+    public static void renderBlock(MatrixStack matrixStack, Impl renderTypeBuffers, World world, BlockState blockState, BlockPos logicPos, Vec3d projectedView, Vec3d renderCoordinates)
+    {
+        BlockRendererDispatcher blockRendererDispatcher = Minecraft.getInstance().getBlockRendererDispatcher();
+        int i = OverlayTexture.NO_OVERLAY;
+
+        matrixStack.push();
+        matrixStack.translate(-projectedView.x + renderCoordinates.x, -projectedView.y + renderCoordinates.y, -projectedView.z + renderCoordinates.z);
+
+        for(RenderType renderType : RenderType.getBlockRenderTypes())
+        {
             if(RenderTypeLookup.canRenderInLayer(blockState, renderType))
-            	blockRendererDispatcher.getBlockModelRenderer().renderModel(world, blockRendererDispatcher.getModelForState(blockState), blockState, logicPos, matrixStack, renderTypeBuffer.getBuffer(renderType), true, new Random(), blockState.getPositionRandom(logicPos), i);
-		}
-		
-		matrixStack.pop();
-	}
+                blockRendererDispatcher.getBlockModelRenderer().renderModel(world, blockRendererDispatcher.getModelForState(blockState), blockState, logicPos, matrixStack, renderTypeBuffers.getBuffer(renderType), true, new Random(), blockState.getPositionRandom(logicPos), i);
+        }
+
+        matrixStack.pop();
+    }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -65,3 +65,5 @@ loaderVersion="[28,)"
     modId="stencil_enable_test"
 [[mods]]
     modId="deferred_registry_test"
+[[mods]]
+    modId="pre_translucent_render_test"


### PR DESCRIPTION
This event is very similar to RenderWorldLastEvent, but is instead called right before translucent blocks are rendered in the WorldRenderer class. The reason for this being that objects rendered from RenderWorldLastEvent are always invisible behind translucent blocks, and using an event called before these blocks are rendered will not lead to this rendering problem.
A while ago I encountered that problem while working on a project involving rendering "sub-world" objects made of blocks but separate from main world chunks. One suggestion I got on Forge Forums was to submit a pull request adding a new event.
Included in this pull request is a small example mod that demonstrates rendering a single "block" in the world with this new event.