### PR TITLE
Implement GUI Stacking feature.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/Minecraft.java
 +++ b/net/minecraft/client/Minecraft.java
+@@ -241,7 +_,7 @@
+ import org.apache.logging.log4j.Logger;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public class Minecraft extends RecursiveEventLoop<Runnable> implements ISnooperInfo, IWindowEventListener {
++public class Minecraft extends RecursiveEventLoop<Runnable> implements ISnooperInfo, IWindowEventListener, net.minecraftforge.client.extensions.IForgeMinecraft {
+    private static Minecraft field_71432_P;
+    private static final Logger field_147123_G = LogManager.getLogger();
+    public static final boolean field_142025_a = Util.func_110647_a() == Util.OS.OSX;
 @@ -368,6 +_,7 @@
     public Minecraft(GameConfiguration p_i45547_1_) {
        super("Client");
@@ -131,10 +140,11 @@
        if (p_147108_1_ == null && this.field_71441_e == null) {
           p_147108_1_ = new MainMenuScreen();
        } else if (p_147108_1_ == null && this.field_71439_g.func_233643_dh_()) {
-@@ -831,6 +_,14 @@
+@@ -831,6 +_,15 @@
           }
        }
  
++      net.minecraftforge.client.ForgeHooksClient.clearGuiLayers(this);
 +      Screen old = this.field_71462_r;
 +      net.minecraftforge.client.event.GuiOpenEvent event = new net.minecraftforge.client.event.GuiOpenEvent(p_147108_1_);
 +      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;

--- a/patches/minecraft/net/minecraft/client/gui/screen/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/Screen.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/gui/screen/Screen.java
 +++ b/net/minecraft/client/gui/screen/Screen.java
+@@ -99,7 +_,7 @@
+    }
+ 
+    public void func_231175_as__() {
+-      this.field_230706_i_.func_147108_a((Screen)null);
++      this.field_230706_i_.popGuiLayer();
+    }
+ 
+    protected <T extends Widget> T func_230480_a_(T p_230480_1_) {
 @@ -113,7 +_,10 @@
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -26,6 +26,19 @@
              }
  
              this.field_78531_r.func_147110_a().func_147610_a(true);
+@@ -448,10 +_,10 @@
+          RenderSystem.clear(256, Minecraft.field_142025_a);
+          RenderSystem.matrixMode(5889);
+          RenderSystem.loadIdentity();
+-         RenderSystem.ortho(0.0D, (double)mainwindow.func_198109_k() / mainwindow.func_198100_s(), (double)mainwindow.func_198091_l() / mainwindow.func_198100_s(), 0.0D, 1000.0D, 3000.0D);
++         RenderSystem.ortho(0.0D, (double)mainwindow.func_198109_k() / mainwindow.func_198100_s(), (double)mainwindow.func_198091_l() / mainwindow.func_198100_s(), 0.0D, 1000.0D, net.minecraftforge.client.ForgeHooksClient.getGuiFarPlane());
+          RenderSystem.matrixMode(5888);
+          RenderSystem.loadIdentity();
+-         RenderSystem.translatef(0.0F, 0.0F, -2000.0F);
++         RenderSystem.translatef(0.0F, 0.0F, 1000.0F - net.minecraftforge.client.ForgeHooksClient.getGuiFarPlane());
+          RenderHelper.func_227784_d_();
+          MatrixStack matrixstack = new MatrixStack();
+          if (p_195458_4_ && this.field_78531_r.field_71441_e != null) {
 @@ -486,7 +_,7 @@
              }
           } else if (this.field_78531_r.field_71462_r != null) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -352,7 +352,8 @@ public class ForgeHooksClient
     {
         mStack.pushPose();
         guiLayers.forEach(layer -> {
-            drawScreenInternal(layer, mStack, -1, -1, partialTicks);
+            // Prevent the background layers from thinking the mouse is over their controls and showing them as highlighted.
+            drawScreenInternal(layer, mStack, Integer.MAX_VALUE, Integer.MAX_VALUE, partialTicks);
             mStack.translate(0,0,2000);
         });
         drawScreenInternal(screen, mStack, mouseX, mouseY, partialTicks);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -31,8 +31,8 @@ import net.minecraft.client.audio.SoundEngine;
 import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.client.gui.ClientBossInfo;
 import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
 import net.minecraft.client.gui.chat.NarratorChatListener;
+import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
 import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.play.NetworkPlayerInfo;
@@ -77,7 +77,6 @@ import net.minecraft.util.math.vector.Matrix4f;
 import net.minecraft.util.math.vector.TransformationMatrix;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.GameType;
@@ -200,8 +199,8 @@ public class ForgeHooksClient
                 if (!(target instanceof EntityRayTraceResult)) return false;
                 return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent.HighlightEntity(context, info, target, partialTicks, matrix, buffers));
             default:
