### PR TITLE
Add info about server list warning

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -92,8 +92,16 @@ public class ClientHooks
             boolean fmlNetMatches = fmlver == FMLNetworkConstants.FMLNETVERSION;
             boolean channelsMatch = NetworkRegistry.checkListPingCompatibilityForClient(remoteChannels);
             AtomicBoolean result = new AtomicBoolean(true);
-            ModList.get().forEachModContainer((modid, mc)-> mc.getCustomExtension(ExtensionPoint.DISPLAYTEST).ifPresent(ext->
-                    result.compareAndSet(true, ext.getRight().test(mods.get(modid), true))));
+            final List<String> extraClientMods = new ArrayList<>();
+            ModList.get().forEachModContainer((modid, mc) ->
+                    mc.getCustomExtension(ExtensionPoint.DISPLAYTEST).ifPresent(ext-> {
+                        boolean foundModOnServer = ext.getRight().test(mods.get(modid), true);
+                        result.compareAndSet(true, foundModOnServer);
+                        if (!foundModOnServer) {
+                            extraClientMods.add(modid);
+                        }
+                    })
+            );
             boolean modsMatch = result.get();
 
             final Map<String, String> extraServerMods = mods.entrySet().stream().
@@ -107,9 +115,13 @@ public class ClientHooks
 
             if (!extraServerMods.isEmpty()) {
                 extraReason = "fml.menu.multiplayer.extraservermods";
+                LOGGER.info(CLIENTHOOKS, ForgeI18n.parseMessage(extraReason) + ": {}", extraServerMods.entrySet().stream()
+                        .map(e -> e.getKey() + "@" + e.getValue())
+                        .collect(Collectors.joining(", ")));
             }
             if (!modsMatch) {
                 extraReason = "fml.menu.multiplayer.modsincompatible";
+                LOGGER.info(CLIENTHOOKS, "Client has mods that are missing on server: {}", extraClientMods);
             }
             if (!channelsMatch) {
                 extraReason = "fml.menu.multiplayer.networkincompatible";


### PR DESCRIPTION
Make it easier to figure out what mods are missing or have to
be marked as client/server side only.

Matches the existing warning for mismatched warning for channel lists, a similar log message could also be found in Forge prior to 1.13.

Some issues I found with this patch:
https://github.com/FTBTeam/FTB-Ranks/commit/9ffa6d89948e306ee02f929480144e316d83b888
https://github.com/mezz/ModNameTooltip/issues/16
https://github.com/ldtteam/DynView/issues/8
https://github.com/Shadows-of-Fire/PackMenu/issues/15
https://github.com/YaLTeR/MouseTweaks/issues/34
https://github.com/iChun/Ding/issues/7
https://github.com/TeamJM/journeymap/issues/256