### PR TITLE
Use new beacon tags, remove old beacon forge methods tag

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/BeaconContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/BeaconContainer.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/inventory/container/BeaconContainer.java
 +++ b/net/minecraft/inventory/container/BeaconContainer.java
-@@ -17,7 +17,7 @@
- public class BeaconContainer extends Container {
-    private final IInventory field_82866_e = new Inventory(1) {
-       public boolean func_94041_b(int p_94041_1_, ItemStack p_94041_2_) {
--         return p_94041_2_.func_77973_b().func_206844_a(ItemTags.field_232908_Z_);
-+         return p_94041_2_.isBeaconPayment();
-       }
- 
-       public int func_70297_j_() {
 @@ -87,10 +87,8 @@
              }
  
@@ -22,12 +13,3 @@
           } else if (p_82846_2_ >= 1 && p_82846_2_ < 28) {
              if (!this.func_75135_a(itemstack1, 28, 37, false)) {
                 return ItemStack.field_190927_a;
-@@ -156,7 +154,7 @@
-       }
- 
-       public boolean func_75214_a(ItemStack p_75214_1_) {
--         return p_75214_1_.func_77973_b().func_206844_a(ItemTags.field_232908_Z_);
-+         return p_75214_1_.isBeaconPayment();
-       }
- 
-       public int func_75219_a() {

--- a/patches/minecraft/net/minecraft/tileentity/BeaconTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/BeaconTileEntity.java.patch
@@ -11,12 +11,3 @@
              if (this.field_213934_g.size() <= 1) {
                 beacontileentity$beamsegment = new BeaconTileEntity.BeamSegment(afloat);
                 this.field_213934_g.add(beacontileentity$beamsegment);
-@@ -184,7 +184,7 @@
- 
-          for(int k = p_213927_1_ - i; k <= p_213927_1_ + i && flag; ++k) {
-             for(int l = p_213927_3_ - i; l <= p_213927_3_ + i; ++l) {
--               if (!this.field_145850_b.func_180495_p(new BlockPos(k, j, l)).func_235714_a_(BlockTags.field_232875_ap_)) {
-+               if (!this.field_145850_b.func_180495_p(new BlockPos(k, j, l)).isBeaconBase(this.field_145850_b, new BlockPos(k, j, l), func_174877_v())) {
-                   flag = false;
-                   break;
-                }

--- a/src/generated/resources/data/forge/tags/items/beacon_payment.json
+++ b/src/generated/resources/data/forge/tags/items/beacon_payment.json
@@ -1,9 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:emerald",
-    "minecraft:diamond",
-    "minecraft:gold_ingot",
-    "minecraft:iron_ingot"
-  ]
-}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -133,7 +133,6 @@ public class Tags
     public static class Items
     {
         public static final ITag.INamedTag<Item> ARROWS = tag("arrows");
-        public static final ITag.INamedTag<Item> BEACON_PAYMENT = tag("beacon_payment");
         public static final ITag.INamedTag<Item> BONES = tag("bones");
         public static final ITag.INamedTag<Item> BOOKSHELVES = tag("bookshelves");
         public static final ITag.INamedTag<Item> CHESTS = tag("chests");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -55,7 +55,6 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         filter = this.tagToBuilder.entrySet().stream().map(e -> e.getKey()).collect(Collectors.toSet());
 
         func_240522_a_(Tags.Items.ARROWS).func_240534_a_(Items.ARROW, Items.TIPPED_ARROW, Items.SPECTRAL_ARROW);
-        func_240522_a_(Tags.Items.BEACON_PAYMENT).func_240534_a_(Items.EMERALD, Items.DIAMOND, Items.GOLD_INGOT, Items.IRON_INGOT);
         func_240522_a_(Tags.Items.BONES).func_240534_a_(Items.BONE);
         func_240522_a_(Tags.Items.BOOKSHELVES).func_240534_a_(Items.BOOKSHELF);
         func_240521_a_(Tags.Blocks.CHESTS, Tags.Items.CHESTS);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -489,22 +489,6 @@ public interface IForgeBlock
         return  false;
     }
 
-   /**
-    * Determines if this block can be used as the base of a beacon.
-    *
-    * @param world The current world
-    * @param pos Block position in world
-    * @param beacon Beacon position in world
-    * @return True, to support the beacon, and make it active with this block.
-    */
-    default boolean isBeaconBase(BlockState state, IWorldReader world, BlockPos pos, BlockPos beacon)
-    {
-        return  state.getBlock() == Blocks.IRON_BLOCK ||
-                state.getBlock() == Blocks.GOLD_BLOCK ||
-                state.getBlock() == Blocks.DIAMOND_BLOCK ||
-                state.getBlock() == Blocks.EMERALD_BLOCK;
-    }
-
     /**
      * Determines if this block can be used as the frame of a conduit.
      *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -408,19 +408,6 @@ public interface IForgeBlockState
         return getBlockState().getBlock().isFertile(getBlockState(), world, pos);
     }
 
-   /**
-    * Determines if this block can be used as the base of a beacon.
-    *
-    * @param world The current world
-    * @param pos Block position in world
-    * @param beacon Beacon position in world
-    * @return True, to support the beacon, and make it active with this block.
-    */
-    default boolean isBeaconBase(IWorldReader world, BlockPos pos, BlockPos beacon)
-    {
-        return getBlockState().getBlock().isBeaconBase(getBlockState(), world, pos, beacon);
-    }
-
     /**
      * Determines if this block can be used as the frame of a conduit.
      *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -640,17 +640,6 @@ public interface IForgeItem
     }
 
     /**
-     * Whether this Item can be used as a payment to activate the vanilla beacon.
-     *
-     * @param stack the ItemStack
-     * @return true if this Item can be used
-     */
-    default boolean isBeaconPayment(ItemStack stack)
-    {
-        return Tags.Items.BEACON_PAYMENT.func_230235_a_(stack.getItem());
-    }
-
-    /**
      * Determine if the player switching between these two item stacks
      *
      * @param oldStack    The old stack that was equipped

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -305,16 +305,6 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     }
 
     /**
-     * Whether this Item can be used as a payment to activate the vanilla beacon.
-     *
-     * @return true if this Item can be used
-     */
-    default boolean isBeaconPayment()
-    {
-        return getStack().getItem().isBeaconPayment(getStack());
-    }
-
-    /**
      * Determines if the specific ItemStack can be placed in the specified armor
      * slot, for the entity.
      *


### PR DESCRIPTION
_This PR fixes #6910._
Minecraft 1.16 introduced the `beacon_base_blocks` and `beacon_payment_items` tags, which controls the valid beacon bases and valid beacon payment items, respectively. Up to now, Forge adds `IForgeBlockState#isBeaconBase` and `IForgeBlock#isBeaconBase` for custom modded valid beacon bases, and `IForgeItemStack#isBeaconPayment` and `IForgeItem#isBeaconPayment` for custom modded beacon payment items. 
However, the patches and default implementations of the methods currently overrides whatever values the aforementioned tags have, preventing the new netherite block from being a valid beacon base block and the new netherite ingot from being a valid beacon payment item.

This PR does the following:
* Reverts part of the patch to `BeaconTileEntity`, specifically the part redirecting the call to the `beacon_base_blocks` tag to `IForgeBlockState#isBeaconBase`;
* Reverts part of the patch to `BeaconContainer`, specifically the part redirecting the call to the `beacon_payment_items` tag to `IForgeItemStack#isBeaconPayment`;
* Removes `IForgeBlock#isBeaconBase`, `IForgeBlockState#isBeaconBase`, `IForgeItem#isBeaconPayment`, and `IForgeItemStack#isBeaconPayment`, because they are obsoleted by the aforementioned tags; and
* Deletes the `forge:beacon_payment` tag, its reference in `Tags$Items` and its datagen code line in `ForgeItemTagsProvider#registerTags`.

The other solution is to change `IForgeBlock#isBeaconBase` and `IForgeItem#isBeaconPayment` to reference the tags. However, both I and the commenters on the issue believe that the block methods are just obsolete, since any conditional beacon base block is too much a hassle that a reasonable player would never use it, and that mechanic is entirely doable in-game using a sticky piston and redstone. The item methods are completely obsoleted by the new tag.

[Attached is a testing datapack][testpack] which adds `minecraft:bedrock` to the `beacon_base_blocks` tag, `minecraft:heart_of_the_sea` to the `beacon_payment_items` tag, and `minecraft:sponge` to both tags. I have used the datapack to verify, using the Forge dev env. with test mods loaded, that the changes above work.

<details>
<summary>In-game image of the changes, with the supplied datapack active</summary>
<img src="https://user-images.githubusercontent.com/21304337/87182771-5e2ea200-c317-11ea-81dc-6d128a1e23ea.png"/>
</details>

[testpack]: https://github.com/MinecraftForge/MinecraftForge/files/4904580/beacon_base_test.zip