### PR TITLE
Expand the range of depth values allowed when the game is drawing GUIs.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -169,6 +169,15 @@
        this.field_71417_B.func_198021_g();
     }
  
+@@ -1104,7 +1115,7 @@
+       RenderSystem.clear(256, field_142025_a);
+       RenderSystem.matrixMode(5889);
+       RenderSystem.loadIdentity();
+-      RenderSystem.ortho(0.0D, (double)this.field_195558_d.func_198109_k(), (double)this.field_195558_d.func_198091_l(), 0.0D, 1000.0D, 3000.0D);
++      RenderSystem.ortho(0.0D, (double)this.field_195558_d.func_198109_k(), (double)this.field_195558_d.func_198091_l(), 0.0D, net.minecraftforge.client.ForgeHooksClient.GUI_DEPTH_NEAR, net.minecraftforge.client.ForgeHooksClient.GUI_DEPTH_FAR);
+       RenderSystem.matrixMode(5888);
+       RenderSystem.loadIdentity();
+       RenderSystem.translatef(0.0F, 0.0F, -2000.0F);
 @@ -1227,11 +1238,21 @@
           if (p_147115_1_ && this.field_71476_x != null && this.field_71476_x.func_216346_c() == RayTraceResult.Type.BLOCK) {
              BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -18,6 +18,15 @@
        }
     }
  
+@@ -445,7 +447,7 @@
+          RenderSystem.clear(256, Minecraft.field_142025_a);
+          RenderSystem.matrixMode(5889);
+          RenderSystem.loadIdentity();
+-         RenderSystem.ortho(0.0D, (double)mainwindow.func_198109_k() / mainwindow.func_198100_s(), (double)mainwindow.func_198091_l() / mainwindow.func_198100_s(), 0.0D, 1000.0D, 3000.0D);
++         RenderSystem.ortho(0.0D, (double)mainwindow.func_198109_k() / mainwindow.func_198100_s(), (double)mainwindow.func_198091_l() / mainwindow.func_198100_s(), 0.0D, net.minecraftforge.client.ForgeHooksClient.GUI_DEPTH_NEAR, net.minecraftforge.client.ForgeHooksClient.GUI_DEPTH_FAR);
+          RenderSystem.matrixMode(5888);
+          RenderSystem.loadIdentity();
+          RenderSystem.translatef(0.0F, 0.0F, -2000.0F);
 @@ -476,7 +478,7 @@
              }
           } else if (this.field_78531_r.field_71462_r != null) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -153,6 +153,10 @@ public class ForgeHooksClient
 {
     private static final Logger LOGGER = LogManager.getLogger();
 
+    // De-inlined to ensure
+    public static final double GUI_DEPTH_NEAR = 1000.0;
+    public static final double GUI_DEPTH_FAR = 30000.0; // Forge: expand from 3000 because quite a lot of mods have issues due to the limited range.
+
     //private static final ResourceLocation ITEM_GLINT = new ResourceLocation("textures/misc/enchanted_item_glint.png");
 
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlotType slot, String type)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -153,7 +153,7 @@ public class ForgeHooksClient
 {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    // De-inlined to ensure
+    // De-inlined to ensure the patches don't get out of sync.
     public static final double GUI_DEPTH_NEAR = 1000.0;
     public static final double GUI_DEPTH_FAR = 30000.0; // Forge: expand from 3000 because quite a lot of mods have issues due to the limited range.
 


### PR DESCRIPTION
The default value is 3000, which is very limiting for a lot of mods.
This expands the far plane to 30000, which still leaves enough precision to not disturb drawing higher detail objects.