### PR TITLE
Add PlayerConnectingEvent 

### DIFF
--- a/patches/minecraft/net/minecraft/network/login/ServerLoginNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/ServerLoginNetHandler.java.patch
@@ -15,17 +15,15 @@
           this.func_147326_c();
        } else if (this.field_147328_g == ServerLoginNetHandler.State.DELAY_ACCEPT) {
           ServerPlayerEntity serverplayerentity = this.field_147327_f.func_184103_al().func_177451_a(this.field_147337_i.getId());
-@@ -91,6 +97,9 @@
+@@ -91,6 +97,7 @@
        }
  
        ITextComponent itextcomponent = this.field_147327_f.func_184103_al().func_206258_a(this.field_147333_a.func_74430_c(), this.field_147337_i);
-+
 +      itextcomponent = net.minecraftforge.event.ForgeEventFactory.onPlayerConnect(this.field_147327_f, this.field_147333_a, this.field_147337_i, itextcomponent);
-+
        if (itextcomponent != null) {
           this.func_194026_b(itextcomponent);
        } else {
-@@ -128,7 +137,7 @@
+@@ -128,7 +135,7 @@
           this.field_147328_g = ServerLoginNetHandler.State.KEY;
           this.field_147333_a.func_179290_a(new SEncryptionRequestPacket("", this.field_147327_f.func_71250_E().getPublic(), this.field_147330_e));
        } else {
@@ -34,7 +32,7 @@
        }
  
     }
-@@ -142,7 +151,7 @@
+@@ -142,7 +149,7 @@
           this.field_147335_k = p_147315_1_.func_149300_a(privatekey);
           this.field_147328_g = ServerLoginNetHandler.State.AUTHENTICATING;
           this.field_147333_a.func_150727_a(this.field_147335_k);
@@ -43,7 +41,7 @@
              public void run() {
                 GameProfile gameprofile = ServerLoginNetHandler.this.field_147337_i;
  
-@@ -151,11 +160,11 @@
+@@ -151,11 +158,11 @@
                    ServerLoginNetHandler.this.field_147337_i = ServerLoginNetHandler.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID)null, gameprofile.getName()), s, this.func_191235_a());
                    if (ServerLoginNetHandler.this.field_147337_i != null) {
                       ServerLoginNetHandler.field_147332_c.info("UUID of player {} is {}", ServerLoginNetHandler.this.field_147337_i.getName(), ServerLoginNetHandler.this.field_147337_i.getId());
@@ -57,7 +55,7 @@
                    } else {
                       ServerLoginNetHandler.this.func_194026_b(new TranslationTextComponent("multiplayer.disconnect.unverified_username"));
                       ServerLoginNetHandler.field_147332_c.error("Username '{}' tried to join with an invalid session", (Object)gameprofile.getName());
-@@ -164,7 +173,7 @@
+@@ -164,7 +171,7 @@
                    if (ServerLoginNetHandler.this.field_147327_f.func_71264_H()) {
                       ServerLoginNetHandler.field_147332_c.warn("Authentication servers are down but will let them in anyway!");
                       ServerLoginNetHandler.this.field_147337_i = ServerLoginNetHandler.this.func_152506_a(gameprofile);
@@ -66,7 +64,7 @@
                    } else {
                       ServerLoginNetHandler.this.func_194026_b(new TranslationTextComponent("multiplayer.disconnect.authservers_down"));
                       ServerLoginNetHandler.field_147332_c.error("Couldn't verify username because servers are unavailable");
-@@ -185,6 +194,7 @@
+@@ -185,6 +192,7 @@
     }
  
     public void func_209526_a(CCustomPayloadLoginPacket p_209526_1_) {

--- a/patches/minecraft/net/minecraft/network/login/ServerLoginNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/login/ServerLoginNetHandler.java.patch
@@ -15,7 +15,17 @@
           this.func_147326_c();
        } else if (this.field_147328_g == ServerLoginNetHandler.State.DELAY_ACCEPT) {
           ServerPlayerEntity serverplayerentity = this.field_147327_f.func_184103_al().func_177451_a(this.field_147337_i.getId());
-@@ -128,7 +134,7 @@
+@@ -91,6 +97,9 @@
+       }
+ 
+       ITextComponent itextcomponent = this.field_147327_f.func_184103_al().func_206258_a(this.field_147333_a.func_74430_c(), this.field_147337_i);
++
++      itextcomponent = net.minecraftforge.event.ForgeEventFactory.onPlayerConnect(this.field_147327_f, this.field_147333_a, this.field_147337_i, itextcomponent);
++
+       if (itextcomponent != null) {
+          this.func_194026_b(itextcomponent);
+       } else {
+@@ -128,7 +137,7 @@
           this.field_147328_g = ServerLoginNetHandler.State.KEY;
           this.field_147333_a.func_179290_a(new SEncryptionRequestPacket("", this.field_147327_f.func_71250_E().getPublic(), this.field_147330_e));
        } else {
@@ -24,7 +34,7 @@
        }
  
     }
