### PR TITLE
Fix patch error in ItemEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/ItemEntity.java.patch
@@ -78,14 +78,14 @@
        if (this.func_200214_m() != null) {
           p_213281_1_.func_186854_a("Thrower", this.func_200214_m());
        }
-@@ -259,6 +277,7 @@
-       if (this.func_200215_l() != null) {
-          p_213281_1_.func_186854_a("Owner", this.func_200215_l());
+@@ -272,6 +290,7 @@
+       if (p_70037_1_.func_74764_b("PickupDelay")) {
+          this.field_145804_b = p_70037_1_.func_74765_d("PickupDelay");
        }
-+      if (p_213281_1_.func_74764_b("Lifespan")) lifespan = p_213281_1_.func_74762_e("Lifespan");
++      if (p_70037_1_.func_74764_b("Lifespan")) lifespan = p_70037_1_.func_74762_e("Lifespan");
  
-       if (!this.func_92059_d().func_190926_b()) {
-          p_213281_1_.func_218657_a("Item", this.func_92059_d().func_77955_b(new CompoundNBT()));
+       if (p_70037_1_.func_186855_b("Owner")) {
+          this.field_145802_g = p_70037_1_.func_186857_a("Owner");
 @@ -291,10 +310,18 @@
  
     public void func_70100_b_(PlayerEntity p_70100_1_) {

--- a/patches/minecraft/net/minecraft/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/HoeItem.java.patch
@@ -3,7 +3,7 @@
 @@ -21,13 +21,15 @@
     protected static final Map<Block, BlockState> field_195973_b = Maps.newHashMap(ImmutableMap.of(Blocks.field_196658_i, Blocks.field_150458_ak.func_176223_P(), Blocks.field_185774_da, Blocks.field_150458_ak.func_176223_P(), Blocks.field_150346_d, Blocks.field_150458_ak.func_176223_P(), Blocks.field_196660_k, Blocks.field_150346_d.func_176223_P()));
  
-    protected HoeItem(IItemTier p_i231595_1_, int p_i231595_2_, float p_i231595_3_, Item.Properties p_i231595_4_) {
+    public HoeItem(IItemTier p_i231595_1_, int p_i231595_2_, float p_i231595_3_, Item.Properties p_i231595_4_) {
 -      super((float)p_i231595_2_, p_i231595_3_, p_i231595_1_, field_234683_c_, p_i231595_4_);
 +      super((float)p_i231595_2_, p_i231595_3_, p_i231595_1_, field_234683_c_, p_i231595_4_.addToolType(net.minecraftforge.common.ToolType.HOE, p_i231595_1_.func_200925_d()));
     }


### PR DESCRIPTION
Fixes #6854 read being called in `writeAdditional` instead of `readAdditional`
Also regenerate Patch for HoeItem as context changed due to a new AT for the constructor