### PR TITLE
Fix ClimberPathNavigator spinning when width is small. Closes #6993

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/ClimberPathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/ClimberPathNavigator.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/pathfinding/ClimberPathNavigator.java
 +++ b/net/minecraft/pathfinding/ClimberPathNavigator.java
-@@ -38,7 +38,7 @@
+@@ -38,7 +38,8 @@
           super.func_75501_e();
        } else {
           if (this.field_179696_f != null) {
 -            if (!this.field_179696_f.func_218137_a(this.field_75515_a.func_213303_ch(), (double)this.field_75515_a.func_213311_cf()) && (!(this.field_75515_a.func_226278_cu_() > (double)this.field_179696_f.func_177956_o()) || !(new BlockPos((double)this.field_179696_f.func_177958_n(), this.field_75515_a.func_226278_cu_(), (double)this.field_179696_f.func_177952_p())).func_218137_a(this.field_75515_a.func_213303_ch(), (double)this.field_75515_a.func_213311_cf()))) {
++            // FORGE: Fix MC-94054
 +            if (!this.field_179696_f.func_218137_a(this.field_75515_a.func_213303_ch(), Math.max((double)this.field_75515_a.func_213311_cf(), 1.0D)) && (!(this.field_75515_a.func_226278_cu_() > (double)this.field_179696_f.func_177956_o()) || !(new BlockPos((double)this.field_179696_f.func_177958_n(), this.field_75515_a.func_226278_cu_(), (double)this.field_179696_f.func_177952_p())).func_218137_a(this.field_75515_a.func_213303_ch(), Math.max((double)this.field_75515_a.func_213311_cf(), 1.0D)))) {
                 this.field_75515_a.func_70605_aq().func_75642_a((double)this.field_179696_f.func_177958_n(), (double)this.field_179696_f.func_177956_o(), (double)this.field_179696_f.func_177952_p(), this.field_75511_d);
              } else {

--- a/patches/minecraft/net/minecraft/pathfinding/ClimberPathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/ClimberPathNavigator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/pathfinding/ClimberPathNavigator.java
++++ b/net/minecraft/pathfinding/ClimberPathNavigator.java
+@@ -38,7 +38,7 @@
+          super.func_75501_e();
+       } else {
+          if (this.field_179696_f != null) {
+-            if (!this.field_179696_f.func_218137_a(this.field_75515_a.func_213303_ch(), (double)this.field_75515_a.func_213311_cf()) && (!(this.field_75515_a.func_226278_cu_() > (double)this.field_179696_f.func_177956_o()) || !(new BlockPos((double)this.field_179696_f.func_177958_n(), this.field_75515_a.func_226278_cu_(), (double)this.field_179696_f.func_177952_p())).func_218137_a(this.field_75515_a.func_213303_ch(), (double)this.field_75515_a.func_213311_cf()))) {
++            if (!this.field_179696_f.func_218137_a(this.field_75515_a.func_213303_ch(), Math.max((double)this.field_75515_a.func_213311_cf(), 1.0D)) && (!(this.field_75515_a.func_226278_cu_() > (double)this.field_179696_f.func_177956_o()) || !(new BlockPos((double)this.field_179696_f.func_177958_n(), this.field_75515_a.func_226278_cu_(), (double)this.field_179696_f.func_177952_p())).func_218137_a(this.field_75515_a.func_213303_ch(), Math.max((double)this.field_75515_a.func_213311_cf(), 1.0D)))) {
+                this.field_75515_a.func_70605_aq().func_75642_a((double)this.field_179696_f.func_177958_n(), (double)this.field_179696_f.func_177956_o(), (double)this.field_179696_f.func_177952_p(), this.field_75511_d);
+             } else {
+                this.field_179696_f = null;


### PR DESCRIPTION
This PR is a fix (also kind of a hack) for #6993 

Entities using `ClimberPathNavigator` (like a spider) keep spinning at the end of their path navigation when their width is 0.9 or smaller.
This PR makes sure when their width is checked for navigation that the width is never lower then 1.

`.withinDistance(this.entity.getPositionVec(), (double)this.entity.getWidth())`
is now
`.withinDistance(this.entity.getPositionVec(), Math.max((double)this.entity.getWidth(), 1.0D))`