### PR TITLE
[1.15.2] Fix misaligned patch for ServerWorld#updateEntity

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -143,17 +143,18 @@
           i += this.field_73012_v.nextInt(8) - this.field_73012_v.nextInt(8);
           j += this.field_73012_v.nextInt(8) - this.field_73012_v.nextInt(8);
           ++k;
-@@ -584,8 +593,9 @@
+@@ -584,9 +593,10 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
 -               return Registry.field_212629_r.func_177774_c(p_217479_1_.func_200600_R()).toString();
 +               return p_217479_1_.func_200600_R().getRegistryName() == null ? p_217479_1_.func_200600_R().toString() : p_217479_1_.func_200600_R().getRegistryName().toString();
              });
-+            if (p_217479_1_.canUpdate())
              iprofiler.func_230035_c_("tickNonPassenger");
++            if (p_217479_1_.canUpdate())
              p_217479_1_.func_70071_h_();
              iprofiler.func_76319_b();
+          }
 @@ -652,6 +662,11 @@
     }
  


### PR DESCRIPTION
_This PR fixes #6516._

As the title says; a misaligned patch for `ServerWorld#updateEntity` makes the `Entity#canUpdate` variable and method useless, as the `if` statement only affects the call to `IProfiler`.

This PR simply moves the `if` statement down to affect the `Entity#tick` method instead. _(or, depending on your viewpoint, moves the call to `IProfiler` up to not be affected by the `if`)_