### PR TITLE
Fix block render type not being applied

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderTypeLookup.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderTypeLookup.java.patch
@@ -32,7 +32,17 @@
     public static RenderType func_239221_b_(BlockState p_239221_0_) {
        Block block = p_239221_0_.func_177230_c();
        if (block instanceof LeavesBlock) {
-@@ -317,11 +321,60 @@
+@@ -295,8 +299,7 @@
+    }
+ 
+    public static RenderType func_239220_a_(BlockState p_239220_0_, boolean p_239220_1_) {
+-      RenderType rendertype = func_228390_a_(p_239220_0_);
+-      if (rendertype == RenderType.func_228645_f_()) {
++      if (canRenderInLayer(p_239220_0_, RenderType.func_228645_f_())) {
+          if (!Minecraft.func_238218_y_()) {
+             return Atlases.func_228785_j_();
+          } else {
+@@ -317,11 +320,60 @@
        }
     }
  


### PR DESCRIPTION
Fixing issue #6823, where items did not correctly get a translucent rendertype.