### PR TITLE
[1.15] Fix being unable to add a custom milk fluid to vanilla milk buckets

### DIFF
--- a/patches/minecraft/net/minecraft/item/MilkBucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MilkBucketItem.java.patch
@@ -20,13 +20,3 @@
        return p_77654_1_.func_190926_b() ? new ItemStack(Items.field_151133_ar) : p_77654_1_;
     }
  
-@@ -44,4 +42,9 @@
-       p_77659_2_.func_184598_c(p_77659_3_);
-       return ActionResult.func_226248_a_(p_77659_2_.func_184586_b(p_77659_3_));
-    }
-+
-+   @Override
-+   public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @javax.annotation.Nullable net.minecraft.nbt.CompoundNBT nbt) {
-+      return new net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper(stack);
-+   }
- }

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -641,10 +641,6 @@ public class FluidUtil
             {
                 return new ItemStack(Items.LAVA_BUCKET);
             }
-            else if (fluid.getRegistryName().equals(new ResourceLocation("milk")))
-            {
-                return new ItemStack(Items.MILK_BUCKET);
-            }
         }
 
         return fluid.getAttributes().getBucket(fluidStack);

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -25,15 +25,14 @@ import javax.annotation.Nullable;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.*;
 import net.minecraft.util.Direction;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 /**
  * Wrapper for vanilla and forge buckets.
@@ -60,7 +59,7 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
 
     public boolean canFillFluidType(FluidStack fluid)
     {
-        if (fluid.getFluid() == Fluids.WATER || fluid.getFluid() == Fluids.LAVA || fluid.getFluid().getRegistryName().equals(new ResourceLocation("milk")))
+        if (fluid.getFluid() == Fluids.WATER || fluid.getFluid() == Fluids.LAVA)
         {
             return true;
         }
@@ -117,7 +116,7 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
     @Override
     public int fill(FluidStack resource, FluidAction action)
     {
-        if (container.getCount() != 1 || resource.getAmount() < FluidAttributes.BUCKET_VOLUME || container.getItem() instanceof MilkBucketItem || !getFluid().isEmpty() || !canFillFluidType(resource))
+        if (container.getCount() != 1 || resource.getAmount() < FluidAttributes.BUCKET_VOLUME || !getFluid().isEmpty() || !canFillFluidType(resource))
         {
             return 0;
         }

--- a/src/test/java/net/minecraftforge/debug/fluid/MilkFluidTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/MilkFluidTest.java
@@ -1,0 +1,180 @@
+package net.minecraftforge.debug.fluid;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.FlowingFluidBlock;
+import net.minecraft.block.material.Material;
+import net.minecraft.fluid.FlowingFluid;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Mod(MilkFluidTest.MODID)
+public class MilkFluidTest
+{
+    public static final String MODID = "milk_fluid_test";
+    // if true, enables the fluid wrapper added by this test mod
+    private static final boolean ENABLE_FLUID_WRAPPER = false;
+
+    public static final ResourceLocation FLUID_TEXTURE = new ResourceLocation("minecraft:block/white_concrete");
+    public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    public static final DeferredRegister<Fluid> FLUIDS = DeferredRegister.create(ForgeRegistries.FLUIDS, MODID);
+
+    private static ForgeFlowingFluid.Properties makeProperties()
+    {
+        return new ForgeFlowingFluid.Properties(milk, milk_flowing, FluidAttributes.builder(FLUID_TEXTURE, FLUID_TEXTURE))
+            .bucket(Items.MILK_BUCKET.delegate).block(milk_block);
+    }
+
+    public static RegistryObject<FlowingFluid> milk = FLUIDS.register("milk", () ->
+        new ForgeFlowingFluid.Source(makeProperties())
+    );
+    public static RegistryObject<FlowingFluid> milk_flowing = FLUIDS.register("flowing_milk", () ->
+        new ForgeFlowingFluid.Flowing(makeProperties())
+    );
+
+    public static RegistryObject<FlowingFluidBlock> milk_block = BLOCKS.register("milk_block", () ->
+        new FlowingFluidBlock(milk, Block.Properties.create(Material.WATER).doesNotBlockMovement().hardnessAndResistance(100.0F).noDrops())
+    );
+
+    public MilkFluidTest()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        BLOCKS.register(modEventBus);
+        FLUIDS.register(modEventBus);
+        MinecraftForge.EVENT_BUS.addGenericListener(ItemStack.class, MilkFluidTest::initCapabilities);
+        if (ENABLE_FLUID_WRAPPER) {
+            MinecraftForge.EVENT_BUS.addListener(MilkFluidTest::useMilk);
+        }
+    }
+
+    public static void initCapabilities(AttachCapabilitiesEvent<ItemStack> event)
+    {
+        ItemStack stack = event.getObject();
+        if (stack.getItem() == Items.MILK_BUCKET)
+        {
+            event.addCapability(new ResourceLocation(MODID, "milk"), new FluidMilkBucketWrapper(stack));
+        }
+    }
+
+    public static void useMilk(PlayerInteractEvent event)
+    {
+        ItemStack stack = event.getItemStack();
+        if (stack.getItem() == Items.MILK_BUCKET)
+        {
+            FluidUtil.getFluidContained(stack).ifPresent((fluid) -> event.getPlayer().sendStatusMessage(new StringTextComponent("Contains ").appendText(fluid.getFluid().getRegistryName().toString()), true));
+        }
+    }
+
+    public static class FluidMilkBucketWrapper implements IFluidHandlerItem, ICapabilityProvider
+    {
+        private final LazyOptional<IFluidHandlerItem> holder = LazyOptional.of(() -> this);
+
+        @Nonnull
+        private ItemStack container;
+        public FluidMilkBucketWrapper(@Nonnull ItemStack container)
+        {
+            this.container = container;
+        }
+
+        @Nonnull
+        @Override
+        public ItemStack getContainer()
+        {
+            return container;
+        }
+
+        @Override
+        public int getTanks()
+        {
+            return 1;
+        }
+
+        @Nonnull
+        private FluidStack getFluid()
+        {
+            return new FluidStack(milk.get(), FluidAttributes.BUCKET_VOLUME);
+        }
+
+        @Nonnull
+        @Override
+        public FluidStack getFluidInTank(int tank)
+        {
+            return getFluid();
+        }
+
+        @Override
+        public int getTankCapacity(int tank)
+        {
+            return FluidAttributes.BUCKET_VOLUME;
+        }
+
+        @Override
+        public boolean isFluidValid(int tank, @Nonnull FluidStack stack)
+        {
+            return true;
+        }
+
+        @Override
+        public int fill(FluidStack resource, FluidAction action)
+        {
+            return 0;
+        }
+
+        @Nonnull
+        @Override
+        public FluidStack drain(FluidStack resource, FluidAction action)
+        {
+            if (resource.getFluid() != milk.get())
+            {
+                return FluidStack.EMPTY;
+            }
+            return drain(resource.getAmount(), action);
+        }
+
+        @Nonnull
+        @Override
+        public FluidStack drain(int maxDrain, FluidAction action)
+        {
+            if (maxDrain < FluidAttributes.BUCKET_VOLUME)
+            {
+                return FluidStack.EMPTY;
+            }
+            if (action.execute())
+            {
+                container = new ItemStack(Items.BUCKET);
+            }
+            return getFluid();
+        }
+
+        @Nonnull
+        @Override
+        public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction side)
+        {
+            return CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY.orEmpty(capability, holder);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -68,3 +68,5 @@ loaderVersion="[28,)"
     modId="stencil_enable_test"
 [[mods]]
     modId="deferred_registry_test"
+[[mods]]
+    modId="milk_fluid_test"

--- a/src/test/resources/assets/milk_fluid_test/blockstates/milk_block.json
+++ b/src/test/resources/assets/milk_fluid_test/blockstates/milk_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "milk_fluid_test:block/milk_block" }
+  }
+}

--- a/src/test/resources/assets/milk_fluid_test/models/block/milk_block.json
+++ b/src/test/resources/assets/milk_fluid_test/models/block/milk_block.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "block/white_concrete"
+  }
+}


### PR DESCRIPTION
Forge currently provides a fluid bucket wrapper that adds fluid support for vanilla buckets. However, on the milk bucket the wrapper does not properly work as Forge provides no milk fluid, and unlike in 1.12 there is no longer a global name for milk (#6769). This pull request removes the milk bucket wrapper as Forge has other systems in place that can meet the same need as that code was intended to meet.

To demonstrate the way modders can accomplish a custom milk and to make sure my changes work, this PR adds a test mod that adds a milk fluid and makes the milk bucket support it. You can test picking up milk by using `/setblock ~ ~ ~ milk_fluid_test:milk_block` then picking it up with a bucket. If you enable the fluid handler wrapper in the test mod, you can then right click the bucket and it will return the contained fluid.