### PR TITLE
[1.16] Restructuring of the Config system

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
@@ -39,8 +39,8 @@ public class NightConfigWrapper implements IConfigurable {
         this.config = config;
     }
 
-    NightConfigWrapper setFile(IModFileInfo file) {
-        this.file = file;
+    public NightConfigWrapper setFile(IModFileInfo file) {
+        if (this.file == null) this.file = file; // Don't overwrite existing IModFileInfo
         return this;
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -21,17 +21,27 @@ package net.minecraftforge.common;
 
 import static net.minecraftforge.fml.loading.LogMarkers.FORGEMOD;
 
+import net.minecraftforge.common.config.ModConfigSpec;
+import net.minecraftforge.common.config.RangeType;
+import net.minecraftforge.common.config.values.BooleanValue;
+import net.minecraftforge.common.config.values.DoubleValue;
+import net.minecraftforge.common.config.values.IntValue;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
-import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
-import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
-import net.minecraftforge.common.ForgeConfigSpec.IntValue;
 
 public class ForgeConfig
 {
+    static {
+        SERVER = ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ForgeConfig.Server::new);
+        CLIENT = ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ForgeConfig.Client::new);
+    }
+    public static void init() { }
+    public static final Server SERVER;
+    public static final Client CLIENT;
+
     public static class Server {
         public final BooleanValue removeErroringEntities;
         public final BooleanValue removeErroringTileEntities;
@@ -52,7 +62,7 @@ public class ForgeConfig
 
         public final BooleanValue fixAdvancementLoading;
 
-        Server(ForgeConfigSpec.Builder builder) {
+        Server(ModConfigSpec builder) {
             builder.comment("Server configuration settings")
                    .push("server");
 
@@ -60,62 +70,62 @@ public class ForgeConfig
                     .comment("Set this to true to remove any Entity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
                     .translation("forge.configgui.removeErroringEntities")
                     .worldRestart()
-                    .define("removeErroringEntities", false);
+                    .defineBoolean("removeErroringEntities", false);
 
             removeErroringTileEntities = builder
                     .comment("Set this to true to remove any TileEntity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
                     .translation("forge.configgui.removeErroringTileEntities")
                     .worldRestart()
-                    .define("removeErroringTileEntities", false);
+                    .defineBoolean("removeErroringTileEntities", false);
 
             fullBoundingBoxLadders = builder
                     .comment("Set this to true to check the entire entity's collision bounding box for ladders instead of just the block they are in. Causes noticeable differences in mechanics so default is vanilla behavior. Default: false.")
                     .translation("forge.configgui.fullBoundingBoxLadders")
                     .worldRestart()
-                    .define("fullBoundingBoxLadders", false);
+                    .defineBoolean("fullBoundingBoxLadders", false);
 
             zombieBaseSummonChance = builder
                     .comment("Base zombie summoning spawn chance. Allows changing the bonus zombie summoning mechanic.")
                     .translation("forge.configgui.zombieBaseSummonChance")
                     .worldRestart()
-                    .defineInRange("zombieBaseSummonChance", 0.1D, 0.0D, 1.0D);
+                    .defineInRange("zombieBaseSummonChance", 0.1D, RangeType.CLOSED.createRange(0.0D, 1.0D));
 
             zombieBabyChance = builder
                     .comment("Chance that a zombie (or subclass) is a baby. Allows changing the zombie spawning mechanic.")
                     .translation("forge.configgui.zombieBabyChance")
                     .worldRestart()
-                    .defineInRange("zombieBabyChance", 0.05D, 0.0D, 1.0D);
+                    .defineInRange("zombieBabyChance", 0.05D, RangeType.CLOSED.createRange(0.0D, 1.0D));
 
             logCascadingWorldGeneration = builder
                     .comment("Log cascading chunk generation issues during terrain population.")
                     .translation("forge.configgui.logCascadingWorldGeneration")
-                    .define("logCascadingWorldGeneration", true);
+                    .defineBoolean("logCascadingWorldGeneration", true);
 
             fixVanillaCascading = builder
                     .comment("Fix vanilla issues that cause worldgen cascading. This DOES change vanilla worldgen so DO NOT report bugs related to world differences if this flag is on.")
                     .translation("forge.configgui.fixVanillaCascading")
-                    .define("fixVanillaCascading", false);
+                    .defineBoolean("fixVanillaCascading", false);
 
             dimensionUnloadQueueDelay = builder
                     .comment("The time in ticks the server will wait when a dimension was queued to unload. This can be useful when rapidly loading and unloading dimensions, like e.g. throwing items through a nether portal a few time per second.")
                     .translation("forge.configgui.dimensionUnloadQueueDelay")
-                    .defineInRange("dimensionUnloadQueueDelay", 0, 0, Integer.MAX_VALUE);
+                    .defineInRange("dimensionUnloadQueueDelay", 0, RangeType.CLOSED.createRange(0, Integer.MAX_VALUE));
 
             clumpingThreshold = builder
                     .comment("Controls the number threshold at which Packet51 is preferred over Packet52, default and minimum 64, maximum 1024.")
                     .translation("forge.configgui.clumpingThreshold")
                     .worldRestart()
-                    .defineInRange("clumpingThreshold", 64, 64, 1024);
+                    .defineInRange("clumpingThreshold", 64, RangeType.CLOSED.createRange(64, 1024));
 
             treatEmptyTagsAsAir = builder
                     .comment("Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.")
                     .translation("forge.configgui.treatEmptyTagsAsAir")
-                    .define("treatEmptyTagsAsAir", false);
+                    .defineBoolean("treatEmptyTagsAsAir", false);
 
             fixAdvancementLoading = builder
                     .comment("Fix advancement loading to use a proper topological sort. This may have visibility side-effects and can thus be turned off if needed for data-pack compatibility.")
                     .translation("forge.configgui.fixAdvancementLoading")
-                    .define("fixAdvancementLoading", true);
+                    .defineBoolean("fixAdvancementLoading", true);
             builder.pop();
         }
     }
@@ -141,75 +151,58 @@ public class ForgeConfig
 
         public final BooleanValue useCombinedDepthStencilAttachment;
 
-        Client(ForgeConfigSpec.Builder builder) {
+        Client(ModConfigSpec builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
 
             zoomInMissingModelTextInGui = builder
                 .comment("Toggle off to make missing model text in the gui fit inside the slot.")
                 .translation("forge.configgui.zoomInMissingModelTextInGui")
-                .define("zoomInMissingModelTextInGui", false);
+                .defineBoolean("zoomInMissingModelTextInGui", false);
 
             forgeCloudsEnabled = builder
                 .comment("Enable uploading cloud geometry to the GPU for faster rendering.")
                 .translation("forge.configgui.forgeCloudsEnabled")
-                .define("forgeCloudsEnabled", true);
+                .defineBoolean("forgeCloudsEnabled", true);
 
             disableStairSlabCulling = builder
                 .comment("Disable culling of hidden faces next to stairs and slabs. Causes extra rendering, but may fix some resource packs that exploit this vanilla mechanic.")
                 .translation("forge.configgui.disableStairSlabCulling")
-                .define("disableStairSlabCulling", false);
+                .defineBoolean("disableStairSlabCulling", false);
 
             alwaysSetupTerrainOffThread = builder
                 .comment("Enable Forge to queue all chunk updates to the Chunk Update thread.",
                         "May increase FPS significantly, but may also cause weird rendering lag.",
                         "Not recommended for computers without a significant number of cores available.")
                 .translation("forge.configgui.alwaysSetupTerrainOffThread")
-                .define("alwaysSetupTerrainOffThread", false);
+                .defineBoolean("alwaysSetupTerrainOffThread", false);
 
             forgeLightPipelineEnabled = builder
                 .comment("Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
                 .translation("forge.configgui.forgeLightPipelineEnabled")
-                .define("forgeLightPipelineEnabled", true);
+                .defineBoolean("forgeLightPipelineEnabled", true);
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
                 .translation("forge.configgui.forgeLightPipelineEnabled")
-                .define("experimentalForgeLightPipelineEnabled", false);
+                .defineBoolean("experimentalForgeLightPipelineEnabled", false);
 
             selectiveResourceReloadEnabled = builder
                 .comment("When enabled, makes specific reload tasks such as language changing quicker to run.")
                 .translation("forge.configgui.selectiveResourceReloadEnabled")
-                .define("selectiveResourceReloadEnabled", true);
+                .defineBoolean("selectiveResourceReloadEnabled", true);
 
             showLoadWarnings = builder
                 .comment("When enabled, Forge will show any warnings that occurred during loading.")
                 .translation("forge.configgui.showLoadWarnings")
-                .define("showLoadWarnings", true);
+                .defineBoolean("showLoadWarnings", true);
 
             useCombinedDepthStencilAttachment = builder
                     .comment("Set to true to use a combined DEPTH_STENCIL attachment instead of two separate ones.")
                     .translation("forge.configgui.useCombinedDepthStencilAttachment")
-                    .define("useCombinedDepthStencilAttachment", false);
+                    .defineBoolean("useCombinedDepthStencilAttachment", false);
 
             builder.pop();
         }
-    }
-
-    static final ForgeConfigSpec clientSpec;
-    public static final Client CLIENT;
-    static {
-        final Pair<Client, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Client::new);
-        clientSpec = specPair.getRight();
-        CLIENT = specPair.getLeft();
-    }
-
-
-    static final ForgeConfigSpec serverSpec;
-    public static final Server SERVER;
-    static {
-        final Pair<Server, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Server::new);
-        serverSpec = specPair.getRight();
-        SERVER = specPair.getLeft();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -64,6 +64,11 @@ import com.google.common.collect.ObjectArrays;
  * Like {@link com.electronwill.nightconfig.core.ConfigSpec} except in builder format, and extended to accept comments, language keys,
  * and other things Forge configs would find useful.
  */
+
+/**
+ * @deprecated Use {@link net.minecraftforge.common.config.ModConfigSpec} instead.
+ */
+@Deprecated
 public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfig> //TODO: Remove extends and pipe everything through getSpec/getValues?
 {
     private Map<List<String>, String> levelComments = new HashMap<>();
@@ -231,6 +236,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         return count;
     }
 
+    @Deprecated
     public static class Builder
     {
         private final Config storage = Config.of(LinkedHashMap::new, InMemoryFormat.withUniversalSupport()); // Use LinkedHashMap for consistent ordering
@@ -538,6 +544,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
+    @Deprecated
     private static class BuilderContext
     {
         private @Nonnull String[] comment = new String[0];
@@ -585,6 +592,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
     }
 
     @SuppressWarnings("unused")
+    @Deprecated
     private static class Range<V extends Comparable<? super V>> implements Predicate<Object>
     {
         private final Class<? extends V> clazz;
@@ -646,6 +654,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
+    @Deprecated
     public static class ValueSpec
     {
         private final String comment;
@@ -688,6 +697,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
+    @Deprecated
     public static class ConfigValue<T>
     {
         private final Builder parent;
@@ -742,6 +752,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
     }
 
+    @Deprecated
     public static class BooleanValue extends ConfigValue<Boolean>
     {
         BooleanValue(Builder parent, List<String> path, Supplier<Boolean> defaultSupplier)
@@ -749,7 +760,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             super(parent, path, defaultSupplier);
         }
     }
-
+    @Deprecated
     public static class IntValue extends ConfigValue<Integer>
     {
         IntValue(Builder parent, List<String> path, Supplier<Integer> defaultSupplier)
@@ -763,7 +774,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return config.getIntOrElse(path, () -> defaultSupplier.get());
         }
     }
-
+    @Deprecated
     public static class LongValue extends ConfigValue<Long>
     {
         LongValue(Builder parent, List<String> path, Supplier<Long> defaultSupplier)
@@ -777,7 +788,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return config.getLongOrElse(path, () -> defaultSupplier.get());
         }
     }
-
+    @Deprecated
     public static class DoubleValue extends ConfigValue<Double>
     {
         DoubleValue(Builder parent, List<String> path, Supplier<Double> defaultSupplier)
@@ -792,7 +803,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             return n == null ? defaultSupplier.get() : n.doubleValue();
         }
     }
-
+    @Deprecated
     public static class EnumValue<T extends Enum<T>> extends ConfigValue<T>
     {
         private final EnumGetMethod converter;

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -26,7 +26,6 @@ import net.minecraft.world.storage.IServerConfiguration;
 import net.minecraft.world.storage.SaveFormat;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.*;
-import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLModIdMappingEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
@@ -110,8 +109,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         ATTRIBUTES.register(modEventBus);
         MinecraftForge.EVENT_BUS.addListener(this::serverStopping);
         MinecraftForge.EVENT_BUS.addGenericListener(SoundEvent.class, this::missingSoundMapping);
-        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
-        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
+        ForgeConfig.init();
         modEventBus.register(ForgeConfig.class);
         // Forge does not display problems when the remote is not matching.
         ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, ()-> Pair.of(()->"ANY", (remote, isServer)-> true));

--- a/src/main/java/net/minecraftforge/common/config/AbstractConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/config/AbstractConfigSpec.java
@@ -1,0 +1,176 @@
+package net.minecraftforge.common.config;
+
+import static com.electronwill.nightconfig.core.ConfigSpec.CorrectionAction.ADD;
+import static com.electronwill.nightconfig.core.ConfigSpec.CorrectionAction.REMOVE;
+import static com.electronwill.nightconfig.core.ConfigSpec.CorrectionAction.REPLACE;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import net.minecraftforge.fml.config.ModConfig;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigSpec;
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+
+public abstract class AbstractConfigSpec extends ConfigSpec
+{
+    protected Map<List<String>, String> levelComments = new HashMap<>();
+    private boolean isCorrecting = false;
+
+    private final ModConfig<?> modConfig;
+    protected AbstractConfigSpec(ModConfig<?> modConfig)
+    {
+        this.modConfig = modConfig;
+    }
+
+    public boolean isCorrecting() {
+        return isCorrecting;
+    }
+
+    public ModConfig<?> getModConfig()
+    {
+        return modConfig;
+    }
+
+    public void save()
+    {
+        Preconditions.checkNotNull(modConfig.getConfigData(), "Cannot save config value without assigned Config object present");
+        modConfig.save();
+    }
+
+    protected synchronized boolean isCorrect(CommentedConfig config) {
+        LinkedList<String> parentPath = new LinkedList<>();
+        return correct(storage, config, parentPath, Collections.unmodifiableList( parentPath ), (a, b, c, d) -> {}, true) == 0;
+    }
+
+    protected int correct(CommentedConfig config) {
+        return correct(config, (action, path, incorrectValue, correctedValue) -> {});
+    }
+
+    public synchronized int correctConfig(CommentedConfig config, CorrectionListener listener) {
+        LinkedList<String> parentPath = new LinkedList<>(); //Linked list for fast add/removes
+        int ret = -1;
+        try {
+            isCorrecting = true;
+            ret = correct(storage, config, parentPath, Collections.unmodifiableList(parentPath), listener, false);
+        } finally {
+            isCorrecting = false;
+        }
+        return ret;
+    }
+
+    private int correct(UnmodifiableConfig spec, CommentedConfig config, LinkedList<String> parentPath, List<String> parentPathUnmodifiable, CorrectionListener listener, boolean dryRun)
+    {
+        int count = 0;
+
+        Map<String, Object> specMap = spec.valueMap();
+        Map<String, Object> configMap = config.valueMap();
+
+        for (Map.Entry<String, Object> specEntry : specMap.entrySet())
+        {
+            final String key = specEntry.getKey();
+            final Object specValue = specEntry.getValue();
+            final Object configValue = configMap.get(key);
+            final CorrectionAction action = configValue == null ? ADD : REPLACE;
+
+            parentPath.addLast(key);
+
+            if (specValue instanceof Config)
+            {
+                if (configValue instanceof CommentedConfig)
+                {
+                    count += correct((Config)specValue, (CommentedConfig)configValue, parentPath, parentPathUnmodifiable, listener, dryRun);
+                    if (count > 0 && dryRun)
+                        return count;
+                }
+                else if (dryRun)
+                {
+                    return 1;
+                }
+                else
+                {
+                    CommentedConfig newValue = config.createSubConfig();
+                    configMap.put(key, newValue);
+                    listener.onCorrect(action, parentPathUnmodifiable, configValue, newValue);
+                    count++;
+                    count += correct((Config)specValue, newValue, parentPath, parentPathUnmodifiable, listener, dryRun);
+                }
+
+                String newComment = levelComments.get(parentPath);
+                String oldComment = config.getComment(key);
+                if (!Objects.equals(oldComment, newComment))
+                {
+                    if (dryRun)
+                        return 1;
+
+                    //TODO: Comment correction listener?
+                    config.setComment(key, newComment);
+                }
+            }
+            else
+            {
+                ValueSpec valueSpec = (ValueSpec)specValue;
+                if (!valueSpec.test(configValue))
+                {
+                    if (dryRun)
+                        return 1;
+
+                    Object newValue = valueSpec.correct(configValue);
+                    configMap.put(key, newValue);
+                    listener.onCorrect(action, parentPathUnmodifiable, configValue, newValue);
+                    count++;
+                }
+                String oldComment = config.getComment(key);
+                if (!Objects.equals(oldComment, valueSpec.getComment()))
+                {
+                    if (dryRun)
+                        return 1;
+
+                    //TODO: Comment correction listener?
+                    config.setComment(key, valueSpec.getComment());
+                }
+            }
+
+            parentPath.removeLast();
+        }
+
+        // Second step: removes the unspecified values
+        for (Iterator<Entry<String, Object>> ittr = configMap.entrySet().iterator(); ittr.hasNext();)
+        {
+            Map.Entry<String, Object> entry = ittr.next();
+            if (!specMap.containsKey(entry.getKey()))
+            {
+                if (dryRun)
+                    return 1;
+
+                ittr.remove();
+                parentPath.addLast(entry.getKey());
+                listener.onCorrect(REMOVE, parentPathUnmodifiable, entry.getValue(), null);
+                parentPath.removeLast();
+                count++;
+            }
+        }
+        return count;
+    }
+
+
+    public static final Joiner LINE_JOINER = Joiner.on("\n");
+    public static final Joiner DOT_JOINER = Joiner.on(".");
+    public static final Splitter DOT_SPLITTER = Splitter.on(".");
+    public static List<String> split(String path)
+    {
+        return Lists.newArrayList(DOT_SPLITTER.split(path));
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/IConfigSpecFactory.java
+++ b/src/main/java/net/minecraftforge/common/config/IConfigSpecFactory.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.common.config;
+
+import net.minecraftforge.fml.config.ModConfig;
+
+/**
+ * The factory that produces a {@link ModConfigSpec}.
+ *
+ * Mods can provide their own implementation of {@link #create(ModConfig)} to have their specific implementation
+ * injected into their config instances.
+ */
+public interface IConfigSpecFactory<V extends ModConfigSpec>
+{
+    /**
+     * Create a new instance of {@link ModConfigSpec} using the given {@link ModConfig}
+     *
+     * @param modConfig the {@link ModConfig}
+     * @return a new instance of {@link ModConfigSpec}
+     */
+    V create(ModConfig<V> modConfig);
+
+    /**
+     * Create a new, default, instance of {@link ModConfigSpec} using the given {@link ModConfig}
+     *
+     * @param modConfig the ModConfig to use
+     * @return a new instance of {@link ModConfigSpec}
+     */
+    public static <V extends ModConfigSpec> V createSpec(ModConfig<V> modConfig) {
+        return (V) new ModConfigSpec(modConfig);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/ModConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/config/ModConfigSpec.java
@@ -1,0 +1,345 @@
+package net.minecraftforge.common.config;
+
+import static java.util.Arrays.asList;
+import static net.minecraftforge.fml.Logging.CORE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import net.minecraftforge.common.config.api.ConfigDefinitions;
+import net.minecraftforge.common.config.values.BooleanValue;
+import net.minecraftforge.common.config.values.ConfigValue;
+import net.minecraftforge.common.config.values.DoubleValue;
+import net.minecraftforge.common.config.values.EnumValue;
+import net.minecraftforge.common.config.values.IntValue;
+import net.minecraftforge.common.config.values.ListValue;
+import net.minecraftforge.common.config.values.LongValue;
+import net.minecraftforge.common.config.values.ModValue;
+import net.minecraftforge.common.config.values.StringValue;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.loading.moddiscovery.NightConfigWrapper;
+import net.minecraftforge.forgespi.language.IConfigurable;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.logging.log4j.LogManager;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.EnumGetMethod;
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import com.google.common.collect.Lists;
+import com.google.common.collect.ObjectArrays;
+import com.google.common.collect.Range;
+
+public class ModConfigSpec extends AbstractConfigSpec implements IConfigurable, ConfigDefinitions
+{
+    private List<String> currentPath = new ArrayList<>();
+    protected List<ConfigValue<?>> values = new ArrayList<>();
+    private SpecContext context = new SpecContext();
+
+    public ModConfigSpec(ModConfig<?> modConfig)
+    {
+        super(modConfig);
+    }
+
+    /**
+     * Correct a given {@link Config}
+     *
+     * @param config the config to correct
+     */
+    public final void correctConfig(CommentedConfig config) {
+        if (config != null) {
+            String configName = config instanceof FileConfig ? ((FileConfig) config).getNioPath().toString() : config.toString();
+            LogManager.getLogger().warn(CORE, "Configuration file {} is not correct. Correcting", configName);
+            correctConfig(config, (action, path, incorrectValue, correctedValue) ->
+                    LogManager.getLogger().warn(CORE, "Incorrect key {} was corrected from {} to {}", DOT_JOINER.join( path ), incorrectValue, correctedValue));
+            if (config instanceof FileConfig) {
+                ((FileConfig) config).save();
+            }
+        }
+    }
+
+    public CommentedConfig getConfig() {
+        return getModConfig().getConfigData();
+    }
+
+    public CommentedConfig createSection() {
+        if (getModConfig() == null || getConfig() == null) {
+            return CommentedConfig.inMemory().createSubConfig();
+        }
+        return getConfig().createSubConfig();
+    }
+
+    //<editor-fold desc="Builder pattern methods">
+    public ModConfigSpec comment(String comment)
+    {
+        context.setComment(comment);
+        return this;
+    }
+
+    public ModConfigSpec comment(String... comment)
+    {
+        context.setComment(comment);
+        return this;
+    }
+
+    public ModConfigSpec translation(String translationKey)
+    {
+        context.setTranslationKey(translationKey);
+        return this;
+    }
+
+    public ModConfigSpec worldRestart()
+    {
+        context.worldRestart();
+        return this;
+    }
+
+    /**
+     * Create a new section in the config with the given name.
+     *
+     * @param path the name of the section which is also the path
+     * @return the spec
+     */
+    public ModConfigSpec push(String path)
+    {
+        return push(split(path));
+    }
+
+    /**
+     * Create new sections using the given path.
+     * Each element in the list will be a section
+     *
+     * @param path the path used to create sections
+     * @return the spec
+     */
+    public ModConfigSpec push(List<String> path)
+    {
+        currentPath.addAll(path);
+        if (context.hasComment()) {
+
+            levelComments.put(new ArrayList<String>(currentPath), context.buildComment());
+            context.setComment(); // Set to empty
+        }
+        context.ensureEmpty();
+        return this;
+    }
+
+    /**
+     * Pop the latest section off the list.
+     * This will remove the last section from the current path.
+     * <i>This will <b>NOT</b> remove the last section from the actual configuration!</i>
+     *
+     * @return the spec
+     */
+    public ModConfigSpec pop()
+    {
+        return pop(1);
+    }
+
+    /**
+     * Pop the latest 'n' sections off the list.
+     * This will remove the last section from the current path.
+     * <i>This will <b>NOT</b> remove the section(s) from the actual configuration!</i>
+     *
+     * @param count the number of sections to remove
+     * @return the spec
+     */
+    public ModConfigSpec pop(int count)
+    {
+        if (count > currentPath.size())
+            throw new IllegalArgumentException("Attempted to pop " + count + " elements when we only had: " + currentPath);
+        for (int x = 0; x < count; x++)
+            currentPath.remove(Math.min(0, currentPath.size() - 1));
+        return this;
+    }
+    //</editor-fold>
+
+    @Override
+    public <T> Optional<T> getConfigElement(String... key)
+    {
+        if (getConfig() == null) {
+            return Optional.empty();
+        }
+        return getConfig().getOptional(Arrays.asList(key));
+    }
+
+    @Override
+    public List<? extends IConfigurable> getConfigList(String... key)
+    {
+        final List<String> path = asList(key);
+        if (this.getConfig().contains(path) && !(this.getConfig().get(path) instanceof Collection)) {
+            throw new IllegalArgumentException("The configuration path "+ path +" is invalid. Expecting a collection!");
+        }
+        final ArrayList<UnmodifiableConfig> nestedConfigs = this.getConfig().getOrElse(path, ArrayList::new);
+        return nestedConfigs.stream()
+                .map(NightConfigWrapper::new)
+                .map(cw -> cw.setFile(getModConfig().getContainer().getModInfo().getOwningFile())) // Match ModFileParser behavior
+                .collect(Collectors.toList());
+    }
+
+    /** The root define method. All methods end here eventually. */
+    //TODO: Better name? 'define' conflicts with night-config's define method
+    protected <T> ConfigValue<T> _define(List<String> path, ValueSpec value, Supplier<T> defaultSupplier) {
+        if (!currentPath.isEmpty()) {
+            List<String> tmp = new ArrayList<>(currentPath.size() + path.size());
+            tmp.addAll(currentPath);
+            tmp.addAll(path);
+            path = tmp;
+        }
+        storage.set(path, value);
+        context = new SpecContext();
+        ConfigValue<T> configValue = new ConfigValue<>(this, path, defaultSupplier);
+        values.add(configValue);
+        return configValue;
+    }
+
+    @Override
+    public <T> ConfigValue<T> defineObject(List<String> path, Supplier<T> defaultSupplier, Predicate<Object> validator, Class<?> clazz)
+    {
+        ValueSpec valueSpec = new ValueSpec(defaultSupplier, validator, context);
+        return _define(path, valueSpec, defaultSupplier);
+    }
+
+    @Override
+    public <V extends Comparable<? super V>> ConfigValue<V> defineInRange(List<String> path, Supplier<V> defaultSupplier, Range<V> range, Class<V> clazz)
+    {
+        ValueRange<V> valueRange = new ValueRange<>(clazz, range);
+        context.setRange(valueRange);
+        context.setComment(ObjectArrays.concat(context.getComment(), "Range: " + range.toString()));
+        ValueSpec valueSpec = new ValueSpec(defaultSupplier, valueRange, context);
+        return _define(path, valueSpec, defaultSupplier);
+    }
+
+    @Override
+    public BooleanValue defineBoolean(List<String> path, Supplier<Boolean> defaultSupplier)
+    {
+        Predicate<Object> isBoolean = o -> o instanceof String ? ("true".equalsIgnoreCase((String)o) || "false".equalsIgnoreCase((String)o)) : o instanceof Boolean;
+        ConfigValue<?> value = _define(path, new ValueSpec(defaultSupplier, isBoolean, context), defaultSupplier);
+        return new BooleanValue(this, value.getPath(), defaultSupplier);
+    }
+
+    private <T extends Comparable<T>> ConfigValue<?> createNumberConfigValue(List<String> path, Supplier<T> supplier, Predicate<Object> validator) {
+        ValueSpec valueSpec = new ValueSpec(supplier, validator, context);
+        return _define(path, valueSpec, supplier);
+    }
+    @Override public IntValue defineNumber(List<String> path, int defaultValue, Predicate<Object> validator)
+    {
+        Supplier<Integer> defaultSupplier = () -> defaultValue;
+        ConfigValue<?> value = createNumberConfigValue(path, defaultSupplier, validator);
+        return new IntValue(this, value.getPath(), defaultSupplier);
+    }
+
+    @Override public DoubleValue defineNumber(List<String> path, double defaultValue, Predicate<Object> validator)
+    {
+        Supplier<Double> defaultSupplier = () -> defaultValue;
+        ConfigValue<?> value = createNumberConfigValue(path, defaultSupplier, validator);
+        return new DoubleValue(this, value.getPath(), defaultSupplier);
+    }
+
+    @Override public LongValue defineNumber(List<String> path, long defaultValue, Predicate<Object> validator)
+    {
+        Supplier<Long> defaultSupplier = () -> defaultValue;
+        ConfigValue<?> value = createNumberConfigValue(path, defaultSupplier, validator);
+        return new LongValue(this, value.getPath(), defaultSupplier);
+    }
+
+    @Override
+    public DoubleValue defineInRange(List<String> path, double defaultValue, Range<Double> range)
+    {
+        ConfigValue<?> value = defineInRange(path, () -> defaultValue, range, Double.class);
+        return new DoubleValue(this, value.getPath(), () -> defaultValue);
+    }
+
+    @Override
+    public IntValue defineInRange(List<String> path, int defaultValue, Range<Integer> range)
+    {
+        ConfigValue<?> value = defineInRange(path, () -> defaultValue, range, Integer.class);
+        return new IntValue(this, value.getPath(), () -> defaultValue);
+    }
+
+    @Override
+    public LongValue defineInRange(List<String> path, long defaultValue, Range<Long> range)
+    {
+        ConfigValue<?> value = defineInRange(path, () -> defaultValue, range, Long.class);
+        return new LongValue(this, value.getPath(), () -> defaultValue);
+    }
+
+    @Override
+    public <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, Supplier<V> defaultSupplier, EnumGetMethod converter, Predicate<Object> validator, Class<V> clazz)
+    {
+        context.setClazz(clazz);
+        V[] allowedValues = clazz.getEnumConstants();
+        context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + Arrays.stream(allowedValues).filter(validator).map(Enum::name).collect(Collectors.joining(", "))));
+        ValueSpec valueSpec = new ValueSpec(defaultSupplier, validator, context);
+        ConfigValue<?> value = _define(path, valueSpec, defaultSupplier);
+        return new EnumValue<V>(this, value.getPath(), defaultSupplier, converter, clazz);
+
+    }
+
+    @Override
+    public StringValue defineString(List<String> path, Supplier<String> defaultSupplier)
+    {
+        ValueSpec spec = new ValueSpec(defaultSupplier, Objects::nonNull, context);
+        ConfigValue<?> value = _define(path, spec, defaultSupplier);
+        return new StringValue(this, value.getPath(), defaultSupplier);
+    }
+
+    @Override
+    public <T> ListValue<T> defineList(List<String> path, Supplier<List<T>> defaultSupplier, Predicate<Object> elementValidator, Function<Object, T> elementConverter)
+    {
+        context.setClazz(List.class);
+        Predicate<Object> configValidator = x -> x instanceof List && ((List<?>)x).stream().allMatch(elementValidator);
+        ValueSpec spec = new ValueSpec(defaultSupplier, configValidator, context) {
+            @Override
+            public Object correct(Object value)
+            {
+                if (!(value instanceof List) || ((List<?>)value).isEmpty()) {
+                    return getDefault();
+                }
+                List<?> rawList = Lists.newArrayList((List<?>)value);
+                rawList.removeIf(elementValidator.negate());
+                if(rawList.isEmpty()) {
+                    return getDefault();
+                }
+                return rawList.stream().map(elementConverter).collect(Collectors.toList());
+            }
+        };
+        ConfigValue<?> value = _define(path, spec, defaultSupplier);
+        return new ListValue<>(this, value.getPath(), defaultSupplier, elementConverter);
+    }
+
+    @Override
+    public <T> ModValue<T> defineModObject(List<String> path, Supplier<T> defaultSupplier, Predicate<Object> validator, ModObjectConverter<T> converter)
+    {
+        return _defineMod(path, defaultSupplier, converter, validator);
+    }
+
+    protected <T> ModValue<T> _defineMod(List<String> path, Supplier<T> defaultSupplier, ModObjectConverter<T> converter, Predicate<Object> validator)
+    {
+        if (!currentPath.isEmpty())
+        {
+            List<String> tmp = new ArrayList<>(currentPath.size() + path.size());
+            tmp.addAll(currentPath);
+            tmp.addAll(path);
+            path = tmp;
+        }
+        Config section = storage.createSubConfig(); // all we need is a sub-config, this does not *need* to depend on the mod's config file
+        converter.saveToConfig(section, path, defaultSupplier.get(), defaultSupplier);
+        ValueSpec value = new ValueSpec(() -> section, validator, context);
+        storage.set(path, value);
+        ConfigValue<T> configValue = new ConfigValue<>(this, path, defaultSupplier);
+        values.add(configValue);
+        return new ModValue<>(this, path, defaultSupplier, converter);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/ModObjectConverter.java
+++ b/src/main/java/net/minecraftforge/common/config/ModObjectConverter.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.common.config;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.electronwill.nightconfig.core.Config;
+
+/**
+ * This interface defines how a custom object is loaded and saved from config.
+ */
+public interface ModObjectConverter<T>
+{
+    /**
+     * Load a custom object from a configuration.
+     *
+     *
+     * @param subConfig
+     * @param path the path to the entry
+     * @param defaultSupplier the default value
+     * @return a new instance of that object
+     */
+    T loadFromConfig(Config subConfig, List<String> path, Supplier<T> defaultSupplier);
+
+    /**
+     * Save a custom object to a configuration.
+     * If there is any problem with the supplied object and default value can be retrieved via the supplier
+     * @param config the {@link Config} to save to
+     * @param path the path to the entry
+     * @param object the object to save
+     * @param defaultSupplier the default value
+     */
+    void saveToConfig(Config config, List<String> path, T object, Supplier<T> defaultSupplier);
+}

--- a/src/main/java/net/minecraftforge/common/config/RangeType.java
+++ b/src/main/java/net/minecraftforge/common/config/RangeType.java
@@ -1,0 +1,108 @@
+package net.minecraftforge.common.config;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+
+/**
+ * Enum that holds the convenience methods to create {@link Range}s.
+ */
+/* Due to some of the ranges only requiring a single argument, and others requiring two this could not be an interface or class. */
+public enum RangeType
+{
+    /**
+     * (a..b) { x | a < x < b } <br>
+     * Create a Range that contains all values strictly greater than lower and less than upper
+     */
+    OPEN {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 1,"Insufficient arguments for the " + name() + " range. Required two. Found " + values.length);
+            return Range.open(values[0], values[1]);
+        }
+    },
+    /**
+     * [a..b] { x | a <= x <= b } <br>
+     * Create a Range that contains all values greater than or equal to lower and less than or equal to upper
+     */
+    CLOSED {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 1,"Insufficient arguments for the " + name() + " range. Required two. Found " + values.length);
+            return Range.closed(values[0], values[1]);
+        }
+    },
+    /**
+     * (a..b] 	{ x | a < x <= b } <br>
+     * Create Returns a range that contains all values strictly greater than lower and less than or equal to upper.
+     */
+    OPEN_CLOSED {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 1,"Insufficient arguments for the " + name() + " range. Required two. Found " + values.length);
+            return Range.openClosed(values[0], values[1]);
+        }
+    },
+    /**
+     * [a..b) 	{ x | a <= x < b } <br>
+     * Create Returns a range that contains all values greater than or equal to lower and strictly less than upper.
+     */
+    CLOSED_OPEN {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 1,"Insufficient arguments for the " + name() + " range. Required two. Found " + values.length);
+            return Range.closedOpen(values[0], values[1]);
+        }
+    },
+    /**
+     * (a..+∞) 	{ x | x > a } <br>
+     * Create Returns a range that contains all values strictly greater than the given value.
+     */
+    GREATERTHAN {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 0,"Insufficient arguments for the " + name() + " range. Required one. Found " + values.length);
+            return Range.greaterThan(values[0]);
+        }
+    },
+    /**
+     * [a..+∞) 	{ x | x >= a } <br>
+     * Create Returns a range that contains all values greater than or equal to the given value.
+     */
+    ATLEAST {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 0,"Insufficient arguments for the " + name() + " range. Required one. Found " + values.length);
+            return Range.atLeast(values[0]);
+        }
+    },
+    /**
+     * (-∞..b] 	{ x | x <= b } <br>
+     * Create Returns a range that contains all values strictly less than the given value.
+     */
+    ATMOST {
+        @Override
+        public <C extends Comparable<C>> Range<C> createRange(C... values)
+        {
+            Preconditions.checkArgument(values.length > 0,"Insufficient arguments for the " + name() + " range. Required one. Found " + values.length);
+            return Range.atMost(values[0]);
+        }
+    };
+
+    private RangeType() {}
+
+    /**
+     * Create a {@link Range} using the given value(s).
+     *
+     * See the javadocs for each Enum for how many values are required for each type of range
+     *
+     * @param values the values that represent the upper and lower bounds of the range
+     * @return a new {@link Range}
+     */
+    public abstract <C extends Comparable<C>> Range<C> createRange(C... values);
+}

