### PR TITLE
Reimplement ITeleporter Patches

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -216,7 +216,56 @@
     }
  
     public boolean func_70028_i(Entity p_70028_1_) {
-@@ -2159,10 +2187,12 @@
+@@ -2072,10 +2100,15 @@
+ 
+    @Nullable
+    public Entity func_241206_a_(ServerWorld p_241206_1_) {
++      return this.changeDimension(p_241206_1_, p_241206_1_.func_85176_s());
++   }
++   @Nullable
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
+       if (this.field_70170_p instanceof ServerWorld && !this.field_70128_L) {
+          this.field_70170_p.func_217381_Z().func_76320_a("changeDimension");
+          this.func_213319_R();
+          this.field_70170_p.func_217381_Z().func_76320_a("reposition");
++         Entity transportedEntity = teleporter.placeEntity(this, (ServerWorld) this.field_70170_p, p_241206_1_, this.field_70177_z, spawnPortal -> { //Forge: Start vanilla logic
+          Vector3d vector3d = this.func_213322_ci();
+          float f = 0.0F;
+          BlockPos blockpos;
+@@ -2105,6 +2138,7 @@
+             d1 = MathHelper.func_151237_a(d1, d4, d6);
+             Vector3d vector3d1 = this.func_181014_aG();
+             blockpos = new BlockPos(d0, this.func_226278_cu_(), d1);
++            if (spawnPortal) {
+             BlockPattern.PortalInfo blockpattern$portalinfo = p_241206_1_.func_85176_s().func_222272_a(blockpos, vector3d, this.func_181012_aH(), vector3d1.field_72450_a, vector3d1.field_72448_b, this instanceof PlayerEntity);
+             if (blockpattern$portalinfo == null) {
+                return null;
+@@ -2113,6 +2147,7 @@
+             blockpos = new BlockPos(blockpattern$portalinfo.field_222505_a);
+             vector3d = blockpattern$portalinfo.field_222506_b;
+             f = (float)blockpattern$portalinfo.field_222507_c;
++            }
+          }
+ 
+          this.field_70170_p.func_217381_Z().func_219895_b("reloading");
+@@ -2126,13 +2161,15 @@
+                ServerWorld.func_241121_a_(p_241206_1_);
+             }
+          }
++         return entity;
++         });//Forge: End vanilla logic
+ 
+          this.func_241204_bJ_();
+          this.field_70170_p.func_217381_Z().func_76319_b();
+          ((ServerWorld)this.field_70170_p).func_82742_i();
+          p_241206_1_.func_82742_i();
+          this.field_70170_p.func_217381_Z().func_76319_b();
+-         return entity;
++         return transportedEntity;
+       } else {
+          return null;
+       }
+@@ -2159,10 +2196,12 @@
     }
  
     public Vector3d func_181014_aG() {
@@ -229,7 +278,7 @@
        return this.field_181018_ap;
     }
  
-@@ -2295,7 +2325,7 @@
+@@ -2295,7 +2334,7 @@
        Pose pose = this.func_213283_Z();
        EntitySize entitysize1 = this.func_213305_a(pose);
        this.field_213325_aI = entitysize1;
@@ -238,7 +287,7 @@
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.func_226277_ct_() - d0, this.func_226278_cu_(), this.func_226281_cx_() - d0, this.func_226277_ct_() + d0, this.func_226278_cu_() + (double)entitysize1.field_220316_b, this.func_226281_cx_() + d0));
-@@ -2769,6 +2799,7 @@
+@@ -2769,6 +2808,7 @@
  
           this.field_233555_aA_ = true;
        }
@@ -246,7 +295,7 @@
  
     }
  
-@@ -2779,4 +2810,69 @@
+@@ -2779,4 +2819,69 @@
     public interface IMoveCallback {
        void accept(Entity p_accept_1_, double p_accept_2_, double p_accept_4_, double p_accept_6_);
     }

