### PR TITLE
Introduce a JSON data structure combiner

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/JsonReloadListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/JsonReloadListener.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/client/resources/JsonReloadListener.java
 +++ b/net/minecraft/client/resources/JsonReloadListener.java
-@@ -61,4 +61,8 @@
+@@ -40,6 +40,7 @@
+          String s = resourcelocation.func_110623_a();
+          ResourceLocation resourcelocation1 = new ResourceLocation(resourcelocation.func_110624_b(), s.substring(i, s.length() - field_223381_b));
+ 
++         if (net.minecraftforge.common.ForgeHooks.readCombinedJson(map, p_212854_1_, resourcelocation, resourcelocation1))
+          try (
+             IResource iresource = p_212854_1_.func_199002_a(resourcelocation);
+             InputStream inputstream = iresource.func_199027_b();
+@@ -61,4 +62,8 @@
  
        return map;
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common;
 
+import java.io.*;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,6 +53,7 @@ import net.minecraft.fluid.*;
 import net.minecraft.loot.LootContext;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
+import net.minecraft.resources.IResourceManager;
 import net.minecraft.tags.ITag;
 import net.minecraft.util.*;
 import net.minecraft.block.BlockState;
@@ -112,6 +114,7 @@ import net.minecraftforge.common.data.IOptionalTagEntry;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.loot.LootModifierManager;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.common.util.JsonMerger;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -845,6 +848,26 @@ public class ForgeHooks
                     .translationKey("block.minecraft.lava")
                     .luminosity(15).density(3000).viscosity(6000).temperature(1300).build(fluid);
         throw new RuntimeException("Mod fluids must override createAttributes.");
+    }
+
+    public static boolean readCombinedJson(Map<ResourceLocation, JsonElement> map, IResourceManager resourceManager, ResourceLocation resourcelocation, ResourceLocation resourcelocation1)
+    {
+        try {
+            JsonElement jsonelement = JsonMerger.combineAllJsonResources(resourceManager, resourcelocation);
+            if (jsonelement != null) {
+                JsonElement jsonelement1 = map.put(resourcelocation1, jsonelement);
+                if (jsonelement1 != null) {
+                    throw new IllegalStateException("Duplicate data file ignored with ID " + resourcelocation1);
+                }
+            } else {
+                LOGGER.error("Couldn't load data file {} from {} as it's null or empty", resourcelocation1, resourcelocation);
+            }
+        } catch (IllegalArgumentException | IOException | JsonParseException jsonparseexception) {
+            LOGGER.error("Couldn't parse data file {} from {}", resourcelocation1, resourcelocation, jsonparseexception);
+        }
+
+        // cancel vanilla behaviour
+        return false;
     }
 
     private static class LootTableContext

--- a/src/main/java/net/minecraftforge/common/util/JsonMerger.java
+++ b/src/main/java/net/minecraftforge/common/util/JsonMerger.java
@@ -253,7 +253,7 @@ public class JsonMerger
                 if (settings.has("index"))
                 {
                     if (mode == MergeMode.APPEND)
-                        throw new JsonSyntaxException("Index is noy available in append mode.");
+                        throw new JsonSyntaxException("Index is not available in append mode.");
                     index = settings.get("index").getAsInt();
                 }
 
@@ -262,7 +262,7 @@ public class JsonMerger
                     if (index != null)
                         throw new JsonSyntaxException("Array replace option 'find' can not be used at the same time as 'index'.");
                     if (mode == MergeMode.APPEND)
-                        throw new JsonSyntaxException("Find is noy available in append mode.");
+                        throw new JsonSyntaxException("Find is not available in append mode.");
                     find = settings.get("find");
                 }
 

