### PR TITLE
FluidAttributes: switch to imperial bucket.

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -58,7 +58,7 @@ import net.minecraft.world.biome.BiomeColors;
  */
 public class FluidAttributes
 {
-    public static final int BUCKET_VOLUME = 1000;
+    public static final int BUCKET_VOLUME = 1296;
 
     private String translationKey;
 


### PR DESCRIPTION
[Forum Thread](https://forums.minecraftforge.net/topic/86964-bucket-volume-or-imperial-vs-metric/)
So. This one may be controversial. A fairly large amount of fluid use is for
'molten $foo', where foo can be vanilla or modded ores, and things of a similar
bent. 1000 units of fluid per bucket don't work terribly well mathmatically for
this use.

Metric is a great system, for the most part, but within minecraft crafting tends
towards a base-9 or base-4 system of crafting. If 1000mb of molten iron is cast
to 1 iron block, there is no even way to divide that evenly into 9 ingots or 81
nuggets. Using 1296, we have 1296mb for a 3x3 block, 144mb for an ingot, and
16mb for a nugget.

With 1.16 to be released soon it seems like now would be the time to make a
clean break, since modders are already going to be updating (hopefully).

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>