### PR TITLE
Add harvest levels for hoes and new 1.16 blocks for pickaxes

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -74,6 +74,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.AxeItem;
 import net.minecraft.item.BucketItem;
 import net.minecraft.item.EnchantedBookItem;
+import net.minecraft.item.HoeItem;
 import net.minecraft.item.PickaxeItem;
 import net.minecraft.item.PotionItem;
 import net.minecraft.item.ShovelItem;
@@ -219,9 +220,12 @@ public class ForgeHooks
         //TODO Axes check Material and Blocks now.
         blocks = getPrivateValue(AxeItem.class, null, 1);
         blocks.forEach(block -> blockToolSetter.accept(block, ToolType.AXE, 0));
+        blocks = getPrivateValue(HoeItem.class, null, 0);
+        blocks.forEach(block -> blockToolSetter.accept(block, ToolType.HOE, 0));
 
-        //This is taken from ItemAxe, if that changes update here.
-        blockToolSetter.accept(Blocks.OBSIDIAN, ToolType.PICKAXE, 3);
+        //This is taken from PickaxeItem, if that changes update here.
+        for (Block block : new Block[]{Blocks.OBSIDIAN, Blocks.field_235399_ni_, Blocks.field_235397_ng_, Blocks.field_235400_nj_, Blocks.field_235398_nh_})
+            blockToolSetter.accept(block, ToolType.PICKAXE, 3);
         for (Block block : new Block[]{Blocks.DIAMOND_BLOCK, Blocks.DIAMOND_ORE, Blocks.EMERALD_ORE, Blocks.EMERALD_BLOCK, Blocks.GOLD_BLOCK, Blocks.GOLD_ORE, Blocks.REDSTONE_ORE})
             blockToolSetter.accept(block, ToolType.PICKAXE, 2);
         for (Block block : new Block[]{Blocks.IRON_BLOCK, Blocks.IRON_ORE, Blocks.LAPIS_BLOCK, Blocks.LAPIS_ORE})


### PR DESCRIPTION
_This PR fixes #7187._

1.16 gave hoes the ability to break blocks such as leaves and netherwart blocks. 1.16 also added new blocks to be broken by a pickaxe with the appropriate harvest level (ex. crying obsidian for diamond pickaxes).

Because Forge overrides `PickaxeItem` to add support for `ToolType`s, the list of pickaxe-effective blocks for harvest level 3 (diamond) in `ForgeHooks.initTools()` is outdated, having none of the new 1.16 blocks. Furthermore, there is no appropriate code in adding the harvest tool and level of blocks affected by `HoeItem`.

This PR modifies the `ForgeHooks` class to:
  * Add the necessary logic to get the effective blocks list for `HoeItem`, and setting those block's effective harvest tool and level;
  * Add the new 1.16 blocks to the list of blocks affected by pickaxes with harvest level 3 and above;
  * Change the comment from `ItemAxe` to `PickaxeItem`.