### PR TITLE
[1.16] Added AnvilBreakEvent, AnvilDamageEvent & AnvilDamageEvent.Falling/Container

### DIFF
--- a/patches/minecraft/net/minecraft/block/AnvilBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AnvilBlock.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/block/AnvilBlock.java
++++ b/net/minecraft/block/AnvilBlock.java
+@@ -91,6 +91,7 @@
+ 
+    @Nullable
+    public static BlockState func_196433_f(BlockState p_196433_0_) {
++      if (net.minecraftforge.common.ForgeHooks.onAnvilDamage(p_196433_0_)) return p_196433_0_;
+       if (p_196433_0_.func_203425_a(Blocks.field_150467_bQ)) {
+          return Blocks.field_196717_eY.func_176223_P().func_206870_a(field_176506_a, p_196433_0_.func_177229_b(field_176506_a));
+       } else {

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -1,19 +1,17 @@
 --- a/net/minecraft/entity/item/FallingBlockEntity.java
 +++ b/net/minecraft/entity/item/FallingBlockEntity.java
-@@ -153,7 +153,7 @@
-                               ((FallingBlock)block).func_176502_a_(this.field_70170_p, blockpos1, this.field_175132_d, blockstate, this);
-                            }
+@@ -198,10 +198,12 @@
+                entity.func_70097_a(damagesource, (float)Math.min(MathHelper.func_76141_d((float)i * this.field_145816_i), this.field_145815_h));
+             }
  
