### PR TITLE
[1.16] Add constructor of ClientWorld for rendering purposes

### DIFF
--- a/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
@@ -62,3 +62,10 @@
        if (p_217384_1_ == this.field_73037_M.field_71439_g) {
           this.field_73037_M.func_147118_V().func_147682_a(new EntityTickableSound(p_217384_3_, p_217384_4_, p_217384_2_));
        }
+@@ -872,4 +889,6 @@
+          return this.field_239146_c_ ? 1.0D : 0.03125D;
+       }
+    }
++   @Deprecated // Only use for "fake" world rendering purposes, warning: some methods may cause NPE when using this constructor
++   protected ClientWorld() { super(); this.field_73035_a = null; this.field_217430_d = null; this.field_239130_d_ = null; this.field_239131_x_ = null; this.field_239129_E_ = null; }
+ }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -385,21 +385,43 @@
                    blockstate.func_215697_a(this, blockpos, p_175666_2_, p_175666_1_, false);
                 }
              }
-@@ -1075,6 +1137,18 @@
+@@ -1075,6 +1137,40 @@
        return this.field_226689_w_;
     }
  
++   /* ==== FORGE START ==== */
++
 +   private double maxEntityRadius = 2.0D;
++
 +   @Override
 +   public double getMaxEntityRadius() {
 +      return maxEntityRadius;
 +   }
++
 +   @Override
 +   public double increaseMaxEntityRadius(double value) {
 +      if (value > maxEntityRadius)
 +         maxEntityRadius = value;
 +      return maxEntityRadius;
 +   }
++
++   @Deprecated // used in ClientWorld for rendering purposes
++   protected World()
++   {
++      super(World.class);
++      this.field_217407_c = null;
++      this.field_234916_c_ = true;
++      this.field_234921_x_ = null;
++      this.field_72986_A = null;
++      this.field_72984_F = null;
++      this.field_72995_K = true;
++      this.field_175728_M = null;
++      this.field_226689_w_ = null;
++      this.field_73011_w = null;
++      this.field_234915_C_ = null;
++   }
++
++   /* ==== FORGE END ==== */
 +
     public final boolean func_234925_Z_() {
        return this.field_234916_c_;


### PR DESCRIPTION
This pr is follow up of #7225.

Situation prior 1.16: our mod is rendering template previews - for that you need to have fake World instance with few overrides so it works the same as normal World rendering, extending World class was sufficient and World constructor does not trigger any special things

Situation in 1.16: extending World class is no longer sufficient (see attached picture), we need to extend ClientWorld class which constructor trigger WorldLoad event (you definitely don't want to trigger it just for rendering purposes)

Solution: I've added two protected constructors to allow no-init of ClientWorld and World class for rendering purposes. Both of these constructors are setting null wherever possible, users are asked to override methods causing NPEs - my idea for this PR was also to create somewhat template classes (extending ClientWorld and Chunk) which would override necessary methods and provide somewhat documentation over what you should do when trying to render previews using vanilla World rendering pipeline <- just ask me to do that if you think it's a good idea

I would like to provide a test mod once #7225 will be merged.

Picture showing the problematic method
![](https://user-images.githubusercontent.com/17338378/88839393-49894f80-d1db-11ea-8949-dae13b4273d9.png)
