### PR TITLE
Add IModBusEvent marker to ModelRegistryEvent

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/ModelRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelRegistryEvent.java
@@ -20,10 +20,11 @@
 package net.minecraftforge.client.event;
 
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.lifecycle.IModBusEvent;
 
 /**
  * Fired when the {@link net.minecraftforge.client.model.ModelLoader} is ready to receive registrations
  */
-public class ModelRegistryEvent extends Event
+public class ModelRegistryEvent extends Event implements IModBusEvent
 {
 }


### PR DESCRIPTION
_This PR fixes #7185._

This PR simply adds the `IModBusEvent` marker to `ModelRegistryEvent`, as the event is fired on the mod event bus.