### PR TITLE
update of documentation DeferredRegister.create

### DIFF
--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -43,8 +43,8 @@ import com.google.common.reflect.TypeToken;
  *
  *Example Usage:
  *<pre>
- *   private static final DeferredRegister<Item> ITEMS = new DeferredRegister<>(ForgeRegistries.ITEMS, MODID);
- *   private static final DeferredRegister<Block> BLOCKS = new DeferredRegister<>(ForgeRegistries.BLOCKS, MODID);
+ *   private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+ *   private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
  *
  *   public static final RegistryObject<Block> ROCK_BLOCK = BLOCKS.register("rock", () -> new Block(Block.Properties.create(Material.ROCK)));
  *   public static final RegistryObject<Item> ROCK_ITEM = ITEMS.register("rock", () -> new BlockItem(ROCK_BLOCK.get(), new Item.Properties().group(ItemGroup.MISC)));


### PR DESCRIPTION
This updates the documentation to show how to use ``DeferredRegister.create`` instead of the recently deprecated ``new DeferredRegister``