### PR TITLE
[1.16.x] Store and expose language on ServerPlayerEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -108,12 +108,20 @@
 +      //Allows mods to specify data that persists after players respawn.
 +      CompoundNBT old = p_193104_1_.getPersistentData();
 +      if (old.func_74764_b(PERSISTED_NBT_TAG))
-+          getPersistentData().func_218657_a(PERSISTED_NBT_TAG, old.func_74781_a(PERSISTED_NBT_TAG));
++         getPersistentData().func_218657_a(PERSISTED_NBT_TAG, old.func_74781_a(PERSISTED_NBT_TAG));
 +      net.minecraftforge.event.ForgeEventFactory.onPlayerClone(this, p_193104_1_, !p_193104_2_);
     }
  
     protected void func_70670_a(EffectInstance p_70670_1_) {
-@@ -1291,14 +1304,14 @@
+@@ -1177,6 +1190,7 @@
+    }
+ 
+    public void func_147100_a(CClientSettingsPacket p_147100_1_) {
++      this.language = p_147100_1_.field_149530_a;
+       this.field_71143_cn = p_147100_1_.func_149523_e();
+       this.field_71140_co = p_147100_1_.func_149520_f();
+       this.func_184212_Q().func_187227_b(field_184827_bp, (byte)p_147100_1_.func_149521_d());
+@@ -1291,14 +1305,14 @@
        this.func_184210_p();
        if (p_200619_1_ == this.field_70170_p) {
           this.field_71135_a.func_147364_a(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
@@ -131,7 +139,7 @@
           this.func_70012_b(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
           this.func_70029_a(p_200619_1_);
           p_200619_1_.func_217446_a(this);
-@@ -1307,6 +1320,7 @@
+@@ -1307,6 +1321,7 @@
           this.field_71134_c.func_73080_a(p_200619_1_);
           this.field_71133_b.func_184103_al().func_72354_b(this, p_200619_1_);
           this.field_71133_b.func_184103_al().func_72385_f(this);
@@ -139,12 +147,27 @@
        }
  
     }
-@@ -1375,6 +1389,8 @@
+@@ -1375,7 +1390,9 @@
        if (itementity == null) {
           return null;
        } else {
+-         this.field_70170_p.func_217376_c(itementity);
 +         if (captureDrops() != null) captureDrops().add(itementity);
 +         else
-          this.field_70170_p.func_217376_c(itementity);
++            this.field_70170_p.func_217376_c(itementity);
           ItemStack itemstack = itementity.func_92059_d();
           if (p_146097_3_) {
+             if (!itemstack.func_190926_b()) {
+@@ -1388,4 +1405,12 @@
+          return itementity;
+       }
+    }
++
++   // Forge Start
++   private String language;
++   @Nullable
++   public String getLanguage() {
++      return this.language;
++   }
++   // Forge End
+ }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -137,6 +137,7 @@ public net.minecraft.item.crafting.TippedArrowRecipe
 private-f net.minecraft.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.loot.LootPool field_186456_d # bonusRolls
 public net.minecraft.nbt.NumberNBT
+public net.minecraft.network.play.client.CClientSettingsPacket field_149530_a # lang
 public net.minecraft.network.status.server.SServerInfoPacket field_149297_a # GSON
 public net.minecraft.particles.BasicParticleType <init>(Z)V
 public net.minecraft.particles.ParticleType <init>(ZLnet/minecraft/particles/IParticleData$IDeserializer;)V


### PR DESCRIPTION
Prior to 1.16, this (private) field was available to mods. In 1.16, Proguard removed this field so this PR re-adds it.

The main use case here is to allow mods to handle localisation without having a client-side mod in place. WorldEdit uses this field inside our `sendMessage` method to strip out WorldEdit internal translation keys and replace them with the translated text. As we are generally server-only, this is required to provide a localised experience for non-English speakers.

This is useful for other mods that wish to do the same as we do, allowing servers to provide a localised experience without requiring a client mod to handle translations.

In vanilla Minecraft, only the English localisation is loaded onto the server, so no inbuilt system is set up to automatically handle custom translations here, meaning some manual effort is still required from the mod maker. This just makes the information required to do this available with a getter and stored field.

A future feature that adds a full translation system based on this field could potentially be added at a later date, but this feature would be a dependency of that either way. That would be a much larger undertaking, however, that we personally would be unable to make use of due to our requirement of being cross-platform.

If Forge did have a server-side translation bundle loading system, it would need to hook into a few places to strip out the components similar to what WorldEdit does, as there are numerous places where a TextComponent is sent via packets. The main of which is the chat packet.

Alternatives:
* We could hook Netty and listen to the CClientSettings packet

Supersedes https://github.com/MinecraftForge/MinecraftForge/pull/6818