### PR TITLE
[1.16] Filter duplicate mod files in mod file scan data

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/ModList.java
@@ -198,6 +198,7 @@ public class ModList
                     map(ModInfo::getOwningFile).
                     filter(Objects::nonNull).
                     map(ModFileInfo::getFile).
+                    distinct().
                     map(ModFile::getScanResult).
                     collect(Collectors.toList());
         }


### PR DESCRIPTION
#6254 for 1.16
I haven't seen any major changes to the mod loading/modfile system compared with the 1.14 and 1.15 mod. So I assume this works exactly the same.
The test mods load properly.

This is a tiny PR, so feel free to fix it independently from this PR.