### PR TITLE
1.16 - Fix TagsUpdateEvent firing too early.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -278,7 +278,15 @@
     }
  
     private void func_184117_aA() {
-@@ -1676,6 +1715,10 @@
+@@ -1643,6 +1682,7 @@
+          try {
+             saveformat$levelsave.func_237287_a_(p_238195_2_, iserverconfiguration);
+             minecraft$packmanager.func_238225_b_().func_240971_i_();
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(minecraft$packmanager.func_238225_b_().func_240966_d_()));
+             YggdrasilAuthenticationService yggdrasilauthenticationservice = new YggdrasilAuthenticationService(this.field_110453_aa, UUID.randomUUID().toString());
+             MinecraftSessionService minecraftsessionservice = yggdrasilauthenticationservice.createMinecraftSessionService();
+             GameProfileRepository gameprofilerepository = yggdrasilauthenticationservice.createProfileRepository();
+@@ -1676,6 +1716,10 @@
           this.field_71424_I.func_76320_a("waitForServer");
  
           while(!this.field_71437_Z.func_71200_ad()) {
@@ -289,7 +297,7 @@
              worldloadprogressscreen.func_231023_e_();
              this.func_195542_b(false);
  
-@@ -1696,7 +1739,12 @@
+@@ -1696,7 +1740,12 @@
           networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_229998_0_) -> {
           }));
           networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -303,7 +311,7 @@
           this.field_71453_ak = networkmanager;
        } else {
           this.func_241559_a_(p_238195_6_, p_238195_1_, flag, () -> {
-@@ -1770,6 +1818,7 @@
+@@ -1770,6 +1819,7 @@
     }
  
     public void func_71403_a(ClientWorld p_71403_1_) {
@@ -311,7 +319,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1801,10 +1850,12 @@
+@@ -1801,10 +1851,12 @@
        IntegratedServer integratedserver = this.field_71437_Z;
        this.field_71437_Z = null;
        this.field_71460_t.func_190564_k();
@@ -324,7 +332,7 @@
           if (integratedserver != null) {
              this.field_71424_I.func_76320_a("waitForServer");
  
-@@ -1819,6 +1870,7 @@
+@@ -1819,6 +1871,7 @@
           this.field_71456_v.func_181029_i();
           this.field_71422_O = null;
           this.field_71455_al = false;
@@ -332,7 +340,7 @@
           this.field_213274_aO.func_216815_b();
        }
  
-@@ -1849,6 +1901,7 @@
+@@ -1849,6 +1902,7 @@
        this.field_71452_i.func_78870_a(p_213257_1_);
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
        this.func_230150_b_();
@@ -340,7 +348,7 @@
     }
  
     public boolean func_238216_r_() {
-@@ -1894,112 +1947,9 @@
+@@ -1894,112 +1948,9 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -456,7 +464,7 @@
        }
     }
  
-@@ -2081,6 +2031,7 @@
+@@ -2081,6 +2032,7 @@
        return field_71432_P;
     }
  
@@ -464,7 +472,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_229993_0_) -> {
           return p_229993_0_;
-@@ -2388,7 +2339,7 @@
+@@ -2388,7 +2340,7 @@
           supplier = func_228022_c_(supplier);
        }
  