--- a/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
@@ -22,3 +22,18 @@
              }
           } else if (entity != null) {
              entity.func_70634_a(this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_());
+@@ -91,12 +94,12 @@
+    }
+ 
+    @Nullable
+-   public Entity func_241206_a_(ServerWorld p_241206_1_) {
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
+       Entity entity = this.func_234616_v_();
+       if (entity != null && entity.field_70170_p.func_234923_W_() != p_241206_1_.func_234923_W_()) {
+          this.func_212361_a((Entity)null);
+       }
+ 
+-      return super.func_241206_a_(p_241206_1_);
++      return super.changeDimension(p_241206_1_, teleporter);
+    }
+ }

--- a/patches/minecraft/net/minecraft/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/ItemEntity.java.patch
@@ -106,6 +106,17 @@
              p_70100_1_.func_71001_a(this, i);
              if (itemstack.func_190926_b()) {
                 this.func_70106_y();
+@@ -318,8 +345,8 @@
+    }
+ 
+    @Nullable
+-   public Entity func_241206_a_(ServerWorld p_241206_1_) {
+-      Entity entity = super.func_241206_a_(p_241206_1_);
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
++      Entity entity = super.changeDimension(p_241206_1_, teleporter);
+       if (!this.field_70170_p.field_72995_K && entity instanceof ItemEntity) {
+          ((ItemEntity)entity).func_85054_d();
+       }
 @@ -392,7 +419,7 @@
  
     public void func_174870_v() {

--- a/patches/minecraft/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java.patch
@@ -1,7 +1,14 @@
 --- a/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java
 +++ b/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java
-@@ -116,12 +116,14 @@
-       return super.func_241206_a_(p_241206_1_);
+@@ -111,17 +111,19 @@
+    }
+ 
+    @Nullable
+-   public Entity func_241206_a_(ServerWorld p_241206_1_) {
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
+       this.field_94112_b = false;
+-      return super.func_241206_a_(p_241206_1_);
++      return super.changeDimension(p_241206_1_, teleporter);
     }
  
 -   public void func_70106_y() {

--- a/patches/minecraft/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java
++++ b/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java
+@@ -164,9 +164,9 @@
+    }
+ 
+    @Nullable
+-   public Entity func_241206_a_(ServerWorld p_241206_1_) {
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
+       this.func_213750_eg();
+-      return super.func_241206_a_(p_241206_1_);
++      return super.changeDimension(p_241206_1_, teleporter);
+    }
+ 
+    protected void func_213750_eg() {

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -8,22 +8,25 @@
        boolean flag = this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223609_l);
        if (flag) {
           ITextComponent itextcomponent = this.func_110142_aN().func_151521_b();
-@@ -597,12 +598,13 @@
+@@ -596,13 +597,14 @@
+    }
  
     @Nullable
-    public Entity func_241206_a_(ServerWorld p_241206_1_) {
+-   public Entity func_241206_a_(ServerWorld p_241206_1_) {
++   public Entity changeDimension(ServerWorld p_241206_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_241206_1_.func_234923_W_())) return null;
        this.field_184851_cj = true;
        ServerWorld serverworld = this.func_71121_q();
        RegistryKey<World> registrykey = serverworld.func_234923_W_();
-       if (registrykey == World.field_234920_i_ && p_241206_1_.func_234923_W_() == World.field_234918_g_) {
+-      if (registrykey == World.field_234920_i_ && p_241206_1_.func_234923_W_() == World.field_234918_g_) {
++      if (registrykey == World.field_234920_i_ && p_241206_1_.func_234923_W_() == World.field_234918_g_ && teleporter instanceof net.minecraft.world.Teleporter) { //Forge: Fix non-vanilla teleporters triggering end credits
           this.func_213319_R();
 -         this.func_71121_q().func_217434_e(this);
 +         this.func_71121_q().removePlayer(this, true); //Forge: The player entity is cloned so keep the data until after cloning calls copyFrom
           if (!this.field_71136_j) {
              this.field_71136_j = true;
              this.field_71135_a.func_147359_a(new SChangeGameStatePacket(SChangeGameStatePacket.field_241768_e_, this.field_192040_cp ? 0.0F : 1.0F));
-@@ -616,8 +618,8 @@
+@@ -616,8 +618,9 @@
           this.field_71135_a.func_147359_a(new SServerDifficultyPacket(iworldinfo.func_176130_y(), iworldinfo.func_176123_z()));
           PlayerList playerlist = this.field_71133_b.func_184103_al();
           playerlist.func_187243_f(this);
@@ -31,10 +34,30 @@
 -         this.field_70128_L = false;
 +         serverworld.removeEntity(this, true); //Forge: the player entity is moved to the new world, NOT cloned. So keep the data alive with no matching invalidate call.
 +         this.revive();
++         Entity e = teleporter.placeEntity(this, serverworld, p_241206_1_, this.field_70177_z, spawnPortal -> {//Forge: Start vanilla logic
           double d0 = this.func_226277_ct_();
           double d1 = this.func_226278_cu_();
           double d2 = this.func_226281_cx_();
-@@ -689,6 +691,7 @@
+@@ -666,7 +669,7 @@
+             ServerWorld.func_241121_a_(p_241206_1_);
+             this.func_70012_b((double)i, (double)j, (double)k, f1, 0.0F);
+             this.func_213317_d(Vector3d.field_186680_a);
+-         } else if (!p_241206_1_.func_85176_s().func_222268_a(this, f2)) {
++         } else if (spawnPortal && !p_241206_1_.func_85176_s().func_222268_a(this, f2)) {
+             p_241206_1_.func_85176_s().func_85188_a(this);
+             p_241206_1_.func_85176_s().func_222268_a(this, f2);
+          }
+@@ -676,6 +679,9 @@
+          p_241206_1_.func_217447_b(this);
+          this.func_213846_b(serverworld);
+          this.field_71135_a.func_147364_a(this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), f1, f);
++         return this;//forge: this is part of the ITeleporter patch
++         });//Forge: End vanilla logic
++         if (e != this) throw new java.lang.IllegalArgumentException(String.format("Teleporter %s returned not the player entity but instead %s, expected PlayerEntity %s", teleporter, e, this));
+          this.field_71134_c.func_73080_a(p_241206_1_);
+          this.field_71135_a.func_147359_a(new SPlayerAbilitiesPacket(this.field_71075_bZ));
+          playerlist.func_72354_b(this, p_241206_1_);
+@@ -689,6 +695,7 @@
           this.field_71144_ck = -1;
           this.field_71149_ch = -1.0F;
           this.field_71146_ci = -1;
@@ -42,7 +65,7 @@
           return this;
        }
     }
-@@ -731,6 +734,9 @@
+@@ -731,6 +738,9 @@
     }
  
     public Either<PlayerEntity.SleepResult, Unit> func_213819_a(BlockPos p_213819_1_) {
@@ -52,7 +75,7 @@
        Direction direction = this.field_70170_p.func_180495_p(p_213819_1_).func_177229_b(HorizontalBlock.field_185512_D);
        if (!this.func_70608_bn() && this.func_70089_S()) {
           if (!this.field_70170_p.func_230315_m_().func_236043_f_()) {
-@@ -775,6 +781,7 @@
+@@ -775,6 +785,7 @@
     }
  
     private boolean func_241147_a_(BlockPos p_241147_1_, Direction p_241147_2_) {
@@ -60,7 +83,7 @@
        return this.func_241158_g_(p_241147_1_) || this.func_241158_g_(p_241147_1_.func_177972_a(p_241147_2_.func_176734_d()));
     }
  
-@@ -874,6 +881,7 @@
+@@ -874,6 +885,7 @@
              this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_()));
              container.func_75132_a(this);
              this.field_71070_bA = container;
@@ -68,7 +91,7 @@
              return OptionalInt.of(this.field_71139_cq);
           }
        }
