### PR TITLE
 IForgeBlock + IForgeBlockState + IForgeTileEntity cleanup

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -425,7 +425,18 @@
           if (this.field_184627_bm.func_222122_m()) {
              this.func_184608_ct();
           }
-@@ -2966,14 +3021,14 @@
+@@ -2949,8 +3004,8 @@
+       }
+ 
+       BlockState blockstate = this.field_70170_p.func_180495_p(p_213342_1_);
+-      if (blockstate.func_177230_c() instanceof BedBlock) {
+-         this.field_70170_p.func_180501_a(p_213342_1_, blockstate.func_206870_a(BedBlock.field_176471_b, Boolean.valueOf(true)), 3);
++      if (blockstate.isBed(field_70170_p, p_213342_1_, this)) {
++         blockstate.setBedOccupied(field_70170_p, p_213342_1_, this, true);
+       }
+ 
+       this.func_213301_b(Pose.SLEEPING);
+@@ -2966,15 +3021,15 @@
  
     private boolean func_213359_p() {
        return this.func_213374_dv().map((p_241350_1_) -> {
@@ -438,10 +449,12 @@
        this.func_213374_dv().filter(this.field_70170_p::func_175667_e).ifPresent((p_241348_1_) -> {
           BlockState blockstate = this.field_70170_p.func_180495_p(p_241348_1_);
 -         if (blockstate.func_177230_c() instanceof BedBlock) {
-+         if (blockstate.isBed(field_70170_p, func_226270_aj_(), this)) {
-             this.field_70170_p.func_180501_a(p_241348_1_, blockstate.func_206870_a(BedBlock.field_176471_b, Boolean.valueOf(false)), 3);
+-            this.field_70170_p.func_180501_a(p_241348_1_, blockstate.func_206870_a(BedBlock.field_176471_b, Boolean.valueOf(false)), 3);
++         if (blockstate.isBed(field_70170_p, p_241348_1_, this)) {
++            blockstate.setBedOccupied(field_70170_p, p_241348_1_, this, false);
              Vector3d vector3d1 = BedBlock.func_220172_a(this.func_200600_R(), this.field_70170_p, p_241348_1_, 0).orElseGet(() -> {
                 BlockPos blockpos = p_241348_1_.func_177984_a();
+                return new Vector3d((double)blockpos.func_177958_n() + 0.5D, (double)blockpos.func_177956_o() + 0.1D, (double)blockpos.func_177952_p() + 0.5D);
 @@ -2993,7 +3048,9 @@
     @OnlyIn(Dist.CLIENT)
     public Direction func_213376_dz() {

--- a/patches/minecraft/net/minecraft/world/spawner/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/WorldEntitySpawner.java.patch
@@ -49,7 +49,14 @@
           BlockState blockstate = p_209382_1_.func_180495_p(p_209382_2_);
           FluidState fluidstate = p_209382_1_.func_204610_c(p_209382_2_);
           BlockPos blockpos = p_209382_2_.func_177984_a();
-@@ -312,8 +322,6 @@
+@@ -306,14 +316,12 @@
+          case ON_GROUND:
+          default:
+             BlockState blockstate1 = p_209382_1_.func_180495_p(blockpos1);
+-            if (!blockstate1.func_215688_a(p_209382_1_, blockpos1, p_209382_3_)) {
++            if (!blockstate1.canCreatureSpawn(p_209382_1_, blockpos1, p_209382_0_, p_209382_3_)) {
+                return false;
+             } else {
                 return func_234968_a_(p_209382_1_, p_209382_2_, blockstate, fluidstate, p_209382_3_) && func_234968_a_(p_209382_1_, blockpos, p_209382_1_.func_180495_p(blockpos), p_209382_1_.func_204610_c(blockpos), p_209382_3_);
              }
           }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -245,7 +245,7 @@ public class ForgeHooks
             if (isCreative && Screen.func_231172_r_() && state.hasTileEntity())
                 te = world.getTileEntity(pos);
 
-            result = state.getBlock().getPickBlock(state, target, world, pos, player);
+            result = state.getPickBlock(target, world, pos, player);
 
             if (result.isEmpty())
                 LOGGER.warn("Picking on: [{}] {} gave null item", target.getType(), state.getBlock().getRegistryName());

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -261,12 +261,9 @@ public interface IForgeBlock
      * @param sleeper The sleeper or camera entity, null in some cases.
      * @param occupied True if we are occupying the bed, or false if they are stopping use of the bed
      */
-    default void setBedOccupied(BlockState state, IWorldReader world, BlockPos pos, LivingEntity sleeper, boolean occupied)
+    default void setBedOccupied(BlockState state, World world, BlockPos pos, LivingEntity sleeper, boolean occupied)
     {
-        if (world instanceof IWorldWriter)
-        {
-            ((IWorldWriter)world).setBlockState(pos, state.with(BedBlock.OCCUPIED,occupied), 4);
-        }
+        world.setBlockState(pos, state.with(BedBlock.OCCUPIED, occupied), 3);
     }
 
    /**
@@ -282,27 +279,6 @@ public interface IForgeBlock
     {
         return state.get(HorizontalBlock.HORIZONTAL_FACING);
     }
-
-    /**
-     * Determines if the current block is the foot half of the bed.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     * @return True if the current block is the foot side of a bed.
-     */
-    default boolean isBedFoot(BlockState state, IWorldReader world, BlockPos pos)
-    {
-        return state.get(BedBlock.PART) == BedPart.FOOT;
-    }
-
-    /**
-     * Called when a leaf should start its decay process.
-     *
-     * @param state The current state
-     * @param world The current world
-     * @param pos Block position in world
-     */
-    default void beginLeaveDecay(BlockState state, IWorldReader world, BlockPos pos) {}
 
     /**
      * Determines this block should be treated as an air block
@@ -348,21 +324,6 @@ public interface IForgeBlock
     }
 
     /**
-     * Determines if the current block is replaceable by Ore veins during world generation.
-     *
-     * @param state The current state
-     * @param world The current world
-     * @param pos Block position in world
-     * @param target The generic target block the gen is looking for, Standards define stone
-     *      for overworld generation, and neatherack for the nether.
-     * @return True to allow this block to be replaced by a ore
-     */
-    default boolean isReplaceableOreGen(BlockState state, IWorldReader world, BlockPos pos, Predicate<BlockState> target)
-    {
-        return target.test(state);
-    }
-
-    /**
      * Location sensitive version of getExplosionResistance
      *
      * @param world The current world
@@ -400,17 +361,6 @@ public interface IForgeBlock
     default ItemStack getPickBlock(BlockState state, RayTraceResult target, IBlockReader world, BlockPos pos, PlayerEntity player)
     {
         return this.getBlock().getItem(world, pos, state);
-    }
-
-    /**
-     * Used by getTopSoilidOrLiquidBlock while placing biome decorations, villages, etc
-     * Also used to determine if the player can spawn in this block.
-     *
-     * @return False to disallow spawning.
-     */
-    default boolean isFoliage(BlockState state, IWorldReader world, BlockPos pos)
-    {
-        return false;
     }
 
     /**
@@ -603,29 +553,6 @@ public interface IForgeBlock
         return state.rotate(direction);
     }
 
-    /**
-     * Get the rotations that can apply to the block at the specified coordinates. Null means no rotations are possible.
-     * Note, this is up to the block to decide. It may not be accurate or representative.
-     * @param state The current state
-     * @param world The world
-     * @param pos Block position in world
-     * @return An array of valid axes to rotate around, or null for none or unknown
-     */
-    @Nullable
-    default Direction[] getValidRotations(BlockState state, IBlockReader world, BlockPos pos)
-    {
-        for (Property<?> prop : state.func_235904_r_())
-        {
-            if ((prop.getName().equals("facing") || prop.getName().equals("rotation")) && prop.getValueClass() == Direction.class)
-            {
-                @SuppressWarnings("unchecked")
-                Collection<Direction> values = ((Collection<Direction>)prop.getAllowedValues());
-                return values.toArray(new Direction[values.size()]);
-            }
-        }
-        return null;
-    }
-
    /**
     * Determines the amount of enchanting power this block can provide to an enchanting table.
     * @param world The World
@@ -635,34 +562,6 @@ public interface IForgeBlock
     default float getEnchantPowerBonus(BlockState state, IWorldReader world, BlockPos pos)
     {
         return state.isIn(Blocks.BOOKSHELF) ? 1: 0;
-    }
-
-   /**
-    * //TODO: Re-Evaluate
-    * Gathers how much experience this block drops when broken.
-    *
-    * @param state The current state
-    * @param world The world
-    * @param pos Block position
-    * @param fortune
-    * @return Amount of XP from breaking this block.
-    */
-    @SuppressWarnings("unchecked")
-    default boolean recolorBlock(BlockState state, IWorld world, BlockPos pos, Direction facing, DyeColor color)
-    {
-        for (Property<?> prop : state.func_235904_r_())
-        {
-            if (prop.getName().equals("color") && prop.getValueClass() == DyeColor.class)
-            {
-                DyeColor current = (DyeColor)state.get(prop);
-                if (current != color && prop.getAllowedValues().contains(color))
-                {
-                    world.setBlockState(pos, state.with(((Property<DyeColor>)prop), color), 3);
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
    /**
@@ -733,14 +632,6 @@ public interface IForgeBlock
         if (tool == ToolType.PICKAXE && (this.getBlock() == Blocks.REDSTONE_ORE || this.getBlock() == Blocks.REDSTONE_LAMP || this.getBlock() == Blocks.OBSIDIAN))
             return false;
         return tool == getHarvestTool(state);
-    }
-
-    /**
-     * Can return IExtendedBlockState
-     */
-    default BlockState getExtendedState(BlockState state, IBlockReader world, BlockPos pos)
-    {
-        return state;
     }
 
     /**
@@ -822,38 +713,6 @@ public interface IForgeBlock
     default BlockState getStateAtViewpoint(BlockState state, IBlockReader world, BlockPos pos, Vector3d viewpoint)
     {
         return state;
-    }
-
-    /** //TODO: Re-Evaluate
-     * Gets the {@link IBlockState} to place
-     * @param world The world the block is being placed in
-     * @param pos The position the block is being placed at
-     * @param facing The side the block is being placed on
-     * @param hitX The X coordinate of the hit vector
-     * @param hitY The Y coordinate of the hit vector
-     * @param hitZ The Z coordinate of the hit vector
-     * @param meta The metadata of {@link ItemStack} as processed by {@link Item#getMetadata(int)}
-     * @param placer The entity placing the block
-     * @param hand The player hand used to place this block
-     * @return The state to be placed in the world
-     */
-    default BlockState getStateForPlacement(BlockState state, Direction facing, BlockState state2, IWorld world, BlockPos pos1, BlockPos pos2, Hand hand)
-    {
-        return this.getBlock().updatePostPlacement(state, facing, state2, world, pos1, pos2);
-    }
-
-
-    /**
-     * Determines if another block can connect to this block
-     *
-     * @param world The current world
-     * @param pos The position of this block
-     * @param facing The side the connecting block is on
-     * @return True to allow another block to connect to this block
-     */
-    default boolean canBeConnectedTo(BlockState state, IBlockReader world, BlockPos pos, Direction facing)
-    {
-        return false;
     }
 
     /**
@@ -991,23 +850,6 @@ public interface IForgeBlock
         }
 
         return true;
-    }
-
-    /**
-     * Ray traces through the blocks collision from start vector to end vector returning a ray trace hit.
-     *
-     * @param state The current state
-     * @param world The current world
-     * @param pos Block position in world
-     * @param start The start vector
-     * @param end The end vector
-     * @param original The original result from {@link Block#collisionRayTrace(IBlockState, World, BlockPos, Vec3d, Vec3d)}
-     * @return A result that suits your block
-     */
-    @Nullable
-    default RayTraceResult getRayTraceResult(BlockState state, World world, BlockPos pos, Vector3d start, Vector3d end, RayTraceResult original)
-    {
-        return original;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -168,12 +168,12 @@ public interface IForgeBlockState
      *
      * @param world The current world
      * @param pos Block position in world
-     * @param player The player or camera entity, null in some cases.
+     * @param sleeper The sleeper or camera entity, null in some cases.
      * @return True to treat this as a bed
      */
-    default boolean isBed(IBlockReader world, BlockPos pos, @Nullable LivingEntity player)
+    default boolean isBed(IBlockReader world, BlockPos pos, @Nullable LivingEntity sleeper)
     {
-        return getBlockState().getBlock().isBed(getBlockState(), world, pos, player);
+        return getBlockState().getBlock().isBed(getBlockState(), world, pos, sleeper);
     }
 
     /**
@@ -211,7 +211,7 @@ public interface IForgeBlockState
      * @param sleeper The sleeper or camera entity, null in some cases.
      * @param occupied True if we are occupying the bed, or false if they are stopping use of the bed
      */
-    default void setBedOccupied(IWorldReader world, BlockPos pos, LivingEntity sleeper, boolean occupied)
+    default void setBedOccupied(World world, BlockPos pos, LivingEntity sleeper, boolean occupied)
     {
         getBlockState().getBlock().setBedOccupied(getBlockState(), world, pos, sleeper, occupied);
     }
@@ -227,29 +227,6 @@ public interface IForgeBlockState
     default Direction getBedDirection(IWorldReader world, BlockPos pos)
     {
         return getBlockState().getBlock().getBedDirection(getBlockState(), world, pos);
-    }
-
-    /**
-     * Determines if the current block is the foot half of the bed.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     * @return True if the current block is the foot side of a bed.
-     */
-    default boolean isBedFoot(IWorldReader world, BlockPos pos)
-    {
-        return getBlockState().getBlock().isBedFoot(getBlockState(), world, pos);
-    }
-
-    /**
-     * Called when a leaf should start its decay process.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     */
-    default void beginLeaveDecay(IWorldReader world, BlockPos pos)
-    {
-        getBlockState().getBlock().beginLeaveDecay(getBlockState(), world, pos);
     }
 
     /**
@@ -282,7 +259,6 @@ public interface IForgeBlockState
     /**
      * Used during tree growth to determine if newly generated logs can replace this block.
      *
-     * @param state The current state
      * @param world The current world
      * @param pos Block position in world
      * @return true if this block can be replaced by growing leaves.
@@ -290,20 +266,6 @@ public interface IForgeBlockState
     default boolean canBeReplacedByLogs(IWorldReader world, BlockPos pos)
     {
         return getBlockState().getBlock().canBeReplacedByLogs(getBlockState(), world, pos);
-    }
-
-    /**
-     * Determines if the current block is replaceable by Ore veins during world generation.
-     *
-     * @param world The current world
-     * @param pos Block position in world
-     * @param target The generic target block the gen is looking for, Standards define stone
-     *      for overworld generation, and neatherack for the nether.
-     * @return True to allow this block to be replaced by a ore
-     */
-    default boolean isReplaceableOreGen(IWorldReader world, BlockPos pos, Predicate<BlockState> target)
-    {
-        return getBlockState().getBlock().isReplaceableOreGen(getBlockState(), world, pos, target);
     }
 
     /**
@@ -343,17 +305,6 @@ public interface IForgeBlockState
     default ItemStack getPickBlock(RayTraceResult target, IBlockReader world, BlockPos pos, PlayerEntity player)
     {
         return getBlockState().getBlock().getPickBlock(getBlockState(), target, world, pos, player);
-    }
-
-    /**
-     * Used by getTopSoilidOrLiquidBlock while placing biome decorations, villages, etc
-     * Also used to determine if the player can spawn in this block.
-     *
-     * @return False to disallow spawning.
-     */
-    default boolean isFoliage(IWorldReader world, BlockPos pos)
-    {
-        return getBlockState().getBlock().isFoliage(getBlockState(), world, pos);
     }
 
     /**
@@ -443,24 +394,6 @@ public interface IForgeBlockState
         return getBlockState().getBlock().canSustainPlant(getBlockState(), world, pos, facing, plantable);
     }
 
-    /**
-     * Called when a plant grows on this block, only implemented for saplings using the WorldGen*Trees classes right now.
-     * Modder may implement this for custom plants.
-     * This does not use ForgeDirection, because large/huge trees can be located in non-representable direction,
-     * so the source location is specified.
-     * Currently this just changes the block to dirt if it was grass.
-     *
-     * Note: This happens DURING the generation, the generation may not be complete when this is called.
-     *
-     * @param world Current world
-     * @param pos Block position in world
-     * @param source Source plant's position in world
-     */
-    default void onPlantGrow(IWorld world, BlockPos pos, BlockPos source)
-    {
-        getBlockState().getBlock().onPlantGrow(getBlockState(), world, pos, source);
-    }
-
    /**
     * Checks if this soil is fertile, typically this means that growth rates
     * of plants on this soil will be slightly sped up.
@@ -540,21 +473,6 @@ public interface IForgeBlockState
     default float getEnchantPowerBonus(IWorldReader world, BlockPos pos)
     {
         return getBlockState().getBlock().getEnchantPowerBonus(getBlockState(), world, pos);
-    }
-
-    /**
-     * //TODO: Re-Evaluate
-     * Gathers how much experience this block drops when broken.
-     *
-     * @param state The current state
-     * @param world The world
-     * @param pos Block position
-     * @param fortune
-     * @return Amount of XP from breaking this block.
-     */
-    default boolean recolorBlock(IWorld world, BlockPos pos, Direction facing, DyeColor color)
-    {
-        return getBlockState().getBlock().recolorBlock(getBlockState(), world, pos, facing, color);
     }
 
    /**
@@ -686,37 +604,6 @@ public interface IForgeBlockState
         return getBlockState().getBlock().getStateAtViewpoint(getBlockState(), world, pos, viewpoint);
     }
 
-    /** //TODO: Re-Evaluate
-     * Gets the {@link IBlockState} to place
-     * @param world The world the block is being placed in
-     * @param pos The position the block is being placed at
-     * @param facing The side the block is being placed on
-     * @param hitX The X coordinate of the hit vector
-     * @param hitY The Y coordinate of the hit vector
-     * @param hitZ The Z coordinate of the hit vector
-     * @param meta The metadata of {@link ItemStack} as processed by {@link Item#getMetadata(int)}
-     * @param placer The entity placing the block
-     * @param hand The player hand used to place this block
-     * @return The state to be placed in the world
-     */
-    default BlockState getStateForPlacement(Direction facing, BlockState state2, IWorld world, BlockPos pos1, BlockPos pos2, Hand hand)
-    {
-        return getBlockState().getBlock().getStateForPlacement(getBlockState(), facing, state2, world, pos1, pos2, hand);
-    }
-
-    /**
-     * Determines if another block can connect to this block
-     *
-     * @param world The current world
-     * @param pos The position of this block
-     * @param facing The side the connecting block is on
-     * @return True to allow another block to connect to this block
-     */
-    default boolean canBeConnectedTo(IBlockReader world, BlockPos pos, Direction facing)
-    {
-        return getBlockState().getBlock().canBeConnectedTo(getBlockState(), world, pos, facing);
-    }
-
     /**
      * @param state The state
      * @return true if the block is sticky block which used for pull or push adjacent blocks (use by piston)
@@ -824,19 +711,6 @@ public interface IForgeBlockState
     default boolean canEntityDestroy(IBlockReader world, BlockPos pos, Entity entity)
     {
         return getBlockState().getBlock().canEntityDestroy(getBlockState(), world, pos, entity);
-    }
-
-    /**
-     * Get the rotations that can apply to the block at the specified coordinates. Null means no rotations are possible.
-     * Note, this is up to the block to decide. It may not be accurate or representative.
-     * @param world The world
-     * @param pos Block position in world
-     * @return An array of valid axes to rotate around, or null for none or unknown
-     */
-    @Nullable
-    default Direction[] getValidRotations(IBlockReader world, BlockPos pos)
-    {
-        return getBlockState().getBlock().getValidRotations(getBlockState(), world, pos);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -156,29 +156,6 @@ public interface IForgeTileEntity extends ICapabilitySerializable<CompoundNBT>
          return bb;
      }
 
-     /**
-      * Checks if this tile entity knows how to render its 'breaking' overlay effect.
-      * If this returns true, The TileEntitySpecialRenderer will be called again with break progress set.
-      * @return True to re-render tile with breaking effect.
-      */
-     default boolean canRenderBreaking()
-     {
-         Block block = getTileEntity().getBlockState().getBlock();
-         return (block instanceof net.minecraft.block.ChestBlock ||
-                 block instanceof net.minecraft.block.EnderChestBlock ||
-                 block instanceof net.minecraft.block.AbstractSignBlock ||
-                 block instanceof net.minecraft.block.SkullBlock);
-     }
-
-     /**
-      * If the TileEntitySpecialRenderer associated with this TileEntity can be batched in with another renderers, and won't access the GL state.
-      * If TileEntity returns true, then TESR should have the same functionality as (and probably extend) the FastTESR class.
-      */
-     default boolean hasFastRenderer()
-     {
-         return false;
-     }
-
     /**
      * Requests a refresh for the model data of your TE
      * Call this every time your {@link #getModelData()} changes


### PR DESCRIPTION
Removes or Reimplements some methods of extension interfaces that were never called.
I have made sure that all the removed methods can not be reimplemented in the way they were designed, or don't serve a purpose in MC 1.16.
If I still removed something anybody still needs, please leave a comment on this PR
Reimplemented:
- `setBedOccupied`
- `isBed`
- `canCreatureSpawn`

Removed:
- `isBedFoot`: already dead in 1.12
- `getStateForPlacement`: Vanilla method has nearly identical parameters, already dead in 1.15
- `recolorBlock`: No longer applies, blocks have been flattened since 1.13
- `isReplaceableOreGen`: Seems no longer applicable due to worldgen rewrite, already dead in 1.15
- `getExtendedState`: This one is dead since the flattening as well
- `getRayTraceResult`: Gone due to VoxelShape, most things should be doable with VoxesShape now
- `isFoliage`: Dead due to new worldgen, leaves tag exists now
- `getValidRotations`: Already dead in 1.12.2
- `canBeConnectedTo`: Connection checking is now done based on tags, also already dead in 1.15

- `canRenderBreaking`: All tileentites can render breaking now
- `hasFastRenderer`: Obsolete with the 1.15 render changes