--                           if (this.field_145810_d != null && block instanceof ITileEntityProvider) {
-+                           if (this.field_145810_d != null && this.field_175132_d.hasTileEntity()) {
-                               TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
-                               if (tileentity != null) {
-                                  CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());
 -            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
-+            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {
++            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.func_226268_ag_(), this.func_130014_f_().func_180495_p(func_226270_aj_()), this.func_226270_aj_(), this, this.func_130014_f_())) {
                 BlockState blockstate = AnvilBlock.func_196433_f(this.field_175132_d);
                 if (blockstate == null) {
 -                  this.field_145808_f = true;
-+                  if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(this.field_175132_d, field_70170_p, func_226268_ag_(), this)) {
++                  if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(this.field_175132_d, this.func_130014_f_(), this.func_226268_ag_(), this, null)) {
 +                     this.field_145808_f = true;
 +                  }
+                } else {
+                   this.field_175132_d = blockstate;
+                }

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -11,3 +11,6 @@
                                   CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());
 -            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
 +            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {
+                BlockState blockstate = AnvilBlock.func_196433_f(this.field_175132_d);
+                if (blockstate == null) {
+                   this.field_145808_f = true;

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -13,4 +13,7 @@
 +            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {
                 BlockState blockstate = AnvilBlock.func_196433_f(this.field_175132_d);
                 if (blockstate == null) {
-                   this.field_145808_f = true;
+-                  this.field_145808_f = true;
++                  if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(this.field_175132_d, field_70170_p, func_226268_ag_(), this)) {
++                     this.field_145808_f = true;
++                  }

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -1,17 +1,11 @@
 --- a/net/minecraft/entity/item/FallingBlockEntity.java
 +++ b/net/minecraft/entity/item/FallingBlockEntity.java
-@@ -198,10 +198,12 @@
-                entity.func_70097_a(damagesource, (float)Math.min(MathHelper.func_76141_d((float)i * this.field_145816_i), this.field_145815_h));
-             }
- 
--            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
-+            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.func_226268_ag_(), this.func_130014_f_().func_180495_p(func_226270_aj_()), this.func_226270_aj_(), this, this.func_130014_f_())) {
-                BlockState blockstate = AnvilBlock.func_196433_f(this.field_175132_d);
-                if (blockstate == null) {
--                  this.field_145808_f = true;
-+                  if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(this.field_175132_d, this.func_130014_f_(), this.func_226268_ag_(), this, null)) {
-+                     this.field_145808_f = true;
-+                  }
-                } else {
-                   this.field_175132_d = blockstate;
-                }
+@@ -153,7 +153,7 @@
+                               ((FallingBlock)block).func_176502_a_(this.field_70170_p, blockpos1, this.field_175132_d, blockstate, this);
+                            }
+
+-                           if (this.field_145810_d != null && block instanceof ITileEntityProvider) {
++                           if (this.field_145810_d != null && this.field_175132_d.hasTileEntity()) {
+                               TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
+                               if (tileentity != null) {
+                                  CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());

--- a/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/FallingBlockEntity.java.patch
@@ -9,3 +9,5 @@
                                TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
                                if (tileentity != null) {
                                   CompoundNBT compoundnbt = tileentity.func_189515_b(new CompoundNBT());
+-            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D) {
++            if (flag && (double)this.field_70146_Z.nextFloat() < (double)0.05F + (double)i * 0.05D && !net.minecraftforge.common.ForgeHooks.onAnvilDamageFalling(this.field_175132_d, this.field_70122_E ? this.func_130014_f_().func_180495_p(this.func_226270_aj_()) : null)) {

--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -7,9 +7,16 @@
 +            float breakChance = net.minecraftforge.common.ForgeHooks.onAnvilRepair(p_230301_1_, p_230301_2_, RepairContainer.this.field_234643_d_.func_70301_a(0), RepairContainer.this.field_234643_d_.func_70301_a(1));
 +
           BlockState blockstate = p_234633_1_.func_180495_p(p_234633_2_);
-          if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F) {
+-         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F) {
++         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F  && !net.minecraftforge.common.ForgeHooks.onAnvilDamageContainer(blockstate, p_230301_1_, p_230301_1_.func_130014_f_())) {
              BlockState blockstate1 = AnvilBlock.func_196433_f(blockstate);
 @@ -96,8 +98,11 @@
+-               p_234633_1_.func_217377_a(p_234633_2_, false);
+-               p_234633_1_.func_217379_c(1029, p_234633_2_, 0);
++               if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(blockstate, p_230301_1_.func_130014_f_(), p_234633_2_, p_230301_1_)) {
++                  p_234633_1_.func_217377_a(p_234633_2_, false);
++                  p_234633_1_.func_217379_c(1029, p_234633_2_, 0);
++               }
           Map<Enchantment, Integer> map = EnchantmentHelper.func_82781_a(itemstack1);
           j = j + itemstack.func_82838_A() + (itemstack2.func_190926_b() ? 0 : itemstack2.func_82838_A());
           this.field_82856_l = 0;

--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/inventory/container/RepairContainer.java
 +++ b/net/minecraft/inventory/container/RepairContainer.java
-@@ -63,6 +63,8 @@
+@@ -63,12 +63,16 @@
  
        this.field_82854_e.func_221494_a(0);
        this.field_234644_e_.func_221486_a((p_234633_1_, p_234633_2_) -> {
@@ -8,15 +8,19 @@
 +
           BlockState blockstate = p_234633_1_.func_180495_p(p_234633_2_);
 -         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F) {
-+         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F  && !net.minecraftforge.common.ForgeHooks.onAnvilDamageContainer(blockstate, p_230301_1_, p_230301_1_.func_130014_f_())) {
++         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F  && !net.minecraftforge.common.ForgeHooks.onAnvilDamageContainer(blockstate, p_230301_1_, p_230301_1_.func_130014_f_(), this)) {
              BlockState blockstate1 = AnvilBlock.func_196433_f(blockstate);
-@@ -96,8 +98,11 @@
+             if (blockstate1 == null) {
 -               p_234633_1_.func_217377_a(p_234633_2_, false);
 -               p_234633_1_.func_217379_c(1029, p_234633_2_, 0);
-+               if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(blockstate, p_230301_1_.func_130014_f_(), p_234633_2_, p_230301_1_)) {
++               if (net.minecraftforge.common.ForgeHooks.onAnvilBreak(blockstate, p_230301_1_.func_130014_f_(), p_234633_2_, null, p_230301_1_)) {
 +                  p_234633_1_.func_217377_a(p_234633_2_, false);
 +                  p_234633_1_.func_217379_c(1029, p_234633_2_, 0);
 +               }
+             } else {
+                p_234633_1_.func_180501_a(p_234633_2_, blockstate1, 2);
+                p_234633_1_.func_217379_c(1030, p_234633_2_, 0);
+@@ -96,8 +100,11 @@
           Map<Enchantment, Integer> map = EnchantmentHelper.func_82781_a(itemstack1);
           j = j + itemstack.func_82838_A() + (itemstack2.func_190926_b() ? 0 : itemstack2.func_82838_A());
           this.field_82856_l = 0;
@@ -29,7 +33,7 @@
              if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2)) {
                 int l2 = Math.min(itemstack1.func_77952_i(), itemstack1.func_77958_k() / 4);
                 if (l2 <= 0) {
-@@ -214,6 +219,7 @@
+@@ -214,6 +221,7 @@
              i += k;
              itemstack1.func_200302_a(new StringTextComponent(this.field_82857_m));
           }
@@ -37,7 +41,7 @@
  
           this.field_82854_e.func_221494_a(j + i);
           if (i <= 0) {
-@@ -269,4 +275,8 @@
+@@ -269,4 +277,8 @@
     public int func_216976_f() {
        return this.field_82854_e.func_221495_b();
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -110,6 +110,8 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.anvil.AnvilDamageEvent;
+import net.minecraftforge.event.anvil.AnvilDamageEvent.Falling;
 import net.minecraftforge.event.anvil.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -673,6 +675,18 @@ public class ForgeHooks
         container.setMaximumCost(e.getCost());
         container.materialCost = e.getMaterialCost();
         return false;
+    }
+
+    public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
+    {
+        Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
+        return MinecraftForge.EVENT_BUS.post(e);
+    }
+
+    public static boolean onAnvilDamage(BlockState currentState)
+    {
+        AnvilDamageEvent e = new AnvilDamageEvent(currentState);
+        return MinecraftForge.EVENT_BUS.post(e);
     }
 
     public static float onAnvilRepair(PlayerEntity player, @Nonnull ItemStack output, @Nonnull ItemStack left, @Nonnull ItemStack right)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -679,7 +679,7 @@ public class ForgeHooks
 
     public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
     {
-        Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
+        AnvilDamageEvent.Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -110,7 +110,7 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.anvil.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -110,6 +110,7 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.anvil.AnvilBreakEvent;
 import net.minecraftforge.event.anvil.AnvilDamageEvent;
 import net.minecraftforge.event.anvil.AnvilDamageEvent.Falling;
 import net.minecraftforge.event.anvil.AnvilUpdateEvent;
@@ -677,15 +678,27 @@ public class ForgeHooks
         return false;
     }
 
+    public static boolean onAnvilDamage(BlockState currentState)
+    {
+        AnvilDamageEvent e = new AnvilDamageEvent(currentState);
+        return MinecraftForge.EVENT_BUS.post(e);
+    }
+
     public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
     {
         AnvilDamageEvent.Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 
-    public static boolean onAnvilDamage(BlockState currentState)
+    public static boolean onAnvilDamageContainer(BlockState currentState, PlayerEntity player, World world)
     {
-        AnvilDamageEvent e = new AnvilDamageEvent(currentState);
+        AnvilDamageEvent.Container e = new AnvilDamageEvent.Container(currentState, player, world);
+        return MinecraftForge.EVENT_BUS.post(e);
+    }
+
+    public static boolean onAnvilBreak(BlockState statePreBreak, World world, BlockPos pos, Entity entity)
+    {
+        AnvilBreakEvent e = new AnvilBreakEvent(statePreBreak, world, pos, entity);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -48,6 +48,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.block.Block;
+import net.minecraft.block.FallingBlock;
+import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.fluid.*;
 import net.minecraft.loot.LootContext;
 import net.minecraft.loot.LootTable;
@@ -678,27 +680,27 @@ public class ForgeHooks
         return false;
     }
 
-    public static boolean onAnvilDamage(BlockState currentState)
+    public static boolean onAnvilDamage(@Nonnull BlockState currentState)
     {
         AnvilDamageEvent e = new AnvilDamageEvent(currentState);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 
-    public static boolean onAnvilDamageFalling(BlockState currentState, BlockState groundState)
+    public static boolean onAnvilDamageFalling(@Nonnull BlockState currentState, @Nonnull BlockPos fallingEntityPos, @Nullable BlockState groundState, @Nonnull BlockPos groundStatePos, @Nonnull FallingBlockEntity fallingBlockEntity, @Nonnull World world)
     {
-        AnvilDamageEvent.Falling e = new AnvilDamageEvent.Falling(currentState, groundState);
+        AnvilDamageEvent.Falling e = new AnvilDamageEvent.Falling(currentState,fallingEntityPos, groundState, groundStatePos, fallingBlockEntity, world);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 
-    public static boolean onAnvilDamageContainer(BlockState currentState, PlayerEntity player, World world)
+    public static boolean onAnvilDamageContainer(@Nonnull BlockState currentState, @Nonnull PlayerEntity player, @Nonnull World world, @Nonnull RepairContainer container)
     {
-        AnvilDamageEvent.Container e = new AnvilDamageEvent.Container(currentState, player, world);
+        AnvilDamageEvent.Container e = new AnvilDamageEvent.Container(currentState, player, world, container);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 
-    public static boolean onAnvilBreak(BlockState statePreBreak, World world, BlockPos pos, Entity entity)
+    public static boolean onAnvilBreak(@Nonnull BlockState statePreBreak, @Nonnull World world, @Nonnull BlockPos pos, @Nullable FallingBlockEntity fallingBlockEntity, @Nullable PlayerEntity playerEntity)
     {
-        AnvilBreakEvent e = new AnvilBreakEvent(statePreBreak, world, pos, entity);
+        AnvilBreakEvent e = new AnvilBreakEvent(statePreBreak, world, pos, fallingBlockEntity, playerEntity);
         return MinecraftForge.EVENT_BUS.post(e);
     }
 

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilBreakEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilBreakEvent.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.event.anvil;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class AnvilBreakEvent extends Event
+{
+    /**
+     * This is the state of the block before it broke.
+     */
+    private final BlockState statePreBreaking;
+
+    /**
+     * This is the World of the Entity, be it the FallingBlockEntity or Player.
+     */
+    private final World world;
+
+    /**
+     * This is the BlockPos of where the block broke.
+     */
+    private final BlockPos pos;
+
+    /**
+     * This is the entity involved with the break.
+     * This can either be a FallingBlockEntity or a PlayerEntity.
+     */
+    private final Entity entity;
+
+    public AnvilBreakEvent(BlockState statePreBreaking, World world, BlockPos pos, Entity entity)
+    {
+        this.statePreBreaking = statePreBreaking;
+        this.world = world;
+        this.pos = pos;
+        this.entity = entity;
+    }
+
+    public BlockState getStatePreBreaking() { return statePreBreaking; }
+
+    public World getWorld() { return world; }
+
+    public BlockPos getPos() { return pos; }
+
+    public Entity getEntity() { return entity; }
+}

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilBreakEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilBreakEvent.java
@@ -1,49 +1,67 @@
 package net.minecraftforge.event.anvil;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.FallingBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 @Cancelable
 public class AnvilBreakEvent extends Event
 {
-    /**
-     * This is the state of the block before it broke.
-     */
+    @Nonnull
     private final BlockState statePreBreaking;
-
-    /**
-     * This is the World of the Entity, be it the FallingBlockEntity or Player.
-     */
+    @Nonnull
     private final World world;
-
-    /**
-     * This is the BlockPos of where the block broke.
-     */
+    @Nonnull
     private final BlockPos pos;
+    @Nullable
+    private final FallingBlockEntity fallingBlockEntity;
+    @Nullable
+    private final PlayerEntity playerEntity;
 
-    /**
-     * This is the entity involved with the break.
-     * This can either be a FallingBlockEntity or a PlayerEntity.
-     */
-    private final Entity entity;
-
-    public AnvilBreakEvent(BlockState statePreBreaking, World world, BlockPos pos, Entity entity)
+    public AnvilBreakEvent(@Nonnull BlockState statePreBreaking, @Nonnull World world, @Nonnull BlockPos pos, @Nullable FallingBlockEntity fallingBlockEntity, @Nullable PlayerEntity playerEntity)
     {
         this.statePreBreaking = statePreBreaking;
         this.world = world;
         this.pos = pos;
-        this.entity = entity;
+        this.fallingBlockEntity = fallingBlockEntity;
+        this.playerEntity = playerEntity;
     }
 
+    /**
+     * @return Returns the BlockState before it broke.
+     */
+    @Nonnull
     public BlockState getStatePreBreaking() { return statePreBreaking; }
 
+    /**
+     * This is either supplied by the FallingBlockEntity or the PlayerEntity.
+     * @return Returns the World where the breaking took place.
+     */
+    @Nonnull
     public World getWorld() { return world; }
 
+    /**
+     * @return Returns the position of where the Break took place.
+     */
+    @Nonnull
     public BlockPos getPos() { return pos; }
 
-    public Entity getEntity() { return entity; }
+    /**
+     * @return Returns the FallingBlockEntity, This can return Null!
+     */
+    @Nullable
+    public FallingBlockEntity getFallingBlockEntity() { return fallingBlockEntity; }
+
+    /**
+     * @return Returns the PlayerEntity, This can return Null!
+     */
+    @Nullable
+    public PlayerEntity getPlayerEntity() { return playerEntity; }
 }

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
@@ -1,7 +1,10 @@
 package net.minecraftforge.event.anvil;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.container.RepairContainer;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
@@ -9,25 +12,25 @@ import net.minecraftforge.eventbus.api.Event;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * A simple event fired whenever code is fired to attempt to damage the Anvil.
+ * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+ * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+ */
 @Cancelable
 public class AnvilDamageEvent extends Event
 {
-    /**
-     * The current state of the Anvil pre-damage
-     */
     @Nonnull
     private final BlockState currentState;
 
-    /**
-     * A simple event fired whenever code is fired to attempt to damage the Anvil.
-     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
-     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
-     */
     public AnvilDamageEvent(@Nonnull BlockState currentState)
     {
         this.currentState = currentState;
     }
 
+    /**
+     * @return Returns the Current BlockState of the Anvil Pre-Damage.
+     */
     @Nonnull
     public BlockState getCurrentState() { return currentState; }
 
@@ -38,50 +41,80 @@ public class AnvilDamageEvent extends Event
      */
     public static class Falling extends AnvilDamageEvent
     {
-        /**
-         * The current blockstate beneath the FallingBlockEntity for the Anvil.
-         */
         @Nullable
         private final BlockState groundState;
+        @Nonnull
+        private final FallingBlockEntity fallingBlockEntity;
+        @Nonnull
+        private final World world;
 
-        public Falling(@Nonnull BlockState currentState, @Nullable BlockState groundState)
+        public Falling(@Nonnull BlockState currentState, @Nonnull BlockPos fallingEntityPos, @Nullable BlockState groundState, @Nonnull BlockPos groundStatePos, @Nonnull FallingBlockEntity fallingBlockEntity, @Nonnull World world)
         {
             super(currentState);
             this.groundState = groundState;
+            this.fallingBlockEntity = fallingBlockEntity;
+            this.world = world;
         }
 
+        /**
+         * @return Returns the state below the FallingBlockEntity.
+         */
         @Nullable
         public BlockState getGroundState() { return groundState; }
+
+        /**
+         * @return Returns the FallingBlockEntity itself.
+         */
+        @Nonnull
+        public FallingBlockEntity getFallingBlockEntity() { return fallingBlockEntity; }
+
+        /**
+         * @return Returns the World of the FallingBlockEntity.
+         */
+        @Nonnull
+        public World getWorld() { return world; }
     }
 
+    /**
+     * A simple event fired whenever code is fired from the RepairContainer to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
     public static class Container extends AnvilDamageEvent
     {
-        /**
-         * The player using the RepairContainer.
-         */
+        @Nonnull
         private final PlayerEntity player;
-
-        /**
-         * The world of the Player.
-         */
+        @Nonnull
         private final World world;
+        @Nonnull
+        private final RepairContainer repairContainer;
 
-        /**
-         * A simple event fired whenever code is fired from the RepairContainer to damage the Anvil.
-         * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
-         * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
-         *
-         * @param currentState
-         */
-        public Container(@Nonnull BlockState currentState, PlayerEntity player, World world)
+        public Container(@Nonnull BlockState currentState, @Nonnull PlayerEntity player, @Nonnull World world, @Nonnull RepairContainer repairContainer)
         {
             super(currentState);
             this.player = player;
             this.world = world;
+            this.repairContainer = repairContainer;
         }
 
+        /**
+         * @return Returns the PlayerEntity using the RepairContainer.
+         */
+        @Nonnull
         public PlayerEntity getPlayer() { return player; }
 
+        /**
+         * @return Returns the World of the PlayerEntity using the RepairContainer.
+         */
+        @Nonnull
         public World getWorld() { return world; }
+
+        /**
+         * @return Returns the RepairContainer.
+         */
+        @Nonnull
+        public RepairContainer getRepairContainer() {
+            return repairContainer;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.event.anvil;
+
+import net.minecraft.block.BlockState;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Cancelable
+public class AnvilDamageEvent extends Event
+{
+    /**
+     * A simple event fired whenever code is fired from the FallingBlockEntity to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
+    public static class Falling extends AnvilDamageEvent
+    {
+        /**
+         * The current blockstate beneath the FallingBlockEntity for the Anvil.
+         */
+        @Nullable
+        private final BlockState groundState;
+
+        public Falling(@Nonnull BlockState currentState, @Nullable BlockState groundState)
+        {
+            super(currentState);
+            this.groundState = groundState;
+        }
+
+        @Nullable
+        public BlockState getGroundState() { return groundState; }
+    }
+
+    /**
+     * The current state of the Anvil pre-damage
+     */
+    @Nonnull
+    private final BlockState currentState;
+
+    /**
+     * A simple event fired whenever code is fired to attempt to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
+    public AnvilDamageEvent(@Nonnull BlockState currentState)
+    {
+        this.currentState = currentState;
+    }
+
+    @Nonnull
+    public BlockState getCurrentState() { return currentState; }
+}

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilDamageEvent.java
@@ -1,6 +1,8 @@
 package net.minecraftforge.event.anvil;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.World;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -10,6 +12,25 @@ import javax.annotation.Nullable;
 @Cancelable
 public class AnvilDamageEvent extends Event
 {
+    /**
+     * The current state of the Anvil pre-damage
+     */
+    @Nonnull
+    private final BlockState currentState;
+
+    /**
+     * A simple event fired whenever code is fired to attempt to damage the Anvil.
+     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+     */
+    public AnvilDamageEvent(@Nonnull BlockState currentState)
+    {
+        this.currentState = currentState;
+    }
+
+    @Nonnull
+    public BlockState getCurrentState() { return currentState; }
+
     /**
      * A simple event fired whenever code is fired from the FallingBlockEntity to damage the Anvil.
      * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
@@ -33,22 +54,34 @@ public class AnvilDamageEvent extends Event
         public BlockState getGroundState() { return groundState; }
     }
 
-    /**
-     * The current state of the Anvil pre-damage
-     */
-    @Nonnull
-    private final BlockState currentState;
-
-    /**
-     * A simple event fired whenever code is fired to attempt to damage the Anvil.
-     * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
-     * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
-     */
-    public AnvilDamageEvent(@Nonnull BlockState currentState)
+    public static class Container extends AnvilDamageEvent
     {
-        this.currentState = currentState;
-    }
+        /**
+         * The player using the RepairContainer.
+         */
+        private final PlayerEntity player;
 
-    @Nonnull
-    public BlockState getCurrentState() { return currentState; }
+        /**
+         * The world of the Player.
+         */
+        private final World world;
+
+        /**
+         * A simple event fired whenever code is fired from the RepairContainer to damage the Anvil.
+         * If the event is canceled, vanilla behaviour will not run and the Anvil's BlockState will not change (It won't be damaged).
+         * If the event is not canceled, vanilla behaviour will run and the Anvil will be damaged.
+         *
+         * @param currentState
+         */
+        public Container(@Nonnull BlockState currentState, PlayerEntity player, World world)
+        {
+            super(currentState);
+            this.player = player;
+            this.world = world;
+        }
+
+        public PlayerEntity getPlayer() { return player; }
+
+        public World getWorld() { return world; }
+    }
 }

--- a/src/main/java/net/minecraftforge/event/anvil/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/anvil/AnvilUpdateEvent.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.event;
+package net.minecraftforge.event.anvil;
 
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;

--- a/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.debug.block;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.event.anvil.AnvilDamageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+
+@Mod("anvil_damage_event_test")
+@EventBusSubscriber
+public class AnvilDamageEventTest
+{
+    @SubscribeEvent
+    public static void onAnvilDamage(AnvilDamageEvent event)
+    {
+        if (event.isCanceled()) return;
+        if (event.getCurrentState().getBlock().equals(Blocks.ANVIL))
+        {
+            System.out.println("Cancelled Anvil Damage");
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onAnvilDamagePre(AnvilDamageEvent.Falling event)
+    {
+        if (event.getGroundState() != null && event.getGroundState().func_235714_a_(BlockTags.WOOL))
+        {
+            System.out.println("Cancelled Anvil Damage from Falling");
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/AnvilDamageEventTest.java
@@ -1,7 +1,13 @@
 package net.minecraftforge.debug.block;
 
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.item.FallingBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Hand;
+import net.minecraftforge.event.anvil.AnvilBreakEvent;
 import net.minecraftforge.event.anvil.AnvilDamageEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -23,12 +29,35 @@ public class AnvilDamageEventTest
     }
 
     @SubscribeEvent
-    public static void onAnvilDamagePre(AnvilDamageEvent.Falling event)
+    public static void onAnvilDamageFalling(AnvilDamageEvent.Falling event)
     {
         if (event.getGroundState() != null && event.getGroundState().func_235714_a_(BlockTags.WOOL))
         {
             System.out.println("Cancelled Anvil Damage from Falling");
             event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onAnvilDamageContainer(AnvilDamageEvent.Container event)
+    {
+        if (event.getPlayer().getHeldItem(Hand.MAIN_HAND).isItemEqual(new ItemStack(Items.STICK)))
+            System.out.println("Cancelled Anvil Damage from Container");
+        event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onAnvilBreak(AnvilBreakEvent event)
+    {
+        if (event.getPlayerEntity() != null)
+        {
+            event.getWorld().setBlockState(event.getPos(), Blocks.DIAMOND_BLOCK.getDefaultState());
+        }
+
+        if (event.getFallingBlockEntity() != null)
+        {
+            event.getFallingBlockEntity().shouldDropItem = false;
+            event.getWorld().setBlockState(event.getPos(), Blocks.GOLD_BLOCK.getDefaultState());
         }
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -68,3 +68,5 @@ loaderVersion="[28,)"
     modId="deferred_registry_test"
 [[mods]]
     modId="create_entity_classification_test"
+[[mods]]
+    modId="anvil_damage_event_test"


### PR DESCRIPTION
This PR aims to add 4 new events.

AnvilBreakEvent - Fired whenever the Anvil breaks by conventional means (Container Damage or FallingBlockDamage).
AnvilDamageEvent - Catch-All event for when an anvil is damaged.
AnvilDamageEvent.Falling - Fired whenever the Anvil is being attempted to be damaged through the FallingBlockEntity Code.
AnvilDamageEvent.Container - Fired whenever the Anvil is being attempted to be damaged through the RepairContainer code.

So what purpose does these events fill?

**AnvilBreakEvent**
Previously we've been able to catch Anvil breaks through the world.
Currently this isn't possible so this event was created to fill that void.

**AnvilDamageEvent**
This event and it's sub-events is created so that you can control if/how the anvil is damaged through the normal means.
For example in the test mod, I've made it so the anvil isn't damaged if it lands on Wool or if the player is holding a stick in the case of the container. This could be used in the case of "RPG" mods to make it so there is a smaller chance for the anvil to take damage the higher the players "smithing" is or whatever.

Included is a test mod that shows off these events.