### PR TITLE
[1.15] Add extra debugging information to the MDK

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -144,3 +144,5 @@ publishing {
         }
     }
 }
+
+System.out.println("Running with java ${System.getProperty("java.version")} (${System.getProperty("os.arch")})")

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -18,6 +18,8 @@ group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming
 archivesBaseName = 'modid'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+//Print out JVM information so that we know what version is running. Extreamly useful for people to know when helping you.
+println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
 minecraft {
     // The mappings can be changed at any time, and must be in the following format.
@@ -144,5 +146,3 @@ publishing {
         }
     }
 }
-
-System.out.println("Running with java ${System.getProperty("java.version")} (${System.getProperty("os.arch")})")


### PR DESCRIPTION
This helps us diagnose issues with the JDK, without asking for command outputs and various other things to get information relevant to debugging.