### PR TITLE
Provide empty/fill sounds for vanilla fluids

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -95,6 +95,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.IntIdentityHashBiMap;
 import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -851,13 +852,17 @@ public class ForgeHooks
                     new ResourceLocation("block/water_flow"))
                     .overlay(new ResourceLocation("block/water_overlay"))
                     .translationKey("block.minecraft.water")
-                    .color(0xFF3F76E4).build(fluid);
+                    .color(0xFF3F76E4)
+                    .sound(SoundEvents.ITEM_BUCKET_FILL, SoundEvents.ITEM_BUCKET_EMPTY)
+                    .build(fluid);
         if (fluid instanceof LavaFluid)
             return net.minecraftforge.fluids.FluidAttributes.builder(
                     new ResourceLocation("block/lava_still"),
                     new ResourceLocation("block/lava_flow"))
                     .translationKey("block.minecraft.lava")
-                    .luminosity(15).density(3000).viscosity(6000).temperature(1300).build(fluid);
+                    .luminosity(15).density(3000).viscosity(6000).temperature(1300)
+                    .sound(SoundEvents.ITEM_BUCKET_FILL_LAVA, SoundEvents.ITEM_BUCKET_EMPTY_LAVA)
+                    .build(fluid);
         throw new RuntimeException("Mod fluids must override createAttributes.");
     }
 


### PR DESCRIPTION
This PR aims to make playing fluid empty/fill sounds easier or mods by providing the Vanilla sounds in the Vanilla fluid attributes. This removes the need to "special-case" this in the mod.

NOTE1: This changes behavior in that previously the "minecraft:lava" fluid tag would toggle the lava empty/fill sound for buckets (if the FluidAttributes did not specify a sound).
Removing the lava fluid from that tag would now no longer change the sound to the water empty/fill sounds.
NOTE2: Without #6786, this PR would incorrectly use the liquid attribute's empty sound when filling a bucket.