-@@ -142,7 +148,7 @@
+@@ -142,7 +151,7 @@
           this.field_147335_k = p_147315_1_.func_149300_a(privatekey);
           this.field_147328_g = ServerLoginNetHandler.State.AUTHENTICATING;
           this.field_147333_a.func_150727_a(this.field_147335_k);
@@ -33,7 +43,7 @@
              public void run() {
                 GameProfile gameprofile = ServerLoginNetHandler.this.field_147337_i;
  
-@@ -151,11 +157,11 @@
+@@ -151,11 +160,11 @@
                    ServerLoginNetHandler.this.field_147337_i = ServerLoginNetHandler.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID)null, gameprofile.getName()), s, this.func_191235_a());
                    if (ServerLoginNetHandler.this.field_147337_i != null) {
                       ServerLoginNetHandler.field_147332_c.info("UUID of player {} is {}", ServerLoginNetHandler.this.field_147337_i.getName(), ServerLoginNetHandler.this.field_147337_i.getId());
@@ -47,7 +57,7 @@
                    } else {
                       ServerLoginNetHandler.this.func_194026_b(new TranslationTextComponent("multiplayer.disconnect.unverified_username"));
                       ServerLoginNetHandler.field_147332_c.error("Username '{}' tried to join with an invalid session", (Object)gameprofile.getName());
-@@ -164,7 +170,7 @@
+@@ -164,7 +173,7 @@
                    if (ServerLoginNetHandler.this.field_147327_f.func_71264_H()) {
                       ServerLoginNetHandler.field_147332_c.warn("Authentication servers are down but will let them in anyway!");
                       ServerLoginNetHandler.this.field_147337_i = ServerLoginNetHandler.this.func_152506_a(gameprofile);
@@ -56,7 +66,7 @@
                    } else {
                       ServerLoginNetHandler.this.func_194026_b(new TranslationTextComponent("multiplayer.disconnect.authservers_down"));
                       ServerLoginNetHandler.field_147332_c.error("Couldn't verify username because servers are unavailable");
-@@ -185,6 +191,7 @@
+@@ -185,6 +194,7 @@
     }
  
     public void func_209526_a(CCustomPayloadLoginPacket p_209526_1_) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -25,6 +25,7 @@ import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.mojang.authlib.GameProfile;
 import com.mojang.blaze3d.matrix.MatrixStack;
 
 import net.minecraft.block.NetherPortalBlock;
@@ -51,6 +52,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUseContext;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.spawner.AbstractSpawner;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.ActionResultType;
@@ -71,7 +74,6 @@ import net.minecraft.world.GameRules;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.WorldSettings;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.storage.IServerWorldInfo;
 import net.minecraft.world.storage.PlayerData;
@@ -721,5 +723,14 @@ public class ForgeEventFactory
         SleepFinishedTimeEvent event = new SleepFinishedTimeEvent(world, newTime, minTime);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getNewTime();
+    }
+
+    @Nullable
+    public static ITextComponent onPlayerConnect(MinecraftServer server, NetworkManager networkManager, GameProfile loginGameProfile, @Nullable ITextComponent original)
+    {
+        PlayerConnectingEvent event = new PlayerConnectingEvent(server, networkManager, loginGameProfile, original);
+        MinecraftForge.EVENT_BUS.post(event);
+
+        return event.getRejectionMessage();
     }
 }

