### PR TITLE
Fix debug world not generating modded blocks

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/DebugChunkGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/DebugChunkGenerator.java.patch
@@ -1,15 +1,13 @@
 --- a/net/minecraft/world/gen/DebugChunkGenerator.java
 +++ b/net/minecraft/world/gen/DebugChunkGenerator.java
-@@ -101,4 +101,12 @@
+@@ -101,4 +101,10 @@
  
        return blockstate;
     }
 +   
 +   public static void initValidStates() {
-+      field_177464_a = StreamSupport.stream(Registry.field_212618_g.spliterator(), false).flatMap((p_236067_0_) -> {
-+         return p_236067_0_.func_176194_O().func_177619_a().stream();
-+      }).collect(Collectors.toList());
-+      field_177462_b = MathHelper.func_76123_f(MathHelper.func_76129_c((float)field_177464_a.size()));
-+      field_181039_c = MathHelper.func_76123_f((float)field_177464_a.size() / (float)field_177462_b);
++      field_177464_a = StreamSupport.stream(Registry.field_212618_g.spliterator(), false).flatMap(block -> block.func_176194_O().func_177619_a().stream()).collect(Collectors.toList());
++      field_177462_b = MathHelper.func_76123_f(MathHelper.func_76129_c(field_177464_a.size()));
++      field_181039_c = MathHelper.func_76123_f((float) (field_177464_a.size() / field_177462_b));
 +   }
  }

--- a/patches/minecraft/net/minecraft/world/gen/DebugChunkGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/DebugChunkGenerator.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/gen/DebugChunkGenerator.java
++++ b/net/minecraft/world/gen/DebugChunkGenerator.java
+@@ -101,4 +101,12 @@
+ 
+       return blockstate;
+    }
++   
++   public static void initValidStates() {
++      field_177464_a = StreamSupport.stream(Registry.field_212618_g.spliterator(), false).flatMap((p_236067_0_) -> {
++         return p_236067_0_.func_176194_O().func_177619_a().stream();
++      }).collect(Collectors.toList());
++      field_177462_b = MathHelper.func_76123_f(MathHelper.func_76129_c((float)field_177464_a.size()));
++      field_181039_c = MathHelper.func_76123_f((float)field_177464_a.size() / (float)field_177462_b);
++   }
+ }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -56,6 +56,7 @@ import net.minecraft.util.registry.SimpleRegistry;
 import net.minecraft.village.PointOfInterestType;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.gen.DebugChunkGenerator;
 import net.minecraft.world.gen.blockplacer.BlockPlacerType;
 import net.minecraft.world.gen.blockstateprovider.BlockStateProviderType;
 import net.minecraft.world.gen.carver.WorldCarver;
@@ -472,6 +473,7 @@ public class GameData
 
                 block.getLootTable();
             }
+            DebugChunkGenerator.initValidStates();
         }
 
         private static class BlockDummyAir extends AirBlock //A named class so DummyBlockReplacementTest can detect if its a dummy

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -302,6 +302,9 @@ public net.minecraft.world.biome.DeepFrozenOceanBiome func_180626_a(Lnet/minecra
 public net.minecraft.world.biome.FrozenOceanBiome func_180626_a(Lnet/minecraft/util/math/BlockPos;)F # getTemperature
 public net.minecraft.world.biome.provider.BiomeProvider field_201540_a # BIOMES_TO_SPAWN_IN
 public net.minecraft.world.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/chunk/ChunkStatus$Type;Lnet/minecraft/world/chunk/ChunkStatus$IGenerationWorker;Lnet/minecraft/world/chunk/ChunkStatus$ILoadingWorker;)V
+private-f net.minecraft.world.gen.DebugChunkGenerator field_177464_a #ALL_VALID_STATES
+private-f net.minecraft.world.gen.DebugChunkGenerator field_177462_b #GRID_WIDTH
+private-f net.minecraft.world.gen.DebugChunkGenerator field_181039_c #GRID_HEIGHT
 public net.minecraft.world.gen.layer.LayerUtil func_202829_a(JLnet/minecraft/world/gen/layer/traits/IAreaTransformer1;Lnet/minecraft/world/gen/area/IAreaFactory;ILjava/util/function/LongFunction;)Lnet/minecraft/world/gen/area/IAreaFactory; # repeat
 private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 private-f net.minecraft.world.server.ChunkHolder field_219320_o # block update location


### PR DESCRIPTION
This PR fixes #6924.
See [my comment on the issue][explaincomment] for the explanation on why the issue exists, and the solutions I found for that issue.

_TL;DR:_ `DebugChunkGenerator` used to be instance-based, now it's singleton. Static reference to `Block` registry means that nothing after that class is loaded will be generated. `private static final` fields; One field is list of blockstates, two others are integers dependent on contents of the list.

This PR does the following:
  * Adds 3 lines to the Forge AccessTransformer to definalize the three fields.
  * Adds a patch to `DebugChunkGenerator`: a method that recalculates the information in the three fields in exactly the same way they are statically initialized.
  * Adds 2 lines (1 import) to the `GameData` class, specifically the `BlockCallbacks` inner class, to call the aforementioned method in `DebugChunkGenerator` when the registry is baked. As only one bake callback can be present for a registry, and `BlockCallbacks` takes that spot, I added to the bake callback.

~~I did find another solution for this problem ([debug_world_fix_1 branch on my fork][firstsolution]), but that requires adding a new patch which modifies the fields to public and introduces a new static method, which I felt to be too intrusive and may break future versions if that class is changed again.~~

Note: I did not put the `/* === FORGE START === */` and end markers, because when I asked on Discord, [tterag responded][tteragquote] that its "not required anymore".

[firstsolution]: https://github.com/sciwhiz12/MinecraftForge/tree/debug_world_fix_1
[explaincomment]: https://github.com/MinecraftForge/MinecraftForge/issues/6924#issuecomment-654184760
[tteragquote]: https://discordapp.com/channels/313125603924639766/725850371834118214/737770783060918285