### PR TITLE
[1.16] Added AnvilDamageEvent and AnvilDamageEvent.Falling for cancelling Anvil damage

### DIFF
--- a/patches/minecraft/net/minecraft/block/AnvilBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AnvilBlock.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/block/AnvilBlock.java
++++ b/net/minecraft/block/AnvilBlock.java
+@@ -91,6 +91,7 @@
+ 
+    @Nullable
+    public static BlockState func_196433_f(BlockState p_196433_0_) {
++      if (net.minecraftforge.common.ForgeHooks.onAnvilDamage(p_196433_0_)) return p_196433_0_;
+       if (p_196433_0_.func_203425_a(Blocks.field_150467_bQ)) {
+          return Blocks.field_196717_eY.func_176223_P().func_206870_a(field_176506_a, p_196433_0_.func_177229_b(field_176506_a));
+       } else {

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -11,3 +11,6 @@
                                   CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());
 -            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
 +            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {
+                BlockState blockstate = AnvilBlock.func_196433_f(this.field_175132_d);
+                if (blockstate == null) {
+                   this.field_145808_f = true;

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -9,3 +9,5 @@
                                TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
                                if (tileentity != null) {
                                   CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());
+-            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
++            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -110,6 +110,8 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.anvil.AnvilDamageEvent;
+import net.minecraftforge.event.anvil.AnvilDamageEvent.Falling;
 import net.minecraftforge.event.anvil.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -673,6 +675,18 @@ public class ForgeHooks
         container.setMaximumCost(e.getCost());
         container.materialCost = e.getMaterialCost();
         return false;
+    }
+
+    public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
+    {
+        Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
+        return MinecraftForge.EVENT_BUS.post(e);
+    }
+
+    public static boolean onAnvilDamage(BlockState currentState)
+    {
+        AnvilDamageEvent e = new AnvilDamageEvent(currentState);
+        return MinecraftForge.EVENT_BUS.post(e);
     }
 
     public static float onAnvilRepair(PlayerEntity player, @Nonnull ItemStack output, @Nonnull ItemStack left, @Nonnull ItemStack right)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -679,7 +679,7 @@ public class ForgeHooks
 
     public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
     {
-        Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
+        AnvilDamageEvent.Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -110,7 +110,7 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.anvil.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.event.anvil;
+
+import net.minecraft.block.BlockState;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Cancelable
+public class AnvilDamageEvent extends Event
+{
+    /**
+     * A simple event fired whenever code is fired from the FallingBlockEntity to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
+    public static class Falling extends AnvilDamageEvent
+    {
+        /**
+         * The current blockstate beneath the FallingBlockEntity for the Anvil.
+         */
+        @Nullable
+        private final BlockState groundState;
+
+        public Falling(@Nonnull BlockState currentState, @Nullable BlockState groundState)
+        {
+            super(currentState);
+            this.groundState = groundState;
+        }
+
+        @Nullable
+        public BlockState getGroundState() { return groundState; }
+    }
+
+    /**
+     * The current state of the Anvil pre-damage
+     */
+    @Nonnull
+    private final BlockState currentState;
+
+    /**
+     * A simple event fired whenever code is fired to attempt to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
+    public AnvilDamageEvent(@Nonnull BlockState currentState)
+    {
+        this.currentState = currentState;
+    }
+
+    @Nonnull
+    public BlockState getCurrentState() { return currentState; }
+}

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilUpdateEvent.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.event;
+package net.minecraftforge.event.anvil;
 
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;

--- a/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.debug.block;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.event.anvil.AnvilDamageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+
+@Mod("anvil_damage_event_test")
+@EventBusSubscriber
+public class AnvilDamageEventTest
+{
+    @SubscribeEvent
+    public static void onAnvilDamage(AnvilDamageEvent event)
+    {
+        if (event.isCanceled()) return;
+        if (event.getCurrentState().getBlock().equals(Blocks.ANVIL))
+        {
+            System.out.println("Cancelled Anvil Damage");
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onAnvilDamagePre(AnvilDamageEvent.Falling event)
+    {
+        if (event.getGroundState() != null && event.getGroundState().func_235714_a_(BlockTags.WOOL))
+        {
+            System.out.println("Cancelled Anvil Damage from Falling");
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -68,3 +68,5 @@ loaderVersion="[28,)"
     modId="deferred_registry_test"
 [[mods]]
     modId="create_entity_classification_test"
+[[mods]]
+    modId="anvil_damage_event_test"


### PR DESCRIPTION
1.16 version of https://github.com/MinecraftForge/MinecraftForge/pull/6887

This PR makes it so that you can cancel the anvil taking damage (going from Anvil -> Chipped -> Damaged).
The normal event targets taking damage in general while the Falling sub-event targets when the anvil is damaged through the FallingBlockEntity code.

Included is a test mod that shows off this feature.