--- a/src/main/java/net/minecraftforge/event/PlayerConnectingEvent.java
+++ b/src/main/java/net/minecraftforge/event/PlayerConnectingEvent.java
@@ -26,11 +26,12 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nullable;
 
 /**
- * ServerConnectEvent is fired when a player is connecting to a server right after the ban and whitelist checks. <br>
+ * PlayerConnectingEvent is fired when a player is connecting to a server right after the ban and whitelist checks. <br>
  * <br>
  * If the event is canceled, the player will be disconnected with either the set rejection message or a generic disconnected message.<br>
  * <br>
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class PlayerConnectingEvent extends net.minecraftforge.eventbus.api.Event {
+public class PlayerConnectingEvent extends Event {
     private final MinecraftServer server;
     private final NetworkManager networkManager;
     private final GameProfile profile;

--- a/src/main/java/net/minecraftforge/event/PlayerConnectingEvent.java
+++ b/src/main/java/net/minecraftforge/event/PlayerConnectingEvent.java
@@ -1,0 +1,103 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+import javax.annotation.Nullable;
+
+/**
+ * ServerConnectEvent is fired when a player is connecting to a server right after the ban and whitelist checks. <br>
+ * <br>
+ * If the event is canceled, the player will be disconnected with either the set rejection message or a generic disconnected message.<br>
+ * <br>
+ * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class PlayerConnectingEvent extends net.minecraftforge.eventbus.api.Event {
+    private final MinecraftServer server;
+    private final NetworkManager networkManager;
+    private final GameProfile profile;
+    @Nullable
+    private final ITextComponent originalMessage;
+    @Nullable
+    private ITextComponent rejectionMessage;
+
+    public PlayerConnectingEvent(MinecraftServer server, NetworkManager networkManager, GameProfile profile, @Nullable ITextComponent original)
+    {
+        this.server = server;
+        this.networkManager = networkManager;
+        this.profile = profile;
+        this.originalMessage = original;
+        this.setRejectionMessage(original);
+    }
+
+    public NetworkManager getNetworkManager()
+    {
+        return networkManager;
+    }
+
+    public GameProfile getProfile()
+    {
+        return profile;
+    }
+
+    @Nullable
+    public ITextComponent getOriginalMessage()
+    {
+        return originalMessage;
+    }
+
+    @Nullable
+    public ITextComponent getRejectionMessage()
+    {
+        if (this.isCanceled() && this.rejectionMessage == null) {
+            return new TranslationTextComponent("multiplayer.disconnect.generic");
+        } else {
+            return rejectionMessage;
+        }
+    }
+
+    public void setRejectionMessage(@Nullable ITextComponent rejectionMessage)
+    {
+        if (rejectionMessage == null) {
+            this.setCanceled(false);
+            this.rejectionMessage = null;
+        } else {
+            this.setCanceled(true);
+            this.rejectionMessage = rejectionMessage;
+        }
+    }
+
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
+}


### PR DESCRIPTION
fires right after whitelist and ban checks, setting a rejection message
or cancelling it will disconnect the player

based on GH-6158
resolves GH-4300

---

I tried to address the feedback in #6158 but not too familiar with the Forge event system in general and how cancelable is usually handled.
Also the event name is quite broad, any better name ideas?