### PR TITLE
[1.16] Fix possible crash when using rendering regionCache

### DIFF
--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -116,7 +116,7 @@ public class MinecraftForgeClient
         if (cache == null)
             regionCache.invalidate(Pair.of(world, position));
         else
-            regionCache.put(Pair.of(world, position), Optional.ofNullable(cache));
+            regionCache.put(Pair.of(world, position), Optional.of(cache));
     }
 
     public static ChunkRenderCache getRegionRenderCache(World world, BlockPos pos)

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.client.renderer.RenderType;
 import org.apache.commons.lang3.tuple.Pair;
@@ -119,6 +120,7 @@ public class MinecraftForgeClient
             regionCache.put(Pair.of(world, position), Optional.of(cache));
     }
 
+    @Nullable
     public static ChunkRenderCache getRegionRenderCache(World world, BlockPos pos)
     {
         return getRegionRenderCacheOptional(world, pos).orElse(null);

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -97,16 +98,16 @@ public class MinecraftForgeClient
         }
     }
 
-    private static final LoadingCache<Pair<World, BlockPos>, ChunkRenderCache> regionCache = CacheBuilder.newBuilder()
+    private static final LoadingCache<Pair<World, BlockPos>, Optional<ChunkRenderCache>> regionCache = CacheBuilder.newBuilder()
         .maximumSize(500)
         .concurrencyLevel(5)
         .expireAfterAccess(1, TimeUnit.SECONDS)
-        .build(new CacheLoader<Pair<World, BlockPos>, ChunkRenderCache>()
+        .build(new CacheLoader<Pair<World, BlockPos>, Optional<ChunkRenderCache>>()
         {
             @Override
-            public ChunkRenderCache load(Pair<World, BlockPos> key)
+            public Optional<ChunkRenderCache> load(Pair<World, BlockPos> key)
             {
-                return ChunkRenderCache.generateCache(key.getLeft(), key.getRight().add(-1, -1, -1), key.getRight().add(16, 16, 16), 1);
+                return Optional.ofNullable(ChunkRenderCache.generateCache(key.getLeft(), key.getRight().add(-1, -1, -1), key.getRight().add(16, 16, 16), 1));
             }
         });
 
@@ -115,10 +116,10 @@ public class MinecraftForgeClient
         if (cache == null)
             regionCache.invalidate(Pair.of(world, position));
         else
-            regionCache.put(Pair.of(world, position), cache);
+            regionCache.put(Pair.of(world, position), Optional.ofNullable(cache));
     }
 
-    public static ChunkRenderCache getRegionRenderCache(World world, BlockPos pos)
+    public static Optional<ChunkRenderCache> getRegionRenderCache(World world, BlockPos pos)
     {
         int x = pos.getX() & ~0xF;
         int y = pos.getY() & ~0xF;

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -119,7 +119,12 @@ public class MinecraftForgeClient
             regionCache.put(Pair.of(world, position), Optional.ofNullable(cache));
     }
 
-    public static Optional<ChunkRenderCache> getRegionRenderCache(World world, BlockPos pos)
+    public static ChunkRenderCache getRegionRenderCache(World world, BlockPos pos)
+    {
+        return getRegionRenderCacheOptional(world, pos).orElse(null);
+    }
+
+    public static Optional<ChunkRenderCache> getRegionRenderCacheOptional(World world, BlockPos pos)
     {
         int x = pos.getX() & ~0xF;
         int y = pos.getY() & ~0xF;

--- a/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
@@ -66,7 +66,8 @@ public class TileEntityRendererAnimation<T extends TileEntity> extends TileEntit
         }
         if(blockRenderer == null) blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
         BlockPos pos = te.getPos();
-        IBlockDisplayReader world = MinecraftForgeClient.getRegionRenderCache(te.getWorld(), pos);
+        IBlockDisplayReader world = MinecraftForgeClient.getRegionRenderCache(te.getWorld(), pos)
+            .map(IBlockDisplayReader.class::cast).orElseGet(() -> te.getWorld());
         BlockState state = world.getBlockState(pos);
         IBakedModel model = blockRenderer.getBlockModelShapes().getModel(state);
         IModelData data = model.getModelData(world, pos, state, ModelDataManager.getModelData(te.getWorld(), pos));

--- a/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
@@ -66,7 +66,7 @@ public class TileEntityRendererAnimation<T extends TileEntity> extends TileEntit
         }
         if(blockRenderer == null) blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
         BlockPos pos = te.getPos();
-        IBlockDisplayReader world = MinecraftForgeClient.getRegionRenderCache(te.getWorld(), pos)
+        IBlockDisplayReader world = MinecraftForgeClient.getRegionRenderCacheOptional(te.getWorld(), pos)
             .map(IBlockDisplayReader.class::cast).orElseGet(() -> te.getWorld());
         BlockState state = world.getBlockState(pos);
         IBakedModel model = blockRenderer.getBlockModelShapes().getModel(state);


### PR DESCRIPTION
Fixes #7197 using Optional as cache value wrapper

[This](https://github.com/MinecraftForge/MinecraftForge/pull/7207/files#diff-6b2a01e94e48c3cec54af7d282a1abd0L116) may be null when a chunk is completely empty (air blocks only)