-@@ -892,6 +900,7 @@
+@@ -892,6 +904,7 @@
        this.field_71135_a.func_147359_a(new SOpenHorseWindowPacket(this.field_71139_cq, p_184826_2_.func_70302_i_(), p_184826_1_.func_145782_y()));
        this.field_71070_bA = new HorseInventoryContainer(this.field_71139_cq, this.field_71071_by, p_184826_2_, p_184826_1_);
        this.field_71070_bA.func_75132_a(this);
@@ -76,7 +99,7 @@
     }
  
     public void func_184814_a(ItemStack p_184814_1_, Hand p_184814_2_) {
-@@ -949,6 +958,7 @@
+@@ -949,6 +962,7 @@
  
     public void func_71128_l() {
        this.field_71070_bA.func_75134_a(this);
@@ -84,7 +107,7 @@
        this.field_71070_bA = this.field_71069_bz;
     }
  
-@@ -1075,6 +1085,13 @@
+@@ -1075,6 +1089,13 @@
        this.field_193110_cw = p_193104_1_.field_193110_cw;
        this.func_192029_h(p_193104_1_.func_192023_dk());
        this.func_192031_i(p_193104_1_.func_192025_dl());
@@ -98,7 +121,7 @@
     }
  
     protected void func_70670_a(EffectInstance p_70670_1_) {
-@@ -1181,6 +1198,7 @@
+@@ -1181,6 +1202,7 @@
        this.field_71140_co = p_147100_1_.func_149520_f();
        this.func_184212_Q().func_187227_b(field_184827_bp, (byte)p_147100_1_.func_149521_d());
        this.func_184212_Q().func_187227_b(field_184828_bq, (byte)(p_147100_1_.func_186991_f() == HandSide.LEFT ? 0 : 1));
@@ -106,7 +129,7 @@
     }
  
     public ChatVisibility func_147096_v() {
-@@ -1291,14 +1309,14 @@
+@@ -1291,14 +1313,14 @@
        this.func_184210_p();
        if (p_200619_1_ == this.field_70170_p) {
           this.field_71135_a.func_147364_a(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
@@ -124,7 +147,7 @@
           this.func_70012_b(p_200619_2_, p_200619_4_, p_200619_6_, p_200619_8_, p_200619_9_);
           this.func_70029_a(p_200619_1_);
           p_200619_1_.func_217446_a(this);
-@@ -1307,6 +1325,7 @@
+@@ -1307,6 +1329,7 @@
           this.field_71134_c.func_73080_a(p_200619_1_);
           this.field_71133_b.func_184103_al().func_72354_b(this, p_200619_1_);
           this.field_71133_b.func_184103_al().func_72385_f(this);
@@ -132,7 +155,7 @@
        }
  
     }
-@@ -1375,6 +1394,8 @@
+@@ -1375,6 +1398,8 @@
        if (itementity == null) {
           return null;
        } else {
@@ -141,7 +164,7 @@
           this.field_70170_p.func_217376_c(itementity);
           ItemStack itemstack = itementity.func_92059_d();
           if (p_146097_3_) {
-@@ -1388,4 +1409,13 @@
+@@ -1388,4 +1413,13 @@
           return itementity;
        }
     }

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -42,8 +42,7 @@ public interface ITeleporter {
      *
      * The initial position of the entity will be its
      * position in the origin world, multiplied horizontally
-     * by the computed cross-dimensional movement factor
-     * (see {@link Dimension#getMovementFactor()}).
+     * by the computed cross-dimensional movement factor.
      *
      * Note that the supplied entity has not yet been spawned
      * in the destination world at the time.
@@ -53,7 +52,7 @@ public interface ITeleporter {
      * @param destWorld        the entity's destination
      * @param yaw              the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
-     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.dimension.DimensionType, ITeleporter)}
+     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.server.ServerWorld, ITeleporter)}
      */
     default Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
        return repositionEntity.apply(true);

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -66,7 +66,7 @@ public class CommandSetDimension
         //    throw INVALID_DIMENSION.create(dim);
 
         entities.stream().filter(e -> e.world == dim).forEach(e -> sender.sendFeedback(new TranslationTextComponent("commands.forge.setdim.invalid.nochange", e.getDisplayName().getString(), dim), true));
-        entities.stream().filter(e -> e.world != dim).forEach(e ->  e.func_241206_a_(dim/* TODO: Custom Teleporters , new ITeleporter()
+        entities.stream().filter(e -> e.world != dim).forEach(e ->  e.changeDimension(dim , new ITeleporter()
         {
             @Override
             public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
@@ -75,7 +75,7 @@ public class CommandSetDimension
                 repositionedEntity.setPositionAndUpdate(pos.getX(), pos.getY(), pos.getZ());
                 return repositionedEntity;
             }
-        }*/));
+        }));
 
 
         return 0;

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -45,18 +45,18 @@ net/minecraft/client/renderer/model/multipart/Multipart.bake(Lnet/minecraft/clie
 net/minecraft/client/resources/ClientResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/resources/IResourcePack;Lnet/minecraft/resources/data/PackMetadataSection;Lnet/minecraft/resources/ResourcePackInfo$Priority;Z)V=|p_i48113_1_,p_i48113_2_,p_i48113_3_,p_i48113_4_,p_i48113_5_,p_i48113_6_,hidden
 net/minecraft/client/resources/ClientResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/resources/PackCompatibility;Lnet/minecraft/resources/ResourcePackInfo$Priority;ZLnet/minecraft/client/renderer/texture/NativeImage;Z)V=|p_i48114_1_,p_i48114_2_,p_i48114_3_,p_i48114_4_,p_i48114_5_,p_i48114_6_,p_i48114_7_,p_i48114_8_,p_i48114_9_,hidden
 
