### PR TITLE
Fix swap offhand keybind not working in GUIs (#6917)

### DIFF
--- a/patches/minecraft/net/minecraft/client/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/GameSettings.java.patch
@@ -38,7 +38,7 @@
           }
  
           for(SoundCategory soundcategory : SoundCategory.values()) {
-@@ -733,4 +739,22 @@
+@@ -733,4 +739,21 @@
  
        p_198017_1_.func_198985_a(set);
     }
@@ -58,6 +58,5 @@
 +      field_74323_J.setKeyConflictContext(inGame);
 +      field_151457_aa.setKeyConflictContext(inGame);
 +      field_151458_ab.setKeyConflictContext(inGame);
-+      field_186718_X.setKeyConflictContext(inGame);
 +   }
  }


### PR DESCRIPTION
This PR fixes #6917.

In previous versions, `Swap Item with Offhand` keybind has `IN_GAME` set as its key conflict context, which only allows the use of the keybind outside of GUIs. Then, Minecraft 1.16 added the ability for the keybind to also swap the contents of the offhand slot while within a GUI, which meant that the key conflict context prevents the keybind from activating while within a GUI.

This PR simply removes the manual setting of the keybind's conflict context to `IN_GAME`. This means that the default key conflict context will be applied, which is `UNIVERSAL`.

I have tested this fix with the conditions in the issue linked above, and confirmed that it works as expected. (survival, creative, adventure player inventories, chest inventory, hopper inventory)