### PR TITLE
Use Fluid's fillSound rather than emptySound when filling buckets

### DIFF
--- a/patches/minecraft/net/minecraft/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BucketItem.java.patch
@@ -35,7 +35,7 @@
                       p_77659_2_.func_71029_a(Stats.field_75929_E.func_199076_b(this));
 -                     p_77659_2_.func_184185_a(fluid.func_207185_a(FluidTags.field_206960_b) ? SoundEvents.field_187633_N : SoundEvents.field_187630_M, 1.0F, 1.0F);
 +
-+                     SoundEvent soundevent = this.field_77876_a.getAttributes().getEmptySound();
++                     SoundEvent soundevent = this.field_77876_a.getAttributes().getFillSound();
 +                     if (soundevent == null) soundevent = fluid.func_207185_a(FluidTags.field_206960_b) ? SoundEvents.field_187633_N : SoundEvents.field_187630_M;
 +                     p_77659_2_.func_184185_a(soundevent, 1.0F, 1.0F);
                       ItemStack itemstack1 = this.func_150910_a(itemstack, p_77659_2_, fluid.func_204524_b());


### PR DESCRIPTION
Probably just a simple mixup here, the getEmptySound() is used where BucketItem actually is picking up a fluid (thus, the fillSound should be played).

The two obfuscated names on the next line for the vanilla sounds map to ITEM_BUCKET_FILL_LAVA & ITEM_BUCKET_FILL.