### PR TITLE
EntityMountEvent Infinite Client Loop Fix

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/player/ClientPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/player/ClientPlayerEntity.java.patch
@@ -37,6 +37,14 @@
              this.field_71174_a.func_147297_a(new CEntityActionPacket(this, CEntityActionPacket.Action.START_FALL_FLYING));
           }
        }
+@@ -777,6 +_,7 @@
+ 
+    public void func_70098_U() {
+       super.func_70098_U();
++      if (this.func_226564_dU_() && this.func_184218_aH()) this.field_71158_b.field_228350_h_ = false;
+       this.field_184844_co = false;
+       if (this.func_184187_bx() instanceof BoatEntity) {
+          BoatEntity boatentity = (BoatEntity)this.func_184187_bx();
 @@ -974,5 +_,17 @@
        } else {
           return super.func_241843_o(p_241843_1_);


### PR DESCRIPTION
Whenever EntityMountEvent was cancelled to dismount the player, there would be an infinite loop triggered on the client side. This is because the client player overrides the standard sneaking methods to use movement inputs instead, so the checks used to see if the player is dismounting a passenger results in something different. Movement inputs are only updated when the client player is ticked. However, since the client player is always riding a passenger, the player gets stuck in an infinite loop on the client.

This PR addresses that issue by adding the forge event hook `ForgeEventFactory::canMountEntity` to `PlayerEntity::updateRidden` which allows the client to update the movement inputs correctly fixing the infinite loop.

The other three changes within the files prevents the crouching animation from occurring when the event is cancelled.

I could have instead overwritten `Entity::setSneaking` in `ClientPlayerEntity` and just set the movement input to the forced values. However, this tended to still set data that the player was getting off for a tick and then back on even though the game still handles the information as on the entity. So, I did the above method instead.