### PR TITLE
Forge gui rendering utils was not using matrixstack

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -82,6 +82,7 @@ public class GuiUtils
      * @param borderSize the size of the box's borders
      * @param zLevel the zLevel to draw at
      */
+    @Deprecated //Use matrix stack version TODO remove 1.17
     public static void drawContinuousTexturedBox(int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
             int borderSize, float zLevel)
     {
@@ -105,6 +106,7 @@ public class GuiUtils
      * @param borderSize the size of the box's borders
      * @param zLevel the zLevel to draw at
      */
+    @Deprecated //Use matrix stack version TODO remove 1.17
     public static void drawContinuousTexturedBox(ResourceLocation res, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
             int borderSize, float zLevel)
     {
@@ -131,6 +133,7 @@ public class GuiUtils
      * @param rightBorder the size of the box's right border
      * @param zLevel the zLevel to draw at
      */
+    @Deprecated //Use matrix stack version TODO remove 1.17
     public static void drawContinuousTexturedBox(ResourceLocation res, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
             int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
     {
@@ -157,7 +160,7 @@ public class GuiUtils
      * @param rightBorder the size of the box's right border
      * @param zLevel the zLevel to draw at
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated //Use matrix stack version TODO remove 1.17
     public static void drawContinuousTexturedBox(int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
             int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
     {
@@ -206,6 +209,7 @@ public class GuiUtils
         }
     }
 
+    @Deprecated //Use matrix stack version TODO remove 1.17
     public static void drawTexturedModalRect(int x, int y, int u, int v, int width, int height, float zLevel)
     {
         final float uScale = 1f / 0x100;
@@ -218,6 +222,166 @@ public class GuiUtils
         wr.pos(x + width, y + height, zLevel).tex((u + width) * uScale, ((v + height) * vScale)).endVertex();
         wr.pos(x + width, y         , zLevel).tex((u + width) * uScale, ( v           * vScale)).endVertex();
         wr.pos(x        , y         , zLevel).tex( u          * uScale, ( v           * vScale)).endVertex();
+        tessellator.draw();
+    }
+
+    /**
+     * Draws a textured box of any size (smallest size is borderSize * 2 square) based on a fixed size textured box with continuous borders
+     * and filler. It is assumed that the desired texture ResourceLocation object has been bound using
+     * Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation).
+     *
+     * @param matrixStack the gui matrix stack
+     * @param x x axis offset
+     * @param y y axis offset
+     * @param u bound resource location image x offset
+     * @param v bound resource location image y offset
+     * @param width the desired box width
+     * @param height the desired box height
+     * @param textureWidth the width of the box texture in the resource location image
+     * @param textureHeight the height of the box texture in the resource location image
+     * @param borderSize the size of the box's borders
+     * @param zLevel the zLevel to draw at
+     */
+    public static void drawContinuousTexturedBox(MatrixStack matrixStack, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
+                                                 int borderSize, float zLevel)
+    {
+        drawContinuousTexturedBox(matrixStack, x, y, u, v, width, height, textureWidth, textureHeight, borderSize, borderSize, borderSize, borderSize, zLevel);
+    }
+
+    /**
+     * Draws a textured box of any size (smallest size is borderSize * 2 square) based on a fixed size textured box with continuous borders
+     * and filler. The provided ResourceLocation object will be bound using
+     * Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation).
+     *
+     * @param matrixStack the gui matrix stack
+     * @param res the ResourceLocation object that contains the desired image
+     * @param x x axis offset
+     * @param y y axis offset
+     * @param u bound resource location image x offset
+     * @param v bound resource location image y offset
+     * @param width the desired box width
+     * @param height the desired box height
+     * @param textureWidth the width of the box texture in the resource location image
+     * @param textureHeight the height of the box texture in the resource location image
+     * @param borderSize the size of the box's borders
+     * @param zLevel the zLevel to draw at
+     */
+    public static void drawContinuousTexturedBox(MatrixStack matrixStack, ResourceLocation res, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
+                                                 int borderSize, float zLevel)
+    {
+        drawContinuousTexturedBox(matrixStack, res, x, y, u, v, width, height, textureWidth, textureHeight, borderSize, borderSize, borderSize, borderSize, zLevel);
+    }
+
+    /**
+     * Draws a textured box of any size (smallest size is borderSize * 2 square) based on a fixed size textured box with continuous borders
+     * and filler. The provided ResourceLocation object will be bound using
+     * Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation).
+     *
+     * @param matrixStack the gui matrix stack
+     * @param res the ResourceLocation object that contains the desired image
+     * @param x x axis offset
+     * @param y y axis offset
+     * @param u bound resource location image x offset
+     * @param v bound resource location image y offset
+     * @param width the desired box width
+     * @param height the desired box height
+     * @param textureWidth the width of the box texture in the resource location image
+     * @param textureHeight the height of the box texture in the resource location image
+     * @param topBorder the size of the box's top border
+     * @param bottomBorder the size of the box's bottom border
+     * @param leftBorder the size of the box's left border
+     * @param rightBorder the size of the box's right border
+     * @param zLevel the zLevel to draw at
+     */
+    public static void drawContinuousTexturedBox(MatrixStack matrixStack, ResourceLocation res, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
+                                                 int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
+    {
+        Minecraft.getInstance().getTextureManager().bindTexture(res);
+        drawContinuousTexturedBox(matrixStack, x, y, u, v, width, height, textureWidth, textureHeight, topBorder, bottomBorder, leftBorder, rightBorder, zLevel);
+    }
+
+    /**
+     * Draws a textured box of any size (smallest size is borderSize * 2 square) based on a fixed size textured box with continuous borders
+     * and filler. It is assumed that the desired texture ResourceLocation object has been bound using
+     * Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation).
+     *
+     * @param matrixStack the gui matrix stack
+     * @param x x axis offset
+     * @param y y axis offset
+     * @param u bound resource location image x offset
+     * @param v bound resource location image y offset
+     * @param width the desired box width
+     * @param height the desired box height
+     * @param textureWidth the width of the box texture in the resource location image
+     * @param textureHeight the height of the box texture in the resource location image
+     * @param topBorder the size of the box's top border
+     * @param bottomBorder the size of the box's bottom border
+     * @param leftBorder the size of the box's left border
+     * @param rightBorder the size of the box's right border
+     * @param zLevel the zLevel to draw at
+     */
+    @SuppressWarnings("deprecation")
+    public static void drawContinuousTexturedBox(MatrixStack matrixStack, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
+                                                 int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
+    {
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+
+        int fillerWidth = textureWidth - leftBorder - rightBorder;
+        int fillerHeight = textureHeight - topBorder - bottomBorder;
+        int canvasWidth = width - leftBorder - rightBorder;
+        int canvasHeight = height - topBorder - bottomBorder;
+        int xPasses = canvasWidth / fillerWidth;
+        int remainderWidth = canvasWidth % fillerWidth;
+        int yPasses = canvasHeight / fillerHeight;
+        int remainderHeight = canvasHeight % fillerHeight;
+
+        // Draw Border
+        // Top Left
+        drawTexturedModalRect(matrixStack, x, y, u, v, leftBorder, topBorder, zLevel);
+        // Top Right
+        drawTexturedModalRect(matrixStack, x + leftBorder + canvasWidth, y, u + leftBorder + fillerWidth, v, rightBorder, topBorder, zLevel);
+        // Bottom Left
+        drawTexturedModalRect(matrixStack, x, y + topBorder + canvasHeight, u, v + topBorder + fillerHeight, leftBorder, bottomBorder, zLevel);
+        // Bottom Right
+        drawTexturedModalRect(matrixStack, x + leftBorder + canvasWidth, y + topBorder + canvasHeight, u + leftBorder + fillerWidth, v + topBorder + fillerHeight, rightBorder, bottomBorder, zLevel);
+
+        for (int i = 0; i < xPasses + (remainderWidth > 0 ? 1 : 0); i++)
+        {
+            // Top Border
+            drawTexturedModalRect(matrixStack, x + leftBorder + (i * fillerWidth), y, u + leftBorder, v, (i == xPasses ? remainderWidth : fillerWidth), topBorder, zLevel);
+            // Bottom Border
+            drawTexturedModalRect(matrixStack, x + leftBorder + (i * fillerWidth), y + topBorder + canvasHeight, u + leftBorder, v + topBorder + fillerHeight, (i == xPasses ? remainderWidth : fillerWidth), bottomBorder, zLevel);
+
+            // Throw in some filler for good measure
+            for (int j = 0; j < yPasses + (remainderHeight > 0 ? 1 : 0); j++)
+                drawTexturedModalRect(matrixStack, x + leftBorder + (i * fillerWidth), y + topBorder + (j * fillerHeight), u + leftBorder, v + topBorder, (i == xPasses ? remainderWidth : fillerWidth), (j == yPasses ? remainderHeight : fillerHeight), zLevel);
+        }
+
+        // Side Borders
+        for (int j = 0; j < yPasses + (remainderHeight > 0 ? 1 : 0); j++)
+        {
+            // Left Border
+            drawTexturedModalRect(matrixStack, x, y + topBorder + (j * fillerHeight), u, v + topBorder, leftBorder, (j == yPasses ? remainderHeight : fillerHeight), zLevel);
+            // Right Border
+            drawTexturedModalRect(matrixStack, x + leftBorder + canvasWidth, y + topBorder + (j * fillerHeight), u + leftBorder + fillerWidth, v + topBorder, rightBorder, (j == yPasses ? remainderHeight : fillerHeight), zLevel);
+        }
+    }
+
+    public static void drawTexturedModalRect(MatrixStack matrixStack, int x, int y, int u, int v, int width, int height, float zLevel)
+    {
+        final float uScale = 1f / 0x100;
+        final float vScale = 1f / 0x100;
+
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder wr = tessellator.getBuffer();
+        wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
+        Matrix4f matrix = matrixStack.getLast().getMatrix();
+        wr.pos(matrix, x        , y + height, zLevel).tex( u          * uScale, ((v + height) * vScale)).endVertex();
+        wr.pos(matrix, x + width, y + height, zLevel).tex((u + width) * uScale, ((v + height) * vScale)).endVertex();
+        wr.pos(matrix, x + width, y         , zLevel).tex((u + width) * uScale, ( v           * vScale)).endVertex();
+        wr.pos(matrix, x        , y         , zLevel).tex( u          * uScale, ( v           * vScale)).endVertex();
         tessellator.draw();
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
@@ -54,7 +54,7 @@ public class ExtendedButton extends Button
             Minecraft mc = Minecraft.getInstance();
             this.field_230692_n_ = mouseX >= this.field_230690_l_ && mouseY >= this.field_230691_m_ && mouseX < this.field_230690_l_ + this.field_230688_j_ && mouseY < this.field_230691_m_ + this.field_230689_k_;
             int k = this.func_230989_a_(this.func_230449_g_());
-            GuiUtils.drawContinuousTexturedBox(field_230687_i_, this.field_230690_l_, this.field_230691_m_, 0, 46 + k * 20, this.field_230688_j_, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
+            GuiUtils.drawContinuousTexturedBox(mStack, field_230687_i_, this.field_230690_l_, this.field_230691_m_, 0, 46 + k * 20, this.field_230688_j_, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
             this.func_230441_a_(mStack, mc, mouseX, mouseY);
 
             ITextComponent buttonText = this.func_230458_i_();

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/Slider.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/Slider.java
@@ -118,7 +118,7 @@ public class Slider extends ExtendedButton
                 updateSlider();
             }
 
-            GuiUtils.drawContinuousTexturedBox(field_230687_i_, this.field_230690_l_ + (int)(this.sliderValue * (float)(this.field_230688_j_ - 8)), this.field_230691_m_, 0, 66, 8, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
+            GuiUtils.drawContinuousTexturedBox(mStack, field_230687_i_, this.field_230690_l_ + (int)(this.sliderValue * (float)(this.field_230688_j_ - 8)), this.field_230691_m_, 0, 66, 8, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/UnicodeGlyphButton.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/UnicodeGlyphButton.java
@@ -52,7 +52,7 @@ public class UnicodeGlyphButton extends ExtendedButton
             Minecraft mc = Minecraft.getInstance();
             this.field_230692_n_ = mouseX >= this.field_230690_l_ && mouseY >= this.field_230691_m_ && mouseX < this.field_230690_l_ + this.field_230688_j_ && mouseY < this.field_230691_m_ + this.field_230689_k_;
             int k = this.func_230989_a_(this.field_230692_n_);
-            GuiUtils.drawContinuousTexturedBox(Button.field_230687_i_, this.field_230690_l_, this.field_230691_m_, 0, 46 + k * 20, this.field_230688_j_, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
+            GuiUtils.drawContinuousTexturedBox(mStack, Button.field_230687_i_, this.field_230690_l_, this.field_230691_m_, 0, 46 + k * 20, this.field_230688_j_, this.field_230689_k_, 200, 20, 2, 3, 2, 2, this.func_230927_p_());
             this.func_230441_a_(mStack, mc, mouseX, mouseY);
 
             ITextComponent buttonText = this.func_230442_c_();


### PR DESCRIPTION
Added matrix stack to all of its functions and use it in the IVertexBuilder.
Also added a constructor to extended button to be able to pass in an ITooltip (a bit unrelated, hope its fine)

Fixes #7126 