### PR TITLE
adds a postRotation to CameraSetup event.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -27,7 +27,7 @@
              } catch (Throwable throwable) {
                 CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Rendering screen");
                 CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Screen render details");
-@@ -589,9 +591,16 @@
+@@ -589,9 +591,17 @@
        Matrix4f matrix4f = matrixstack.func_227866_c_().func_227870_a_();
        this.func_228379_a_(matrix4f);
        activerenderinfo.func_216772_a(this.field_78531_r.field_71441_e, (Entity)(this.field_78531_r.func_175606_aa() == null ? this.field_78531_r.field_71439_g : this.field_78531_r.func_175606_aa()), this.field_78531_r.field_71474_y.field_74320_O > 0, this.field_78531_r.field_71474_y.field_74320_O == 2, p_228378_1_);
@@ -38,13 +38,14 @@
 +
        p_228378_4_.func_227863_a_(Vector3f.field_229179_b_.func_229187_a_(activerenderinfo.func_216777_e()));
        p_228378_4_.func_227863_a_(Vector3f.field_229181_d_.func_229187_a_(activerenderinfo.func_216778_f() + 180.0F));
++      p_228378_4_.func_227863_a_(cameraSetup.getPostRotation());
        this.field_78531_r.field_71438_f.func_228426_a_(p_228378_4_, p_228378_1_, p_228378_2_, flag, activerenderinfo, this, this.field_78513_d, matrix4f);
 +      this.field_78531_r.func_213239_aq().func_219895_b("forge_render_last");
 +      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_1_, matrix4f, p_228378_2_);
        this.field_78531_r.func_213239_aq().func_219895_b("hand");
        if (this.field_175074_C) {
           RenderSystem.clear(256, Minecraft.field_142025_a);
-@@ -671,4 +680,9 @@
+@@ -671,4 +681,9 @@
     public OverlayTexture func_228385_m_() {
        return this.field_228375_t_;
     }

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -23,6 +23,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.FogRenderer.FogType;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.util.math.vector.Quaternion;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
@@ -149,6 +150,7 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
         private float yaw;
         private float pitch;
         private float roll;
+        private Quaternion postRotation;
 
         public CameraSetup(GameRenderer renderer, ActiveRenderInfo info, double renderPartialTicks, float yaw, float pitch, float roll)
         {
@@ -156,6 +158,7 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
             this.setYaw(yaw);
             this.setPitch(pitch);
             this.setRoll(roll);
+            this.postRotation = Quaternion.ONE;
         }
 
         public float getYaw() { return yaw; }
@@ -164,6 +167,8 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
         public void setPitch(float pitch) { this.pitch = pitch; }
         public float getRoll() { return roll; }
         public void setRoll(float roll) { this.roll = roll; }
+        public Quaternion getPostRotation() {return postRotation;}
+        public void setPostRotation(Quaternion postRotation) {this.postRotation = postRotation;}
     }
 
     /**


### PR DESCRIPTION
The this fixes is gimbal lock in the camera's rotation. some translations are impossible or very without the use of quaternions. my change is as minimal as possible in order to avoid conflicts.