@@ -473,7 +481,7 @@
     }
  
     private static Supplier<IResourcePack> func_228021_b_(Supplier<IResourcePack> p_228021_0_) {
-@@ -2407,6 +2358,14 @@
+@@ -2407,6 +2359,14 @@
        this.field_175617_aL.func_229355_a_(p_228020_1_);
     }
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -144,7 +144,15 @@
           for(ResourcePackInfo resourcepackinfo : this.field_195577_ad.func_198980_d()) {
              if (stringbuilder.length() > 0) {
                 stringbuilder.append(", ");
-@@ -1284,6 +1304,7 @@
+@@ -1271,6 +1291,7 @@
+          this.field_195577_ad.func_198985_a(p_240780_1_);
+          this.field_240768_i_.func_230410_a_(func_240771_a_(this.field_195577_ad));
+          p_240782_2_.func_240971_i_();
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(p_240782_2_.func_240966_d_()));
+          this.func_184103_al().func_72389_g();
+          this.func_184103_al().func_193244_w();
+          this.field_200258_al.func_240946_a_(this.field_195576_ac.func_240960_a_());
+@@ -1284,6 +1305,7 @@
     }
  
     public static DatapackCodec func_240772_a_(ResourcePackList<ResourcePackInfo> p_240772_0_, DatapackCodec p_240772_1_, boolean p_240772_2_) {
@@ -152,7 +160,7 @@
        p_240772_0_.func_198983_a();
        if (p_240772_2_) {
           p_240772_0_.func_198985_a(Collections.singleton("vanilla"));
-@@ -1437,6 +1458,31 @@
+@@ -1437,6 +1459,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  
@@ -184,7 +192,7 @@
     public void func_223711_a(Path p_223711_1_) throws IOException {
        Path path = p_223711_1_.resolve("levels");
  
-@@ -1564,4 +1610,8 @@
+@@ -1564,4 +1611,8 @@
     public IServerConfiguration func_240793_aU_() {
        return this.field_240768_i_;
     }

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -18,11 +18,12 @@
        ServerProperties serverproperties = this.field_71340_o.func_219034_a();
        if (this.func_71264_H()) {
           this.func_71189_e("127.0.0.1");
-@@ -153,17 +156,20 @@
+@@ -153,17 +156,21 @@
        if (!PreYggdrasilConverter.func_219587_e(this)) {
           return false;
        } else {
 +         net.minecraftforge.fml.server.ServerModLoader.end();
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(getDataPackRegistries().func_240966_d_()));
           this.func_184105_a(new DedicatedPlayerList(this, this.field_240767_f_, this.field_240766_e_));
           long i = Util.func_211178_c();
           this.func_71191_d(serverproperties.field_219026_t);
@@ -39,7 +40,7 @@
           if (serverproperties.field_219027_u != null) {
              this.func_200252_aR().func_223585_a(GameRules.field_223620_w).func_223570_a(serverproperties.field_219027_u, this);
           }
-@@ -189,11 +195,12 @@
+@@ -189,11 +196,12 @@
           }
  
           Items.field_190931_a.func_150895_a(ItemGroup.field_78027_g, NonNullList.func_191196_a());
@@ -53,7 +54,7 @@
        }
     }
  
-@@ -506,6 +513,11 @@
+@@ -506,6 +514,11 @@
        return false;
     }
  

--- a/patches/minecraft/net/minecraft/tags/NetworkTagManager.java.patch
+++ b/patches/minecraft/net/minecraft/tags/NetworkTagManager.java.patch
@@ -1,9 +1,0 @@
---- a/net/minecraft/tags/NetworkTagManager.java
-+++ b/net/minecraft/tags/NetworkTagManager.java
-@@ -86,5 +86,6 @@
-       FluidTags.func_206953_a(this.field_205705_c);
-       EntityTypeTags.func_219759_a(this.field_215299_d);
-       Blocks.func_235419_a_();
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(this));
-    }
- }


### PR DESCRIPTION
On servers, players can not enter any fuel into furnaces. However, it works after doing the /reload command.
This is because when the TagsUpdatedEvent is fired, forge sets up the burntime of fuels and uses that to determine if an item is a valid fuel. However, the TagsUpdateEvent currently fires before modloading end, while the EventBus is still shutdown and the event is ignored. 
the reload command fires the event, the burntimes are updated and everything works again.

This PR simply strips out the firing of the event from the NetworkTagManager's function and adds it to each relevant places as well as right after modloading ended. 
This is still a bit weird, because the event is firing after tags updated because it simply cant be fired at that time. 

The firing of the event can definitely be moved somewhere else in DedicatedServer, it really just needs to be fired at some point is all. 