### PR TITLE
[1.15.x] Fix tryEmptyContainer() ignoring doDrain, and always filling the dest container

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -180,7 +180,7 @@ public class FluidUtil
                 .map(containerFluidHandler -> {
 
                     // We are acting on a COPY of the stack, so performing changes is acceptable even if we are simulating.
-                    FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, true);
+                    FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, doDrain);
                     if (transfer.isEmpty())
                         return FluidActionResult.FAILURE;
 


### PR DESCRIPTION
#6796