### PR TITLE
[1.16.x] Fixed custom models ignoring "gui_light" model tag

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
@@ -105,8 +105,9 @@ public class BlockModelConfiguration implements IModelConfiguration
     }
 
     @Override
-    public boolean isShadedInGui() {
-        return true;
+    public boolean isShadedInGui()
+    {
+        return owner.func_230176_c_().func_230178_a_();
     }
 
     @Override


### PR DESCRIPTION
Custom models always used "SIDE" gui light completely ignoring "gui_light" model tag.
Before:
![image](https://user-images.githubusercontent.com/6237881/89072693-b76f7b80-d381-11ea-9401-766b46043975.png)
After:
![image](https://user-images.githubusercontent.com/6237881/89072810-f30a4580-d381-11ea-8030-91747319ba88.png)

