### PR TITLE
[1.16] Replace EntityHeight event with EntitySize event

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -31,18 +31,20 @@
        this.field_200606_g = p_i48580_1_;
        this.field_70170_p = p_i48580_2_;
        this.field_213325_aI = p_i48580_1_.func_220334_j();
-@@ -211,7 +214,9 @@
+@@ -211,7 +214,11 @@
        this.field_70180_af.func_187214_a(field_189655_aD, false);
        this.field_70180_af.func_187214_a(field_213330_X, Pose.STANDING);
        this.func_70088_a();
 -      this.field_213326_aJ = this.func_213316_a(Pose.STANDING, this.field_213325_aI);
-+      this.field_213326_aJ = getEyeHeightForge(Pose.STANDING, this.field_213325_aI);
++      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.field_213325_aI, this.func_213316_a(Pose.STANDING, this.field_213325_aI));
++      this.field_213325_aI = sizeEvent.getNewSize();
++      this.field_213326_aJ = sizeEvent.getNewEyeHeight();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -317,7 +322,13 @@
+@@ -317,7 +324,13 @@
     }
  
     public void func_70106_y() {
@@ -56,7 +58,7 @@
     }
  
     public void func_213301_b(Pose p_213301_1_) {
-@@ -330,6 +341,7 @@
+@@ -330,6 +343,7 @@
  
     public boolean func_233562_a_(Entity p_233562_1_, double p_233562_2_) {
        double d0 = p_233562_1_.field_233557_ao_.field_72450_a - this.field_233557_ao_.field_72450_a;
@@ -64,7 +66,7 @@
        double d1 = p_233562_1_.field_233557_ao_.field_72448_b - this.field_233557_ao_.field_72448_b;
        double d2 = p_233562_1_.field_233557_ao_.field_72449_c - this.field_233557_ao_.field_72449_c;
        return d0 * d0 + d1 * d1 + d2 * d2 < p_233562_2_ * p_233562_2_;
-@@ -560,7 +572,7 @@
+@@ -560,7 +574,7 @@
  
              this.field_70140_Q = (float)((double)this.field_70140_Q + (double)MathHelper.func_76133_a(func_213296_b(vector3d)) * 0.6D);
              this.field_82151_R = (float)((double)this.field_82151_R + (double)MathHelper.func_76133_a(d0 * d0 + d1 * d1 + d2 * d2) * 0.6D);
@@ -73,7 +75,7 @@
                 this.field_70150_b = this.func_203009_ad();
                 if (this.func_70090_H()) {
                    Entity entity = this.func_184207_aI() && this.func_184179_bs() != null ? this.func_184179_bs() : this;
-@@ -575,7 +587,7 @@
+@@ -575,7 +589,7 @@
                 } else {
                    this.func_180429_a(blockpos, blockstate);
                 }
@@ -82,7 +84,7 @@
                 this.field_191959_ay = this.func_191954_d(this.field_82151_R);
              }
           }
-@@ -591,8 +603,9 @@
+@@ -591,8 +605,9 @@
  
           float f2 = this.func_225515_ai_();
           this.func_213317_d(this.func_213322_ci().func_216372_d((double)f2, 1.0D, (double)f2));
@@ -94,7 +96,7 @@
           }) && this.field_190534_ay <= 0) {
              this.func_241209_g_(-this.func_190531_bD());
           }
-@@ -611,11 +624,10 @@
+@@ -611,11 +626,10 @@
        int j = MathHelper.func_76128_c(this.field_233557_ao_.field_72448_b - (double)0.2F);
        int k = MathHelper.func_76128_c(this.field_233557_ao_.field_72449_c);
        BlockPos blockpos = new BlockPos(i, j, k);
@@ -108,7 +110,7 @@
              return blockpos1;
           }
        }
