### PR TITLE
[1.15] Redirect to new Forge model methods in vanilla multipart model

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/client/renderer/model/MultipartBakedModel.java
++++ b/net/minecraft/client/renderer/model/MultipartBakedModel.java
+@@ -27,10 +27,12 @@
+    protected final ItemCameraTransforms field_188624_d;
+    protected final ItemOverrideList field_188625_e;
+    private final Map<BlockState, BitSet> field_210277_g = new Object2ObjectOpenCustomHashMap<>(Util.func_212443_g());
++   private final IBakedModel firstModel;
+ 
+    public MultipartBakedModel(List<Pair<Predicate<BlockState>, IBakedModel>> p_i48273_1_) {
+       this.field_188626_f = p_i48273_1_;
+       IBakedModel ibakedmodel = p_i48273_1_.iterator().next().getRight();
++      this.firstModel = ibakedmodel;
+       this.field_188621_a = ibakedmodel.func_177555_b();
+       this.field_188622_b = ibakedmodel.func_177556_c();
+       this.field_230185_c_ = ibakedmodel.func_230044_c_();
+@@ -98,6 +100,22 @@
+       return this.field_188625_e;
+    }
+ 
++   public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, net.minecraftforge.client.model.data.IModelData extraData) {
++      return net.minecraftforge.client.ForgeHooksClient.getMultipartModelQuads(this.field_188626_f, this.field_210277_g, state, side, rand, extraData);
++   }
++
++   public boolean isAmbientOcclusion(BlockState state) {
++      return this.firstModel.isAmbientOcclusion(state);
++   }
++
++   public net.minecraftforge.client.model.data.IModelData getModelData(net.minecraft.world.ILightReader world, net.minecraft.util.math.BlockPos pos, BlockState state, net.minecraftforge.client.model.data.IModelData tileData) {
++      return this.firstModel.getModelData(world, pos, state, tileData);
++   }
++
++   public TextureAtlasSprite getParticleTexture(net.minecraftforge.client.model.data.IModelData data) {
++      return this.firstModel.getParticleTexture(data);
++   }
++
+    @OnlyIn(Dist.CLIENT)
+    public static class Builder {
+       private final List<Pair<Predicate<BlockState>, IBakedModel>> field_188649_a = Lists.newArrayList();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -42,20 +42,28 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.async.ThreadNameCachingStrategy;
@@ -659,6 +667,41 @@ public class ForgeHooksClient
             tr.push(stack);
         }
         return model;
+    }
+
+    public static List<BakedQuad> getMultipartModelQuads(List<Pair<Predicate<BlockState>, IBakedModel>> selectors, Map<BlockState, BitSet> bitSetMap, @Nullable BlockState state, @Nullable Direction side, Random rand, IModelData data) {
+        if (state == null)
+        {
+            return Collections.emptyList();
+        }
+
+        BitSet bitset = bitSetMap.get(state);
+        if (bitset == null)
+        {
+            bitset = new BitSet();
+
+            for(int i = 0; i < selectors.size(); ++i)
+            {
+                Pair<Predicate<BlockState>, IBakedModel> pair = selectors.get(i);
+                if (pair.getLeft().test(state))
+                {
+                    bitset.set(i);
+                }
+            }
+
+            bitSetMap.put(state, bitset);
+        }
+
+        List<BakedQuad> list = Lists.newArrayList();
+        long k = rand.nextLong();
+        for(int j = 0; j < bitset.length(); ++j)
+        {
+            if (bitset.get(j)) {
+                list.addAll(selectors.get(j).getRight().getQuads(state, side, new Random(k), data));
+            }
+        }
+
+        return list;
     }
 
     public static void onInputUpdate(PlayerEntity player, MovementInput movementInput)

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -25,9 +25,14 @@ import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.FenceBlock;
 import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.IModelTransform;
 import net.minecraft.client.renderer.model.IUnbakedModel;
+import net.minecraft.client.renderer.model.ItemOverrideList;
 import net.minecraft.client.renderer.model.ModelBakery;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -44,10 +49,15 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.ILightReader;
+import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.IModelBuilder;
 import net.minecraftforge.client.model.IModelConfiguration;
 import net.minecraftforge.client.model.IModelLoader;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
+import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.data.ModelDataMap;
+import net.minecraftforge.client.model.data.ModelProperty;
 import net.minecraftforge.client.model.geometry.ISimpleModelGeometry;
 import net.minecraftforge.client.model.pipeline.BakedQuadBuilder;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -58,11 +68,15 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Mod(NewModelLoaderTest.MODID)
 public class NewModelLoaderTest
@@ -96,6 +110,8 @@ public class NewModelLoaderTest
             }
     );
 
