### PR TITLE
Fix harvest level and tool type not actually getting set

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -113,7 +113,7 @@
           return abstractblock$properties;
        }
  
-@@ -861,6 +877,16 @@
+@@ -861,6 +877,24 @@
           return this;
        }
  
@@ -127,10 +127,18 @@
 +         return this;
 +      }
 +
++      public int getHarvestLevel() {
++         return this.harvestLevel;
++      }
++
++      public net.minecraftforge.common.ToolType getHarvestTool() {
++         return this.harvestTool;
++      }
++
        public AbstractBlock.Properties func_200941_a(float p_200941_1_) {
           this.field_200961_i = p_200941_1_;
           return this;
-@@ -917,7 +943,7 @@
+@@ -917,7 +951,7 @@
        }
  
        public AbstractBlock.Properties func_222379_b(Block p_222379_1_) {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -13,7 +13,16 @@
     private static final LoadingCache<VoxelShape, Boolean> field_223006_b = CacheBuilder.newBuilder().maximumSize(512L).weakKeys().build(new CacheLoader<VoxelShape, Boolean>() {
        public Boolean load(VoxelShape p_load_1_) {
           return !VoxelShapes.func_197879_c(VoxelShapes.func_197868_b(), p_load_1_, IBooleanFunction.field_223236_g_);
-@@ -270,7 +271,7 @@
+@@ -151,6 +152,8 @@
+       super(p_i48440_1_);
+       StateContainer.Builder<Block, BlockState> builder = new StateContainer.Builder<>(this);
+       this.func_206840_a(builder);
++      this.harvestLevel = p_i48440_1_.getHarvestLevel();
++      this.harvestTool = p_i48440_1_.getHarvestTool();
+       this.field_176227_L = builder.func_235882_a_(Block::func_176223_P, BlockState::new);
+       this.func_180632_j(this.field_176227_L.func_177621_b());
+    }
+@@ -270,7 +273,7 @@
     }
  
     public static void func_180635_a(World p_180635_0_, BlockPos p_180635_1_, ItemStack p_180635_2_) {
@@ -22,7 +31,7 @@
           float f = 0.5F;
           double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
           double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -282,7 +283,7 @@
+@@ -282,7 +285,7 @@
     }
  
     public void func_180637_b(World p_180637_1_, BlockPos p_180637_2_, int p_180637_3_) {
@@ -31,7 +40,7 @@
           while(p_180637_3_ > 0) {
              int i = ExperienceOrbEntity.func_70527_a(p_180637_3_);
              p_180637_3_ -= i;
-@@ -292,6 +293,7 @@
+@@ -292,6 +295,7 @@
  
     }
  
@@ -39,7 +48,7 @@
     public float func_149638_a() {
        return this.field_235689_au_;
     }
-@@ -341,6 +343,7 @@
+@@ -341,6 +345,7 @@
        p_176216_2_.func_213317_d(p_176216_2_.func_213322_ci().func_216372_d(1.0D, 0.0D, 1.0D));
     }
  
@@ -47,7 +56,7 @@
     public ItemStack func_185473_a(IBlockReader p_185473_1_, BlockPos p_185473_2_, BlockState p_185473_3_) {
        return new ItemStack(this);
     }
-@@ -372,6 +375,7 @@
+@@ -372,6 +377,7 @@
     public void func_176224_k(World p_176224_1_, BlockPos p_176224_2_) {
     }
  
@@ -55,7 +64,7 @@
     public boolean func_149659_a(Explosion p_149659_1_) {
        return true;
     }
-@@ -391,6 +395,7 @@
+@@ -391,6 +397,7 @@
        return this.field_196275_y;
     }
  
@@ -63,7 +72,7 @@
     public SoundType func_220072_p(BlockState p_220072_1_) {
        return this.field_149762_H;
     }
-@@ -400,7 +405,7 @@
+@@ -400,7 +407,7 @@
           this.field_220086_i = Item.func_150898_a(this);
        }
  
@@ -72,7 +81,7 @@
     }
  
     public boolean func_208619_r() {
-@@ -408,7 +413,7 @@
+@@ -408,7 +415,7 @@
     }
  
     public String toString() {
@@ -81,7 +90,7 @@
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -419,6 +424,83 @@
+@@ -419,6 +426,83 @@
        return this;
     }
  


### PR DESCRIPTION
In the port to 1.16 it seems the patch setting the harvest level and harvest tool of custom blocks got lost (probably due to the split of Block and AbstractBlock). This fixes #6906