### PR TITLE
[1.15] Re-added PlayerEvent.NameFormat

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -451,10 +451,10 @@
  
     public ITextComponent func_145748_c_() {
 -      ITextComponent itextcomponent = ScorePlayerTeam.func_200541_a(this.func_96124_cp(), this.func_200200_C_());
-+      if (this.displayname == null) this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_().func_150261_e());
++      if (this.displayname == null) this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_());
 +      ITextComponent itextcomponent = new StringTextComponent("");
 +      prefixes.forEach(e -> itextcomponent.func_150257_a(e));
-+      itextcomponent.func_150257_a(ScorePlayerTeam.func_200541_a(this.func_96124_cp(), new StringTextComponent(this.displayname)));
++      itextcomponent.func_150257_a(ScorePlayerTeam.func_200541_a(this.func_96124_cp(), this.displayname));
 +      suffixes.forEach(e -> itextcomponent.func_150257_a(e));
        return this.func_208016_c(itextcomponent);
     }
@@ -481,12 +481,12 @@
 +       return this.suffixes;
 +   }
 +   
-+   private String displayname = null;
++   private ITextComponent displayname = null;
 +   /**
 +    * Force the displayed name to refresh, by firing {@link net.minecraftforge.event.entity.player.PlayerEvent.NameFormat}, using the real player name as event parameter.
 +    */
 +   public void refreshDisplayName() {
-+      this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_().func_150261_e());
++      this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_());
 +   }
 +   
 +   private final net.minecraftforge.common.util.LazyOptional<net.minecraftforge.items.IItemHandler>

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -446,19 +446,20 @@
        this.field_71068_ca += p_82242_1_;
        if (this.field_71068_ca < 0) {
           this.field_71068_ca = 0;
-@@ -1789,7 +1914,10 @@
+@@ -1789,7 +1914,11 @@
     }
  
     public ITextComponent func_145748_c_() {
 -      ITextComponent itextcomponent = ScorePlayerTeam.func_200541_a(this.func_96124_cp(), this.func_200200_C_());
++      if (this.displayname == null) this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_().func_150261_e());
 +      ITextComponent itextcomponent = new StringTextComponent("");
 +      prefixes.forEach(e -> itextcomponent.func_150257_a(e));
-+      itextcomponent.func_150257_a(ScorePlayerTeam.func_200541_a(this.func_96124_cp(), this.func_200200_C_()));
++      itextcomponent.func_150257_a(ScorePlayerTeam.func_200541_a(this.func_96124_cp(), new StringTextComponent(this.displayname)));
 +      suffixes.forEach(e -> itextcomponent.func_150257_a(e));
        return this.func_208016_c(itextcomponent);
     }
  
-@@ -2029,4 +2157,45 @@
+@@ -2029,4 +2158,53 @@
           return this.field_221260_g;
        }
     }
@@ -479,7 +480,15 @@
 +   public Collection<ITextComponent> getSuffixes() {
 +       return this.suffixes;
 +   }
-+
++   
++   private String displayname = null;
++   /**
++    * Force the displayed name to refresh, by firing {@link net.minecraftforge.event.entity.player.PlayerEvent.NameFormat}, using the real player name as event parameter.
++    */
++   public void refreshDisplayName() {
++      this.displayname = net.minecraftforge.event.ForgeEventFactory.getPlayerDisplayName(this, this.func_200200_C_().func_150261_e());
++   }
++   
 +   private final net.minecraftforge.common.util.LazyOptional<net.minecraftforge.items.IItemHandler>
 +         playerMainHandler = net.minecraftforge.common.util.LazyOptional.of(
 +               () -> new net.minecraftforge.items.wrapper.PlayerMainInvWrapper(field_71071_by));

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -64,6 +64,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.IWorld;
@@ -240,11 +241,20 @@ public class ForgeEventFactory
         return maxCanSpawnEvent.getResult() == Result.ALLOW ? maxCanSpawnEvent.getMaxPackSize() : entity.getMaxSpawnedInChunk();
     }
 
+    /**
+     * Removed in 1.16. Use {@link ForgeEventFactory#getPlayerDisplayName(PlayerEntity, ITextComponent)}
+     */
+    @Deprecated
     public static String getPlayerDisplayName(PlayerEntity player, String username)
