### PR TITLE
Fix canRepair not being set true as default

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -125,7 +125,7 @@
        private Rarity field_208104_e = Rarity.COMMON;
        private Food field_221541_f;
        private boolean field_234688_g_;
-+      private boolean canRepair;
++      private boolean canRepair = true;
 +      private java.util.Map<net.minecraftforge.common.ToolType, Integer> toolClasses = Maps.newHashMap();
 +      private java.util.function.Supplier<java.util.concurrent.Callable<net.minecraft.client.renderer.tileentity.ItemStackTileEntityRenderer>> ister;
  


### PR DESCRIPTION
This PR closes #6934 and #6935.

`Item.Properties#canRepair` was not being set to `true` as default, so all items, regardless of whether they call `setNoRepair()` or not, were always not repairable (`canRepair == false`), leading to issues where items are being repaired. This PR simply adds the default value of `true`.

I have tested that this fixes the above linked issues using the steps provided.