### PR TITLE
Custom Item integration with Piglins

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/monster/piglin/PiglinEntity.java
++++ b/net/minecraft/entity/monster/piglin/PiglinEntity.java
+@@ -367,7 +367,7 @@
+    }
+ 
+    protected void func_234439_n_(ItemStack p_234439_1_) {
+-      if (p_234439_1_.func_77973_b() == PiglinTasks.field_234444_a_) {
++      if (p_234439_1_.isPiglinCurrency()) {
+          this.func_184201_a(EquipmentSlotType.OFFHAND, p_234439_1_);
+          this.func_233663_d_(EquipmentSlotType.OFFHAND);
+       } else {

--- a/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/entity/monster/piglin/PiglinTasks.java
++++ b/net/minecraft/entity/monster/piglin/PiglinTasks.java
+@@ -231,7 +231,7 @@
+       ItemStack itemstack = p_234477_0_.func_184586_b(Hand.OFF_HAND);
+       p_234477_0_.func_184611_a(Hand.OFF_HAND, ItemStack.field_190927_a);
+       if (p_234477_0_.func_234421_eJ_()) {
+-         boolean flag = func_234492_b_(itemstack.func_77973_b());
++         boolean flag = itemstack.isPiglinCurrency();
+          if (p_234477_1_ && flag) {
+             func_234475_a_(p_234477_0_, func_234524_k_(p_234477_0_));
+          } else if (!flag) {
+@@ -317,7 +317,7 @@
+          return false;
+       } else if (func_234453_C_(p_234474_0_) && p_234474_0_.func_213375_cj().func_218191_a(MemoryModuleType.field_234103_o_)) {
+          return false;
+-      } else if (func_234492_b_(item)) {
++      } else if (p_234474_1_.isPiglinCurrency()) {
+          return func_234455_E_(p_234474_0_);
+       } else {
+          boolean flag = p_234474_0_.func_234437_l_(p_234474_1_);
+@@ -417,7 +417,7 @@
+    }
+ 
+    protected static boolean func_234489_b_(PiglinEntity p_234489_0_, ItemStack p_234489_1_) {
+-      return !func_234453_C_(p_234489_0_) && !func_234451_A_(p_234489_0_) && p_234489_0_.func_234421_eJ_() && func_234492_b_(p_234489_1_.func_77973_b());
++      return !func_234453_C_(p_234489_0_) && !func_234451_A_(p_234489_0_) && p_234489_0_.func_234421_eJ_() && p_234489_1_.isPiglinCurrency();
+    }
+ 
+    protected static void func_234468_a_(PiglinEntity p_234468_0_, LivingEntity p_234468_1_) {
+@@ -518,7 +518,7 @@
+    public static boolean func_234460_a_(LivingEntity p_234460_0_) {
+       for(ItemStack itemstack : p_234460_0_.func_184193_aE()) {
+          Item item = itemstack.func_77973_b();
+-         if (item instanceof ArmorItem && ((ArmorItem)item).func_200880_d() == ArmorMaterial.GOLD) {
++         if (itemstack.pacifiesPiglins()) {
+             return true;
+          }
+       }

--- a/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
@@ -32,7 +32,7 @@
        for(ItemStack itemstack : p_234460_0_.func_184193_aE()) {
           Item item = itemstack.func_77973_b();
 -         if (item instanceof ArmorItem && ((ArmorItem)item).func_200880_d() == ArmorMaterial.GOLD) {
-+         if (itemstack.pacifiesPiglins()) {
++         if (itemstack.pacifiesPiglins(p_234460_0_)) {
              return true;
           }
        }

--- a/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinTasks.java.patch
@@ -32,7 +32,7 @@
        for(ItemStack itemstack : p_234460_0_.func_184193_aE()) {
           Item item = itemstack.func_77973_b();
 -         if (item instanceof ArmorItem && ((ArmorItem)item).func_200880_d() == ArmorMaterial.GOLD) {
-+         if (itemstack.pacifiesPiglins(p_234460_0_)) {
++         if (itemstack.makesPiglinsNeutral(p_234460_0_)) {
              return true;
           }
        }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -36,7 +36,10 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.item.ItemEntity;
+import net.minecraft.entity.monster.piglin.PiglinTasks;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.Items;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.Item;
@@ -111,6 +114,24 @@ public interface IForgeItem
     default ActionResultType onItemUseFirst(ItemStack stack, ItemUseContext context)
     {
         return ActionResultType.PASS;
+    }
+
+    /**
+     * Called by Piglins when checking to see if they will give an item or something in exchange for this item.
+     *
+     * @return True if this item can be used as "currency" by piglins
+     */
+    default boolean isPiglinCurrency(ItemStack stack) {
+        return stack.getItem() == PiglinTasks.field_234444_a_;
+    }
+
+    /**
+     * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
+     *
+     * @return True if piglins are neutral to players wearing this item in an armor slot
+     */
+    default boolean pacifiesPiglins(ItemStack stack) {
+        return stack.getItem() instanceof ArmorItem && ((ArmorItem) stack.getItem()).getArmorMaterial() == ArmorMaterial.GOLD;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -121,7 +121,8 @@ public interface IForgeItem
      *
      * @return True if this item can be used as "currency" by piglins
      */
-    default boolean isPiglinCurrency(ItemStack stack) {
+    default boolean isPiglinCurrency(ItemStack stack)
+    {
         return stack.getItem() == PiglinTasks.field_234444_a_;
     }
 
@@ -132,7 +133,8 @@ public interface IForgeItem
      *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins(ItemStack stack, LivingEntity wearer) {
+    default boolean pacifiesPiglins(ItemStack stack, LivingEntity wearer)
+    {
         return stack.getItem() instanceof ArmorItem && ((ArmorItem) stack.getItem()).getArmorMaterial() == ArmorMaterial.GOLD;
     }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -127,13 +127,14 @@ public interface IForgeItem
     }
 
     /**
-     * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
+     * Called by Piglins to check if a given item prevents hostility on sight. If this is true the Piglins will be neutral to the entity wearing this item, and will not
+     * attack on sight. Note: This does not prevent Piglins from becoming hostile due to other actions, nor does it make Piglins that are already hostile stop being so.
      *
      * @param wearer The entity wearing this ItemStack
      *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins(ItemStack stack, LivingEntity wearer)
+    default boolean makesPiglinsNeutral(ItemStack stack, LivingEntity wearer)
     {
         return stack.getItem() instanceof ArmorItem && ((ArmorItem) stack.getItem()).getArmorMaterial() == ArmorMaterial.GOLD;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -128,9 +128,11 @@ public interface IForgeItem
     /**
      * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
      *
+     * @param wearer The entity wearing this ItemStack
+     *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins(ItemStack stack) {
+    default boolean pacifiesPiglins(ItemStack stack, LivingEntity wearer) {
         return stack.getItem() instanceof ArmorItem && ((ArmorItem) stack.getItem()).getArmorMaterial() == ArmorMaterial.GOLD;
     }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -450,4 +450,22 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     {
         return getStack().getItem().isRepairable(getStack());
     }
+
+    /**
+     * Called by Piglins when checking to see if they will give an item or something in exchange for this item.
+     *
+     * @return True if this item can be used as "currency" by piglins
+     */
+    default boolean isPiglinCurrency() {
+        return getStack().getItem().isPiglinCurrency(getStack());
+    }
+
+    /**
+     * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
+     *
+     * @return True if piglins are neutral to players wearing this item in an armor slot
+     */
+    default boolean pacifiesPiglins() {
+        return getStack().getItem().pacifiesPiglins(getStack());
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -462,14 +462,15 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     }
 
     /**
-     * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
+     * Called by Piglins to check if a given item prevents hostility on sight. If this is true the Piglins will be neutral to the entity wearing this item, and will not
+     * attack on sight. Note: This does not prevent Piglins from becoming hostile due to other actions, nor does it make Piglins that are already hostile stop being so.
      *
      * @param wearer The entity wearing this ItemStack
      *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins(LivingEntity wearer)
+    default boolean makesPiglinsNeutral(LivingEntity wearer)
     {
-        return getStack().getItem().pacifiesPiglins(getStack(), wearer);
+        return getStack().getItem().makesPiglinsNeutral(getStack(), wearer);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -456,7 +456,8 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
      *
      * @return True if this item can be used as "currency" by piglins
      */
-    default boolean isPiglinCurrency() {
+    default boolean isPiglinCurrency()
+    {
         return getStack().getItem().isPiglinCurrency(getStack());
     }
 
@@ -467,7 +468,8 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
      *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins(LivingEntity wearer) {
+    default boolean pacifiesPiglins(LivingEntity wearer)
+    {
         return getStack().getItem().pacifiesPiglins(getStack(), wearer);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -463,9 +463,11 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     /**
      * Called by Piglins to check if a given item marks a player as "honorable" and should not be attacked.
      *
+     * @param wearer The entity wearing this ItemStack
+     *
      * @return True if piglins are neutral to players wearing this item in an armor slot
      */
-    default boolean pacifiesPiglins() {
-        return getStack().getItem().pacifiesPiglins(getStack());
+    default boolean pacifiesPiglins(LivingEntity wearer) {
+        return getStack().getItem().pacifiesPiglins(getStack(), wearer);
     }
 }


### PR DESCRIPTION
Allows custom items to be marked as "currency" for piglin, so that when they are given them they use their loot table and give something random back. This PR also allows marking an item when worn in an armor slot as an item that can "pacify" the piglin and keep them neutral while worn.