+    public static RegistryObject<Block> multipart_block = BLOCKS.register("multipart_block", () -> new FenceBlock(Block.Properties.create(Material.WOOD).hardnessAndResistance(10)));
+
     public static RegistryObject<Item> obj_item = ITEMS.register("obj_block", () ->
             new BlockItem(obj_block.get(), new Item.Properties().group(ItemGroup.MISC)) {
                 @Override
@@ -105,6 +121,7 @@ public class NewModelLoaderTest
                 }
             }
     );
+    public static RegistryObject<Item> multipart_item = ITEMS.register("multipart_block", () -> new BlockItem(multipart_block.get(), new Item.Properties().group(ItemGroup.MISC)));
 
     public static RegistryObject<Item> custom_transforms = ITEMS.register("custom_transforms", () ->
             new Item(new Item.Properties().group(ItemGroup.MISC))
@@ -171,6 +188,12 @@ public class NewModelLoaderTest
             modelBuilder.addGeneralQuad(builder.build());
         }
 
+        @Override
+        public IBakedModel bake(IModelConfiguration owner, ModelBakery bakery, Function<net.minecraft.client.renderer.model.Material, TextureAtlasSprite> spriteGetter, IModelTransform modelTransform, ItemOverrideList overrides, ResourceLocation modelLocation)
+        {
+            return new BakedTestModel(ISimpleModelGeometry.super.bake(owner, bakery, spriteGetter, modelTransform, overrides, modelLocation));
+        }
+
         private void putVertex(BakedQuadBuilder builder, int x, float y, float z, float u, float v, float red, float green, float blue)
         {
             ImmutableList<VertexFormatElement> elements = DefaultVertexFormats.BLOCK.getElements();
@@ -201,6 +224,34 @@ public class NewModelLoaderTest
         public Collection<net.minecraft.client.renderer.model.Material> getTextures(IModelConfiguration owner, Function<ResourceLocation, IUnbakedModel> modelGetter, Set<Pair<String, String>> missingTextureErrors)
         {
             return Collections.singleton(owner.resolveTexture("particle"));
+        }
+    }
+
+    static class BakedTestModel extends BakedModelWrapper<IBakedModel>
+    {
+        private static final ModelProperty<Boolean> INVISIBLE = new ModelProperty<>();
+        BakedTestModel(IBakedModel originalModel)
+        {
+            super(originalModel);
+        }
+
+        @Override
+        public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, IModelData extraData)
+        {
+            if (extraData.getData(INVISIBLE) == Boolean.TRUE) {
+                return ImmutableList.of();
+            }
+            return originalModel.getQuads(state, side, rand, extraData);
+        }
+
+        @Nonnull
+        @Override
+        public IModelData getModelData(ILightReader world, BlockPos pos, BlockState state, IModelData tileData)
+        {
+            if (world.getBlockState(pos.down()).getBlock() == Blocks.WHITE_WOOL) {
+                return new ModelDataMap.Builder().withInitial(INVISIBLE, true).build();
+            }
+            return tileData;
         }
     }
 }

--- a/src/test/resources/assets/new_model_loader_test/blockstates/multipart_block.json
+++ b/src/test/resources/assets/new_model_loader_test/blockstates/multipart_block.json
@@ -1,0 +1,17 @@
+{
+    "multipart": [
+        {   "apply": { "model": "new_model_loader_test:block/multipart_block" }},
+        {   "when": { "north": "true" },
+            "apply": { "model": "block/oak_fence_side", "uvlock": true }
+        },
+        {   "when": { "east": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 90, "uvlock": true }
+        },
+        {   "when": { "south": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 180, "uvlock": true }
+        },
+        {   "when": { "west": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 270, "uvlock": true }
+        }
+    ]
+}

--- a/src/test/resources/assets/new_model_loader_test/models/block/multipart_block.json
+++ b/src/test/resources/assets/new_model_loader_test/models/block/multipart_block.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/block",
+  "loader": "new_model_loader_test:custom_loader",
+  "textures": {
+    "particle": "block/oak_planks"
+  }
+}


### PR DESCRIPTION
This pull request makes the vanilla multipart model redirect the Forge `BlockState` variants of `isAmbientOcclusion` and `getParticleTexture` to the first model in the multipart model, for consistency with the stateless variants.

In addition, `getQuads` now passes along the `IModelData` instance to each submodel. I currently have that logic pulled into `ForgeHooksClient` as it was quite large, let me know if there is a preferred place to put that code.

I simply redirected `getModelData` to the first model for consistency with the other methods, as that is sufficient for most needs, including my own. We could potentially call the method for each submodel, passing the previous as `tileData`, but I think its very unlikely to have two different model loaders/sets of model data in a single multipart model, and in many cases that will be inefficient as you run the same logic multiple times (as each child likely has the same loader).

----

Included in this pull request is an update to the model loader test mod, adding in `multipart_block`. This block uses the fence model, but the center post is replaced with a "dynamic" model that turns invisible when placed above white wool. Note it does not have the tag for the block to connect to itself, so place it near solid blocks to test (was not sure it was worth adding the tag since that is beyond the point of the test mod)