### PR TITLE
Make baking of blockstate-id map reentrant

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -462,6 +462,8 @@ public class GameData
             @SuppressWarnings("unchecked")
             ClearableObjectIntIdentityMap<BlockState> blockstateMap = owner.getSlaveMap(BLOCKSTATE_TO_ID, ClearableObjectIntIdentityMap.class);
 
+            // onBake must be re-entrant as it may be called multiple times in a row without onCreate in between
+            blockstateMap.clear();
             for (Block block : owner)
             {
                 for (BlockState state : block.getStateContainer().getValidStates())


### PR DESCRIPTION
Fixes issues with "Open to LAN" if a resource pack is included in the world. A world resourcepack will cause bake to be called again due to reloading of resources.
This will cause the BlockState-ID map to become completely messed up, as it now contains every state twice. Someone joining the LAN world will see a completely empty map, as they receive completely wrong state IDs. For some reason it still seems to work locally.

To reproduce this issue create a world with a world resourcepack (must be called `resources.zip` in the world folder). Open the world to LAN and join with a 2nd game instance.