### PR TITLE
Fix modproperties property in mods.toml causing exception

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -75,8 +75,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
             .orElseThrow(()->new InvalidModFileException("Missing License, please supply a license.", this));
          */
         this.showAsResourcePack = config.<Boolean>getConfigElement("showAsResourcePack").orElse(false);
-        this.properties = config.<UnmodifiableConfig>getConfigElement("properties").
-                map(UnmodifiableConfig::valueMap).orElse(Collections.emptyMap());
+        this.properties = config.<Map<String, Object>>getConfigElement("properties").orElse(Collections.emptyMap());
         this.modFile.setFileProperties(this.properties);
         this.issueURL = config.<String>getConfigElement("issueTrackerURL").map(StringUtils::toURL).orElse(null);
         final List<? extends IConfigurable> modConfigs = config.getConfigList("mods");

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
@@ -45,8 +45,14 @@ public class NightConfigWrapper implements IConfigurable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> Optional<T> getConfigElement(final String... key) {
-        return this.config.getOptional(asList(key));
+        return this.config.getOptional(asList(key)).map(value -> {
+            if (value instanceof UnmodifiableConfig) {
+                return (T) ((UnmodifiableConfig) value).valueMap();
+            }
+            return (T) value;
+        });
     }
 
     @Override


### PR DESCRIPTION
There is a little known and undocumented property in `mods.toml`: the `modproperties` property. It allows modders to add custom data to their `IModInfo`, accessible through `IModInfo#getModProperties`, which returns a `Map<String, Object>`.

A commit was made to both [Forge][mcforgecommit] and [ForgeSPI][forgespicommit] that modified how modfiles were loaded, changing, among other things, how the `modproperties` property was loaded. This change causes a `java.lang.ClassCastException: com.electronwill.nightconfig.core.SimpleCommentedConfig cannot be cast to java.util.Map` on line 99 of `ModInfo`.

The exact same problem also will occur on line 79 of `ModFileInfo`, for the (also little known and undocumented) `properties` property, which exists for adding custom data to the `IModFileInfo` (the `mods.toml` for Forge), accessible through `IModFileInfo#getFileProperties`, which also returns a `Map<String, Object>`.

The only reason that this crash was discovered and this PR was created is because [JTK222 asked for help on Discord][discordconvo] regarding this property, which worked fine before on their 1.15 workspace but crashes on 1.16, and the underlying issue was found: a missing call to `UnmodifiableConfig#valueMap` to convert it from `UnmodifiableConfig` to a `Map<String, Object>`.

This PR adds the aforemetioned method to the `Optional` call chains of both `modproperties` and `properties`, fixing the issue. I have tested this fix locally on my machine with the `modproperties` values given in the Discord conversation.

[mcforgecommit]: https://github.com/MinecraftForge/MinecraftForge/commit/20f78ac724164110d80c30a19473ee0bc1d2ecc1
[forgespicommit]: https://github.com/MinecraftForge/ForgeSPI/commit/d73b00cc9e868d99951c7dd22d73dbc310b400b7
[discordconvo]: https://discordapp.com/channels/313125603924639766/725850371834118214/738138530445918298