### PR TITLE
[1.15.x] Fix modproperties in mods.toml causing exception

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -62,8 +62,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
                 map(MavenVersionAdapter::createFromVersionSpec).
                 orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
         this.showAsResourcePack = config.<Boolean>getConfigElement("showAsResourcePack").orElse(false);
-        this.properties = config.<UnmodifiableConfig>getConfigElement("properties").
-                map(UnmodifiableConfig::valueMap).orElse(Collections.emptyMap());
+        this.properties = config.<Map<String, Object>>getConfigElement("properties").orElse(Collections.emptyMap());
         this.modFile.setFileProperties(this.properties);
         this.issueURL = config.<String>getConfigElement("issueTrackerURL").map(StringUtils::toURL).orElse(null);
         final List<? extends IConfigurable> modConfigs = config.getConfigList("mods");

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
@@ -26,8 +26,14 @@ public class NightConfigWrapper implements IConfigurable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> Optional<T> getConfigElement(final String... key) {
-        return this.config.getOptional(asList(key));
+        return this.config.getOptional(asList(key)).map(value -> {
+            if (value instanceof UnmodifiableConfig) {
+                return (T) ((UnmodifiableConfig) value).valueMap();
+            }
+            return (T) value;
+        });
     }
 
     @Override


### PR DESCRIPTION
_This PR is a LTS backport of #7192._

See the main PR for details of the issue and the fix.
_TL;DR:_ `modproperties` property in `mods.toml` allows custom data. [A commit][forgecommit] during 1.15 made use of the property throw a `ClassCastException`. Only reason crash was discovered was because someone [asked for help on Discord][discordconvo], which led to the root cause of the commit. This PR adds the missing `Optional`-chained call to `UnmodifiableConfig#valueMap`.

[forgecommit]: https://github.com/MinecraftForge/MinecraftForge/commit/20f78ac724164110d80c30a19473ee0bc1d2ecc1
[discordconvo]: https://discordapp.com/channels/313125603924639766/725850371834118214/738138530445918298