-net/minecraft/entity/Entity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
+net/minecraft/entity/Entity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 net/minecraft/entity/EntityClassification.create(Ljava/lang/String;Ljava/lang/String;IZZ)Lnet/minecraft/entity/EntityClassification;=|name,p_i50381_3_,p_i50381_4_,p_i50381_5_,p_i50381_6_
 net/minecraft/entity/EntityType.<init>(Lnet/minecraft/entity/EntityType$IFactory;Lnet/minecraft/entity/EntityClassification;ZZZZLnet/minecraft/entity/EntitySize;Ljava/util/function/Predicate;Ljava/util/function/ToIntFunction;Ljava/util/function/ToIntFunction;Ljava/util/function/BiFunction;)V=|p_i51559_1_,p_i51559_2_,p_i51559_3_,p_i51559_4_,p_i51559_5_,p_i51559_6_,p_i51559_7_,velocityUpdateSupplier,trackingRangeSupplier,updateIntervalSupplier,customClientFactory
 
-net/minecraft/entity/item/EnderPearlEntity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
-net/minecraft/entity/item/ItemEntity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
-net/minecraft/entity/item/minecart/ContainerMinecartEntity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
+net/minecraft/entity/item/EnderPearlEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
+net/minecraft/entity/item/ItemEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
+net/minecraft/entity/item/minecart/ContainerMinecartEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 
-net/minecraft/entity/merchant/villager/AbstractVillagerEntity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
+net/minecraft/entity/merchant/villager/AbstractVillagerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 
 net/minecraft/entity/player/PlayerEntity.getDigSpeed(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)F=|p_184813_1_,pos
-net/minecraft/entity/player/ServerPlayerEntity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
+net/minecraft/entity/player/ServerPlayerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 
 net/minecraft/item/BoneMealItem.applyBonemeal(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)Z=|p_195966_0_,p_195966_1_,p_195966_2_,player
 net/minecraft/item/FilledMapItem.getCustomMapData(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;)Lnet/minecraft/world/storage/MapData;=|p_195950_0_,p_195950_1_


### PR DESCRIPTION
Ports the patches relating to ITeleporter to 1.16. (See #6404 and #6505 for more details). I tested via the forge `setdimension` command and also with a modified version of Mekanism to verify that the system is properly working.