### PR TITLE
Fix AnvilRepairEvent having wrong items and not affecting break chance

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -1,15 +1,23 @@
 --- a/net/minecraft/inventory/container/RepairContainer.java
 +++ b/net/minecraft/inventory/container/RepairContainer.java
-@@ -63,6 +63,8 @@
+@@ -48,6 +48,7 @@
+          p_230301_1_.func_82242_a(-this.field_82854_e.func_221495_b());
+       }
  
++      final float breakChance = net.minecraftforge.common.ForgeHooks.onAnvilRepair(p_230301_1_, p_230301_2_, field_234643_d_.func_70301_a(0), field_234643_d_.func_70301_a(1));
+       this.field_234643_d_.func_70299_a(0, ItemStack.field_190927_a);
+       if (this.field_82856_l > 0) {
+          ItemStack itemstack = this.field_234643_d_.func_70301_a(1);
+@@ -64,7 +65,7 @@
        this.field_82854_e.func_221494_a(0);
        this.field_234644_e_.func_221486_a((p_234633_1_, p_234633_2_) -> {
-+            float breakChance = net.minecraftforge.common.ForgeHooks.onAnvilRepair(p_230301_1_, p_230301_2_, RepairContainer.this.field_234643_d_.func_70301_a(0), RepairContainer.this.field_234643_d_.func_70301_a(1));
-+
           BlockState blockstate = p_234633_1_.func_180495_p(p_234633_2_);
-          if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F) {
+-         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < 0.12F) {
++         if (!p_230301_1_.field_71075_bZ.field_75098_d && blockstate.func_235714_a_(BlockTags.field_200572_k) && p_230301_1_.func_70681_au().nextFloat() < breakChance) {
              BlockState blockstate1 = AnvilBlock.func_196433_f(blockstate);
-@@ -96,8 +98,11 @@
+             if (blockstate1 == null) {
+                p_234633_1_.func_217377_a(p_234633_2_, false);
+@@ -96,8 +97,11 @@
           Map<Enchantment, Integer> map = EnchantmentHelper.func_82781_a(itemstack1);
           j = j + itemstack.func_82838_A() + (itemstack2.func_190926_b() ? 0 : itemstack2.func_82838_A());
           this.field_82856_l = 0;
@@ -22,7 +30,7 @@
              if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2)) {
                 int l2 = Math.min(itemstack1.func_77952_i(), itemstack1.func_77958_k() / 4);
                 if (l2 <= 0) {
-@@ -214,6 +219,7 @@
+@@ -214,6 +218,7 @@
              i += k;
              itemstack1.func_200302_a(new StringTextComponent(this.field_82857_m));
           }
@@ -30,7 +38,7 @@
  
           this.field_82854_e.func_221494_a(j + i);
           if (i <= 0) {
-@@ -269,4 +275,8 @@
+@@ -269,4 +274,8 @@
     public int func_216976_f() {
        return this.field_82854_e.func_221495_b();
     }

--- a/src/test/java/net/minecraftforge/debug/block/AnvilRepairTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/AnvilRepairTest.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.debug.block;
+
+import net.minecraftforge.event.entity.player.AnvilRepairEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(AnvilRepairTest.MODID)
+@Mod.EventBusSubscriber(modid = AnvilRepairTest.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class AnvilRepairTest
+{
+    static final String MODID = "anvil_repair_test";
+    static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    static void onAnvilRepair(AnvilRepairEvent event)
+    {
+        final float newChance = 1.0F;
+        LOGGER.info("AnvilRepairEvent: {} + {} -> {}, chance is {}. setting to {}", event.getItemInput(), event.getIngredientInput(), event.getItemResult(), event.getBreakChance(), newChance);
+        event.setBreakChance(newChance);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -70,3 +70,5 @@ loaderVersion="[28,)"
     modId="create_entity_classification_test"
 [[mods]]
     modId="ender_mask_test"
+[[mods]]
+    modId="anvil_repair_test"


### PR DESCRIPTION
_This PR fixes #6950._

See my [comment in the linked issue][explaincomment] for the description of the issue.
_TL;DR:_ `AnvilRepairEvent` is called from wrong place, so input items are wrong, and the break chance is hardcoded, so any set break chance is disregarded.

This PR does the following:
* Modifies the patch to `RepairContainer` to:
    * move the call to `ForgeHooks#onAnvilRepair` to before the slots are emptied and deducted of their contents, to fix the input items being wrong; and
    * remove the hardcoded anvil break chance, to use the event-provided one.
* Adds a test mod `anvil_repair_test` which prints to the log all `AnvilRepairEvent`s and sets their break chance to `1.0F`, or 100%. The event is at `LOWEST` priority. _(I'm unsure whether the test mod or priority is needed)_

[explaincomment]: https://github.com/MinecraftForge/MinecraftForge/issues/6950#issuecomment-657079003