+    {
+        return getPlayerDisplayName(player, new StringTextComponent(username)).getString();
+    }
+    
+    public static ITextComponent getPlayerDisplayName(PlayerEntity player, ITextComponent username)
     {
         PlayerEvent.NameFormat event = new PlayerEvent.NameFormat(player, username);
         MinecraftForge.EVENT_BUS.post(event);
-        return event.getDisplayname();
+        return event.getDisplaynameComponent();
     }
 
     public static float fireBlockHarvesting(NonNullList<ItemStack> drops, World world, BlockPos pos, BlockState state, int fortune, float dropChance, boolean silkTouch, PlayerEntity player)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -136,9 +136,9 @@ public class PlayerEvent extends LivingEvent
     /**
      * NameFormat is fired when a player's display name is retrieved.<br>
      * This event is fired whenever a player's name is retrieved in
-     * {@link EntityPlayer#getDisplayName()} or {@link EntityPlayer#refreshDisplayName()}.<br>
+     * {@link PlayerEntity#getDisplayName()} for the first time or if {@link PlayerEntity#refreshDisplayName()} is called.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#getPlayerDisplayName(EntityPlayer, String)}.<br>
+     * This event is fired via {@link ForgeEventFactory#getPlayerDisplayName(PlayerEntity, String)}.<br>
      * <br>
      * {@link #username} contains the username of the player.
      * {@link #displayname} contains the display name of the player.

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -32,6 +32,8 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -138,7 +140,7 @@ public class PlayerEvent extends LivingEvent
      * This event is fired whenever a player's name is retrieved in
      * {@link PlayerEntity#getDisplayName()} for the first time or if {@link PlayerEntity#refreshDisplayName()} is called.<br>
      * <br>
-     * This event is fired via {@link ForgeEventFactory#getPlayerDisplayName(PlayerEntity, String)}.<br>
+     * This event is fired via {@link ForgeEventFactory#getPlayerDisplayName(PlayerEntity, String)} or {@link ForgeEventFactory#getPlayerDisplayName(PlayerEntity, ITextComponent)}.<br>
      * <br>
      * {@link #username} contains the username of the player.
      * {@link #displayname} contains the display name of the player.
@@ -153,26 +155,71 @@ public class PlayerEvent extends LivingEvent
     {
         private final String username;
         private String displayname;
-
-        public NameFormat(PlayerEntity player, String username) {
+        private final ITextComponent usernameComponent;
+        private ITextComponent displaynameComponent;
+        
+        /**
+         * Removed in 1.16. Use {@link NameFormat(PlayerEntity, ITextComponent)}
+         */
+        @Deprecated
+        public NameFormat(PlayerEntity player, String username) 
+        {
             super(player);
             this.username = username;
-            this.setDisplayname(username);
+            this.usernameComponent = new StringTextComponent(username);
+            this.setDisplaynameComponent(new StringTextComponent(username));
+        }
+        
+        public NameFormat(PlayerEntity player, ITextComponent username) 
+        {
+            super(player);
+            this.username = username.getString();
+            this.usernameComponent = username;
+            this.setDisplaynameComponent(username);
         }
 
+        /**
+         * Removed in 1.16. Use {@link NameFormat#getUsernameComponent()}
+         */
+        @Deprecated
         public String getUsername()
         {
             return username;
         }
 
+        /**
+         * Removed in 1.16. Use {@link NameFormat#getDisplaynameComponent()}
+         */
+        @Deprecated
         public String getDisplayname()
         {
             return displayname;
         }
 
+        /**
+         * Removed in 1.16. Use {@link NameFormat#setDisplaynameComponent(ITextComponent)}
+         */
+        @Deprecated
         public void setDisplayname(String displayname)
         {
             this.displayname = displayname;
+            this.displaynameComponent = new StringTextComponent(displayname);
+        }
+        
+        public ITextComponent getUsernameComponent()
+        {
+            return usernameComponent;
+        }
+
+        public ITextComponent getDisplaynameComponent()
+        {
+            return displaynameComponent;
+        }
+
+        public void setDisplaynameComponent(ITextComponent displayname)
+        {
+            this.displayname = displayname.getString();
+            this.displaynameComponent = displayname;
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("player_name_event_test")
+@Mod.EventBusSubscriber()
+public class PlayerNameEventTest
+{
+    private static final boolean ENABLE = false;
+
+    @SubscribeEvent
+    public static void onPlayerNameEvent(PlayerEvent.NameFormat event)
+    {
+        if (!ENABLE) return;
+        event.setDisplayname(TextFormatting.AQUA + "Test Name");
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.debug.entity.player;
 
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -15,6 +16,7 @@ public class PlayerNameEventTest
     public static void onPlayerNameEvent(PlayerEvent.NameFormat event)
     {
         if (!ENABLE) return;
-        event.setDisplayname(TextFormatting.AQUA + "Test Name");
+        event.setDisplaynameComponent(new StringTextComponent("Test Name"));
+        event.setDisplayname(TextFormatting.AQUA + "Test Name"); //Old method also works
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -68,3 +68,5 @@ loaderVersion="[28,)"
     modId="stencil_enable_test"
 [[mods]]
     modId="deferred_registry_test"
+[[mods]]
+    modId="player_name_event_test"


### PR DESCRIPTION
1.15 Backport of #6992 
Since it seems that `PlayerEvent.NameFormat` wasn't ported to more recent versions of Forge, I have reimplemented it here.
The behavior is identical to how it used to work:
- The `PlayerEvent.NameFormat` is fired properly and can change the display name of a player.
- This affects the name tag in the world and in the chat.
- This does not affect the name in the player list (tab). This is intended and how it used to work.
- `EntityPlayer#refreshDisplayName()` needs to be called to re-fire the `PlayerEvent.NameFormat` event.

Changes:
- Didn't readd `EntityPlayer#getDisplayNameString()`. Instead, the `displayname` field is now set in `EntityPlayer#getDisplayName()`

- This PR also contains a test mod

This PR should be non-breaking, for all those that used `PlayerEvent.NameFormat` in their mods (but didn't notice that it is never fired).