### PR TITLE
[1.15.2] Fix ChunkDataEvents using different data tags

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -28,7 +28,7 @@
  
              this.field_219255_i.func_217381_Z().func_230035_c_("chunkSave");
              CompoundNBT compoundnbt1 = ChunkSerializer.func_222645_a(this.field_219255_i, p_219229_1_);
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Save(p_219229_1_, p_219229_1_.getWorldForge() != null ? p_219229_1_.getWorldForge() : this.field_219255_i, compoundnbt1));
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Save(p_219229_1_, p_219229_1_.getWorldForge() != null ? p_219229_1_.getWorldForge() : this.field_219255_i, compoundnbt1.func_74775_l("Level")));
              this.func_219100_a(chunkpos, compoundnbt1);
              return true;
           } catch (Exception exception) {


### PR DESCRIPTION
_This PR fixes #6957._

This PR is the same as #6961, but for 1.15.2. See that issue and PR for details.