### PR TITLE
Document: Update the outdated name "PotionEffect"

### DIFF
--- a/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
@@ -54,7 +54,7 @@ public class VanillaBrewingRecipe implements IBrewingRecipe {
 
     /**
      * Code copied from TileEntityBrewingStand.brewPotions()
-     * It brews the potion by doing the bit-shifting magic and then checking if the new PotionEffect list is different to the old one,
+     * It brews the potion by doing the bit-shifting magic and then checking if the new EffectInstance list is different to the old one,
      * or if the new potion is a splash potion when the old one wasn't.
      */
     @Override

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEffect.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEffect.java
@@ -39,21 +39,21 @@ public interface IForgeEffect {
 
     /**
      * If the Potion effect should be displayed in the players inventory
-     * @param effect the active PotionEffect
+     * @param effect the active EffectInstance
      * @return true to display it (default), false to hide it.
      */
     default boolean shouldRender(EffectInstance effect) { return true; }
 
     /**
-     * If the standard PotionEffect text (name and duration) should be drawn when this potion is active.
-     * @param effect the active PotionEffect
+     * If the standard EffectInstance text (name and duration) should be drawn when this potion is active.
+     * @param effect the active EffectInstance
      * @return true to draw the standard text
      */
     default boolean shouldRenderInvText(EffectInstance effect) { return true; }
 
     /**
      * If the Potion effect should be displayed in the player's ingame HUD
-     * @param effect the active PotionEffect
+     * @param effect the active EffectInstance
      * @return true to display it (default), false to hide it.
      */
     default boolean shouldRenderHUD(EffectInstance effect) { return true; }
@@ -62,7 +62,7 @@ public interface IForgeEffect {
      * Called to draw the this Potion onto the player's inventory when it's active.
      * This can be used to e.g. render Potion icons from your own texture.
      *
-     * @param effect the active PotionEffect
+     * @param effect the active EffectInstance
      * @param gui the gui instance
      * @param x the x coordinate
      * @param y the y coordinate
@@ -74,7 +74,7 @@ public interface IForgeEffect {
     /**
      * Called to draw the this Potion onto the player's ingame HUD when it's active.
      * This can be used to e.g. render Potion icons from your own texture.
-     * @param effect the active PotionEffect
+     * @param effect the active EffectInstance
      * @param gui the gui instance
      * @param x the x coordinate
      * @param y the y coordinate
@@ -86,8 +86,8 @@ public interface IForgeEffect {
 
     /**
      * Get a fresh list of items that can cure this Potion.
-     * All new PotionEffects created from this Potion will call this to initialize the default curative items
-     * @see PotionEffect#getCurativeItems
+     * All new EffectInstances created from this Potion will call this to initialize the default curative items
+     * @see EffectInstance#getCurativeItems
      * @return A list of items that can cure this Potion
      */
     default List<ItemStack> getCurativeItems() {
@@ -97,10 +97,10 @@ public interface IForgeEffect {
     }
 
     /**
-     * Used for determining {@code PotionEffect} sort order in GUIs.
-     * Defaults to the {@code PotionEffect}'s liquid color.
-     * @param potionEffect the {@code PotionEffect} instance containing the potion
-     * @return a value used to sort {@code PotionEffect}s in GUIs
+     * Used for determining {@code EffectInstance} sort order in GUIs.
+     * Defaults to the {@code EffectInstance}'s liquid color.
+     * @param EffectInstance the {@code EffectInstance} instance containing the potion
+     * @return a value used to sort {@code EffectInstance}s in GUIs
      */
     default int getGuiSortColor(EffectInstance potionEffect) {
        return getEffect().getLiquidColor();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEffectInstance.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEffectInstance.java
@@ -46,7 +46,7 @@ public interface IForgeEffectInstance {
     }
 
     /**
-     * If the standard PotionEffect text (name and duration) should be drawn when this potion is active.
+     * If the standard EffectInstance text (name and duration) should be drawn when this potion is active.
      * @return true to draw the standard text
      */
     default boolean shouldRenderInvText() {
@@ -100,8 +100,8 @@ public interface IForgeEffectInstance {
 
     /***
      * Checks the given ItemStack to see if it is in the list of curative items for the potion effect
-     * @param stack The ItemStack being checked against the list of curative items for this PotionEffect
-     * @return true if the given ItemStack is in the list of curative items for this PotionEffect, false otherwise
+     * @param stack The ItemStack being checked against the list of curative items for this EffectInstance
+     * @return true if the given ItemStack is in the list of curative items for this EffectInstance, false otherwise
      */
     default boolean isCurativeItem(ItemStack stack) {
        return this.getCurativeItems().stream().anyMatch(e -> e.isItemEqual(stack));
@@ -114,7 +114,7 @@ public interface IForgeEffectInstance {
     void setCurativeItems(List<ItemStack> curativeItems);
 
     /***
-     * Adds the given stack to the list of curative items for this PotionEffect
+     * Adds the given stack to the list of curative items for this EffectInstance
      * @param stack The ItemStack being added to the curative item list
      */
     default void addCurativeItem(ItemStack stack) {

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -44,7 +44,7 @@ public class PotionEvent extends LivingEvent
         this.effect = effect;
     }
     /**
-     * Retuns the PotionEffect.
+     * Retuns the EffectInstance.
      */
     @Nullable
     public EffectInstance getPotionEffect()
@@ -83,7 +83,7 @@ public class PotionEvent extends LivingEvent
         }
         
         /**
-         * @return the PotionEffect. In the remove event this can be null if the Entity does not have a {@link Potion} of the right type active.
+         * @return the EffectInstance. In the remove event this can be null if the Entity does not have a {@link Potion} of the right type active.
          */
         @Override
         @Nullable
@@ -110,7 +110,7 @@ public class PotionEvent extends LivingEvent
         }
         
         /**
-         * @return the PotionEffect.
+         * @return the EffectInstance.
          */
         @Override
         @Nonnull
@@ -136,7 +136,7 @@ public class PotionEvent extends LivingEvent
         }
         
         /**
-         * @return the added PotionEffect. This is the umerged PotionEffect if the old PotionEffect is not null.
+         * @return the added EffectInstance. This is the umerged EffectInstance if the old EffectInstance is not null.
          */
         @Override
         @Nonnull
@@ -146,7 +146,7 @@ public class PotionEvent extends LivingEvent
         }
         
         /**
-         * @return the old PotionEffect. THis can be null if the entity did not have an effect of this kind before.
+         * @return the old EffectInstance. THis can be null if the entity did not have an effect of this kind before.
          */
         @Nullable
         public EffectInstance getOldPotionEffect()


### PR DESCRIPTION
Change:
    Replace name "PotionEffect" to "EffectInstance" in documents.

Note:
    Does NOT change the name of methods.