-@@ -801,6 +813,7 @@
+@@ -801,6 +815,7 @@
     public void func_174829_m() {
        AxisAlignedBB axisalignedbb = this.func_174813_aQ();
        this.func_226288_n_((axisalignedbb.field_72340_a + axisalignedbb.field_72336_d) / 2.0D, axisalignedbb.field_72338_b, (axisalignedbb.field_72339_c + axisalignedbb.field_72334_f) / 2.0D);
@@ -116,7 +118,7 @@
     }
  
     protected SoundEvent func_184184_Z() {
-@@ -849,7 +862,7 @@
+@@ -849,7 +864,7 @@
     protected void func_180429_a(BlockPos p_180429_1_, BlockState p_180429_2_) {
        if (!p_180429_2_.func_185904_a().func_76224_d()) {
           BlockState blockstate = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a());
@@ -125,7 +127,7 @@
           this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
        }
     }
-@@ -1056,9 +1069,10 @@
+@@ -1056,9 +1071,10 @@
        int k = MathHelper.func_76128_c(this.func_226281_cx_());
        BlockPos blockpos = new BlockPos(i, j, k);
        BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
@@ -137,7 +139,7 @@
        }
  
     }
-@@ -1377,6 +1391,7 @@
+@@ -1377,6 +1393,7 @@
           if (this.field_184238_ar) {
              p_189511_1_.func_74757_a("Glowing", this.field_184238_ar);
           }
@@ -145,7 +147,7 @@
  
           if (!this.field_184236_aF.isEmpty()) {
              ListNBT listnbt = new ListNBT();
-@@ -1388,6 +1403,10 @@
+@@ -1388,6 +1405,10 @@
              p_189511_1_.func_218657_a("Tags", listnbt);
           }
  
