### PR TITLE
Expose the DataPackRegistries instance to the AddReloadListenerEvent

### DIFF
--- a/patches/minecraft/net/minecraft/resources/DataPackRegistries.java.patch
+++ b/patches/minecraft/net/minecraft/resources/DataPackRegistries.java.patch
@@ -4,7 +4,7 @@
        this.field_240952_b_.func_219534_a(this.field_240957_g_);
        this.field_240952_b_.func_219534_a(this.field_240959_i_);
        this.field_240952_b_.func_219534_a(this.field_240958_h_);
-+      net.minecraftforge.event.ForgeEventFactory.onResourceReload().forEach(field_240952_b_::func_219534_a);
++      net.minecraftforge.event.ForgeEventFactory.onResourceReload(this).forEach(field_240952_b_::func_219534_a);
     }
  
     public FunctionReloader func_240960_a_() {

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -18,8 +18,13 @@ import java.util.List;
 public class AddReloadListenerEvent extends Event
 {
    private final List<IFutureReloadListener> listeners = new ArrayList<>();
-
-   /**
+   private final DataPackRegistries dataPackRegistries;
+    
+    public AddReloadListenerEvent(DataPackRegistries dataPackRegistries) {
+        this.dataPackRegistries = dataPackRegistries;
+    }
+    
+    /**
     * @param listener the listener to add to the ResourceManager on reload
     */
    public void addListener(IFutureReloadListener listener)
@@ -31,4 +36,8 @@ public class AddReloadListenerEvent extends Event
    {
       return ImmutableList.copyOf(listeners);
    }
+    
+    public DataPackRegistries getDataPackRegistries() {
+        return dataPackRegistries;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -20,7 +20,8 @@ public class AddReloadListenerEvent extends Event
    private final List<IFutureReloadListener> listeners = new ArrayList<>();
    private final DataPackRegistries dataPackRegistries;
     
-    public AddReloadListenerEvent(DataPackRegistries dataPackRegistries) {
+    public AddReloadListenerEvent(DataPackRegistries dataPackRegistries)
+    {
         this.dataPackRegistries = dataPackRegistries;
     }
     
@@ -37,7 +38,8 @@ public class AddReloadListenerEvent extends Event
       return ImmutableList.copyOf(listeners);
    }
     
-    public DataPackRegistries getDataPackRegistries() {
+    public DataPackRegistries getDataPackRegistries()
+    {
         return dataPackRegistries;
     }
 }

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -17,15 +17,15 @@ import java.util.List;
  */
 public class AddReloadListenerEvent extends Event
 {
-   private final List<IFutureReloadListener> listeners = new ArrayList<>();
-   private final DataPackRegistries dataPackRegistries;
+    private final List<IFutureReloadListener> listeners = new ArrayList<>();
+    private final DataPackRegistries dataPackRegistries;
     
     public AddReloadListenerEvent(DataPackRegistries dataPackRegistries)
     {
         this.dataPackRegistries = dataPackRegistries;
     }
     
-    /**
+   /**
     * @param listener the listener to add to the ResourceManager on reload
     */
    public void addListener(IFutureReloadListener listener)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -52,6 +52,7 @@ import net.minecraft.item.ItemUseContext;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
 import net.minecraft.resources.IFutureReloadListener;
+import net.minecraft.resources.DataPackRegistries;
 import net.minecraft.world.spawner.AbstractSpawner;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.ActionResultType;
@@ -724,9 +725,9 @@ public class ForgeEventFactory
         return event.getNewTime();
     }
 
-    public static List<IFutureReloadListener> onResourceReload()
+    public static List<IFutureReloadListener> onResourceReload(DataPackRegistries dataPackRegistries)
     {
-        AddReloadListenerEvent event = new AddReloadListenerEvent();
+        AddReloadListenerEvent event = new AddReloadListenerEvent(dataPackRegistries);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getListeners();
     }


### PR DESCRIPTION
This makes it that reload listeners can use the data inside the managers that DataPackRegistries holds (in my case I need the RecipeManager specifically)