### PR TITLE
[1.16.x] Fix ChunkDataEvents using different data tags

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
@@ -21,7 +21,7 @@
        }
  
        if (chunkstatus$type == ChunkStatus.Type.LEVELCHUNK) {
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, compoundnbt, chunkstatus$type));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_4_, chunkstatus$type));
           return new ChunkPrimerWrapper((Chunk)ichunk);
        } else {
           ChunkPrimer chunkprimer1 = (ChunkPrimer)ichunk;
@@ -29,7 +29,7 @@
              chunkprimer1.func_205767_a(generationstage$carving, BitSet.valueOf(compoundnbt5.func_74770_j(s1)));
           }
  
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, compoundnbt, chunkstatus$type));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_4_, chunkstatus$type));
 +
           return chunkprimer1;
        }


### PR DESCRIPTION
_This PR fixes #6957, for 1.16.x._

The linked issue's author summed up the problem nicely: `ChunkDataEvent.Save` and `ChunkDataEvent.Load` gave different data tags; `Save` gives the whole chunk tag, both the `Level` tag and the `DataVersion`, while `Load` gives only the `Level` subtag.

This PR does one thing: modifies the patch to `ChunkManager` so the two calls to post the `Load` event use the root tag instead of the `Level` subtag.

My previous commit was changing the `Save` event to conform to the `Load` event, but as [stated by LexManos][lexcomment], modders could use the `ChunkDataEvent`s to store custom chunk data.

[lexcomment]: https://github.com/MinecraftForge/MinecraftForge/pull/6961#issuecomment-657744142