### PR TITLE
[1.16] Redirect to new Forge model methods in vanilla multipart model

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/client/renderer/model/MultipartBakedModel.java
++++ b/net/minecraft/client/renderer/model/MultipartBakedModel.java
+@@ -27,10 +27,12 @@
+    protected final ItemCameraTransforms field_188624_d;
+    protected final ItemOverrideList field_188625_e;
+    private final Map<BlockState, BitSet> field_210277_g = new Object2ObjectOpenCustomHashMap<>(Util.func_212443_g());
++   private final IBakedModel firstModel;
+ 
+    public MultipartBakedModel(List<Pair<Predicate<BlockState>, IBakedModel>> p_i48273_1_) {
+       this.field_188626_f = p_i48273_1_;
+       IBakedModel ibakedmodel = p_i48273_1_.iterator().next().getRight();
++      this.firstModel = ibakedmodel;
+       this.field_188621_a = ibakedmodel.func_177555_b();
+       this.field_188622_b = ibakedmodel.func_177556_c();
+       this.field_230185_c_ = ibakedmodel.func_230044_c_();
+@@ -98,6 +100,22 @@
+       return this.field_188625_e;
+    }
+ 
++   public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, net.minecraftforge.client.model.data.IModelData extraData) {
++      return net.minecraftforge.client.ForgeHooksClient.getMultipartModelQuads(this.field_188626_f, this.field_210277_g, state, side, rand, extraData);
++   }
++
++   public boolean isAmbientOcclusion(BlockState state) {
++      return this.firstModel.isAmbientOcclusion(state);
++   }
++
++   public net.minecraftforge.client.model.data.IModelData getModelData(net.minecraft.world.IBlockDisplayReader world, net.minecraft.util.math.BlockPos pos, BlockState state, net.minecraftforge.client.model.data.IModelData tileData) {
++      return this.firstModel.getModelData(world, pos, state, tileData);
++   }
++
++   public TextureAtlasSprite getParticleTexture(net.minecraftforge.client.model.data.IModelData data) {
++      return this.firstModel.getParticleTexture(data);
++   }
++
+    @OnlyIn(Dist.CLIENT)
+    public static class Builder {
+       private final List<Pair<Predicate<BlockState>, IBakedModel>> field_188649_a = Lists.newArrayList();

--- a/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
@@ -13,12 +13,15 @@
        this.field_188621_a = ibakedmodel.func_177555_b();
        this.field_188622_b = ibakedmodel.func_177556_c();
        this.field_230185_c_ = ibakedmodel.func_230044_c_();
-@@ -98,6 +100,22 @@
+@@ -98,6 +100,25 @@
        return this.field_188625_e;
     }
  
 +   public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, net.minecraftforge.client.model.data.IModelData extraData) {
-+      return net.minecraftforge.client.ForgeHooksClient.getMultipartModelQuads(this.field_188626_f, this.field_210277_g, state, side, rand, extraData);
++      if (state == null) return Collections.emptyList();
++      BitSet bitset = field_210277_g.computeIfAbsent(state, (s) -> java.util.stream.IntStream.range(0, field_188626_f.size()).filter((i) -> field_188626_f.get(i).getLeft().test(s)).collect(BitSet::new, BitSet::set, BitSet::or));
++      long seed = rand.nextLong();
++      return bitset.stream().mapToObj(field_188626_f::get).flatMap(pair -> pair.getRight().getQuads(state, side, new Random(seed), extraData).stream()).collect(java.util.stream.Collectors.toList());
 +   }
 +
 +   public boolean isAmbientOcclusion(BlockState state) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -42,21 +42,15 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-import com.google.common.collect.Lists;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.model.*;
 import net.minecraft.client.settings.KeyBinding;
@@ -69,10 +63,8 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.IBlockDisplayReader;
 import net.minecraftforge.client.event.RenderHandEvent;
-import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.async.ThreadNameCachingStrategy;
@@ -662,43 +654,6 @@ public class ForgeHooksClient
             tr.push(stack);
         }
         return model;
