### PR TITLE
Fix RenderTickEvent using wrong partial ticks value when game is paused

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -152,13 +152,13 @@
        RenderSystem.enableCull();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
-+         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickStart(this.field_71428_T.field_194147_b);
++         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickStart(this.field_71445_n ? this.field_193996_ah : this.field_71428_T.field_194147_b);
           this.field_71424_I.func_219895_b("gameRenderer");
           this.field_71460_t.func_195458_a(this.field_71445_n ? this.field_193996_ah : this.field_71428_T.field_194147_b, i, p_195542_1_);
           this.field_71424_I.func_219895_b("toasts");
           this.field_193034_aS.func_238541_a_(new MatrixStack());
           this.field_71424_I.func_76319_b();
-+         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickEnd(this.field_71428_T.field_194147_b);
++         net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickEnd(this.field_71445_n ? this.field_193996_ah : this.field_71428_T.field_194147_b);
        }
  
        if (this.field_238174_aV_ != null) {


### PR DESCRIPTION
_This PR fixes #6991._

During normal gameplay, the `renderPartialTicks` from the game's `Timer` instance is used for smoothly rendering between ticks. However, as described in the linked issue, when the game is paused, the `renderPartialTicksPaused` is used instead when rendering to prevent jittering.

Everything works normally in Minecraft rendering and most custom Forge-provided rendering events, as they use the `partialTicks` parameter passed to `GameRenderer#updateCameraAndRender`. 
However, the `RenderTickEvent` posted by Forge does not use `renderPartialTicksPaused` when the game is paused, but always uses `renderPartialTicks`. This causes the jittering, because `renderPartialTicks` still increments event when paused _(`renderPartialTicksPaused` is set to the last `renderPartialTicks` before pausing)_.

This PR replicates the ternary operation used in `GameRenderer#updateCameraAndRender` to the calls that post `RenderTickEvent`.

**Snippet of the lines of code causing the issue**
```java
// Minecraft.java, commit 8f9e52c26030e1033e66517271131c02dcb5e02f, L948-956
if (!this.skipRenderWorld) {
   net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickStart(this.timer.renderPartialTicks);
   this.profiler.endStartSection("gameRenderer");
   this.gameRenderer.updateCameraAndRender(this.isGamePaused ? this.renderPartialTicksPaused : this.timer.renderPartialTicks, i, renderWorldIn);
   this.profiler.endStartSection("toasts");
   this.toastGui.func_238541_a_(new MatrixStack());
   this.profiler.endSection();
   net.minecraftforge.fml.hooks.BasicEventHooks.onRenderTickEnd(this.timer.renderPartialTicks);
}
```