### PR TITLE
[1.16] Add extra debugging information to the MDK

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -144,3 +144,5 @@ publishing {
         }
     }
 }
+
+System.out.println("Running with java ${System.getProperty("java.version")} (${System.getProperty("os.arch")})")


### PR DESCRIPTION
Same as #6882. Extra information useful for debugging Java issues.