### PR TITLE
Added func_240719_a_ (setFontId) to the side annotation stripper.

### DIFF
--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -92,3 +92,4 @@ net/minecraft/util/Direction$Axis func_176717_a(Ljava/lang/String;)Lnet/minecraf
 net/minecraft/util/math/vector/Vector3d func_216371_e()Lnet/minecraft/util/math/vector/Vector3d;
 net/minecraft/util/math/vector/Vector3d func_189984_a(Lnet/minecraft/util/math/vector/Vector2f;)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw
 net/minecraft/util/math/vector/Vector3d func_189986_a(FF)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw
+net/minecraft/util/text/Style func_240719_a_(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/text/Style; #setFontId

--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -93,3 +93,4 @@ net/minecraft/util/math/vector/Vector3d func_216371_e()Lnet/minecraft/util/math/
 net/minecraft/util/math/vector/Vector3d func_189984_a(Lnet/minecraft/util/math/vector/Vector2f;)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw
 net/minecraft/util/math/vector/Vector3d func_189986_a(FF)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw
 net/minecraft/util/text/Style func_240719_a_(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/text/Style; #setFontId
+net/minecraft/util/text/Style func_240723_c_(Lnet/minecraft/util/text/TextFormatting;)Lnet/minecraft/util/text/Style; #forceFormatting


### PR DESCRIPTION
This PR adds Style.setFontId to the side annotation stripper config. In 1.16 Style is designed to be immutable and the constructor is not visible. The font data exists on the server vanilla just never sets it there using this method. Use cases for calling this on the server would be for applying font to item display names or applying it to things via commands. 