### PR TITLE
[1.16.x] Store and expose language on ServerPlayerEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -15,7 +15,15 @@
  import javax.annotation.Nullable;
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.advancements.PlayerAdvancements;
-@@ -464,6 +460,7 @@
+@@ -145,6 +141,7 @@
+    private boolean field_71147_cj = true;
+    private int field_71144_ck = -99999999;
+    private int field_147101_bU = 60;
++   public String language;
+    private ChatVisibility field_71143_cn;
+    private boolean field_71140_co = true;
+    private long field_143005_bX = Util.func_211177_b();
+@@ -464,6 +461,7 @@
     }
  
     public void func_70645_a(DamageSource p_70645_1_) {
@@ -23,7 +31,7 @@
        boolean flag = this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223609_l);
        if (flag) {
           ITextComponent itextcomponent = this.func_110142_aN().func_151521_b();
-@@ -597,12 +594,13 @@
+@@ -597,12 +595,13 @@
  
     @Nullable
     public Entity func_241206_a_(ServerWorld p_241206_1_) {
@@ -38,7 +46,7 @@
           if (!this.field_71136_j) {
              this.field_71136_j = true;
              this.field_71135_a.func_147359_a(new SChangeGameStatePacket(SChangeGameStatePacket.field_241768_e_, this.field_192040_cp ? 0.0F : 1.0F));
-@@ -616,8 +614,8 @@
+@@ -616,8 +615,8 @@
           this.field_71135_a.func_147359_a(new SServerDifficultyPacket(iworldinfo.func_176130_y(), iworldinfo.func_176123_z()));
           PlayerList playerlist = this.field_71133_b.func_184103_al();
           playerlist.func_187243_f(this);
@@ -49,7 +57,7 @@
           double d0 = this.func_226277_ct_();
           double d1 = this.func_226278_cu_();
           double d2 = this.func_226281_cx_();
-@@ -689,6 +687,7 @@
+@@ -689,6 +688,7 @@
           this.field_71144_ck = -1;
           this.field_71149_ch = -1.0F;
           this.field_71146_ci = -1;
@@ -57,7 +65,7 @@
           return this;
        }
     }
-@@ -731,6 +730,9 @@
+@@ -731,6 +731,9 @@
     }
  
     public Either<PlayerEntity.SleepResult, Unit> func_213819_a(BlockPos p_213819_1_) {
@@ -67,7 +75,7 @@
        Direction direction = this.field_70170_p.func_180495_p(p_213819_1_).func_177229_b(HorizontalBlock.field_185512_D);
        if (!this.func_70608_bn() && this.func_70089_S()) {
           if (!this.field_70170_p.func_230315_m_().func_236043_f_()) {
-@@ -775,6 +777,7 @@
+@@ -775,6 +778,7 @@
     }
  
     private boolean func_241147_a_(BlockPos p_241147_1_, Direction p_241147_2_) {
@@ -75,7 +83,7 @@
        return this.func_241158_g_(p_241147_1_) || this.func_241158_g_(p_241147_1_.func_177972_a(p_241147_2_.func_176734_d()));
     }
  
-@@ -874,6 +877,7 @@
+@@ -874,6 +878,7 @@
              this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_()));
              container.func_75132_a(this);
              this.field_71070_bA = container;
@@ -83,7 +91,7 @@
              return OptionalInt.of(this.field_71139_cq);
           }
        }
-@@ -892,6 +896,7 @@
+@@ -892,6 +897,7 @@
        this.field_71135_a.func_147359_a(new SOpenHorseWindowPacket(this.field_71139_cq, p_184826_2_.func_70302_i_(), p_184826_1_.func_145782_y()));
        this.field_71070_bA = new HorseInventoryContainer(this.field_71139_cq, this.field_71071_by, p_184826_2_, p_184826_1_);
        this.field_71070_bA.func_75132_a(this);
@@ -91,7 +99,7 @@
     }
  
     public void func_184814_a(ItemStack p_184814_1_, Hand p_184814_2_) {
-@@ -949,6 +954,7 @@
+@@ -949,6 +955,7 @@
  
     public void func_71128_l() {
        this.field_71070_bA.func_75134_a(this);
@@ -99,7 +107,7 @@
        this.field_71070_bA = this.field_71069_bz;
     }
  
-@@ -1075,6 +1081,13 @@
+@@ -1075,6 +1082,13 @@
        this.field_193110_cw = p_193104_1_.field_193110_cw;
        this.func_192029_h(p_193104_1_.func_192023_dk());
        this.func_192031_i(p_193104_1_.func_192025_dl());
@@ -113,7 +121,15 @@
     }
  
     protected void func_70670_a(EffectInstance p_70670_1_) {
-@@ -1291,14 +1304,14 @@
+@@ -1177,6 +1191,7 @@
+    }
+ 
+    public void func_147100_a(CClientSettingsPacket p_147100_1_) {
++      this.language = p_147100_1_.field_149530_a;
+       this.field_71143_cn = p_147100_1_.func_149523_e();
+       this.field_71140_co = p_147100_1_.func_149520_f();
+       this.func_184212_Q().func_187227_b(field_184827_bp, (byte)p_147100_1_.func_149521_d());
+@@ -1291,14 +1306,14 @@
        this.func_184210_p();
        if (p_200619_1_ == this.field_70170_p) {
           this.field_71135_a.func_147364_a(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
@@ -131,7 +147,7 @@
           this.func_70012_b(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
           this.func_70029_a(p_200619_1_);
           p_200619_1_.func_217446_a(this);
-@@ -1307,6 +1320,7 @@
+@@ -1307,6 +1322,7 @@
           this.field_71134_c.func_73080_a(p_200619_1_);
           this.field_71133_b.func_184103_al().func_72354_b(this, p_200619_1_);
           this.field_71133_b.func_184103_al().func_72385_f(this);
@@ -139,7 +155,7 @@
        }
  
     }
-@@ -1375,6 +1389,8 @@
+@@ -1375,6 +1391,8 @@
        if (itementity == null) {
           return null;
        } else {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -137,6 +137,7 @@ public net.minecraft.item.crafting.TippedArrowRecipe
 private-f net.minecraft.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.loot.LootPool field_186456_d # bonusRolls
 public net.minecraft.nbt.NumberNBT
+public net.minecraft.network.play.client.CClientSettingsPacket field_149530_a # lang
 public net.minecraft.network.status.server.SServerInfoPacket field_149297_a # GSON
 public net.minecraft.particles.BasicParticleType <init>(Z)V
 public net.minecraft.particles.ParticleType <init>(ZLnet/minecraft/particles/IParticleData$IDeserializer;)V


### PR DESCRIPTION
This is needed by WorldEdit to have its strings translated according to the client's language, without needing WorldEdit to be installed on the client.