@@ -156,7 +158,7 @@
           this.func_213281_b(p_189511_1_);
           if (this.func_184207_aI()) {
              ListNBT listnbt1 = new ListNBT();
-@@ -1458,6 +1477,9 @@
+@@ -1458,6 +1479,9 @@
                 this.func_174810_b(p_70020_1_.func_74767_n("Silent"));
                 this.func_189654_d(p_70020_1_.func_74767_n("NoGravity"));
                 this.func_184195_f(p_70020_1_.func_74767_n("Glowing"));
@@ -166,7 +168,7 @@
                 if (p_70020_1_.func_150297_b("Tags", 9)) {
                    this.field_184236_aF.clear();
                    ListNBT listnbt3 = p_70020_1_.func_150295_c("Tags", 8);
-@@ -1546,6 +1568,8 @@
+@@ -1546,6 +1570,8 @@
        } else {
           ItemEntity itementity = new ItemEntity(this.field_70170_p, this.func_226277_ct_(), this.func_226278_cu_() + (double)p_70099_2_, this.func_226281_cx_(), p_70099_1_);
           itementity.func_174869_p();
@@ -175,7 +177,7 @@
           this.field_70170_p.func_217376_c(itementity);
           return itementity;
        }
-@@ -1582,6 +1606,7 @@
+@@ -1582,6 +1608,7 @@
  
     public void func_70098_U() {
        this.func_213317_d(Vector3d.field_186680_a);
@@ -183,7 +185,7 @@
        this.func_70071_h_();
        if (this.func_184218_aH()) {
           this.func_184187_bx().func_184232_k(this);
-@@ -1627,6 +1652,7 @@
+@@ -1627,6 +1654,7 @@
           }
        }
  
@@ -191,7 +193,7 @@
        if (p_184205_2_ || this.func_184228_n(p_184205_1_) && p_184205_1_.func_184219_q(this)) {
           if (this.func_184218_aH()) {
              this.func_184210_p();
-@@ -1659,6 +1685,7 @@
+@@ -1659,6 +1687,7 @@
     public void func_233575_bb_() {
        if (this.field_184239_as != null) {
           Entity entity = this.field_184239_as;
@@ -199,7 +201,7 @@
           this.field_184239_as = null;
           entity.func_184225_p(this);
        }
-@@ -1816,6 +1843,7 @@
+@@ -1816,6 +1845,7 @@
        return !this.func_184188_bt().isEmpty();
     }
  
@@ -207,7 +209,7 @@
     public boolean func_205710_ba() {
        return true;
     }
-@@ -2032,7 +2060,7 @@
+@@ -2032,7 +2062,7 @@
     }
  
     protected ITextComponent func_225513_by_() {
@@ -216,7 +218,7 @@
     }
  
     public boolean func_70028_i(Entity p_70028_1_) {
-@@ -2087,6 +2115,10 @@
+@@ -2087,6 +2117,10 @@
  
     @Nullable
     public Entity func_241206_a_(ServerWorld p_241206_1_) {
@@ -227,7 +229,7 @@
        if (this.field_70170_p instanceof ServerWorld && !this.field_70128_L) {
           this.field_70170_p.func_217381_Z().func_76320_a("changeDimension");
           this.func_213319_R();
-@@ -2095,6 +2127,7 @@
+@@ -2095,6 +2129,7 @@
           if (portalinfo == null) {
              return null;
           } else {
@@ -235,7 +237,7 @@
              this.field_70170_p.func_217381_Z().func_219895_b("reloading");
              Entity entity = this.func_200600_R().func_200721_a(p_241206_1_);
              if (entity != null) {
-@@ -2102,17 +2135,19 @@
+@@ -2102,17 +2137,19 @@
                 entity.func_70012_b(portalinfo.field_222505_a.field_72450_a, portalinfo.field_222505_a.field_72448_b, portalinfo.field_222505_a.field_72449_c, portalinfo.field_242960_c, entity.field_70125_A);
                 entity.func_213317_d(portalinfo.field_222506_b);
                 p_241206_1_.func_217460_e(entity);
@@ -257,16 +259,20 @@
           }
        } else {
           return null;
-@@ -2322,7 +2357,7 @@
+@@ -2320,9 +2357,10 @@
+    public void func_213323_x_() {
+       EntitySize entitysize = this.field_213325_aI;
        Pose pose = this.func_213283_Z();
-       EntitySize entitysize1 = this.func_213305_a(pose);
+-      EntitySize entitysize1 = this.func_213305_a(pose);
++      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, this.func_213305_a(pose), this.func_213316_a(pose, entitysize));
++      EntitySize entitysize1 = sizeEvent.getNewSize();
        this.field_213325_aI = entitysize1;
 -      this.field_213326_aJ = this.func_213316_a(pose, entitysize1);
-+      this.field_213326_aJ = getEyeHeightForge(pose, entitysize1);
++      this.field_213326_aJ = sizeEvent.getNewEyeHeight();
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.func_226277_ct_() - d0, this.func_226278_cu_(), this.func_226281_cx_() - d0, this.func_226277_ct_() + d0, this.func_226278_cu_() + (double)entitysize1.field_220316_b, this.func_226281_cx_() + d0));
-@@ -2796,6 +2831,7 @@
+@@ -2796,6 +2834,7 @@
  
           this.field_233555_aA_ = true;
        }
@@ -274,7 +280,7 @@
  
     }
  
-@@ -2811,4 +2847,69 @@
+@@ -2811,4 +2850,63 @@
     public interface IMoveCallback {
        void accept(Entity p_accept_1_, double p_accept_2_, double p_accept_4_, double p_accept_6_);
     }
@@ -336,11 +342,5 @@
 +   public void revive() {
 +      this.field_70128_L = false;
 +      this.reviveCaps();
-+   }
-+
-+   private float getEyeHeightForge(Pose pose, EntitySize size) {
-+      net.minecraftforge.event.entity.EntityEvent.EyeHeight evt = new net.minecraftforge.event.entity.EntityEvent.EyeHeight(this, pose, size, this.func_213316_a(pose, size));
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
-+      return evt.getNewHeight();
 +   }
  }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -8,16 +8,17 @@
     public static final EntitySize field_213835_bs = EntitySize.func_220314_b(0.6F, 1.8F);
     private static final Map<Pose, EntitySize> field_213836_b = ImmutableMap.<Pose, EntitySize>builder().put(Pose.STANDING, field_213835_bs).put(Pose.SLEEPING, field_213377_as).put(Pose.FALL_FLYING, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.SWIMMING, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.SPIN_ATTACK, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.CROUCHING, EntitySize.func_220314_b(0.6F, 1.5F)).put(Pose.DYING, EntitySize.func_220311_c(0.2F, 0.2F)).build();
     private static final DataParameter<Float> field_184829_a = EntityDataManager.func_187226_a(PlayerEntity.class, DataSerializers.field_187193_c);
-@@ -150,6 +151,8 @@
+@@ -150,6 +151,9 @@
     private final CooldownTracker field_184832_bU = this.func_184815_l();
     @Nullable
     public FishingBobberEntity field_71104_cf;
 +   private final java.util.Collection<IFormattableTextComponent> prefixes = new java.util.LinkedList<>();
 +   private final java.util.Collection<IFormattableTextComponent> suffixes = new java.util.LinkedList<>();
++   @Nullable private Pose forcedPose;
  
     public PlayerEntity(World p_i241920_1_, BlockPos p_i241920_2_, float p_i241920_3_, GameProfile p_i241920_4_) {
        super(EntityType.field_200729_aH, p_i241920_1_);
-@@ -175,7 +178,7 @@
+@@ -175,7 +179,7 @@
     }
  
     public static AttributeModifierMap.MutableAttribute func_234570_el_() {
@@ -26,7 +27,7 @@
     }
  
     protected void func_70088_a() {
-@@ -189,6 +192,7 @@
+@@ -189,6 +193,7 @@
     }
  
     public void func_70071_h_() {
@@ -34,7 +35,7 @@
        this.field_70145_X = this.func_175149_v();
        if (this.func_175149_v()) {
           this.field_70122_E = false;
-@@ -204,7 +208,7 @@
+@@ -204,7 +209,7 @@
              this.field_71076_b = 100;
           }
  
@@ -43,7 +44,7 @@
              this.func_225652_a_(false, true);
           }
        } else if (this.field_71076_b > 0) {
-@@ -258,6 +262,7 @@
+@@ -258,6 +263,7 @@
        this.func_203041_m();
        this.field_184832_bU.func_185144_a();
        this.func_213832_dB();
@@ -51,7 +52,18 @@
     }
  
     public boolean func_226563_dT_() {
-@@ -550,6 +555,7 @@
+@@ -333,6 +339,10 @@
+    }
+ 
+    protected void func_213832_dB() {
++      if(forcedPose != null) {
++         this.func_213301_b(forcedPose);
++         return;
++      }
+       if (this.func_213298_c(Pose.SWIMMING)) {
+          Pose pose;
+          if (this.func_184613_cA()) {
+@@ -550,6 +560,7 @@
     }
  
     public void func_70645_a(DamageSource p_70645_1_) {
@@ -59,7 +71,7 @@
        super.func_70645_a(p_70645_1_);
        this.func_226264_Z_();
        if (!this.func_175149_v()) {
-@@ -603,12 +609,14 @@
+@@ -603,12 +614,14 @@
     }
  
     public boolean func_225609_n_(boolean p_225609_1_) {
@@ -76,7 +88,7 @@
     }
  
     @Nullable
-@@ -646,7 +654,12 @@
+@@ -646,7 +659,12 @@
        }
     }
  
@@ -89,7 +101,7 @@
        float f = this.field_71071_by.func_184438_a(p_184813_1_);
        if (f > 1.0F) {
           int i = EnchantmentHelper.func_185293_e(this);
-@@ -688,11 +701,12 @@
+@@ -688,11 +706,12 @@
           f /= 5.0F;
        }
  
@@ -103,7 +115,7 @@
     }
  
     public void func_70037_a(CompoundNBT p_70037_1_) {
-@@ -767,6 +781,7 @@
+@@ -767,6 +786,7 @@
     }
  
     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_) {
@@ -111,7 +123,7 @@
        if (this.func_180431_b(p_70097_1_)) {
           return false;
        } else if (this.field_71075_bZ.field_75102_a && !p_70097_1_.func_76357_e()) {
-@@ -798,7 +813,7 @@
+@@ -798,7 +818,7 @@
  
     protected void func_190629_c(LivingEntity p_190629_1_) {
        super.func_190629_c(p_190629_1_);
@@ -120,7 +132,7 @@
           this.func_190777_m(true);
        }
  
-@@ -819,7 +834,7 @@
+@@ -819,7 +839,7 @@
     }
  
     protected void func_184590_k(float p_184590_1_) {
@@ -129,7 +141,7 @@
           if (!this.field_70170_p.field_72995_K) {
              this.func_71029_a(Stats.field_75929_E.func_199076_b(this.field_184627_bm.func_77973_b()));
           }
-@@ -829,6 +844,7 @@
+@@ -829,6 +849,7 @@
              Hand hand = this.func_184600_cs();
              this.field_184627_bm.func_222118_a(i, this, (p_213833_1_) -> {
                 p_213833_1_.func_213334_d(hand);
@@ -137,7 +149,7 @@
              });
              if (this.field_184627_bm.func_190926_b()) {
                 if (hand == Hand.MAIN_HAND) {
-@@ -847,10 +863,13 @@
+@@ -847,10 +868,13 @@
  
     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_) {
        if (!this.func_180431_b(p_70665_1_)) {
@@ -151,7 +163,7 @@
           float f = p_70665_2_ - f2;
           if (f > 0.0F && f < 3.4028235E37F) {
              this.func_195067_a(Stats.field_212738_J, Math.round(f * 10.0F));
-@@ -909,6 +928,8 @@
+@@ -909,6 +933,8 @@
  
           return ActionResultType.PASS;
        } else {
@@ -160,7 +172,7 @@
           ItemStack itemstack = this.func_184586_b(p_190775_2_);
           ItemStack itemstack1 = itemstack.func_77946_l();
           ActionResultType actionresulttype = p_190775_1_.func_184230_a(this, p_190775_2_);
-@@ -917,6 +938,9 @@
+@@ -917,6 +943,9 @@
                 itemstack.func_190920_e(itemstack1.func_190916_E());
              }
  
@@ -170,7 +182,7 @@
              return actionresulttype;
           } else {
              if (!itemstack.func_190926_b() && p_190775_1_ instanceof LivingEntity) {
-@@ -927,6 +951,7 @@
+@@ -927,6 +956,7 @@
                 ActionResultType actionresulttype1 = itemstack.func_111282_a_(this, (LivingEntity)p_190775_1_, p_190775_2_);
                 if (actionresulttype1.func_226246_a_()) {
                    if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d) {
@@ -178,7 +190,7 @@
                       this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                    }
  
-@@ -1011,6 +1036,7 @@
+@@ -1011,6 +1041,7 @@
     }
  
     public void func_71059_n(Entity p_71059_1_) {
@@ -186,7 +198,7 @@
        if (p_71059_1_.func_70075_an()) {
           if (!p_71059_1_.func_85031_j(this)) {
              float f = (float)this.func_233637_b_(Attributes.field_233823_f_);
-@@ -1038,8 +1064,10 @@
+@@ -1038,8 +1069,10 @@
  
                 boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(Effects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof LivingEntity;
                 flag2 = flag2 && !this.func_70051_ag();
@@ -198,7 +210,7 @@
                 }
  
                 f = f + f1;
-@@ -1127,8 +1155,10 @@
+@@ -1127,8 +1160,10 @@
                    }
  
                    if (!this.field_70170_p.field_72995_K && !itemstack1.func_190926_b() && entity instanceof LivingEntity) {
@@ -209,7 +221,7 @@
                          this.func_184611_a(Hand.MAIN_HAND, ItemStack.field_190927_a);
                       }
                    }
-@@ -1170,7 +1200,7 @@
+@@ -1170,7 +1205,7 @@
        }
  
        if (this.field_70146_Z.nextFloat() < f) {
@@ -218,7 +230,7 @@
           this.func_184602_cy();
           this.field_70170_p.func_72960_a(this, (byte)30);
        }
-@@ -1196,8 +1226,9 @@
+@@ -1196,8 +1231,9 @@
     public void func_71004_bE() {
     }
  
@@ -230,7 +242,7 @@
        this.field_71069_bz.func_75134_a(this);
        if (this.field_71070_bA != null) {
           this.field_71070_bA.func_75134_a(this);
-@@ -1220,6 +1251,7 @@
+@@ -1220,6 +1256,7 @@
     }
  
     public void func_225652_a_(boolean p_225652_1_, boolean p_225652_2_) {
@@ -238,7 +250,7 @@
        super.func_213366_dy();
        if (this.field_70170_p instanceof ServerWorld && p_225652_2_) {
           ((ServerWorld)this.field_70170_p).func_72854_c();
-@@ -1242,8 +1274,8 @@
+@@ -1242,8 +1279,8 @@
           }
  
           return optional;
@@ -249,7 +261,7 @@
        } else if (!p_242374_3_) {
           return Optional.empty();
        } else {
-@@ -1425,6 +1457,7 @@
+@@ -1425,6 +1462,7 @@
  
     public boolean func_225503_b_(float p_225503_1_, float p_225503_2_) {
        if (this.field_71075_bZ.field_75101_c) {
@@ -257,7 +269,7 @@
           return false;
        } else {
           if (p_225503_1_ >= 2.0F) {
-@@ -1438,7 +1471,7 @@
+@@ -1438,7 +1476,7 @@
     public boolean func_226566_ei_() {
        if (!this.field_70122_E && !this.func_184613_cA() && !this.func_70090_H() && !this.func_70644_a(Effects.field_188424_y)) {
           ItemStack itemstack = this.func_184582_a(EquipmentSlotType.CHEST);
@@ -266,7 +278,7 @@
              this.func_226567_ej_();
              return true;
           }
-@@ -1479,6 +1512,10 @@
+@@ -1479,6 +1517,10 @@
     }
  
     public void func_195068_e(int p_195068_1_) {
@@ -277,7 +289,7 @@
        this.func_85039_t(p_195068_1_);
        this.field_71106_cc += (float)p_195068_1_ / (float)this.func_71050_bK();
        this.field_71067_cb = MathHelper.func_76125_a(this.field_71067_cb + p_195068_1_, 0, Integer.MAX_VALUE);
-@@ -1507,7 +1544,7 @@
+@@ -1507,7 +1549,7 @@
     }
  
     public void func_192024_a(ItemStack p_192024_1_, int p_192024_2_) {
@@ -286,7 +298,7 @@
        if (this.field_71068_ca < 0) {
           this.field_71068_ca = 0;
           this.field_71106_cc = 0.0F;
-@@ -1518,6 +1555,10 @@
+@@ -1518,6 +1560,10 @@
     }
  
     public void func_82242_a(int p_82242_1_) {
@@ -297,7 +309,7 @@
        this.field_71068_ca += p_82242_1_;
        if (this.field_71068_ca < 0) {
           this.field_71068_ca = 0;
-@@ -1708,7 +1749,11 @@
+@@ -1708,7 +1754,11 @@
     }
  
     public ITextComponent func_145748_c_() {
@@ -310,7 +322,7 @@
        return this.func_208016_c(iformattabletextcomponent);
     }
  
-@@ -1987,4 +2032,45 @@
+@@ -1987,4 +2037,62 @@
           return this.field_221260_g;
        }
     }
@@ -354,5 +366,22 @@
 +         else if (facing.func_176740_k().func_176722_c()) return playerEquipmentHandler.cast();
 +      }
 +      return super.getCapability(capability, facing);
++   }
++
++   /**
++    * Force a pose for the player. If set, the vanilla pose determination and clearance check is skipped. Make sure the pose is clear yourself (e.g. in PlayerTick).
++    * This has to be set just once, do not set it every tick.
++    * Make sure to clear (null) the pose if not required anymore and only use if necessary.
++    */
++   public void setForcedPose(@Nullable Pose pose) {
++      this.forcedPose = pose;
++   }
++
++   /**
++    * @return The forced pose if set, null otherwise
++    */
++   @Nullable
++   public Pose getForcedPose() {
++      return this.forcedPose;
 +   }
  }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -35,6 +35,8 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.Pose;
+import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
@@ -741,5 +743,12 @@ public class ForgeEventFactory
     {
         RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment);
         MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity player, Pose pose, EntitySize size, float eyeHeight)
+    {
+        EntityEvent.Size evt = new EntityEvent.Size(player, pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -137,10 +137,11 @@ public class EntityEvent extends Event
         public int getOldChunkZ() { return oldChunkZ; }
         public void setOldChunkZ(int oldChunkZ) { this.oldChunkZ = oldChunkZ; }
     }
-    
+
     /**
-     * EyeHeight is fired when an Entity's eye height changes. <br>
      * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -148,26 +149,31 @@ public class EntityEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class EyeHeight extends EntityEvent
+    public static class Size extends EntityEvent
     {
         private final Pose pose;
-        private final EntitySize size;
-        private final float oldHeight;
-        private float newHeight;
-     
-        public EyeHeight(Entity entity, Pose pose, EntitySize size, float defaultHeight)
+        private final EntitySize oldSize;
+        private EntitySize newSize;
+        private final float oldEyeHeight;
+        private float newEyeHeight;
+
+        public Size(Entity entity, Pose pose, EntitySize size, float defaultEyeHeight)
         {
             super(entity);
             this.pose = pose;
-            this.size = size;
-            this.oldHeight = defaultHeight;
-            this.newHeight = defaultHeight;
+            this.oldSize = size;
+            this.newSize = size;
+            this.oldEyeHeight = defaultEyeHeight;
+            this.newEyeHeight = defaultEyeHeight;
         }
-        
+
+
         public Pose getPose() { return pose; }
-        public EntitySize getSize() { return size; }
-        public float getOldHeight() { return oldHeight; }
-        public float getNewHeight() { return newHeight; }
-        public void setNewHeight(float newSize) { this.newHeight = newSize; }
+        public EntitySize getOldSize() { return oldSize; }
+        public EntitySize getNewSize() { return newSize; }
+        public void setNewSize(EntitySize size) { this.newSize = size; }
+        public float getOldEyeHeight() { return oldEyeHeight; }
+        public float getNewEyeHeight() { return newEyeHeight; }
+        public void setNewEyeHeight(float newHeight) { this.newEyeHeight = newHeight; }
     }
 }


### PR DESCRIPTION
1.16 version of #6369
For the reasoning see: #6059

This PR replaces the existing `EntityEvent#Height` with a `EntityEvent#Size` which allows modifying the entity size in addition to the eye height. This is binary breaking.

I personally only need to modify the player size, but as the existing `Height` event is posted for all entities, this system is therefore available for all entities.

If needed, I can commit a small test mod.

<details>
  <summary>Very basic test code</summary>

```
@Mod("player_size_test")
public class PlayerSizeTest
{
    public PlayerSizeTest(){
        MinecraftForge.EVENT_BUS.register(this);
    }


    @SubscribeEvent
    public void onEntitySize(EntityEvent.Size event){
        if(event.getEntity() instanceof PlayerEntity){
            if(((PlayerEntity) event.getEntity()).inventory !=null && ((PlayerEntity) event.getEntity()).getHeldItemMainhand().getItem() == Items.STICK){
                event.setNewSize(EntitySize.fixed(0.2f,0.2f));
                event.setNewEyeHeight(0.15f);
                ((PlayerEntity) event.getEntity()).setForcedPose(Pose.STANDING); //In theory only necessary once
            }
            else{
                ((PlayerEntity) event.getEntity()).setForcedPose(null); //In theory only necessary once
            }
        }
    }

}
```

This simple changes the player's size and pose while holding a stick (have to sneak to update the size here)
If adding a proper test mod, I would write something more suitable.
</details>