### PR TITLE
[1.16] Add senderUUID to ClientChatReceivedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
@@ -30,7 +30,7 @@
     public void func_147251_a(SChatPacket p_147251_1_) {
        PacketThreadUtil.func_218797_a(p_147251_1_, this, this.field_147299_f);
 -      this.field_147299_f.field_71456_v.func_238450_a_(p_147251_1_.func_192590_c(), p_147251_1_.func_148915_c(), p_147251_1_.func_240810_e_());
-+      net.minecraft.util.text.ITextComponent message = net.minecraftforge.event.ForgeEventFactory.onClientChat(p_147251_1_.func_192590_c(), p_147251_1_.func_148915_c());
++      net.minecraft.util.text.ITextComponent message = net.minecraftforge.event.ForgeEventFactory.onClientChat(p_147251_1_.func_192590_c(), p_147251_1_.func_148915_c(), p_147251_1_.func_240810_e_());
 +      if (message == null) return;
 +      this.field_147299_f.field_71456_v.func_238450_a_(p_147251_1_.func_192590_c(), message, p_147251_1_.func_240810_e_());
     }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -24,15 +24,33 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
-@net.minecraftforge.eventbus.api.Cancelable
-public class ClientChatReceivedEvent extends net.minecraftforge.eventbus.api.Event
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * Fired on the client when a chat message is received.<br>
+ * If this event is cancelled, the message is not displayed in the chat message window.<br>
+ * Fired on {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class ClientChatReceivedEvent extends Event
 {
     private ITextComponent message;
     private final ChatType type;
+    @Nullable
+    private final UUID senderUUID;
+
+    @Deprecated // use constructor that takes senderUUID
     public ClientChatReceivedEvent(ChatType type, ITextComponent message)
     {
+        this(type, message, null);
+    }
+
+    public ClientChatReceivedEvent(ChatType type, ITextComponent message, @Nullable UUID senderUUID)
+    {
         this.type = type;
-        this.setMessage(message);
+        this.message = message;
+        this.senderUUID = senderUUID;
     }
 
     public ITextComponent getMessage()
@@ -48,5 +66,15 @@ public class ClientChatReceivedEvent extends net.minecraftforge.eventbus.api.Eve
     public ChatType getType()
     {
         return type;
+    }
+
+    /**
+     * The UUID of the player or entity that sent this message, or null if not known.
+     * This will be equal to {@link net.minecraft.util.Util#field_240973_b_} for system messages.
+     */
+    @Nullable
+    public UUID getSenderUUID()
+    {
+        return senderUUID;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -40,12 +40,6 @@ public class ClientChatReceivedEvent extends Event
     @Nullable
     private final UUID senderUUID;
 
-    @Deprecated // use constructor that takes senderUUID
-    public ClientChatReceivedEvent(ChatType type, ITextComponent message)
-    {
-        this(type, message, null);
-    }
-
     public ClientChatReceivedEvent(ChatType type, ITextComponent message, @Nullable UUID senderUUID)
     {
         this.type = type;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -336,6 +336,7 @@ public class ForgeEventFactory
         return onClientChat(type, message, null);
     }
 
+    @Nullable
     public static ITextComponent onClientChat(ChatType type, ITextComponent message, @Nullable UUID senderUUID)
     {
         ClientChatReceivedEvent event = new ClientChatReceivedEvent(type, message, senderUUID);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -330,13 +330,6 @@ public class ForgeEventFactory
     }
 
     @Nullable
-    @Deprecated // use version with senderUUID
-    public static ITextComponent onClientChat(ChatType type, ITextComponent message)
-    {
-        return onClientChat(type, message, null);
-    }
-
-    @Nullable
     public static ITextComponent onClientChat(ChatType type, ITextComponent message, @Nullable UUID senderUUID)
     {
         ClientChatReceivedEvent event = new ClientChatReceivedEvent(type, message, senderUUID);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -330,9 +330,15 @@ public class ForgeEventFactory
     }
 
     @Nullable
+    @Deprecated // use version with senderUUID
     public static ITextComponent onClientChat(ChatType type, ITextComponent message)
     {
-        ClientChatReceivedEvent event = new ClientChatReceivedEvent(type, message);
+        return onClientChat(type, message, null);
+    }
+
+    public static ITextComponent onClientChat(ChatType type, ITextComponent message, @Nullable UUID senderUUID)
+    {
+        ClientChatReceivedEvent event = new ClientChatReceivedEvent(type, message, senderUUID);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
 


### PR DESCRIPTION
Vanilla now includes the UUID of the sending entity in server->client chat messages, pass this info on to `ClientChatReceivedEvent`.
Also adds javadocs to the event that was previously missing.

