### PR TITLE
Added Xdoclint:none to javadoc task (browser docs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1546,3 +1546,13 @@ task setup() {
 }
 
 
+allprojects {
+    repositories {
+        jcenter()
+    }
+    gradle.projectsEvaluated {
+        tasks.withType(Javadoc) {
+            options.addStringOption("Xdoclint:none","-quiet")
+        }
+    }
+}


### PR DESCRIPTION
It's useful to be able to have documentation in browser so you can see an overview of things outside of your IDE.
This change allows you to compile them without all the "reference not found" errors etc.