--- a/src/main/java/net/minecraftforge/common/config/SpecContext.java
+++ b/src/main/java/net/minecraftforge/common/config/SpecContext.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.common.config;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.LINE_JOINER;
+
+import javax.annotation.Nonnull;
+
+public class SpecContext
+{
+    private @Nonnull String[] comment = new String[0];
+    private String langKey;
+    private ValueRange<?> range;
+    private boolean worldRestart = false;
+    private Class<?> clazz;
+
+    public void setComment(String... value) { this.comment = value; }
+    public boolean hasComment() { return this.comment.length > 0; }
+    public String[] getComment() { return this.comment; }
+    public String buildComment() { return LINE_JOINER.join(comment); }
+    public void setTranslationKey(String value) { this.langKey = value; }
+    public String getTranslationKey() { return this.langKey; }
+    public <V extends Comparable<? super V>> void setRange(ValueRange<V> value)
+    {
+        this.range = value;
+        this.setClazz(value.getClazz());
+    }
+    @SuppressWarnings("unchecked")
+    public <V extends Comparable<? super V>> ValueRange<V> getRange() { return (ValueRange<V>)this.range; }
+    public void worldRestart() { this.worldRestart = true; }
+    public boolean needsWorldRestart() { return this.worldRestart; }
+    public void setClazz(Class<?> clazz) { this.clazz = clazz; }
+    public Class<?> getClazz(){ return this.clazz; }
+
+    public void ensureEmpty()
+    {
+        validate(hasComment(), "Non-empty comment when empty expected");
+        validate(langKey, "Non-null translation key when null expected");
+        validate(range, "Non-null range when null expected");
+        validate(worldRestart, "Dangeling world restart value set to true");
+    }
+
+    private void validate(Object value, String message)
+    {
+        if (value != null)
+            throw new IllegalStateException(message);
+    }
+    private void validate(boolean value, String message)
+    {
+        if (value)
+            throw new IllegalStateException(message);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/ValueRange.java
+++ b/src/main/java/net/minecraftforge/common/config/ValueRange.java
@@ -1,0 +1,59 @@
+package net.minecraftforge.common.config;
+
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.collect.Range;
+
+public class ValueRange<V extends Comparable<? super V>> implements Predicate<Object>
+{
+    private final Range<V> range;
+    private final Class<? extends V> clazz;
+
+    public ValueRange(@Nonnull Class<V> clazz, @Nonnull Range<V> range)
+    {
+        this.clazz = clazz;
+        this.range = range;
+    }
+
+    public Class<? extends V> getClazz() { return clazz; }
+    public Range<V> getRange() { return range; }
+
+    @Override
+    public boolean test(Object t)
+    {
+        if (!clazz.isInstance(t)) return false;
+        V c = clazz.cast(t);
+        return range.contains(c);
+    }
+
+    /*
+     * First, check if the range has a lower bound, and if so is the given value greater or equal to the lower endpoint
+     * If it's not, return the minimum value
+     * Second, check if the range has an upper bound and if so is the give value less than or equal to the higher endpoint
+     * Last, now that we know the value is within the upper and lower bounds set by the range, the number is correct
+     * so just return it
+     *
+     * Having the BoundType.OPEN means that specific bound does not exist (i.e. goes to infinity)
+     * so any value will be valid as long as it's of the correct type
+     */
+    public Object correct(Object value, Object def)
+    {
+        if (!clazz.isInstance(value)) return def;
+        V num = clazz.cast(value);
+        if (range.hasLowerBound() && num.compareTo(range.lowerEndpoint()) < 0) {
+            return range.lowerEndpoint();
+        }
+        if (range.hasUpperBound() && num.compareTo(range.upperEndpoint()) >= 1) {
+            return range.upperEndpoint();
+        }
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return range.toString();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/ValueSpec.java
+++ b/src/main/java/net/minecraftforge/common/config/ValueSpec.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.common.config;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class ValueSpec
+{
+    private final String comment;
+    private final String langKey;
+    private final ValueRange<?> range;
+    private final boolean worldRestart;
+    private final Class<?> clazz;
+    private final Supplier<?> supplier;
+    private final Predicate<Object> validator;
+    private Object _default = null;
+
+    public ValueSpec(Supplier<?> supplier, Predicate<Object> validator, SpecContext context)
+    {
+        Objects.requireNonNull(supplier, "Default supplier can not be null");
+        Objects.requireNonNull(validator, "Validator can not be null");
+
+        this.comment = context.hasComment() ? context.buildComment() : null;
+        this.langKey = context.getTranslationKey();
+        this.range = context.getRange();
+        this.worldRestart = context.needsWorldRestart();
+        this.clazz = context.getClazz();
+        this.supplier = supplier;
+        this.validator = validator;
+    }
+
+    public String getComment() { return comment; }
+    public String getTranslationKey() { return langKey; }
+    @SuppressWarnings("unchecked")
+    public <V extends Comparable<? super V>> ValueRange<V> getRange() { return (ValueRange<V>)this.range; }
+    public boolean needsWorldRestart() { return this.worldRestart; }
+    public Class<?> getClazz(){ return this.clazz; }
+    public boolean test(Object value) { return validator.test(value); }
+    public Object correct(Object value) { return range == null ? getDefault() : range.correct(value, getDefault()); }
+
+    public Object getDefault()
+    {
+        if (_default == null)
+            _default = supplier.get();
+        return _default;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/api/ConfigDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/ConfigDefinitions.java
@@ -1,0 +1,5 @@
+package net.minecraftforge.common.config.api;
+
+public interface ConfigDefinitions extends PrimitiveDefinitions, RangeDefinitions, EnumDefinitions, StringDefinitions, ListDefinitions, CustomObjectDefinitions
+{
+}

--- a/src/main/java/net/minecraftforge/common/config/api/CustomObjectDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/CustomObjectDefinitions.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModObjectConverter;
+import net.minecraftforge.common.config.values.ModValue;
+
+/**
+ * This defines how custom objects are saved to and from configs.
+ */
+public interface CustomObjectDefinitions
+{
+    /**
+     * Define a custom mod object to be saved to the config.
+     * By default, {@link Objects#nonNull(Object)} is used for the Predicate.
+     *
+     * @param path the path to the configuration entry
+     * @param defaultSupplier the default value for this entry
+     * @param validator the {@link Predicate} which will determine if the given configuration entry is valid
+     * @param converter the {@link ModObjectConverter} which will transform the entry between TOML and the mod's object instance
+     * @return a new {@link ModValue}
+     */
+    <T> ModValue<T> defineModObject(List<String> path, Supplier<T> defaultSupplier, Predicate<Object> validator, ModObjectConverter<T> converter);
+
+    /** @see #defineModObject(List, Supplier, Predicate, ModObjectConverter) */
+    default <T> ModValue<T> defineModObject(String path, T object, ModObjectConverter<T> converter) {
+        return defineModObject(split(path), () -> object, Objects::nonNull, converter);
+    }
+    /** @see #defineModObject(List, Supplier, Predicate, ModObjectConverter) */
+    default <T> ModValue<T> defineModObject(String path, T object, Predicate<Object> validator, ModObjectConverter<T> converter) {
+        return defineModObject(split(path), () -> object, validator, converter);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/api/EnumDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/EnumDefinitions.java
@@ -1,0 +1,130 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.values.EnumValue;
+
+import com.electronwill.nightconfig.core.EnumGetMethod;
+
+public interface EnumDefinitions
+{
+    /**
+     * Define a new enum value.
+     * For methods that do not contain {@link EnumGetMethod} as a parameter, it will default to {@link EnumGetMethod#NAME_IGNORECASE}
+     *
+     * @param path the path to the value
+     * @param defaultSupplier the default value
+     * @param converter how the config will convert from a string to the correct enum. See {@link EnumGetMethod}
+     * @param validator the validator to make sure the incoming object is valid
+     * @param clazz the type of the value
+     * @return a new {@link EnumValue}
+     */
+    <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, Supplier<V> defaultSupplier, EnumGetMethod converter, Predicate<Object> validator, Class<V> clazz);
+
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default  <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue) {
+        return defineEnumValue(split(path), defaultValue);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, EnumGetMethod converter) {
+        return defineEnumValue(split(path), defaultValue, converter);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue) {
+        return defineEnumValue(path, defaultValue, defaultValue.getDeclaringClass().getEnumConstants());
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, EnumGetMethod converter) {
+        return defineEnumValue(path, defaultValue, converter, defaultValue.getDeclaringClass().getEnumConstants());
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, Predicate<Object> validator) {
+        return defineEnumValue(split(path), defaultValue, validator);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, EnumGetMethod converter, Predicate<Object> validator) {
+        return defineEnumValue(split(path), defaultValue, converter, validator);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, Predicate<Object> validator) {
+        return defineEnumValue(path, () -> defaultValue, validator, defaultValue.getDeclaringClass());
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, EnumGetMethod converter, Predicate<Object> validator) {
+        return defineEnumValue(path, () -> defaultValue, converter, validator, defaultValue.getDeclaringClass());
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, Supplier<V> defaultSupplier, Predicate<Object> validator, Class<V> clazz) {
+        return defineEnumValue(split(path), defaultSupplier, validator, clazz);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, Supplier<V> defaultSupplier, EnumGetMethod converter, Predicate<Object> validator, Class<V> clazz) {
+        return defineEnumValue(split(path), defaultSupplier, converter, validator, clazz);
+    }
+    /** @see #defineEnumValue(List, Supplier, EnumGetMethod, Predicate, Class) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, Supplier<V> defaultSupplier, Predicate<Object> validator, Class<V> clazz) {
+        return defineEnumValue(path, defaultSupplier, EnumGetMethod.NAME_IGNORECASE, validator, clazz);
+    }
+
+
+    // Restricted Enums
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, V... acceptableValues) {
+        return defineEnumValue(split(path), defaultValue, acceptableValues);
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, EnumGetMethod converter, V... acceptableValues) {
+        return defineEnumValue(split(path), defaultValue, converter, acceptableValues);
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, V... acceptableValues) {
+        return defineEnumValue(path, defaultValue, Arrays.asList(acceptableValues));
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, EnumGetMethod converter, V... acceptableValues) {
+        return defineEnumValue(path, defaultValue, converter, Arrays.asList(acceptableValues));
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, Collection<V> acceptableValues) {
+        return defineEnumValue(split(path), defaultValue, acceptableValues);
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(String path, V defaultValue, EnumGetMethod converter, Collection<V> acceptableValues) {
+        return defineEnumValue(split(path), defaultValue, converter, acceptableValues);
+    }
+    /** @see #defineEnumValue(List, Enum, EnumGetMethod, Collection) */
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, Collection<V> acceptableValues) {
+        return defineEnumValue(path, defaultValue, EnumGetMethod.NAME_IGNORECASE, acceptableValues);
+    }
+    /**
+     * Define a new enum value which can only be a part of the given collection
+     *
+     * @param path the path to the given value
+     * @param defaultValue the default value
+     * @param converter how the config will convert the config object to the correct type. See {@link EnumGetMethod}
+     * @param acceptableValues a collection containing the acceptable values
+     * @return a new {@link EnumValue}
+     */
+    @SuppressWarnings("unchecked")
+    default <V extends Enum<V>> EnumValue<V> defineEnumValue(List<String> path, V defaultValue, EnumGetMethod converter, Collection<V> acceptableValues) {
+        return defineEnumValue(path, defaultValue, converter, obj -> {
+            if (obj instanceof Enum) {
+                return acceptableValues.contains(obj);
+            }
+            if (obj == null) {
+                return false;
+            }
+            try {
+                return acceptableValues.contains(converter.get(obj, defaultValue.getClass()));
+            } catch (IllegalArgumentException | ClassCastException e) {
+                return false;
+            }
+        });
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/api/ListDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/ListDefinitions.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.values.ListValue;
+
+/**
+ * The define methods used to define entries for lists.
+ *
+ * The old 'ForgeConfigSpec' had 'defineInList' methods, however all of them pointed to the
+ * root define method and simple called 'Collection::contains'.
+ * I chose not to include these because that behavior is already possible using existing methods.
+ */
+public interface ListDefinitions
+{
+    /**
+     * Define a new list entry in the config.
+     *
+     * @param path the path to the configuration entry
+     * @param defaultSupplier the default value if the list is null or empty.
+     * @param elementValidator the predicate that will validate the list entries.
+     *                         If not supplied this defaults to {@link java.util.Objects#nonNull(Object)}
+     * @param elementConverter the function that will convert each element of the list to its appropriate type
+     * @return a new {@link ListValue}
+     */
+    <T> ListValue<T> defineList(List<String> path, Supplier<List<T>> defaultSupplier, Predicate<Object> elementValidator, Function<Object, T> elementConverter);
+
+    /** @see #defineList(List, Supplier, Predicate, Function) **/
+    default  <T> ListValue<T> defineList(String path, List<T> defaultValue, Function<Object, T> elementConverter) {
+        return defineList(split(path), () -> defaultValue, Objects::nonNull, elementConverter);
+    }
+    /** @see #defineList(List, Supplier, Predicate, Function) **/
+    default  <T> ListValue<T> defineList(String path, List<T> defaultValue, Predicate<Object> elementValidator, Function<Object, T> elementConverter) {
+        return defineList(split(path), () -> defaultValue, elementValidator, elementConverter);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/api/PrimitiveDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/PrimitiveDefinitions.java
@@ -1,0 +1,148 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import net.minecraft.tileentity.TileEntityMerger.ICallbackWrapper.Double;
+import net.minecraftforge.common.config.values.BooleanValue;
+import net.minecraftforge.common.config.values.ConfigValue;
+import net.minecraftforge.common.config.values.DoubleValue;
+import net.minecraftforge.common.config.values.IntValue;
+import net.minecraftforge.common.config.values.LongValue;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+/**
+ * Generic primitive definitions for mod configs.
+ * We can't use 'define' because it conflicts with night-config's ConfigSpec
+ */
+public interface PrimitiveDefinitions
+{
+    /**
+     * Define any object.
+     *
+     * @param path the path to the value
+     * @param defaultSupplier the default value
+     * @param validator the validator that makes sure the given value is valid
+     * @param clazz the type of the value
+     * @return a new {@link ConfigValue} containing the type of the value and it's current value
+     */
+    <T> ConfigValue<T> defineObject(List<String> path, Supplier<T> defaultSupplier, Predicate<Object> validator, Class<?> clazz);
+
+    /**
+     * Define a new boolean value
+     *
+     * @param path the path to the value
+     * @param defaultSupplier the default value
+     * @return a new {@link BooleanValue}
+     */
+    BooleanValue defineBoolean(List<String> path, Supplier<Boolean> defaultSupplier);
+
+    /**
+     * Define a new, simple, numerical configuration entry
+     * If a method does not have the Predicate, {@link #isNumber()} will be used by default.
+     *
+     * @param path the path to the value
+     * @param defaultValue the default value
+     * @return a new {@link IntValue}
+     */
+    IntValue defineNumber(List<String> path, int defaultValue, Predicate<Object> validator);
+
+    /**
+     * Define a new, simple, numerical configuration entry
+     * If a method does not have the Predicate, {@link #isNumber()} will be used by default.
+     *
+     * @param path the path to the value
+     * @param defaultValue the default value
+     * @return a new {@link IntValue}
+     */
+    DoubleValue defineNumber(List<String> path, double defaultValue, Predicate<Object> validator);
+
+    /**
+     * Define a new, simple, numerical configuration entry
+     * If a method does not have the Predicate, {@link #isNumber()} will be used by default.
+     *
+     * @param path the path to the value
+     * @param defaultValue the default value
+     * @return a new {@link IntValue}
+     */
+    LongValue defineNumber(List<String> path, long defaultValue, Predicate<Object> validator);
+
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(String path, T defaultValue) {
+        return defineObject(split(path), defaultValue);
+    }
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(List<String> path, T defaultValue) {
+        return defineObject(path, defaultValue, o -> o != null && defaultValue.getClass().isAssignableFrom(o.getClass()));
+    }
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(String path, T defaultValue, Predicate<Object> validator) {
+        return defineObject(split(path), defaultValue, validator);
+    }
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(List<String> path, T defaultValue, Predicate<Object> validator) {
+        Objects.requireNonNull(defaultValue, "Default value can not be null");
+        return defineObject(path, () -> defaultValue, validator);
+    }
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(String path, Supplier<T> defaultSupplier, Predicate<Object> validator) {
+        return defineObject(split(path), defaultSupplier, validator);
+    }
+    /** @see #defineObject(List, Supplier, Predicate, Class) */
+    default <T> ConfigValue<T> defineObject(List<String> path, Supplier<T> defaultSupplier, Predicate<Object> validator) {
+        return defineObject(path, defaultSupplier, validator, Object.class);
+    }
+
+    // Boolean
+    /** @see #defineBoolean(List, Supplier) */
+    default BooleanValue defineBoolean(String path, boolean defaultValue) {
+        return defineBoolean(split(path), defaultValue);
+    }
+    /** @see #defineBoolean(List, Supplier) */
+    default BooleanValue defineBoolean(List<String> path, boolean defaultValue) {
+        return defineBoolean(path, () -> defaultValue);
+    }
+    /** @see #defineBoolean(List, Supplier) */
+    default BooleanValue defineBoolean(String path, Supplier<Boolean> defaultSupplier) {
+        return defineBoolean(split(path), defaultSupplier);
+    }
+
+    // Int
+    /** @see #defineNumber(List, int, Predicate) */
+    default IntValue defineNumber(String path, int value) {
+        return defineNumber(split(path), value, isNumber());
+    }
+    /** @see #defineNumber(List, int, Predicate) */
+    default IntValue defineNumber(String path, int value, Predicate<Object> validator) {
+        return defineNumber(split(path), value,validator);
+    }
+    // Double
+    /** @see #defineNumber(List, double, Predicate) */
+    default DoubleValue defineNumber(String path, double value) {
+        return defineNumber(split(path), value, isNumber());
+    }
+    /** @see #defineNumber(List, double, Predicate) */
+    default DoubleValue defineNumber(String path, double value, Predicate<Object> validator) {
+        return defineNumber(split(path), value,validator);
+    }
+    // Long
+    /** @see #defineNumber(List, long, Predicate) */
+    default LongValue defineNumber(String path, long value) {
+        return defineNumber(split(path), value, isNumber());
+    }
+    /** @see #defineNumber(List, long, Predicate) */
+    default LongValue defineNumber(String path, long value, Predicate<Object> validator) {
+        return defineNumber(split(path), value,validator);
+    }
+
+    static Predicate<Object> isNumber() {
+        return o -> {
+            return o instanceof Number || (o instanceof String ? NumberUtils.isCreatable((String) o) : (o != null && Number.class.isAssignableFrom(o.getClass())));
+        };
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/api/RangeDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/RangeDefinitions.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.RangeType;
+import net.minecraftforge.common.config.ValueRange;
+import net.minecraftforge.common.config.values.ConfigValue;
+import net.minecraftforge.common.config.values.DoubleValue;
+import net.minecraftforge.common.config.values.IntValue;
+import net.minecraftforge.common.config.values.LongValue;
+
+import com.google.common.collect.Range;
+
+/**
+ * Where are {@link ValueRange} definitions are specified.
+ *
+ * These methods allow the creation of a simple numerical entry that can only be a part of the given range.
+ */
+public interface RangeDefinitions
+{
+    /**
+     * Define a Comparable that should be within a given minimum and maximum
+     * Comparable's can be any {@link Number}, or anything that inherits from {@link Comparable}
+     *
+     * @param path the path to the value
+     * @param defaultSupplier the default value supplier
+     * @param range the type of {@link com.google.common.collect.Range} to use. See {@link RangeType} for more information.
+     * @param clazz the type of the value
+     * @return a new {@link ConfigValue} containing the type of the value and it's current value
+     */
+    <V extends Comparable<? super V>> ConfigValue<V> defineInRange(List<String> path, Supplier<V> defaultSupplier, Range<V> range, Class<V> clazz);
+
+    //Double
+    /** @see #defineInRange */
+    default DoubleValue defineInRange(String path, double defaultValue, Range<Double> range) {
+        return defineInRange(split(path), defaultValue, range);
+    }
+
+    /** @see #defineInRange(List, Supplier, Range, Class)  */
+    DoubleValue defineInRange(List<String> path, double defaultValue, Range<Double> range);
+
+    //Ints
+    /** @see #defineInRange(List, int, Range)  */
+    default IntValue defineInRange(String path, int defaultValue, Range<Integer> range) {
+        return defineInRange(split(path), defaultValue, range);
+    }
+    /** @see #defineInRange(List, Supplier, Range, Class)  */
+    IntValue defineInRange(List<String> path, int defaultValue, Range<Integer> range);
+
+    //Longs
+    /** @see #defineInRange(List, long, Range)  */
+    default LongValue defineInRange(String path, long defaultValue, Range<Long> range) {
+        return defineInRange(split(path), defaultValue, range);
+    }
+    /** @see #defineInRange(List, Supplier, Range, Class)  */
+    LongValue defineInRange(List<String> path, long defaultSupplier, Range<Long> range);
+}

--- a/src/main/java/net/minecraftforge/common/config/api/StringDefinitions.java
+++ b/src/main/java/net/minecraftforge/common/config/api/StringDefinitions.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.common.config.api;
+
+import static net.minecraftforge.common.config.AbstractConfigSpec.split;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.values.StringValue;
+
+public interface StringDefinitions
+{
+    /**
+     * Define a new String configuration entry.
+     *
+     * @param path the path to the configuration entry
+     * @param defaultSupplier the default value
+     * @return a new {@link StringValue}
+     */
+    StringValue defineString(List<String>path, Supplier<String> defaultSupplier);
+
+    /** @see #defineString(List, Supplier) */
+    default StringValue defineString(String path, String value) {
+        return defineString(split(path), () -> value);
+    }
+    /** @see #defineString(List, Supplier) */
+    default StringValue defineString(List<String> path, String defaultValue) {
+        return defineString(path, () -> defaultValue);
+    }
+    /** @see #defineString(List, Supplier) */
+    default StringValue defineString(String path, Supplier<String> defaultSupplier) {
+        return defineString(split(path), defaultSupplier);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/BooleanValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/BooleanValue.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+public class BooleanValue extends ConfigValue<Boolean>
+{
+    public BooleanValue(ModConfigSpec parent, List<String> path, Supplier<Boolean> defaultSupplier)
+    {
+        super(parent, path, defaultSupplier);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/ConfigValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/ConfigValue.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.google.common.base.Preconditions;
+
+public class ConfigValue<T>
+{
+    protected final ModConfigSpec parent;
+    protected final List<String> path;
+    protected final Supplier<T> defaultSupplier;
+
+    public ConfigValue(ModConfigSpec parent, List<String> path, Supplier<T> defaultSupplier)
+    {
+        this.parent = parent;
+        this.path = path;
+        this.defaultSupplier = defaultSupplier;
+    }
+
+    public List<String> getPath()
+    {
+        return path;
+    }
+
+    public T get()
+    {
+        Preconditions.checkNotNull(parent, "Cannot get config value before spec is built");
+        if (parent.getConfig() == null) {
+            return defaultSupplier.get();
+        }
+        return getRaw(parent.getConfig(), path, defaultSupplier);
+    }
+
+    protected T getRaw(CommentedConfig config, List<String> path, Supplier<T> defaultSupplier)
+    {
+        return config.getOrElse(path, defaultSupplier);
+    }
+
+    public void save()
+    {
+        Preconditions.checkNotNull(parent,"Cannot save config value before spec is built");
+        Preconditions.checkNotNull(parent.getConfig(),"Cannot save config value without assigned Config present");
+        parent.save();
+    }
+
+    public void set(T value)
+    {
+        Preconditions.checkNotNull(parent,"Cannot set config value before spec is built");
+        Preconditions.checkNotNull(parent.getConfig(),"Cannot set config value without assigned Config present");
+        parent.getConfig().set(getPath(), value);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/DoubleValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/DoubleValue.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+
+public class DoubleValue extends ConfigValue<Double>
+{
+    public DoubleValue(ModConfigSpec parent, List<String> path, Supplier<Double> defaultSupplier)
+    {
+        super(parent, path, defaultSupplier);
+    }
+
+    @Override
+    protected Double getRaw(CommentedConfig config, List<String> path, Supplier<Double> defaultSupplier)
+    {
+        Number n = config.<Number>get(path);
+        return n == null ? defaultSupplier.get() : n.doubleValue();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/EnumValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/EnumValue.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.EnumGetMethod;
+
+public class EnumValue<T extends Enum<T>> extends ConfigValue<T>
+{
+    private final EnumGetMethod converter;
+    private final Class<T> clazz;
+    public EnumValue(ModConfigSpec parent, List<String> path, Supplier<T> defaultSupplier, EnumGetMethod converter, Class<T> clazz)
+    {
+        super(parent, path, defaultSupplier);
+        this.converter = converter;
+        this.clazz = clazz;
+    }
+
+    @Override
+    protected T getRaw(CommentedConfig config, List<String> path, Supplier<T> defaultSupplier)
+    {
+        return config.getEnumOrElse(path, clazz, converter, defaultSupplier);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/IntValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/IntValue.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+
+public class IntValue extends ConfigValue<Integer>
+{
+    public IntValue(ModConfigSpec parent, List<String> path, Supplier<Integer> defaultSupplier)
+    {
+        super(parent, path, defaultSupplier);
+    }
+
+    @Override
+    protected Integer getRaw(CommentedConfig config, List<String> path, Supplier<Integer> defaultSupplier)
+    {
+        return config.getIntOrElse(path, defaultSupplier::get);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/ListValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/ListValue.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+
+public class ListValue<T> extends ConfigValue<List<T>>
+{
+    private final Function<Object, T> elementConverter;
+    public ListValue(ModConfigSpec parent, List<String> path, Supplier<List<T>> defaultSupplier, Function<Object, T> converter)
+    {
+        super(parent, path, defaultSupplier);
+        this.elementConverter = converter;
+    }
+
+    @Override
+    protected List<T> getRaw(CommentedConfig config, List<String> path, Supplier<List<T>> defaultSupplier)
+    {
+        List<?> rawList = config.getOrElse(path, defaultSupplier);
+        return rawList.stream().map(elementConverter).collect(Collectors.toList()); // Unfortunately, we have to run map twice in order to get the correct type back
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/LongValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/LongValue.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+
+public class LongValue extends ConfigValue<Long>
+{
+    public LongValue(ModConfigSpec parent, List<String> path, Supplier<Long> defaultSupplier)
+    {
+        super(parent, path, defaultSupplier);
+    }
+
+    @Override
+    protected Long getRaw(CommentedConfig config, List<String> path, Supplier<Long> defaultSupplier)
+    {
+        return config.getLongOrElse(path, defaultSupplier::get);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/ModValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/ModValue.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+import net.minecraftforge.common.config.ModObjectConverter;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.google.common.base.Preconditions;
+
+public class ModValue<V> extends ConfigValue<V>
+{
+    private final ModObjectConverter<V> converter;
+    public ModValue(ModConfigSpec parent, List<String> path, Supplier<V> defaultSupplier, ModObjectConverter<V> converter)
+    {
+        super(parent, path, defaultSupplier);
+        this.converter = converter;
+    }
+
+    @Override
+    protected V getRaw(CommentedConfig config, List<String> path, Supplier<V> defaultSupplier)
+    {
+        CommentedConfig section = config.getOrElse(path, config.createSubConfig());
+        return converter.loadFromConfig(section, path, defaultSupplier);
+    }
+
+    @Override
+    public void set(V value)
+    {
+        Preconditions.checkNotNull(parent,"Cannot set config value before spec is built");
+        Preconditions.checkNotNull(parent.getConfig(),"Cannot set config value without assigned Config present");
+        CommentedConfig subConfig = parent.getConfig().createSubConfig();
+        converter.saveToConfig(subConfig, getPath(), value, defaultSupplier);
+        parent.getConfig().set(getPath(), subConfig);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/values/StringValue.java
+++ b/src/main/java/net/minecraftforge/common/config/values/StringValue.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.common.config.values;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import net.minecraftforge.common.config.ModConfigSpec;
+
+public class StringValue extends ConfigValue<String>
+{
+    public StringValue(ModConfigSpec parent, List<String> path,
+            Supplier<String> defaultSupplier)
+    {
+        super(parent, path, defaultSupplier);
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -128,8 +128,7 @@ public class ConfigTracker {
     public void loadDefaultServerConfigs() {
         configSets.get(ModConfig.Type.SERVER).forEach(modConfig -> {
             final CommentedConfig commentedConfig = CommentedConfig.inMemory();
-            modConfig.getSpec().correct(commentedConfig);
-            modConfig.setConfigData(commentedConfig);
+            modConfig.setConfigData(commentedConfig); // setConfigData corrects the config
             modConfig.fireEvent(new ModConfig.Loading(modConfig));
         });
     }

--- a/src/test/java/net/minecraftforge/debug/config/ForgeConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/config/ForgeConfigTest.java
@@ -1,0 +1,297 @@
+package net.minecraftforge.debug.config;
+
+import static net.minecraft.command.Commands.literal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import net.minecraft.command.CommandSource;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.ModConfigSpec;
+import net.minecraftforge.common.config.ModObjectConverter;
+import net.minecraftforge.common.config.RangeType;
+import net.minecraftforge.common.config.values.BooleanValue;
+import net.minecraftforge.common.config.values.DoubleValue;
+import net.minecraftforge.common.config.values.EnumValue;
+import net.minecraftforge.common.config.values.IntValue;
+import net.minecraftforge.common.config.values.ListValue;
+import net.minecraftforge.common.config.values.LongValue;
+import net.minecraftforge.common.config.values.ModValue;
+import net.minecraftforge.common.config.values.StringValue;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+
+import com.electronwill.nightconfig.core.Config;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.mojang.brigadier.CommandDispatcher;
+
+@Mod(ForgeConfigTest.MODID)
+public class ForgeConfigTest
+{
+    private static final Logger LOGGER = Logger.getLogger("ForgeConfigTest");
+    public static final String MODID = "forge_config_test";
+
+
+    public final ConfigSpecTest CLIENT;
+    public final ConfigSpecTest SERVER;
+    public ForgeConfigTest()
+    {
+        CLIENT = ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigSpecTest::new);
+        SERVER = ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ConfigSpecTest::new);
+
+        MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
+    }
+
+    @SubscribeEvent
+    public void registerCommands(RegisterCommandsEvent event)
+    {
+        CommandDispatcher<CommandSource> dispatcher = event.getDispatcher();
+        dispatcher.register(
+                literal("fct")
+                .then(literal("client").executes( c -> {
+                    testClientSpec();
+                    return 1;
+                }))
+                .then(literal("server").executes(c -> {
+                    testServerSpec();
+                    return 1;
+                })
+        ));
+    }
+
+    public void testClientSpec()
+    {
+        print("*#*#*#*#*#*#*#* CLIENT CONFIG TESTING START *#*#*#*#*#*#*#*");
+        testConfigSpec(CLIENT);
+        print("*#*#*#*#*#*#*#* CLIENT CONFIG TESTING END *#*#*#*#*#*#*#*");
+    }
+
+    public void testServerSpec()
+    {
+        print("*#*#*#*#*#*#*#* SERVER CONFIG TESTING START *#*#*#*#*#*#*#*");
+        testConfigSpec(SERVER);
+        print("*#*#*#*#*#*#*#* SERVER CONFIG TESTING END *#*#*#*#*#*#*#*");
+    }
+
+    public void testConfigSpec(ConfigSpecTest spec)
+    {
+        print("BOOL_TEST = " + spec.BOOL_TEST.get() + " == " + spec.BOOL_TEST_VALUE);
+        print("DOUBLE_TEST = " + spec.DOUBLE_TEST.get() + " == " + spec.DOUBLE_TEST_VALUE);
+        print("DOUBLE_RANGE_TEST = ");
+        printRangeTest(spec.DOUBLE_RANGE_TEST.get(), spec.DOUBLE_RANGE_TASTE_RANGE, spec.DOUBLE_RANGE_TEST_VALUE);
+        print("ENUM_TEST = " + spec.ENUM_TEST.get() + " == " + spec.ENUM_TEST_VALUE);
+        print("INT_TEST = " + spec.INT_TEST.get() + " == " + spec.INT_TEST_VALUE);
+        print("INT_RANGE_TEST = ");
+        printRangeTest(spec.INT_RANGE_TEST.get(), spec.INT_RANGE_TEST_RANGE, spec.INT_RANGE_TEST_VALUE);
+        print("LIST_TEST = ");
+        printListTest(spec.LIST_TEST.get(), spec.CONFIG_LIST);
+        print("LONG_TEST = " + spec.LONG_TEST.get() + " == " + spec.LONG_TEST_VALUE);
+        print("LONG_RANGE_TEST = ");
+        printRangeTest(spec.LONG_RANGE_TEST.get(), spec.LONG_RANG_TEST_RANGE, spec.LONG_RANGE_TEST_VALUE);
+        print("MOD_VALUE_TEST = ");
+        printModObject(spec.MOD_VALUE_TEST, spec.CONFIG_MOD_OBJECT);
+        print("BLOCK_POS_TEST = ");
+        printModObject(spec.BLOCK_POS_TEST, spec.CONFIG_POS);
+        print("STRING_TEST = " + spec.STRING_TEST.get() + " == " + spec.STRING_TEST_VALUE + " == " + spec.STRING_TEST.get().equals(spec.STRING_TEST_VALUE));
+    }
+    public static class ConfigSpecTest
+    {
+        public final BooleanValue BOOL_TEST;
+        public final boolean BOOL_TEST_VALUE = true;
+
+        public final DoubleValue DOUBLE_TEST;
+        public final DoubleValue DOUBLE_RANGE_TEST;
+        public final double DOUBLE_TEST_VALUE = Math.PI;
+        public final double DOUBLE_RANGE_TEST_VALUE = -31.5D;
+        public final Range<Double> DOUBLE_RANGE_TASTE_RANGE = RangeType.CLOSED.createRange(0.0D, 4.0D);
+
+        public final EnumValue<Direction> ENUM_TEST;
+        public final Direction ENUM_TEST_VALUE = Direction.NORTH;
+
+        public final IntValue INT_TEST;
+        public final int INT_TEST_VALUE = 817471491;
+        public final IntValue INT_RANGE_TEST;
+        public final int INT_RANGE_TEST_VALUE = 55;
+        public final Range<Integer> INT_RANGE_TEST_RANGE = RangeType.ATLEAST.createRange(65);
+
+        public final ListValue<String> LIST_TEST;
+        private final List<String> CONFIG_LIST = Lists.newArrayList("world", "DIM1", "DIM-1");
+
+        public final LongValue LONG_TEST;
+        public final long LONG_TEST_VALUE = 3481094824908109L;
+        public final LongValue LONG_RANGE_TEST;
+        public final long LONG_RANGE_TEST_VALUE = 45454545454545L;
+        public final Range<Long> LONG_RANG_TEST_RANGE = RangeType.ATMOST.createRange(500000L);
+
+        public final ModValue<ConfigModObject> MOD_VALUE_TEST;
+        private final ConfigModObject CONFIG_MOD_OBJECT = new ConfigModObject();
+        private final ConfigModObjectConverter CONFIG_MOD_OBJ_CONVERTER = new ConfigModObjectConverter();
+
+        public final ModValue<BlockPos> BLOCK_POS_TEST;
+        private final BlockPos CONFIG_POS;
+        private final BlockPosConverter BLOCK_POS_CONVERTER = new BlockPosConverter();
+
+        public final StringValue STRING_TEST;
+        public final String STRING_TEST_VALUE = "45d6s4fa51823!*!)$)#++\\uue";
+
+        public ConfigSpecTest(ModConfigSpec builder)
+        {
+            int randX = ThreadLocalRandom.current().nextInt(450);
+            int randY = ThreadLocalRandom.current().nextInt(450);
+            int randZ = ThreadLocalRandom.current().nextInt(450);
+            CONFIG_POS = new BlockPos(randX, randY, randZ);
+            builder.comment("Initial test comment. Please ignore.")
+                   .push("TestSection");
+
+            BOOL_TEST = builder.comment("Test boolean entry")
+                    .translation("test.bool")
+                    .defineBoolean("test_bool", BOOL_TEST_VALUE);
+            DOUBLE_TEST = builder.comment("Test double entry")
+                    .translation("test.double")
+                    .defineNumber("test.double", DOUBLE_TEST_VALUE);
+            DOUBLE_RANGE_TEST = builder.comment("Range test with doubles")
+                    .translation("test.range.double")
+                    .defineInRange("test.range.double", DOUBLE_RANGE_TEST_VALUE, DOUBLE_RANGE_TASTE_RANGE);
+            ENUM_TEST = builder.comment("Test enum test")
+                    .translation("test.enum")
+                    .defineEnumValue("test.enum", ENUM_TEST_VALUE);
+            INT_TEST = builder.comment("Integer number test")
+                    .translation("test.int")
+                    .defineNumber("test.int", INT_TEST_VALUE);
+            INT_RANGE_TEST = builder.comment("Integer range test")
+                    .translation("test.range.int")
+                    .defineInRange("test.range.int", INT_RANGE_TEST_VALUE, INT_RANGE_TEST_RANGE);
+            LIST_TEST = builder.comment("List test")
+                    .translation("list.test")
+                    .defineList("list.test", CONFIG_LIST, Object::toString);
+            LONG_TEST = builder.comment("Long test")
+                    .translation("test.long")
+                    .defineNumber("long.test", LONG_TEST_VALUE);
+            LONG_RANGE_TEST = builder.comment("Long range test")
+                    .translation("test.range.long")
+                    .defineInRange("test.range.long", LONG_RANGE_TEST_VALUE, LONG_RANG_TEST_RANGE);
+            MOD_VALUE_TEST = builder.comment("Custom Mod Object Test")
+                    .translation("test.mod.object")
+                    .defineModObject("test.mod.object", CONFIG_MOD_OBJECT, CONFIG_MOD_OBJ_CONVERTER);
+            BLOCK_POS_TEST = builder.comment("Block Pos Test")
+                    .translation("test.block_pos")
+                    .defineModObject("test.block_pos", CONFIG_POS, BLOCK_POS_CONVERTER);
+            STRING_TEST = builder.comment("String test")
+                    .translation("test.string")
+                    .defineString("test.string", STRING_TEST_VALUE);
+            builder.pop();
+        }
+    }
+
+
+
+    public void printModObject(ModValue<?> configObject, Object defaultObject)
+    {
+        print("CONFIG: " + configObject.get().toString());
+        print("DEFAULT: " + defaultObject.toString());
+    }
+
+    public void printListTest(List<String> configList, List<String> defaultList)
+    {
+        print("CONFIG: " + Arrays.deepToString(configList.toArray()));
+        print("DEFAULT: " + Arrays.deepToString(defaultList.toArray()));
+        print("EQUAL = " + configList.equals(defaultList));
+    }
+
+    public <V extends Comparable<V>> void printRangeTest(V configValue, Range<V> range, V defaultValue)
+    {
+        print(configValue + " ~ " + range.contains(configValue) + " ~ " + range.toString() + " ~ " + defaultValue);
+    }
+
+    private void print(String msg) {
+        LOGGER.info(msg);
+    }
+
+    public static class ConfigModObject
+    {
+        public final long num;
+        public final UUID uuid;
+        public ConfigModObject()
+        {
+            num = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+            uuid = java.util.UUID.randomUUID();
+        }
+
+        public ConfigModObject(long num, UUID uuid)
+        {
+            this.num = num;
+            this.uuid = uuid;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            ConfigModObject that = (ConfigModObject) o;
+            return num == that.num &&
+                    uuid.equals(that.uuid);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ConfigModObject{" +
+                    "num=" + num +
+                    ", uuid=" + uuid +
+                    '}';
+        }
+    }
+
+    public static class ConfigModObjectConverter implements ModObjectConverter<ConfigModObject>
+    {
+
+        @Override
+        public ConfigModObject loadFromConfig(Config subConfig, List<String> path, Supplier<ConfigModObject> defaultSupplier)
+        {
+            long num = subConfig.get("long_num");
+            UUID uuid = UUID.fromString(subConfig.get("uuid"));
+            return new ConfigModObject(num, uuid);
+        }
+
+        @Override
+        public void saveToConfig(Config subConfig, List<String> path, ConfigModObject object, Supplier<ConfigModObject> defaultSupplier)
+        {
+            subConfig.set("long_num", object.num);
+            subConfig.set("uuid", object.uuid.toString());
+        }
+    }
+
+    public static class BlockPosConverter implements ModObjectConverter<BlockPos>
+    {
+
+        @Override
+        public BlockPos loadFromConfig(Config subConfig, List<String> path, Supplier<BlockPos> defaultSupplier)
+        {
+            int x = subConfig.get("x");
+            int y = subConfig.get("y");
+            int z = subConfig.get("z");
+            return new BlockPos(x, y, z);
+        }
+
+        @Override
+        public void saveToConfig(Config subConfig, List<String> path, BlockPos object, Supplier<BlockPos> defaultSupplier)
+        {
+            subConfig.set("x", object.getX());
+            subConfig.set("y", object.getY());
+            subConfig.set("z", object.getZ());
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -3,6 +3,8 @@ loaderVersion="[28,)"
 license="LGPL v2.1"
 
 [[mods]]
+    modId="forge_config_test"
+[[mods]]
 	modId="containertypetest"
 [[mods]]
     modId="potion_event_test"


### PR DESCRIPTION
***This PR is a breaking change.*** 
Just wanted to get that out there before I go any further.

I'd really love feedback on what I could do better or what needs/should to be changed. Thanks!

## Justification
The current Configuration system works, and it supports almost everything that mods can realistically want.
However, it lacks certain features that would be nice and/or useful. There are three(3) main features that either need better support or actual implementation. These features are String support, List support, and custom object support.
Features such as String support without having to use `ConfigValue<String>` instead of just `StringValue` isn't a big deal, but it just makes the code a bit easier to read and understand.
The same thing cannot be said about lists. The current `ConfigValue<List<? super T>>` means you will always lose the type contained in the list. This PR introduces the `ListValue<T>` which will retain it's type.
There is currently no support for custom objects. This isn't Forge's fault, as night-config's support for those things is limited as well.

This PR will be broken down into three main parts. Changes in how configs are registered, the new `ModConfigSpec` class, and custom object support.

## Registration
Mods now register their configs via the same `ModLoadingContext#registerConfig` methods. However, these methods' signatures have changed (all old methods will be broken).
The new methods now allow for mods to a `Function` that will be called *after* their respective `ModConfig` has finished instantiation. This allows mods to register and create their configuration instances in a much cleaner way then previously.
`ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ForgeConfig.Server::new);`
The following are the changed/new register methods.
1. `registerConfig(ModConfig.Type)` will just return the default `ModConfigSpec` that Forge creates. Mods will have to create their config instances using the returned `ModConfigSpec`.
2. `registerConfig(ModConfig.Type, IConfigSpecFactory, Function)`
	* This will use the given `IConfigSpecFactory` to create the specification for the configuration and when the `ModConfig` is finished constructing the `Function` will be called using the completed spec that `IConfigSpecFactory` created.
3. `registerConfig(ModConfig.Type, IConfigSpecFactory, String, Function)`
	* This will do the same as above but the `String` will be the config's file name.

## ModConfigSpec
The new `ModConfigSpec` (name can be changed, I'm not 100% sold on it) is built on top of `AbstractConfigSpec` which simply extends night-config's `ConfigSpec`.
This is good because it allows mods to take advantage of the Night Config API. Yes, the API that the Forge config system has is good enough for almost all cases, however if a mod does need to use the Night Config API they can do that without any extra hassle.
However, this also means that the Forge config API cannot use the `define` methods. This isn't terrible, but it is a bit annoying.
I have kept many of the builder pattern methods the same for ease of use (and because it's super useful).
However, some of the methods did have to change.
For example, to define a generic `ConfigValue<?>` you used to be able to do `define(...)` however that has changed to `defineObject`. In return I have implemented support for most primitives and objects.
To cut down on the length of `ModConfigSpec` I have broken the API down into several interfaces and only implemented the method that *actually* defines(registers) the new configuration entry.
Yes, this means there's more interfaces but it means that the actual `ModConfigSpec` implementation is much cleaner and doesn't have any unnecessary methods in it (i.e. methods that only overload other methods).

Finally, `ForgeConfigSpec` is deprecated. As well, everything in it has been deprecated to let anything using those objects know to change them because they can't be used in `ModConfigSpec`
## Custom Object Support
So, this is the part that I'm not the most confident about because the only way to support custom object serialization/de-serialization was to just give the mods a sub-config to write their data to and hope they do it in a way that Night Config supports.
Custom objects are defined in `ModConfigSpec#_defineMod`. Those objects have to be converted to a format that Night Config supports. The only thing that would provide the most options for mods as well as long-term support is the `Config` option. This `Config` is *not* the actual configuration on file, it is a sub config created using `ConfigSpec` (i.e. `Config#createSubConfig`).
To save/load objects from config needs a converter, this is what `ModObjectConverter` is for (I don't like the name but I can't think of another one, feel free to provide one). These sub configs are then passed into the converter so that the mods can save their object's data to the configuration.
Custom objects are then stored in the config like any other config value. `ModValue` is this config value type (Again I'm not sold on the name).
I chose not to just use `ConfigValue<CustomObject>` because this would mean that there would have to be support for both regular objects AND custom objects in the same class. I believe this would just get messy over time.

**Tests**
There is a test for the new config system. `ForgeConfigTest` tests every value type implemented.
There are two tests for custom objects. One is for a class inside the test itself (`ConfigModObject`) and `BlockPos`. Both tests were successful.

LOG: https://gist.github.com/Senmori/53294dcd4923977de611dd77a6c751fb

The configs are the same but here's links to both of them.
Client Config: https://gist.github.com/Senmori/33409cb88ae6cef08b47ec1c9eeda7db
Server Config: https://gist.github.com/Senmori/72160cc67c1f709eb10ac92f9efbc763

**Thoughts**
I was able to join both a local world and a server without any errors showing up.
I made sure to keep the instantiation of `ForgeConfig` basically the same (e.g. public static final in a static block). To accomplish that I moved the registering of the configs from `ForgeMod` to `ForgeConfig` so I could maintain the `final` modifier.

There is a hard dependency on Guava's `Range`. I don't think this is a deal breaker personally but it could be removed somewhat easily if need be. I chose Guava's `Range` because it was already set up to use. I did not have to implement every detail (i.e. toString showing the correct range, the ability to check if a number is within that range, etc).
