### PR TITLE
[1.15.x] Fix IItemHandler wrappers for chests not updating both chests

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
@@ -17,7 +17,7 @@
           TileEntity tileentity = p_195481_0_.func_175625_s(p_195481_1_);
           if (tileentity instanceof ChestTileEntity) {
              return ((ChestTileEntity)tileentity).field_145987_o;
-@@ -221,4 +222,56 @@
+@@ -221,4 +222,69 @@
     protected Container func_213906_a(int p_213906_1_, PlayerInventory p_213906_2_) {
        return ChestContainer.func_216992_a(p_213906_1_, p_213906_2_, this);
     }
@@ -57,9 +57,22 @@
 +               if (ote instanceof ChestTileEntity) {
 +                  IInventory top    = type == ChestType.RIGHT ? this : (IInventory)ote;
 +                  IInventory bottom = type == ChestType.RIGHT ? (IInventory)ote : this;
++                  class ChestWrapper extends net.minecraftforge.items.wrapper.InvWrapper {
++                     public ChestWrapper(IInventory inv)
++                     {
++                        super(inv);
++                     }
++
++                     @Override
++                     protected void markDirty()
++                     {
++                        top.func_70296_d();
++                        bottom.func_70296_d();
++                     }
++                  }
 +                  return new net.minecraftforge.items.wrapper.CombinedInvWrapper(
-+                     new net.minecraftforge.items.wrapper.InvWrapper(top),
-+                     new net.minecraftforge.items.wrapper.InvWrapper(bottom));
++                     new ChestWrapper(top),
++                     new ChestWrapper(bottom));
 +               }
 +            }
 +         }

--- a/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
@@ -17,7 +17,7 @@
           TileEntity tileentity = p_195481_0_.func_175625_s(p_195481_1_);
           if (tileentity instanceof ChestTileEntity) {
              return ((ChestTileEntity)tileentity).field_145987_o;
-@@ -221,4 +222,69 @@
+@@ -221,4 +222,39 @@
     protected Container func_213906_a(int p_213906_1_, PlayerInventory p_213906_2_) {
        return ChestContainer.func_216992_a(p_213906_1_, p_213906_2_, this);
     }
@@ -46,38 +46,8 @@
 +      if (!(state.func_177230_c() instanceof ChestBlock)) {
 +         return new net.minecraftforge.items.wrapper.InvWrapper(this);
 +      }
-+      ChestType type = state.func_177229_b(ChestBlock.field_196314_b);
-+      if (type != ChestType.SINGLE) {
-+         BlockPos opos = this.func_174877_v().func_177972_a(ChestBlock.func_196311_i(state));
-+         BlockState ostate = this.func_145831_w().func_180495_p(opos);
-+         if (state.func_177230_c() == ostate.func_177230_c()) {
-+            ChestType otype = ostate.func_177229_b(ChestBlock.field_196314_b);
-+            if (otype != ChestType.SINGLE && type != otype && state.func_177229_b(ChestBlock.field_176459_a) == ostate.func_177229_b(ChestBlock.field_176459_a)) {
-+               TileEntity ote = this.func_145831_w().func_175625_s(opos);
-+               if (ote instanceof ChestTileEntity) {
-+                  IInventory top    = type == ChestType.RIGHT ? this : (IInventory)ote;
-+                  IInventory bottom = type == ChestType.RIGHT ? (IInventory)ote : this;
-+                  class ChestWrapper extends net.minecraftforge.items.wrapper.InvWrapper {
-+                     public ChestWrapper(IInventory inv)
-+                     {
-+                        super(inv);
-+                     }
-+
-+                     @Override
-+                     protected void markDirty()
-+                     {
-+                        top.func_70296_d();
-+                        bottom.func_70296_d();
-+                     }
-+                  }
-+                  return new net.minecraftforge.items.wrapper.CombinedInvWrapper(
-+                     new ChestWrapper(top),
-+                     new ChestWrapper(bottom));
-+               }
-+            }
-+         }
-+      }
-+      return new net.minecraftforge.items.wrapper.InvWrapper(this);
++      IInventory inv = ChestBlock.func_226916_a_((ChestBlock) state.func_177230_c(), state, func_145831_w(), func_174877_v(), true);
++      return new net.minecraftforge.items.wrapper.InvWrapper(inv == null ? this : inv);
 +   }
 +
 +   @Override

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -98,7 +98,7 @@ public class InvWrapper implements IItemHandlerModifiable
                     ItemStack copy = stack.copy();
                     copy.grow(stackInSlot.getCount());
                     getInv().setInventorySlotContents(slot, copy);
