### PR TITLE
[1.16] Re-introduce "outdated" notification on Mods button in main menu

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -56,6 +56,7 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.BrandingControl;
 import net.minecraftforge.fml.LoadingFailedException;
 import net.minecraftforge.fml.LogicalSidedProvider;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModLoadingStage;
 import net.minecraftforge.fml.ModLoadingWarning;
@@ -138,7 +139,12 @@ public class ClientModLoader
 
     public static VersionChecker.Status checkForUpdates()
     {
-        return VersionChecker.Status.UP_TO_DATE;
+
+        boolean anyOutdated = ModList.get().getMods().stream()
+                .map(VersionChecker::getResult)
+                .map(result -> result.status)
+                .anyMatch(status -> status == VersionChecker.Status.OUTDATED || status == VersionChecker.Status.BETA_OUTDATED);
+        return anyOutdated ? VersionChecker.Status.OUTDATED : null;
     }
 
     public static boolean completeModLoading()


### PR DESCRIPTION
1.12 and earlier showed the emerald "outdated" icon on the Mods button in the main menu when any mod is outdated.
This was removed in 1.13.