### PR TITLE
Fix Forge experimental render pipeline lighting issue

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 
 public class VertexLighterFlat extends QuadGatheringTransformer
 {
+    private static final float LIGHT_UNPACK_SCALE = (float) Short.MAX_VALUE / 0xF0;
     protected static final VertexFormatElement NORMAL_4F = new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.NORMAL, 4);
 
     protected final BlockInfo blockInfo;
@@ -198,7 +199,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
                 z += normal[v][2] * .5f;
             }
 
-            float blockLight = lightmap[v][0], skyLight = lightmap[v][1];
+            float blockLight = lightmap[v][0] * LIGHT_UNPACK_SCALE, skyLight = lightmap[v][1] * LIGHT_UNPACK_SCALE;
             updateLightmap(normal[v], lightmap[v], x, y, z);
             if(dataLength[lightmapIndex] > 1)
             {


### PR DESCRIPTION
This PR fixes the experimental lighting pipeline not properly taking unpacked BakedQuad lighting into account.

Specifically, VertexLighterFlat fails to scale light values unpacked via LightUtil from a scale of 0 -> (240 / Short.MAX_VALUE) to a scale of 0 -> 1, as is used by subsequent lighting logic. The proposed changes add this scaling to allow for proper comparison against scaled lighting of unpacked BakedQuads.