### PR TITLE
Load client world capabilities

### DIFF
--- a/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
@@ -4,7 +4,7 @@
        this.func_239136_a_(new BlockPos(8, 64, 8));
        this.func_72966_v();
        this.func_72947_a();
-+      //this.gatherCapabilities(dimension.initCapabilities()); //TODO
++      this.gatherCapabilities();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Load(this));
     }
  


### PR DESCRIPTION
I dug into this.

Since the IForgeDimension that has capabilities doesn't exist anymore and is also not called from the server side either.
This should be enough to enable them on the client side too.
I tested it and it worked fine for me after this.