### PR TITLE
Fix villager trades tool enchants

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -23,7 +23,7 @@
  
        for(Enchantment enchantment : Registry.field_212628_q) {
 -         if ((!enchantment.func_185261_e() || p_185291_2_) && enchantment.func_230310_i_() && (enchantment.field_77351_y.func_77557_a(item) || flag)) {
-+         if ((!enchantment.func_185261_e() || p_185291_2_) && (enchantment.canApplyAtEnchantingTable(p_185291_1_) || (flag || enchantment.isAllowedOnBooks()))) {
++         if ((!enchantment.func_185261_e() || p_185291_2_) && (enchantment.canApplyAtEnchantingTable(p_185291_1_) || (flag && enchantment.isAllowedOnBooks()))) {
              for(int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i) {
                 if (p_185291_0_ >= enchantment.func_77321_a(i) && p_185291_0_ <= enchantment.func_223551_b(i)) {
                    list.add(new EnchantmentData(enchantment, i));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -174,3 +174,4 @@ private-f net.minecraft.world.server.ChunkHolder field_219320_o # block update l
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 public net.minecraft.world.storage.FolderName <init>(Ljava/lang/String;)V # constructor
+public net.minecraft.item.ItemModelsProperties func_239418_a_(Lnet/minecraft/item/Item;Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/IItemPropertyGetter;)V


### PR DESCRIPTION
The person who went over the patch put an OR instead of an AND

also added an AT for ItemModelProperties (aka itempropertyoverrides)