### PR TITLE
Fix forge loading screen

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -140,6 +140,7 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
 
         glEnableClientState(GL11.GL_VERTEX_ARRAY);
         glEnable(GL_BLEND);
+        renderBackground();
         renderMessages();
         glfwSwapBuffers(window);
     }
@@ -208,6 +209,16 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         int k = clamp((int)(f5 * 255.0F), 0, 255);
         int l = clamp((int)(f6 * 255.0F), 0, 255);
         return j << 16 | k << 8 | l;
+    }
+
+    private void renderBackground() {
+        glBegin(GL_QUADS);
+        glColor4f(239F / 255F, 50F / 255F, 61F / 255F, 255F / 255F); //Color from ResourceLoadProgressGui
+        glVertex2f(0, 0);
+        glVertex2f(0, screenHeight);
+        glVertex2f(screenWidth, screenHeight);
+        glVertex2f(screenWidth, 0);
+        glEnd();
     }
 
     private void renderMessages() {
@@ -299,10 +310,5 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         glfwSwapBuffers(window);
         glfwSwapInterval(1);
         return window;
-    }
-
-    @Override
-    public boolean replacedWindow() {
-        return running; // TODO is this method necessary? it's only used to prevent the vanilla icon set, which we do want as it only occurs after handoff
     }
 }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
@@ -40,10 +40,6 @@ public enum EarlyProgressVisualization {
         return visualization.handOffWindow(width, height, title, monitor);
     }
 
-    public boolean replacedWindow() {
-        return visualization.replacedWindow();
-    }
-
     interface Visualization {
         Runnable start();
 
@@ -55,8 +51,6 @@ public enum EarlyProgressVisualization {
                 }
             }.getAsLong();
         }