-    }
-
-    public static List<BakedQuad> getMultipartModelQuads(List<Pair<Predicate<BlockState>, IBakedModel>> selectors, Map<BlockState, BitSet> bitSetMap, @Nullable BlockState state, @Nullable Direction side, Random rand, IModelData data)
-    {
-        if (state == null)
-        {
-            return Collections.emptyList();
-        }
-
-        BitSet bitset = bitSetMap.get(state);
-        if (bitset == null)
-        {
-            bitset = new BitSet();
-
-            for(int i = 0; i < selectors.size(); ++i)
-            {
-                Pair<Predicate<BlockState>, IBakedModel> pair = selectors.get(i);
-                if (pair.getLeft().test(state))
-                {
-                    bitset.set(i);
-                }
-            }
-
-            bitSetMap.put(state, bitset);
-        }
-
-        List<BakedQuad> list = Lists.newArrayList();
-        long k = rand.nextLong();
-        for(int j = 0; j < bitset.length(); ++j)
-        {
-            if (bitset.get(j))
-            {
-                list.addAll(selectors.get(j).getRight().getQuads(state, side, new Random(k), data));
-            }
-        }
-
-        return list;
     }
 
     public static void onInputUpdate(PlayerEntity player, MovementInput movementInput)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -42,15 +42,21 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.model.*;
 import net.minecraft.client.settings.KeyBinding;
@@ -63,8 +69,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.IBlockDisplayReader;
 import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.async.ThreadNameCachingStrategy;
@@ -654,6 +662,43 @@ public class ForgeHooksClient
             tr.push(stack);
         }
         return model;
+    }
+
+    public static List<BakedQuad> getMultipartModelQuads(List<Pair<Predicate<BlockState>, IBakedModel>> selectors, Map<BlockState, BitSet> bitSetMap, @Nullable BlockState state, @Nullable Direction side, Random rand, IModelData data)
+    {
+        if (state == null)
+        {
+            return Collections.emptyList();
+        }
+
+        BitSet bitset = bitSetMap.get(state);
+        if (bitset == null)
+        {
+            bitset = new BitSet();
+
+            for(int i = 0; i < selectors.size(); ++i)
+            {
+                Pair<Predicate<BlockState>, IBakedModel> pair = selectors.get(i);
+                if (pair.getLeft().test(state))
+                {
+                    bitset.set(i);
+                }
+            }
+
+            bitSetMap.put(state, bitset);
+        }
+
+        List<BakedQuad> list = Lists.newArrayList();
+        long k = rand.nextLong();
+        for(int j = 0; j < bitset.length(); ++j)
+        {
+            if (bitset.get(j))
+            {
+                list.addAll(selectors.get(j).getRight().getQuads(state, side, new Random(k), data));
+            }
+        }
+
+        return list;
     }
 
     public static void onInputUpdate(PlayerEntity player, MovementInput movementInput)

--- a/src/test/resources/assets/new_model_loader_test/blockstates/multipart_block.json
+++ b/src/test/resources/assets/new_model_loader_test/blockstates/multipart_block.json
@@ -1,0 +1,17 @@
+{
+    "multipart": [
+        {   "apply": { "model": "new_model_loader_test:block/multipart_block" }},
+        {   "when": { "north": "true" },
+            "apply": { "model": "block/oak_fence_side", "uvlock": true }
+        },
+        {   "when": { "east": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 90, "uvlock": true }
+        },
+        {   "when": { "south": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 180, "uvlock": true }
+        },
+        {   "when": { "west": "true" },
+            "apply": { "model": "block/oak_fence_side", "y": 270, "uvlock": true }
+        }
+    ]
+}

--- a/src/test/resources/assets/new_model_loader_test/models/block/multipart_block.json
+++ b/src/test/resources/assets/new_model_loader_test/models/block/multipart_block.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/block",
+  "loader": "new_model_loader_test:custom_loader",
+  "textures": {
+    "particle": "block/oak_planks"
+  }
+}


### PR DESCRIPTION
Same as #6788, but for 1.16. Description copied below:

----

This pull request makes the vanilla multipart model redirect the Forge `BlockState` variants of `isAmbientOcclusion` and `getParticleTexture` to the first model in the multipart model, for consistency with the stateless variants.

In addition, `getQuads` now passes along the `IModelData` instance to each submodel. I currently have that logic pulled into `ForgeHooksClient` as it was quite large, let me know if there is a preferred place to put that code.

I simply redirected `getModelData` to the first model for consistency with the other methods, as that is sufficient for most needs, including my own. We could potentially call the method for each submodel, passing the previous as `tileData`, but I think its very unlikely to have two different model loaders/sets of model data in a single multipart model, and in many cases that will be inefficient as you run the same logic multiple times (as each child likely has the same loader).

----

Included in this pull request is an update to the model loader test mod, adding in `multipart_block`. This block uses the fence model, but the center post is replaced with a "dynamic" model that turns invisible when placed above white wool. Note it does not have the tag for the block to connect to itself, so place it near solid blocks to test (was not sure it was worth adding the tag since that is beyond the point of the test mod)