### PR TITLE
[1.16.x] Add Method for blocks to decide if they solidify concrete powder.

### DIFF
--- a/patches/minecraft/net/minecraft/block/ConcretePowderBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/ConcretePowderBlock.java.patch
@@ -1,0 +1,35 @@
+--- a/net/minecraft/block/ConcretePowderBlock.java
++++ b/net/minecraft/block/ConcretePowderBlock.java
+@@ -34,7 +34,7 @@
+    }
+ 
+    private static boolean func_230137_b_(IBlockReader p_230137_0_, BlockPos p_230137_1_, BlockState p_230137_2_) {
+-      return func_212566_x(p_230137_2_) || func_196441_b(p_230137_0_, p_230137_1_);
++      return causesSolidify(p_230137_2_, null, p_230137_0_, p_230137_1_) || func_196441_b(p_230137_0_, p_230137_1_);
+    }
+ 
+    private static boolean func_196441_b(IBlockReader p_196441_0_, BlockPos p_196441_1_) {
+@@ -43,14 +43,12 @@
+ 
+       for(Direction direction : Direction.values()) {
+          BlockState blockstate = p_196441_0_.func_180495_p(blockpos$mutable);
+-         if (direction != Direction.DOWN || func_212566_x(blockstate)) {
+             blockpos$mutable.func_239622_a_(p_196441_1_, direction);
+             blockstate = p_196441_0_.func_180495_p(blockpos$mutable);
+-            if (func_212566_x(blockstate) && !blockstate.func_224755_d(p_196441_0_, p_196441_1_, direction.func_176734_d())) {
++            if (causesSolidify(blockstate, direction.func_176734_d(), p_196441_0_, blockpos$mutable)) {
+                flag = true;
+                break;
+             }
+-         }
+       }
+ 
+       return flag;
+@@ -59,6 +57,7 @@
+    private static boolean func_212566_x(BlockState p_212566_0_) {
+       return p_212566_0_.func_204520_s().func_206884_a(FluidTags.field_206959_a);
+    }
++   private static boolean causesSolidify(BlockState p_212566_0_, @javax.annotation.Nullable Direction side, IBlockReader world, BlockPos pos) { return p_212566_0_.causesConcretePowderToSolidify(side, world, pos); }
+ 
+    public BlockState func_196271_a(BlockState p_196271_1_, Direction p_196271_2_, BlockState p_196271_3_, IWorld p_196271_4_, BlockPos p_196271_5_, BlockPos p_196271_6_) {
+       return func_196441_b(p_196271_4_, p_196271_5_) ? this.field_200294_a : super.func_196271_a(p_196271_1_, p_196271_2_, p_196271_3_, p_196271_4_, p_196271_5_, p_196271_6_);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -45,6 +45,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShovelItem;
 import net.minecraft.pathfinding.PathNodeType;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
@@ -922,5 +923,19 @@ public interface IForgeBlock
     default boolean isScaffolding(BlockState state, IWorldReader world, BlockPos pos, LivingEntity entity)
     {
         return state.is(Blocks.SCAFFOLDING);
+    }
+
+    /**
+     * Called to determine whether this block causes concrete powder to convert to concrete.
+     * Defaults to the vanilla implementation.
+     * 
+     * @param state The state
+     * @param side The side of this block to determine if it causes concrete powder to convert to concrete, can be null
+     * @param world The world
+     * @param pos The position in the world
+     */
+    default boolean causesConcretePowderToSolidify(BlockState state, @Nullable Direction side, IBlockReader world, BlockPos pos)
+    {
+        return state.getFluidState().isTagged(FluidTags.WATER) && (side == null || (side != Direction.UP && !state.isSolidSide(world, pos, side)));
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -808,4 +808,16 @@ public interface IForgeBlockState
     {
         return getBlockState().getBlock().isScaffolding(getBlockState(), entity.level, entity.blockPosition(), entity);
     }
+
+    /**
+     * Determines whether this state causes concrete powder to convert to concrete
+     *
+     * @param side The side of this state to determine if it causes concrete powder to convert to concrete, can be null
+     * @param world The world
+     * @param pos The position in the world
+     */
+    default boolean causesConcretePowderToSolidify(@Nullable Direction side, IBlockReader world, BlockPos pos)
+    {
+        return getBlockState().getBlock().causesConcretePowderToSolidify(getBlockState(), side, world, pos);
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/block/ConcretePowderConversionTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ConcretePowderConversionTest.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.debug.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(ConcretePowderConversionTest.MOD_ID)
+@Mod.EventBusSubscriber
+public class ConcretePowderConversionTest
+{
+    public static final String MOD_ID = "concrete_powder_conversion_test";
+
+    @Mod.EventBusSubscriber(bus= Mod.EventBusSubscriber.Bus.MOD, modid = MOD_ID)
+    private static class RegistryHandler
+    {
+        @SubscribeEvent
+        public static void registerBlocks(final RegistryEvent.Register<Block> event)
+        {
+            event.getRegistry().register(new TestBlock());
+        }
+    }
+
+    private static class TestBlock extends Block
+    {
+        public TestBlock()
+        {
+            super(Properties.from(Blocks.DIRT));
+            this.setRegistryName(MOD_ID, "test_block");
+        }
+
+        @Override
+        public boolean causesConcretePowderToSolidify(BlockState state, Direction side, IBlockReader world, BlockPos pos)
+        {
+            return true;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -116,3 +116,5 @@ license="LGPL v2.1"
     modId="worldgen_registry_desync_test"
 [[mods]]
     modId="add_entity_attribute_test"
+[[mods]]
+    modId="concrete_powder_conversion_test"

--- a/src/test/resources/assets/concrete_powder_conversion_test/blockstates/test_block.json
+++ b/src/test/resources/assets/concrete_powder_conversion_test/blockstates/test_block.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "minecraft:block/dirt"
+        }
+    }
+} 


### PR DESCRIPTION
Adds a method to `IForgeBlock` and `IForgeBlockState` to allow blocks to decide whether concrete powder should solidify when they are touching on a certain side. Includes parameters for the `BlockState`, `Direction`, `IBlockReader`, and `BlockPos`.
Includes a test mod.