### PR TITLE
[1.16.x] Use default config values if a parsing exception is thrown

### DIFF
--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.config;
 import com.electronwill.nightconfig.core.ConfigFormat;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.file.FileWatcher;
+import com.electronwill.nightconfig.core.io.ParsingException;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import net.minecraftforge.fml.loading.FMLConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
@@ -50,7 +51,13 @@ public class ConfigFileTypeHandler {
                     writingMode(WritingMode.REPLACE).
                     build();
             LOGGER.debug(CONFIG, "Built TOML config for {}", configPath.toString());
-            configData.load();
+            try {
+                configData.load();
+            } catch (ParsingException e) {
+                LOGGER.warn("Failed to load TOML config file {}, replacing with defaults: {}", configPath.toString(), e);
+                configData.save();
+                configData.load();
+            }
             LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath.toString());
             try {
                 FileWatcher.defaultInstance().addWatch(configPath, new ConfigWatcher(c, configData, Thread.currentThread().getContextClassLoader()));


### PR DESCRIPTION
Currently, if a config file is corrupted that `nightconfig` cannot parse it, it crashes the game with `ParsingException: Not enough data available`. This has an easy solution: delete the offending config file. However, it is easier to implement a fix such that if a config file cannot be parsed, then the default config values are used.

This PR does the following:
* Modifies `FMLConfig` so any `ParsingException`s are caught, and an attempt is made to delete the corrupted `fml.toml` file and then load the config. The default config from `defaultfmlconfig.toml` will then be copied and saved by the save operation. If the delete fails, a message is logged, and the successive config load will most likely error.
* Modifies `ConfigTracker` so any `ParsingException`s are caught, and the default values are saved to disk, overwriting the corrupted config file.

Attached is the [corrupted config file][corrupted] that I used to test the PR, packaged in a ZIP archive.

[corrupted]: https://github.com/MinecraftForge/MinecraftForge/files/4913991/corrupted.zip