### PR TITLE
Fixed handleServerAboutToStart being called too late on integrated servers

### DIFF
--- a/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/server/integrated/IntegratedServer.java
 +++ b/net/minecraft/server/integrated/IntegratedServer.java
-@@ -60,8 +60,9 @@
+@@ -59,9 +59,10 @@
+       this.func_71245_h(true);
        field_147148_h.info("Generating keypair");
        this.func_71253_a(CryptManager.func_75891_b());
-       this.func_240800_l__();
 +      if (!net.minecraftforge.fml.server.ServerLifecycleHooks.handleServerAboutToStart(this)) return false;
+       this.func_240800_l__();
        this.func_71205_p(this.func_71214_G() + " - " + this.func_240793_aU_().func_76065_j());
 -      return true;
 +      return net.minecraftforge.fml.server.ServerLifecycleHooks.handleServerStarting(this);


### PR DESCRIPTION
Reopening this now that I have done more testing and realized I was entirely wrong about what was causing me to crash when I opened #6859 initially, and I now understand what this PR is fixing. `ServerLifecycleHooks#handleServerAboutToStart` sets the current server, on the dedicated server this is called ***before*** the world starts to be loaded (`func_240800_l__`). On an integrated server however, this is called ***after*** the server starts to load so `ServerLifecycleHooks#getCurrentServer` returns null when queried from places like `WorldEvent.Load` (which if you want to use the "global" save data for some information by grabbing the overworld, makes this useless in singleplayer as you aren't able to access it). This PR moves the call on the Integrated server to handling server about to start to before the world starts loading on the server.