### PR TITLE
[1.16] Allow any armor to have custom knockback resistance

### DIFF
--- a/patches/minecraft/net/minecraft/item/ArmorItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/ArmorItem.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/item/ArmorItem.java
 +++ b/net/minecraft/item/ArmorItem.java
+@@ -69,7 +69,7 @@
+       UUID uuid = field_185084_n[p_i48534_2_.func_188454_b()];
+       builder.put(Attributes.field_233826_i_, new AttributeModifier(uuid, "Armor modifier", (double)this.field_77879_b, AttributeModifier.Operation.ADDITION));
+       builder.put(Attributes.field_233827_j_, new AttributeModifier(uuid, "Armor toughness", (double)this.field_189415_e, AttributeModifier.Operation.ADDITION));
+-      if (p_i48534_1_ == ArmorMaterial.NETHERITE) {
++      if (this.field_234655_c_ > 0) {
+          builder.put(Attributes.field_233820_c_, new AttributeModifier(uuid, "Armor knockback resistance", (double)this.field_234655_c_, AttributeModifier.Operation.ADDITION));
+       }
+ 
 @@ -113,6 +113,10 @@
        return this.field_77879_b;
     }


### PR DESCRIPTION
This replaces a hardcoded check for Netherite armor, with a check for `IArmorMaterial.func_230304_f_ > 0`. 
This function is only used here, meaning it most likely means `getKnockbackResistance`.