-                    getInv().markDirty();
+                    markDirty();
                 }
 
                 return ItemStack.EMPTY;
@@ -112,7 +112,7 @@ public class InvWrapper implements IItemHandlerModifiable
                     ItemStack copy = stack.split(m);
                     copy.grow(stackInSlot.getCount());
                     getInv().setInventorySlotContents(slot, copy);
-                    getInv().markDirty();
+                    markDirty();
                     return stack;
                 }
                 else
@@ -135,7 +135,7 @@ public class InvWrapper implements IItemHandlerModifiable
                 if (!simulate)
                 {
                     getInv().setInventorySlotContents(slot, stack.split(m));
-                    getInv().markDirty();
+                    markDirty();
                     return stack;
                 }
                 else
@@ -149,7 +149,7 @@ public class InvWrapper implements IItemHandlerModifiable
                 if (!simulate)
                 {
                     getInv().setInventorySlotContents(slot, stack);
-                    getInv().markDirty();
+                    markDirty();
                 }
                 return ItemStack.EMPTY;
             }
@@ -187,7 +187,7 @@ public class InvWrapper implements IItemHandlerModifiable
             int m = Math.min(stackInSlot.getCount(), amount);
 
             ItemStack decrStackSize = getInv().decrStackSize(slot, m);
-            getInv().markDirty();
+            markDirty();
             return decrStackSize;
         }
     }
@@ -214,4 +214,10 @@ public class InvWrapper implements IItemHandlerModifiable
     {
         return inv;
     }
+
+    protected void markDirty()
+    {
+        getInv().markDirty();
+    }
+
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -98,7 +98,7 @@ public class InvWrapper implements IItemHandlerModifiable
                     ItemStack copy = stack.copy();
                     copy.grow(stackInSlot.getCount());
                     getInv().setInventorySlotContents(slot, copy);
-                    markDirty();
+                    getInv().markDirty();
                 }
 
                 return ItemStack.EMPTY;
@@ -112,7 +112,7 @@ public class InvWrapper implements IItemHandlerModifiable
                     ItemStack copy = stack.split(m);
                     copy.grow(stackInSlot.getCount());
                     getInv().setInventorySlotContents(slot, copy);
-                    markDirty();
+                    getInv().markDirty();
                     return stack;
                 }
                 else
@@ -135,7 +135,7 @@ public class InvWrapper implements IItemHandlerModifiable
                 if (!simulate)
                 {
                     getInv().setInventorySlotContents(slot, stack.split(m));
-                    markDirty();
+                    getInv().markDirty();
                     return stack;
                 }
                 else
@@ -149,7 +149,7 @@ public class InvWrapper implements IItemHandlerModifiable
                 if (!simulate)
                 {
                     getInv().setInventorySlotContents(slot, stack);
-                    markDirty();
+                    getInv().markDirty();
                 }
                 return ItemStack.EMPTY;
             }
@@ -187,7 +187,7 @@ public class InvWrapper implements IItemHandlerModifiable
             int m = Math.min(stackInSlot.getCount(), amount);
 
             ItemStack decrStackSize = getInv().decrStackSize(slot, m);
-            markDirty();
+            getInv().markDirty();
             return decrStackSize;
         }
     }
@@ -214,10 +214,4 @@ public class InvWrapper implements IItemHandlerModifiable
     {
         return inv;
     }
-
-    protected void markDirty()
-    {
-        getInv().markDirty();
-    }
-
 }


### PR DESCRIPTION
Fixes #6873.
`markDirty` needs to be called on both chests when either one is updated, comparators attached to one chest won't get updated.