### PR TITLE
Add missing copyright / license headers.

### DIFF
--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2020.
+ * Copyright (c) 2016-2020.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2020.
+ * Copyright (c) 2016-2020.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/item/EnderMaskTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/EnderMaskTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.entity.monster.EndermanEntity;

--- a/src/test/java/net/minecraftforge/debug/world/RaidEnumTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/RaidEnumTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.entity.EntityType;


### PR DESCRIPTION
I noticed this when the gradle `checkLicense` task was failing. This is what I ended up doing to make that task pass. I'm assuming these are just oversights?