### PR TITLE
Allows the old screen to be accessed in GuiOpenEvent  

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -136,7 +136,7 @@
        }
  
 +      Screen old = this.field_71462_r;
-+      net.minecraftforge.client.event.GuiOpenEvent event = new net.minecraftforge.client.event.GuiOpenEvent(p_147108_1_);
++      net.minecraftforge.client.event.GuiOpenEvent event = new net.minecraftforge.client.event.GuiOpenEvent(p_147108_1_, old);
 +      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
 +
 +      p_147108_1_ = event.getGui();

--- a/src/main/java/net/minecraftforge/client/event/GuiOpenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiOpenEvent.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.client.event;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.client.gui.screen.Screen;
 
 /**
@@ -34,9 +32,11 @@ import net.minecraft.client.gui.screen.Screen;
 public class GuiOpenEvent extends net.minecraftforge.eventbus.api.Event
 {
     private Screen gui;
-    public GuiOpenEvent(Screen gui)
+    private final Screen oldGui;
+    public GuiOpenEvent(Screen gui, Screen oldGui)
     {
         this.setGui(gui);
+        this.oldGui = oldGui;
     }
 
     public Screen getGui()
@@ -47,5 +47,10 @@ public class GuiOpenEvent extends net.minecraftforge.eventbus.api.Event
     public void setGui(Screen gui)
     {
         this.gui = gui;
+    }
+
+    public Screen getOldGui()
+    {
+        return oldGui;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/GuiOpenEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiOpenEventTest.java
@@ -1,0 +1,94 @@
+package net.minecraftforge.debug.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.*;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.client.event.GuiOpenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Field;
+
+@Mod("gui_open_event_test")
+@Mod.EventBusSubscriber
+public class GuiOpenEventTest
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final boolean IS_ENABLE = false;
+
+    @SubscribeEvent
+    public static void onGuiOpenEvent(GuiOpenEvent event)
+    {
+        if (IS_ENABLE)
+        {
+            Screen gui = event.getGui();
+            Screen oldGui = event.getOldGui();
+
+            LOGGER.info("[GuiOpenEventTest] new gui: {}", gui);
+            LOGGER.info("[GuiOpenEventTest] old gui: {}", oldGui);
+
+            // tests
+            try
+            {
+                Field field = null;
+
+                if (gui instanceof ChatOptionsScreen)
+                    field = SettingsScreen.class.getDeclaredField("parentScreen");
+                else if (gui instanceof ShareToLanScreen)
+                    field = ShareToLanScreen.class.getDeclaredField("lastScreen");
+
+                if (field != null)
+                {
+                    field.setAccessible(true);
+                    Screen parentGui = (Screen) field.get(gui);
+
+                    if (oldGui == parentGui)
+                        LOGGER.info("[GuiOpenEventTest] YEAH! parent gui {}", parentGui);
+                }
+            }
+            catch (IllegalAccessException | NoSuchFieldException e)
+            {
+                e.printStackTrace();
+            }
+
+            // example use case
+            if (gui instanceof ChatOptionsScreen || gui instanceof ShareToLanScreen)
+                event.setGui(new MyCustomScreen(oldGui));
+        }
+    }
+
+    private static class MyCustomScreen extends Screen
+    {
+        private final Screen oldGui;
+
+        public MyCustomScreen(Screen oldGui)
+        {
+            super(new StringTextComponent("My Custom Screen"));
+            this.oldGui = oldGui;
+        }
+
+        // init gui
+        @Override
+        protected void func_231160_c_()
+        {
+            int x = (this.field_230708_k_ - 150) / 2;
+            int y = (this.field_230709_l_ - 20) / 2;
+
+            // add close button
+            this.func_230480_a_(new Button(x, y, 150, 20, new StringTextComponent("Done"), (p_213085_1_) -> {
+                LOGGER.info("[GuiOpenEventTest] Done Button - onPress");
+                this.field_230706_i_.displayGuiScreen(this.oldGui); // return to parent gui
+            }));
+        }
+
+        // draw gui
+        @Override
+        public void func_230430_a_(MatrixStack p_230430_1_, int p_230430_2_, int p_230430_3_, float p_230430_4_) {
+            this.func_230446_a_(p_230430_1_); // draw background
+            super.func_230430_a_(p_230430_1_, p_230430_2_, p_230430_3_, p_230430_4_);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -10,7 +10,6 @@ loaderVersion="[28,)"
 [[mods]]
     modId="farmland_trample_test"
 [[mods]]
-
     modId="neighbor_notify_event_test"
 [[mods]]
     modId="block_place_event_test"
@@ -68,3 +67,5 @@ loaderVersion="[28,)"
     modId="deferred_registry_test"
 [[mods]]
     modId="create_entity_classification_test"
+[[mods]]
+    modId="gui_open_event_test"


### PR DESCRIPTION
This PR allows, when replacing a screen in GuiOpenEvent, the parent screen can be passed as a reference to new screen.

old issue #4624 lol