### PR TITLE
Fix swim speed being incorrect

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -310,7 +310,7 @@
     }
  
     protected float func_189749_co() {
-@@ -1868,16 +1896,20 @@
+@@ -1868,11 +1896,15 @@
     public void func_213352_e(Vector3d p_213352_1_) {
        if (this.func_70613_aW() || this.func_184186_bw()) {
           double d0 = 0.08D;
@@ -327,12 +327,6 @@
  
           FluidState fluidstate = this.field_70170_p.func_204610_c(this.func_233580_cy_());
           if (this.func_70090_H() && this.func_241208_cS_() && !this.func_230285_a_(fluidstate.func_206886_c())) {
-             double d8 = this.func_226278_cu_();
--            float f5 = this.func_70051_ag() ? 0.9F : this.func_189749_co();
-+            float f5 = this.field_70170_p.func_180495_p(this.func_226270_aj_()).getSlipperiness(field_70170_p, this.func_226270_aj_(), this);
-             float f6 = 0.02F;
-             float f7 = (float)EnchantmentHelper.func_185294_d(this);
-             if (f7 > 3.0F) {
 @@ -1897,6 +1929,7 @@
                 f5 = 0.96F;
              }
@@ -341,6 +335,15 @@
              this.func_213309_a(f6, p_213352_1_);
              this.func_213315_a(MoverType.SELF, this.func_213322_ci());
              Vector3d vector3d6 = this.func_213322_ci();
+@@ -1975,7 +2008,7 @@
+             }
+          } else {
+             BlockPos blockpos = this.func_226270_aj_();
+-            float f3 = this.field_70170_p.func_180495_p(blockpos).func_177230_c().func_208618_m();
++            float f3 = this.field_70170_p.func_180495_p(this.func_226270_aj_()).getSlipperiness(field_70170_p, this.func_226270_aj_(), this);
+             float f4 = this.field_70122_E ? f3 * 0.91F : 0.91F;
+             Vector3d vector3d5 = this.func_233633_a_(p_213352_1_, f3);
+             double d2 = vector3d5.field_72448_b;
 @@ -2075,6 +2108,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -1,18 +1,6 @@
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -12,10 +12,7 @@
- import java.net.InetAddress;
- import java.net.Proxy;
- import java.nio.charset.StandardCharsets;
--import java.util.Collections;
--import java.util.List;
--import java.util.Locale;
--import java.util.Optional;
-+import java.util.*;
- import java.util.function.BooleanSupplier;
- import java.util.regex.Pattern;
- import javax.annotation.Nullable;
-@@ -77,6 +74,7 @@
+@@ -77,6 +77,7 @@
     public boolean func_71197_b() throws IOException {
        Thread thread = new Thread("Server console handler") {
           public void run() {
@@ -20,7 +8,7 @@
              BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
  
              String s1;
-@@ -98,7 +96,9 @@
+@@ -98,7 +99,9 @@
           field_155771_h.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
        }
  
@@ -30,7 +18,7 @@
        ServerProperties serverproperties = this.field_71340_o.func_219034_a();
        if (this.func_71264_H()) {
           this.func_71189_e("127.0.0.1");
-@@ -153,17 +153,20 @@
+@@ -153,17 +156,20 @@
        if (!PreYggdrasilConverter.func_219587_e(this)) {
           return false;
        } else {
@@ -51,7 +39,7 @@
           if (serverproperties.field_219027_u != null) {
              this.func_200252_aR().func_223585_a(GameRules.field_223620_w).func_223570_a(serverproperties.field_219027_u, this);
           }
-@@ -175,6 +178,7 @@
+@@ -175,6 +181,7 @@
           }
  
           if (serverproperties.field_219030_x) {
@@ -59,7 +47,7 @@
              field_155771_h.info("Starting remote control listener");
              this.field_71339_n = new MainThread(this);
              this.field_71339_n.func_72602_a();
-@@ -193,7 +197,8 @@
+@@ -193,7 +200,8 @@
              ServerInfoMBean.func_233490_a_(this);
           }
  
@@ -69,12 +57,12 @@
        }
     }
  
-@@ -506,6 +511,11 @@
+@@ -506,6 +514,11 @@
        return false;
     }
  
 +   @Override //Forge: Enable formated text for colors in console.
-+   public void func_145747_a(net.minecraft.util.text.ITextComponent message, UUID p_145747_2_) {
++   public void func_145747_a(net.minecraft.util.text.ITextComponent message, java.util.UUID p_145747_2_) {
 +      field_155771_h.info(message.getString());
 +   }
 +


### PR DESCRIPTION
A patch was misapplied due to a local var having the same name between 1.15 and 1.16 but not representing the same thing. 

Also removed imports from the dedicatedserver patch