### PR TITLE
1.16 rail rotation fix

### DIFF
--- a/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
@@ -35,7 +35,18 @@
                    return p_208071_1_.func_175640_z(p_208071_2_) ? true : this.func_176566_a(p_208071_1_, p_208071_2_, blockstate, p_208071_3_, p_208071_4_ + 1);
                 } else {
                    return false;
-@@ -255,4 +261,8 @@
+@@ -156,6 +162,10 @@
+             return p_185499_1_.func_206870_a(field_176568_b, RailShape.SOUTH_EAST);
+          case NORTH_EAST:
+             return p_185499_1_.func_206870_a(field_176568_b, RailShape.SOUTH_WEST);
++         //Forge fix: MC-196102
++         case NORTH_SOUTH:
++         case EAST_WEST:
++            return p_185499_1_;
+          }
+       case COUNTERCLOCKWISE_90:
+          switch((RailShape)p_185499_1_.func_177229_b(field_176568_b)) {
+@@ -255,4 +265,8 @@
     protected void func_206840_a(StateContainer.Builder<Block, BlockState> p_206840_1_) {
        p_206840_1_.func_206894_a(field_176568_b, field_176569_M);
     }

--- a/patches/minecraft/net/minecraft/block/RailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/RailBlock.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/block/RailBlock.java
++++ b/net/minecraft/block/RailBlock.java
+@@ -49,6 +49,10 @@
+             return p_185499_1_.func_206870_a(field_176565_b, RailShape.SOUTH_EAST);
+          case NORTH_EAST:
+             return p_185499_1_.func_206870_a(field_176565_b, RailShape.SOUTH_WEST);
++             //Forge fix: MC-196102
++         case NORTH_SOUTH:
++         case EAST_WEST:
++            return p_185499_1_;
+          }
+       case COUNTERCLOCKWISE_90:
+          switch((RailShape)p_185499_1_.func_177229_b(field_176565_b)) {


### PR DESCRIPTION
Vanilla was missing two cases in their switch statement for the rails and powered rails rotation.

This PR adds the remaining two cases to fix the rotation bug.

180 degree rotation for rails will keep the state