--- a/src/main/java/net/minecraftforge/common/util/JsonMerger.java
+++ b/src/main/java/net/minecraftforge/common/util/JsonMerger.java
@@ -1,0 +1,421 @@
+package net.minecraftforge.common.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.gson.*;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.resources.IResource;
+import net.minecraft.resources.IResourceManager;
+import net.minecraft.util.ResourceLocation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class JsonMerger
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final Gson SERIALIZER = new GsonBuilder().create();
+
+    public static JsonElement combineAllJsonResources(IResourceManager resourceManager, ResourceLocation location) throws IOException
+    {
+        List<Either<JsonElement, Exception>> results = resourceManager.getAllResources(location).stream().map(res -> {
+            try (
+                    IResource t = res;
+                    InputStream is = t.getInputStream();
+                    InputStreamReader rd = new InputStreamReader(is))
+            {
+                JsonElement jsonElement = SERIALIZER.fromJson(rd, JsonElement.class);
+                if (jsonElement == null) {
+                    LOGGER.error("Couldn't load data from {} as it's null or empty", location);
+                }
+                return Either.<JsonElement, Exception>left(jsonElement);
+            }
+            catch(IOException e)
+            {
+                return Either.<JsonElement, Exception>right(e);
+            }
+        }).collect(Collectors.toList());
+
+        JsonElement merged = null;
+        for(Either<JsonElement, Exception> result : results)
+        {
+            Optional<Exception> ex = result.right();
+            if (ex.isPresent())
+            {
+                LOGGER.error("Error reading JSON from {}", location, ex.get());
+                continue;
+            }
+
+            JsonElement next = result.orThrow();
+            if (merged == null)
+            {
+                merged = next;
+            }
+            else
+            {
+                merged = combineJsonElements(merged, next, MergeMode.OVERWRITE);
+            }
+        }
+        return merged;
+    }
+
+    public static JsonElement combineAllJsonResources(List<JsonElement> elements)
+    {
+        JsonElement merged = null;
+        for(JsonElement next : elements)
+        {
+            if (merged == null)
+            {
+                merged = next;
+            }
+            else
+            {
+                merged = combineJsonElements(merged, next, MergeMode.OVERWRITE);
+            }
+        }
+        return merged;
+    }
+
+    private static JsonElement combineJsonElements(JsonElement first, JsonElement second, MergeMode parentMode)
+    {
+        MergeMode mode = parentMode;
+        JsonObject settings;
+        if (second.isJsonObject())
+        {
+            JsonObject secondObj = second.getAsJsonObject();
+            if (secondObj.has("_forge_combine"))
+            {
+                settings = secondObj.getAsJsonObject("_forge_combine");
+
+                if (settings.has("mode"))
+                {
+                    String modeName = settings.get("mode").getAsString();
+                    mode = MergeMode.byName(modeName);
+                    if (mode == null)
+                        throw new JsonSyntaxException(String.format("Unknown combine mode: %s",  modeName));
+                }
+
+                if (settings.has("value"))
+                {
+                    second = settings.get("value");
+                }
+            }
+        }
+
+        return getCombinedInternal(first, second, mode);
+    }
+
+    private static void processJsonArrayElement(List<JsonElement> parent, JsonElement second)
+    {
+        MergeMode mode = MergeMode.APPEND;
+        JsonObject settings;
+        Integer index = null;
+        JsonElement find = null;
+        boolean silent = false;
+        boolean exact = false;
+        if (second.isJsonObject())
+        {
+            JsonObject secondObj = second.getAsJsonObject();
+            if (secondObj.has("_forge_combine"))
+            {
+                settings = secondObj.getAsJsonObject("_forge_combine");
+
+                if (settings.has("mode"))
+                {
+                    String modeName = settings.get("mode").getAsString();
+                    mode = MergeMode.byName(modeName);
+                    if (mode == null)
+                        throw new JsonSyntaxException(String.format("Unknown combine mode: %s",  modeName));
+                }
+
+                if (settings.has("value"))
+                {
+                    second = settings.get("value");
+                }
+
+                if (settings.has("index"))
+                {
+                    index = settings.get("index").getAsInt();
+                }
+
+                if (settings.has("find"))
+                {
+                    if (index != null)
+                        throw new JsonSyntaxException("Array replace option 'find' can not be used at the same time as 'index'.");
+                    find = settings.get("find");
+                }
+
+                if (settings.has("silent"))
+                    silent = settings.get("silent").getAsBoolean();
+
+                if (settings.has("exact"))
+                    exact = settings.get("exact").getAsBoolean();
+            }
+        }
+
+        switch(mode)
+        {
+            case INSERT:
+            {
+                if (index == null)
+                    throw new JsonSyntaxException("Insert mode must specify an index.");
+                parent.add(index, second);
+                break;
+            }
+            case REPLACE:
+            {
+                if (index == null && find == null)
+                    throw new JsonSyntaxException("Replace mode must specify an 'index' or a 'find' search pattern.");
+                if (index != null)
+                    parent.set(index, second);
+                else
+                {
+                    boolean found = false;
+                    for(int i=0;i<parent.size();i++)
+                    {
+                        if (compareWithPattern(parent.get(i), find, exact))
+                        {
+                            parent.set(i, second);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found && !silent)
+                    {
+                        LOGGER.warn("Replace pattern did not find a target while looking for: {}", find.toString());
+                    }
+                }
+                break;
+            }
+            case APPEND:
+            {
+                parent.add(second);
+                break;
+            }
+        }
+    }
+
+    private static boolean compareWithPattern(JsonElement base, JsonElement pattern, boolean exact)
+    {
+        if (pattern.isJsonObject())
+        {
+            if (!base.isJsonObject())
+                return false;
+            return compareObjectWithPattern(base.getAsJsonObject(), pattern.getAsJsonObject(), exact);
+        }
+        else if(pattern.isJsonArray())
+        {
+            if (!base.isJsonArray())
+                return false;
+            return compareArrayWithPattern(base.getAsJsonArray(), pattern.getAsJsonArray(), exact);
+        }
+        else
+        {
+            return base.equals(pattern);
+        }
+    }
+
+    private static boolean compareArrayWithPattern(JsonArray array, JsonArray pattern, boolean exact)
+    {
+        if (exact)
+        {
+            if (array.size() != pattern.size())
+                return false;
+
+            for(int i=0;i<pattern.size();i++)
+            {
+                if (!compareWithPattern(array.get(i), pattern.get(i), true))
+                    return false;
+            }
+        }
+
+        if (pattern.size() > array.size())
+            return false;
+
+        BitSet processedIndices = new BitSet();
+        for(int i=0;i<pattern.size();i++)
+        {
+            boolean found = false;
+            for(int j=0;j<array.size();j++)
+            {
+                if (processedIndices.get(j))
+                    continue;
+
+                if (compareWithPattern(array.get(j), pattern.get(i), true))
+                {
+                    processedIndices.set(j);
+                    found = true;
+                    break;
+                }
+            }
+
+            if(!found)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static boolean compareObjectWithPattern(JsonObject obj, JsonObject pattern, boolean exact)
+    {
+        for(Map.Entry<String, JsonElement> entry : pattern.entrySet())
+        {
+            String key = entry.getKey();
+            if (!obj.has(key))
+                return false;
+            if (!compareWithPattern(obj.get(key), entry.getValue(), exact))
+                return false;
+        }
+
+        if (exact)
+        {
+            for(Map.Entry<String, JsonElement> entry : pattern.entrySet())
+            {
+                String key = entry.getKey();
+                if (!pattern.has(key))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static JsonElement getCombinedInternal(JsonElement first, JsonElement second, MergeMode mode)
+    {
+        if (mode == MergeMode.OVERWRITE)
+            return second;
+
+        if (first.isJsonObject())
+        {
+            if (!second.isJsonObject())
+            {
+                throw new JsonSyntaxException("The combining counterpart for a json object must be another json object");
+            }
+
+            if (mode == MergeMode.COMBINE)
+            {
+                return combineObjects(first.getAsJsonObject(), second.getAsJsonObject());
+            }
+
+            throw new JsonSyntaxException(String.format("Invalid combine mode for a json object: %s. Allowed: overwrite, combine", mode));
+        }
+        else if (first.isJsonArray())
+        {
+            switch(mode)
+            {
+                case COMBINE:
+                    return concatenateArrays(first.getAsJsonArray(), second.getAsJsonArray());
+                case ZIP:
+                    return zipArrays(first.getAsJsonArray(), second.getAsJsonArray());
+                default:
+                    throw new JsonSyntaxException(String.format("Invalid combine mode for a json array: %s. Allowed: overwrite, combine, zip", mode));
+            }
+        }
+        else if (first.isJsonNull())
+        {
+            throw new JsonSyntaxException(String.format("Invalid combine mode for a json null: %s", mode));
+        }
+        else
+        {
+            throw new JsonSyntaxException(String.format("Invalid combine mode for a json primitive: %s", mode));
+        }
+    }
+
+    private static JsonElement zipArrays(JsonArray first, JsonArray second)
+    {
+        JsonArray a = new JsonArray();
+        int end = Math.min(first.size(),second.size());
+        for(int i=0;i<end;i++)
+        {
+            a.add(combineJsonElements(first.get(i), second.get(i), MergeMode.COMBINE));
+        }
+        return null;
+    }
+
+    private static JsonElement concatenateArrays(JsonArray first, JsonArray second)
+    {
+        List<JsonElement> elements = Lists.newArrayList();
+        for(int i=0;i<first.size();i++)
+            elements.add(first.get(i));
+        for(int i=0;i<second.size();i++)
+            processJsonArrayElement(elements, second.get(i));
+
+        JsonArray result = new JsonArray();
+        for (JsonElement element : elements)
+            result.add(element);
+        return result;
+    }
+
+    public static JsonElement combineObjects(JsonObject first, JsonObject second)
+    {
+        JsonObject result = new JsonObject();
+        for(Map.Entry<String, JsonElement> entry : first.entrySet())
+        {
+            String key = entry.getKey();
+            JsonElement value = entry.getValue();
+            if (second.has(key))
+            {
+                result.add(key, combineJsonElements(value, second.get(key), MergeMode.COMBINE));
+            }
+            else
+            {
+                result.add(key, value);
+            }
+        }
+        for(Map.Entry<String, JsonElement> entry : first.entrySet())
+        {
+            String key = entry.getKey();
+            JsonElement value = entry.getValue();
+            if (!result.has(key))
+            {
+                result.add(key, value);
+            }
+        }
+        return result;
+    }
+
+    public enum MergeMode
+    {
+        OVERWRITE("overwrite"), /* default vanilla behaviour */
+        COMBINE("combine"), /* OBJECTS: combines values with same key; ARRAYS: inserts, replaces or appends the elements of the second array into the first */
+        ZIP("zip"), /* ARRAYS ONLY: zips the arrays, combining each pair of elements */
+        REPLACE("replace"), /* CHILDREN OF ARRAYS ONLY: replaces the specified index */
+        INSERT("insert"), /* CHILDREN OF ARRAYS ONLY: inserts the element at the specified index */
+        APPEND("insert"); /* CHILDREN OF ARRAYS ONLY: inserts the element at the end of the array (DEFAULT) */
+
+        private final String name;
+
+        MergeMode(String name)
+        {
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public static final ImmutableList<MergeMode> VALUES = ImmutableList.copyOf(values());
+
+        @Nullable
+        public static MergeMode byName(String name)
+        {
+            for(MergeMode m : VALUES)
+            {
+                if (m.getName().equals(name))
+                    return m;
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/util/JsonMerger.java
+++ b/src/main/java/net/minecraftforge/common/util/JsonMerger.java
@@ -353,12 +353,16 @@ public class JsonMerger
         }
         else if (first.isJsonNull())
         {
-            throw new JsonSyntaxException(String.format("Invalid combine mode for a json null: %s", mode));
+            if (mode != MergeMode.COMBINE)
+                throw new JsonSyntaxException(String.format("Invalid combine mode for a json null: %s", mode));
         }
         else
         {
-            throw new JsonSyntaxException(String.format("Invalid combine mode for a json primitive: %s", mode));
+            if (mode != MergeMode.COMBINE)
+                throw new JsonSyntaxException(String.format("Invalid combine mode for a json primitive: %s", mode));
         }
+
+        return second;
     }
 
     private static JsonElement zipArrays(JsonArray first, JsonArray second)

--- a/src/test/resources/data/minecraft/loot_tables/entities/cow.json
+++ b/src/test/resources/data/minecraft/loot_tables/entities/cow.json
@@ -1,0 +1,69 @@
+{
+  "_forge_combine": {
+    "mode": "combine"
+  },
+  "pools": [
+    {
+      "_forge_combine": {
+        "__comment": "Finds and replaces a loot pool that has an entry with an item type that drops leather",
+        "mode": "replace",
+        "find": {
+          "entries": [{
+            "type": "minecraft:item",
+            "name": "minecraft:leather"
+          }]
+        }
+      },
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:phantom_membrane"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/data/minecraft/loot_tables/entities/cow.json
+++ b/src/test/resources/data/minecraft/loot_tables/entities/cow.json
@@ -6,7 +6,7 @@
     {
       "_forge_combine": {
         "__comment": "Finds and replaces a loot pool that has an entry with an item type that drops leather",
-        "mode": "replace",
+        "mode": "overwrite",
         "find": {
           "entries": [{
             "type": "minecraft:item",


### PR DESCRIPTION
This will allow processing the json files as they load, before they are passed into the corresponding deserializer.

## How to use

This feature is available on specific supported json files (eg, loot tables).

Json objects can contain a "_forge_combine" key, which should itself be a json object. 

By default, all json files start in "overwrite" mode, which returns the file as-is, maintaining the default vanilla behaviour. 

Certain alternative modes are available depending on the element type.

### Objects:

- Combine: The two objects are combined, processing the child elements recursively.

### Arrays:

- Combine: The two arrays are combined, processing the child elements recursively. When in combine mode, array elements can have special modes to choose what to replace, or where to insert.
- Zip: The two arrays are combined pairwise, combining each pair of elements into a new element.

### Child elements within arrays:

- Append (default): The element is added to the end of the list.
- Overwrite: The element with either the specified index, or the specified search pattern, gets replaced.
- Combine: Same as replace, but combines the existing value instead of overwriting.
- Insert: The element is inserted at the position with the specified index.

### How it's processed

The process begins at the root object, which defaults to "overwrite". If this object is set to "combine" instead, the merger will iterate through the key sets of both the original and the new, combining values for keys that exist on both objects. Children of combined objects inherit the combine mode, but they can choose to overwrite instead, by specifying this explicitly.

For arrays, the combine operation adds elements to the array, without combining them. However those child elements can specify their own mode, in which case the element will either be inserted at a chosen location, will replace (overwrite) and existing value, or will be combined with an existing value. This behaviour is guided either by index, or by search pattern.

For all other data types (primitives, null), overwrite and combine act the same: the element is returned as-is.

### Controlling the insertion behaviour for non-object elements

Since only json objects can contain the "_forge_combine" key, another feature is available: any object which has the "_forge_combine" key, and inside has a "value" key, the contents of this value key are used, instead of the object. This allows inserting/replacing arrays, strings, or other primitives, contained within other arrays, or controlling the mode of values in individual keys within an object.

That is, the following object: 

```json
{
  "_forge_combine": { "value": 1 }
}
```

is equivalent to the primitive `1`.

## Todo

- [ ] Tie into dimension json import logic, which isn't based on datapack reload listeners.
- [x] Add support for a DELETE mode, which would work within children of objects and arrays.