-
-        default boolean replacedWindow() { return false; }
     }
 
     private static class NoVisualization implements Visualization {

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/StartupMessageManager.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/StartupMessageManager.java
@@ -72,7 +72,7 @@ public class StartupMessageManager {
     }
 
     enum MessageType {
-        MC(0.0f, 0.0f, 0.0f),
+        MC(1.0f, 1.0f, 1.0f),
         ML(0.0f, 0.0f, 0.5f),
         LOC(0.0f, 0.5f, 0.0f),
         MOD(0.5f, 0.0f, 0.0f);

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -123,14 +123,12 @@ public class EarlyLoaderGUI {
     void renderMessage(final String message, final float[] colour, int line, float alpha) {
         ByteBuffer vertexBuf = MemoryUtil.memAlloc(message.length() * 270);
         int quads = STBEasyFont.stb_easy_font_print(0, 0, message, null, vertexBuf);
-        GL14.glVertexPointer(2, GL11.GL_FLOAT, 16, vertexBuf);
 
         RenderSystem.enableBlend();
         RenderSystem.disableTexture();
         GL14.glBlendColor(0,0,0, alpha);
         RenderSystem.blendFunc(GlStateManager.SourceFactor.CONSTANT_ALPHA, GlStateManager.DestFactor.ONE_MINUS_CONSTANT_ALPHA);
         RenderSystem.pushMatrix();
-        RenderSystem.translatef(10, line * 10, 0);
         RenderSystem.scalef(1, 1, 0);
 
         //The quads need to be flipped in order for some reason
@@ -140,6 +138,7 @@ public class EarlyLoaderGUI {
         float[] quadPosX = new float[4];
         float[] quadPosY = new float[4];
         float[] quadPosZ = new float[4];
+        int lineOffset = line * 10;
         for (int quad = 0; quad < quads; quad++) {
             for (int vertex = 0; vertex < 4; vertex++) {
                 quadPosX[vertex] = vertexBuf.getFloat();
@@ -148,7 +147,7 @@ public class EarlyLoaderGUI {
                 vertexBuf.getInt(); //color, but it is ignored, as we use our own color
             }
             for (int i = 3; i >= 0; i--)
-                bufferbuilder.pos(quadPosX[i], quadPosY[i], quadPosZ[i]).color(colour[0], colour[1], colour[2], 1.0F).endVertex();
+                bufferbuilder.pos(quadPosX[i] + 10, quadPosY[i] + lineOffset, quadPosZ[i]).color(colour[0], colour[1], colour[2], 1.0F).endVertex();
         }
         bufferbuilder.finishDrawing();
         WorldVertexBufferUploader.draw(bufferbuilder);

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -124,7 +124,9 @@ public class EarlyLoaderGUI {
 
         RenderSystem.enableBlend();
         RenderSystem.disableTexture();
-        RenderSystem.disableCull();
+        // STBEasyFont's quads are in reverse order or what OGGL expects, so it gets culled for facing the wrong way. 
+        // So Disable culling https://github.com/MinecraftForge/MinecraftForge/pull/6824
+        RenderSystem.disableCull(); 
         GL14.glBlendColor(0,0,0, alpha);
         RenderSystem.blendFunc(GlStateManager.SourceFactor.CONSTANT_ALPHA, GlStateManager.DestFactor.ONE_MINUS_CONSTANT_ALPHA);
         RenderSystem.color3f(colour[0],colour[1],colour[2]);

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -24,6 +24,10 @@ import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.minecraft.client.MainWindow;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.WorldVertexBufferUploader;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
 import org.apache.commons.lang3.tuple.Pair;
@@ -72,9 +76,20 @@ public class EarlyLoaderGUI {
         RenderSystem.clear(GL11.GL_COLOR_BUFFER_BIT, Minecraft.IS_RUNNING_ON_MAC);
         RenderSystem.pushMatrix();
         setupMatrix();
+        renderBackground();
         renderMessages();
         window.flipFrame();
         RenderSystem.popMatrix();
+    }
+
+    private void renderBackground() {
+        GL11.glBegin(GL11.GL_QUADS);
+        GL11.glColor4f(239F / 255F, 50F / 255F, 61F / 255F, 255F / 255F); //Color from ResourceLoadProgressGui
+        GL11.glVertex3f(0, 0, -10);
+        GL11.glVertex3f(0, window.getScaledHeight(), -10);
+        GL11.glVertex3f(window.getScaledWidth(), window.getScaledHeight(), -10);
+        GL11.glVertex3f(window.getScaledWidth(), 0, -10);
+        GL11.glEnd();
     }
 
     private void renderMessages() {
@@ -106,23 +121,41 @@ public class EarlyLoaderGUI {
     }
 
     void renderMessage(final String message, final float[] colour, int line, float alpha) {
-        GlStateManager.enableClientState(GL11.GL_VERTEX_ARRAY);
-        ByteBuffer charBuffer = MemoryUtil.memAlloc(message.length() * 270);
-        int quads = STBEasyFont.stb_easy_font_print(0, 0, message, null, charBuffer);
-        GL14.glVertexPointer(2, GL11.GL_FLOAT, 16, charBuffer);
+        ByteBuffer vertexBuf = MemoryUtil.memAlloc(message.length() * 270);
+        int quads = STBEasyFont.stb_easy_font_print(0, 0, message, null, vertexBuf);
+        GL14.glVertexPointer(2, GL11.GL_FLOAT, 16, vertexBuf);
 
         RenderSystem.enableBlend();
         RenderSystem.disableTexture();
         GL14.glBlendColor(0,0,0, alpha);
         RenderSystem.blendFunc(GlStateManager.SourceFactor.CONSTANT_ALPHA, GlStateManager.DestFactor.ONE_MINUS_CONSTANT_ALPHA);
-        RenderSystem.color3f(colour[0],colour[1],colour[2]);
         RenderSystem.pushMatrix();
         RenderSystem.translatef(10, line * 10, 0);
         RenderSystem.scalef(1, 1, 0);
-        RenderSystem.drawArrays(GL11.GL_QUADS, 0, quads * 4);
+
+        //The quads need to be flipped in order for some reason
+        //So quad 0 -> quad 3, quad 1 -> quad 2, quad 2 -> quad 1 and quad 3 -> quad 0
+        BufferBuilder bufferbuilder = Tessellator.getInstance().getBuffer();
+        bufferbuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
+        float[] quadPosX = new float[4];
+        float[] quadPosY = new float[4];
+        float[] quadPosZ = new float[4];
+        for (int quad = 0; quad < quads; quad++) {
+            for (int vertex = 0; vertex < 4; vertex++) {
+                quadPosX[vertex] = vertexBuf.getFloat();
+                quadPosY[vertex] = vertexBuf.getFloat();
+                quadPosZ[vertex] = vertexBuf.getFloat();
+                vertexBuf.getInt(); //color, but it is ignored, as we use our own color
+            }
+            for (int i = 3; i >= 0; i--)
+                bufferbuilder.pos(quadPosX[i], quadPosY[i], quadPosZ[i]).color(colour[0], colour[1], colour[2], 1.0F).endVertex();
+        }
+        bufferbuilder.finishDrawing();
+        WorldVertexBufferUploader.draw(bufferbuilder);
+
+
         RenderSystem.popMatrix();
 
-        GlStateManager.disableClientState(GL11.GL_VERTEX_ARRAY);
-        MemoryUtil.memFree(charBuffer);
+        MemoryUtil.memFree(vertexBuf);
     }
 }


### PR DESCRIPTION
- The early and the intermediary loading screen now have the new mojang background color
- The late loading gui now renders text correctly again (I'm not sure if it is the correct way to fix it, though)
- The MC log color is now white instead of black for better readability. Other colors may need to be changed as well to work better with the new red background