### PR TITLE
[1.15.x / LTS version] Make ArgumentList a public class

### DIFF
--- a/src/userdev/java/net/minecraftforge/userdev/ArgumentList.java
+++ b/src/userdev/java/net/minecraftforge/userdev/ArgumentList.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  * A class that attempts to parse command line arguments into key value pairs to allow addition and editing.
  * Can not use JOptSimple as that doesn't parse out the values for keys unless the spec says it has a value.
  */
-class ArgumentList {
+public class ArgumentList {
     private static final Logger LOGGER = LogManager.getLogger();
     private List<Supplier<String[]>> entries = new ArrayList<>();
     private Map<String, EntryValue> values = new HashMap<>();


### PR DESCRIPTION
This is a useful util class used by forge run launchers, that would be nice if it could be used by external launch configs without a hassle. My personal use case is a custom run config that launches JUnit tests from within a dedicated server launch config. I don't see any particular API reason why this class isn't already public other than nothing within forge needs it outside if the package.