### PR TITLE
Comment out updateJSONURL, change all URLs to example.com

### DIFF
--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -8,7 +8,7 @@ modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
 loaderVersion="[32,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # A URL to refer people to when problems occur with this mod
-issueTrackerURL="http://my.issue.tracker/" #optional
+issueTrackerURL="https://example.com/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -18,9 +18,9 @@ version="${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="Example Mod" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification <here>
-updateJSONURL="http://myurl.me/" #optional
+#updateJSONURL="https://example.com/" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="http://example.com/" #optional
+displayURL="https://example.com/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="examplemod.png" #optional
 # A text field displayed in the mod UI


### PR DESCRIPTION
A [discussion on Discord][discuss] which was prompted by a false-report, led to `http://myurl.me`, the default value for `updateJSONURL`, being discovered as owned by a third-party and causing false reports about it erroring on a `4xx` code, and the `http` protocol thought as being a vulnerability for hijacking _(ex. something MITMs all `http` connections on the network)_.

This PR simply does the following changes to the MDK's `mods.toml`:
* comments out `updateJSONURL`, so no unnecessary connections are made; and
* replaces all URLs present to `https://example.com`, a known safe example site. (as defined in [RFC 2606, §3][rfc2606])

[discuss]: https://discordapp.com/channels/313125603924639766/454376090362970122/730123352886476823
[rfc2606]: https://tools.ietf.org/html/rfc2606#section-3