### PR TITLE
[1.15] Fix Language.javaLocale parsing

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -4,7 +4,7 @@
        this.field_135037_b = p_i1303_2_;
        this.field_135038_c = p_i1303_3_;
        this.field_135036_d = p_i1303_4_;
-+      String[] splitLangCode = field_135038_c.split("_", 2);
++      String[] splitLangCode = field_135039_a.split("_", 2);
 +      if (splitLangCode.length == 1) { // Vanilla has some languages without underscores
 +          this.javaLocale = new java.util.Locale(field_135039_a);
 +      } else {


### PR DESCRIPTION
Locale should be based on `languageCode`, not `name`.