-        return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent(context, info, target, partialTicks, matrix, buffers));
-    }
+                return MinecraftForge.EVENT_BUS.post(new DrawHighlightEvent(context, info, target, partialTicks, matrix, buffers));
+        }
     }
 
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -148,7 +148,7 @@ public class ForgeHooksClient
     private static void popGuiLayerInternal(Minecraft minecraft)
     {
         if (minecraft.screen != null)
-            minecraft.screen.removed(); // onClose
+            minecraft.screen.removed();
         minecraft.screen = guiLayers.pop();
     }
 

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeMinecraft.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeMinecraft.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2020.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,25 +17,21 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.debug.client.rendering;
+package net.minecraftforge.client.extensions;
 
 import net.minecraft.client.Minecraft;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.fml.DeferredWorkQueue;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraftforge.client.ForgeHooksClient;
 
-@Mod("stencil_enable_test")
-public class StencilEnableTest {
-    public static boolean ENABLED = false;
+public interface IForgeMinecraft
+{
+    default Minecraft getSelf() { return (Minecraft)this; }
 
-    public StencilEnableTest() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
+    default void pushGuiLayer(Screen screen) {
+        ForgeHooksClient.pushGuiLayer(getSelf(), screen);
     }
 
-    private void clientSetup(FMLClientSetupEvent event) {
-        if (ENABLED)
-            event.enqueueWork(() -> Minecraft.getInstance().getMainRenderTarget().enableStencil());
+    default void popGuiLayer() {
+        ForgeHooksClient.popGuiLayer(getSelf());
     }
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeMinecraft.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeMinecraft.java
@@ -27,11 +27,13 @@ public interface IForgeMinecraft
 {
     default Minecraft getSelf() { return (Minecraft)this; }
 
-    default void pushGuiLayer(Screen screen) {
+    default void pushGuiLayer(Screen screen)
+    {
         ForgeHooksClient.pushGuiLayer(getSelf(), screen);
     }
 
-    default void popGuiLayer() {
+    default void popGuiLayer()
+    {
         ForgeHooksClient.popGuiLayer(getSelf());
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -67,7 +67,7 @@ public class GuiLayeringTest
             public void render(MatrixStack mStack, int mouseX, int mouseY, float partialTicks)
             {
                 this.renderBackground(mStack);
-                drawString(mStack, this.font, this.title, this.width / 2, 15, 16777215);
+                drawString(mStack, this.font, this.title, this.width / 2, 15, 0xFFFFFF);
                 super.render(mStack, mouseX, mouseY, partialTicks);
             }
 

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -1,0 +1,111 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.GuiScreenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.Random;
+
+@Mod(GuiLayeringTest.MODID)
+public class GuiLayeringTest
+{
+    private static final Random RANDOM = new Random();
+    public static final String MODID="gui_layer_test";
+
+    @Mod.EventBusSubscriber(value= Dist.CLIENT, modid=MODID, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    public static class ClientEvents
+    {
+        @SubscribeEvent
+        public static void guiOpen(GuiScreenEvent.InitGuiEvent event)
+        {
+            if (event.getGui() instanceof ContainerScreen)
+            {
+                event.addWidget(new Button(2, 2, 150, 20, new StringTextComponent("Test Gui Layering"), btn -> {
+                    Minecraft.getInstance().pushGuiLayer(new TestLayer(new StringTextComponent("LayerScreen")));
+                }));
+                event.addWidget(new Button(2, 25, 150, 20, new StringTextComponent("Test Gui Normal"), btn -> {
+                    Minecraft.getInstance().setScreen(new TestLayer(new StringTextComponent("LayerScreen")));
+                }));
+            }
+        }
+
+        public static class TestLayer extends Screen
+        {
+            protected TestLayer(ITextComponent titleIn)
+            {
+                super(titleIn);
+            }
+
+            @Override
+            public void render(MatrixStack mStack, int mouseX, int mouseY, float partialTicks)
+            {
+                this.renderBackground(mStack);
+                drawString(mStack, this.font, this.title, this.width / 2, 15, 16777215);
+                super.render(mStack, mouseX, mouseY, partialTicks);
+            }
+
+            @Override
+            protected void init()
+            {
+                int buttonWidth = 150;
+                int buttonHeight = 20;
+                int buttonGap = 4;
+                int buttonSpacing = (buttonHeight + buttonGap);
+                int buttons = 3;
+
+                int xoff = (this.width - buttonWidth);
+                int yoff = (this.height - buttonHeight - buttonSpacing * (buttons - 1));
+                int cnt = 0;
+
+                xoff = RANDOM.nextInt(xoff);
+                yoff = RANDOM.nextInt(yoff);
+
+                this.addButton(new Button(xoff, yoff + buttonSpacing * (cnt++), buttonWidth, buttonHeight, new StringTextComponent("Push New Layer"), this::pushLayerButton));
+                this.addButton(new Button(xoff, yoff + buttonSpacing * (cnt++), buttonWidth, buttonHeight, new StringTextComponent("Pop Current Layer"), this::popLayerButton));
+                this.addButton(new Button(xoff, yoff + buttonSpacing * (cnt++), buttonWidth, buttonHeight, new StringTextComponent("Close entire stack"), this::closeStack));
+            }
+
+            private void closeStack(Button button)
+            {
+                this.minecraft.setScreen(null);
+            }
+
+            private void popLayerButton(Button button)
+            {
+                this.minecraft.popGuiLayer();
+            }
+
+            private void pushLayerButton(Button button)
+            {
+                this.minecraft.pushGuiLayer(new TestLayer(new StringTextComponent("LayerScreen")));
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("stencil_enable_test")
 public class StencilEnableTest {
-    public static boolean ENABLED = false;
+    public static boolean ENABLED = true;
 
     public StencilEnableTest() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ loaderVersion="[28,)"
 license="LGPL v2.1"
 
 [[mods]]
-	modId="containertypetest"
+    modId="containertypetest"
 [[mods]]
     modId="potion_event_test"
 [[mods]]

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ loaderVersion="[28,)"
 license="LGPL v2.1"
 
 [[mods]]
-    modId="containertypetest"
+	modId="containertypetest"
 [[mods]]
     modId="potion_event_test"
 [[mods]]
@@ -140,5 +140,7 @@ license="LGPL v2.1"
     modId="player_attack_knockback_test"
 [[mods]]
     modId="send_datapacks_to_client"
+[[mods]]
+    modId="gui_layer_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
You can now use `mc.pushGuiLayer` and `mc.popGuiLayer` to manage the layers.
mc.displayGuiScreen behaves such that if called with a non-null screen it replaces the entire stack, and if called with null it closes the entire stack.

![stack showcase](https://cdn.discordapp.com/attachments/679070190721433659/729784664700616835/unknown.png)

Supersedes #6867