### PR TITLE
[1.15.x] Fixed custom models ignoring "gui_light" model tag

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
@@ -105,8 +105,9 @@ public class BlockModelConfiguration implements IModelConfiguration
     }
 
     @Override
-    public boolean isShadedInGui() {
-        return true;
+    public boolean isShadedInGui()
+    {
+        return owner.func_230176_c_().func_230178_a_();
     }
 
     @Override


### PR DESCRIPTION
Same as https://github.com/MinecraftForge/MinecraftForge/pull/7199 but for 1.15.x