### PR TITLE
[1.16.x] Added Hoe to ToolType

### DIFF
--- a/patches/minecraft/net/minecraft/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/HoeItem.java.patch
@@ -1,6 +1,13 @@
 --- a/net/minecraft/item/HoeItem.java
 +++ b/net/minecraft/item/HoeItem.java
-@@ -27,7 +27,9 @@
+@@ -21,13 +21,15 @@
+    protected static final Map<Block, BlockState> field_195973_b = Maps.newHashMap(ImmutableMap.of(Blocks.field_196658_i, Blocks.field_150458_ak.func_176223_P(), Blocks.field_185774_da, Blocks.field_150458_ak.func_176223_P(), Blocks.field_150346_d, Blocks.field_150458_ak.func_176223_P(), Blocks.field_196660_k, Blocks.field_150346_d.func_176223_P()));
+ 
+    protected HoeItem(IItemTier p_i231595_1_, int p_i231595_2_, float p_i231595_3_, Item.Properties p_i231595_4_) {
+-      super((float)p_i231595_2_, p_i231595_3_, p_i231595_1_, field_234683_c_, p_i231595_4_);
++      super((float)p_i231595_2_, p_i231595_3_, p_i231595_1_, field_234683_c_, p_i231595_4_.addToolType(net.minecraftforge.common.ToolType.HOE, p_i231595_1_.func_200925_d()));
+    }
+ 
     public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
        World world = p_195939_1_.func_195991_k();
        BlockPos blockpos = p_195939_1_.func_195995_a();

--- a/src/main/java/net/minecraftforge/common/ToolType.java
+++ b/src/main/java/net/minecraftforge/common/ToolType.java
@@ -30,6 +30,7 @@ public final class ToolType
     private static final Map<String, ToolType> values = Maps.newHashMap();
 
     public static final ToolType AXE = get("axe");
+    public static final ToolType HOE = get("hoe");
     public static final ToolType PICKAXE = get("pickaxe");
     public static final ToolType SHOVEL = get("shovel");
 


### PR DESCRIPTION
In 1.16, the hoe is now a tool which is effective on a few blocks. Because of that we need hoe as tooltype. This PR adds this.