### PR TITLE
Allow to connect using TLS and TLS with SNI

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screen/AddServerScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/AddServerScreen.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/client/gui/screen/AddServerScreen.java
++++ b/net/minecraft/client/gui/screen/AddServerScreen.java
+@@ -24,6 +24,7 @@
+    private TextFieldWidget field_146308_f;
+    private TextFieldWidget field_146309_g;
+    private Button field_152176_i;
++   private Button buttonTlsMode;
+    private final Screen field_228179_g_;
+    private final Predicate<String> field_181032_r = (p_210141_0_) -> {
+       if (StringUtils.func_151246_b(p_210141_0_)) {
+@@ -72,10 +73,14 @@
+          this.field_146311_h.func_152584_a(ServerData.ServerResourceMode.values()[(this.field_146311_h.func_152586_b().ordinal() + 1) % ServerData.ServerResourceMode.values().length]);
+          this.field_152176_i.func_238482_a_(func_238624_a_(this.field_146311_h.func_152586_b()));
+       }));
+-      this.field_195179_a = this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, this.field_230709_l_ / 4 + 96 + 18, 200, 20, new TranslationTextComponent("addServer.add"), (p_213030_1_) -> {
++      this.buttonTlsMode = this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, this.field_230709_l_ / 4 + 96, 200, 20, getForTlsMode(this.field_146311_h.getTlsMode()), (mode) -> {
++         this.field_146311_h.setTlsMode(ServerData.TlsMode.values()[(this.field_146311_h.getTlsMode().ordinal() + 1) % ServerData.TlsMode.values().length]);
++         this.buttonTlsMode.func_238482_a_(getForTlsMode(this.field_146311_h.getTlsMode()));
++      }));
++      this.field_195179_a = this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, this.field_230709_l_ / 4 + 120, 200, 20, new TranslationTextComponent("addServer.add"), (p_213030_1_) -> {
+          this.func_195172_h();
+       }));
+-      this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, this.field_230709_l_ / 4 + 120 + 18, 200, 20, DialogTexts.field_240633_d_, (p_213029_1_) -> {
++      this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, this.field_230709_l_ / 4 + 144, 200, 20, DialogTexts.field_240633_d_, (p_213029_1_) -> {
+          this.field_213032_b.accept(false);
+       }));
+       this.func_228180_b_();
+@@ -85,6 +90,10 @@
+       return (new TranslationTextComponent("addServer.resourcePack")).func_240702_b_(": ").func_230529_a_(p_238624_0_.func_152589_a());
+    }
+ 
++   private static ITextComponent getForTlsMode(ServerData.TlsMode tlsMode) {
++      return (new TranslationTextComponent("addServer.tls")).func_240702_b_(": ").func_230529_a_(tlsMode.getMotd());
++   }
++
+    public void func_231152_a_(Minecraft p_231152_1_, int p_231152_2_, int p_231152_3_) {
+       String s = this.field_146308_f.func_146179_b();
+       String s1 = this.field_146309_g.func_146179_b();

--- a/patches/minecraft/net/minecraft/client/gui/screen/ConnectingScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/ConnectingScreen.java.patch
@@ -1,0 +1,51 @@
+--- a/net/minecraft/client/gui/screen/ConnectingScreen.java
++++ b/net/minecraft/client/gui/screen/ConnectingScreen.java
+@@ -41,7 +41,7 @@
+       ServerAddress serveraddress = ServerAddress.func_78860_a(p_i1181_3_.field_78845_b);
+       p_i1181_2_.func_213254_o();
+       p_i1181_2_.func_71351_a(p_i1181_3_);
+-      this.func_146367_a(serveraddress.func_78861_a(), serveraddress.func_78864_b());
++      this.connect(serveraddress.func_78861_a(), serveraddress.func_78864_b(), p_i1181_3_.tlsMode);
+    }
+ 
+    public ConnectingScreen(Screen p_i1182_1_, Minecraft p_i1182_2_, String p_i1182_3_, int p_i1182_4_) {
+@@ -49,11 +49,11 @@
+       this.field_230706_i_ = p_i1182_2_;
+       this.field_146374_i = p_i1182_1_;
+       p_i1182_2_.func_213254_o();
+-      this.func_146367_a(p_i1182_3_, p_i1182_4_);
++      this.connect(p_i1182_3_, p_i1182_4_, ServerData.TlsMode.DISABLED);
+    }
+ 
+-   private void func_146367_a(final String p_146367_1_, final int p_146367_2_) {
+-      field_146370_f.info("Connecting to {}, {}", p_146367_1_, p_146367_2_);
++   private void connect(final String ip, final int port, final ServerData.TlsMode tlsMode) {
++      field_146370_f.info("Connecting to {}, {}, tls={}", ip, port, tlsMode);
+       Thread thread = new Thread("Server Connector #" + field_146372_a.incrementAndGet()) {
+          public void run() {
+             InetAddress inetaddress = null;
+@@ -63,12 +63,12 @@
+                   return;
+                }
+ 
+-               inetaddress = InetAddress.getByName(p_146367_1_);
+-               ConnectingScreen.this.field_146371_g = NetworkManager.func_181124_a(inetaddress, p_146367_2_, ConnectingScreen.this.field_230706_i_.field_71474_y.func_181148_f());
++               inetaddress = InetAddress.getByName(ip);
++               ConnectingScreen.this.field_146371_g = NetworkManager.createNetworkManagerAndConnect(inetaddress, ip, port, ConnectingScreen.this.field_230706_i_.field_71474_y.func_181148_f(), tlsMode);
+                ConnectingScreen.this.field_146371_g.func_150719_a(new ClientLoginNetHandler(ConnectingScreen.this.field_146371_g, ConnectingScreen.this.field_230706_i_, ConnectingScreen.this.field_146374_i, (p_209549_1_) -> {
+                   ConnectingScreen.this.func_209514_a(p_209549_1_);
+                }));
+-               ConnectingScreen.this.field_146371_g.func_179290_a(new CHandshakePacket(p_146367_1_, p_146367_2_, ProtocolType.LOGIN));
++               ConnectingScreen.this.field_146371_g.func_179290_a(new CHandshakePacket(ip, port, ProtocolType.LOGIN));
+                ConnectingScreen.this.field_146371_g.func_179290_a(new CLoginStartPacket(ConnectingScreen.this.field_230706_i_.func_110432_I().func_148256_e()));
+             } catch (UnknownHostException unknownhostexception) {
+                if (ConnectingScreen.this.field_146373_h) {
+@@ -85,7 +85,7 @@
+                }
+ 
+                ConnectingScreen.field_146370_f.error("Couldn't connect to server", (Throwable)exception);
+-               String s = inetaddress == null ? exception.toString() : exception.toString().replaceAll(inetaddress + ":" + p_146367_2_, "");
++               String s = inetaddress == null ? exception.toString() : exception.toString().replaceAll(inetaddress + ":" + port, "");
+                ConnectingScreen.this.field_230706_i_.execute(() -> {
+                   ConnectingScreen.this.field_230706_i_.func_147108_a(new DisconnectedScreen(ConnectingScreen.this.field_146374_i, "connect.failed", new TranslationTextComponent("disconnect.genericReason", s)));
+                });

--- a/patches/minecraft/net/minecraft/client/multiplayer/ServerData.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ServerData.java.patch
@@ -1,10 +1,80 @@
 --- a/net/minecraft/client/multiplayer/ServerData.java
 +++ b/net/minecraft/client/multiplayer/ServerData.java
-@@ -26,6 +26,7 @@
+@@ -26,6 +26,8 @@
     @Nullable
     private String field_147411_m;
     private boolean field_181042_l;
 +   public net.minecraftforge.fml.client.ExtendedServerListData forgeData = null;
++   public TlsMode tlsMode = TlsMode.DISABLED;
  
     public ServerData(String p_i46420_1_, String p_i46420_2_, boolean p_i46420_3_) {
        this.field_78847_a = p_i46420_1_;
+@@ -47,6 +49,8 @@
+          compoundnbt.func_74757_a("acceptTextures", false);
+       }
+ 
++      compoundnbt.func_74778_a("tlsMode", this.tlsMode.name());
++
+       return compoundnbt;
+    }
+ 
+@@ -74,6 +78,14 @@
+          serverdata.func_152584_a(ServerData.ServerResourceMode.PROMPT);
+       }
+ 
++      String tlsMode = p_78837_0_.func_74779_i("tlsMode");
++      if (!tlsMode.isEmpty()) {
++         try {
++            serverdata.tlsMode = TlsMode.valueOf(tlsMode);
++         } catch(Exception e) {
++            serverdata.tlsMode = TlsMode.DISABLED;
++         }
++      }
+       return serverdata;
+    }
+ 
+@@ -90,12 +102,21 @@
+       return this.field_181042_l;
+    }
+ 
++   public void setTlsMode(TlsMode tlsMode) {
++      this.tlsMode = tlsMode;
++   }
++
++   public TlsMode getTlsMode() {
++      return this.tlsMode;
++   }
++
+    public void func_152583_a(ServerData p_152583_1_) {
+       this.field_78845_b = p_152583_1_.field_78845_b;
+       this.field_78847_a = p_152583_1_.field_78847_a;
+       this.func_152584_a(p_152583_1_.func_152586_b());
+       this.field_147411_m = p_152583_1_.field_147411_m;
+       this.field_181042_l = p_152583_1_.field_181042_l;
++      this.tlsMode = p_152583_1_.tlsMode;
+    }
+ 
+    @OnlyIn(Dist.CLIENT)
+@@ -114,4 +135,22 @@
+          return this.field_152594_d;
+       }
+    }
++
++   @OnlyIn(Dist.CLIENT)
++   public static enum TlsMode {
++      DISABLED("disabled"),
++      ENABLED("enabled"),
++      ENABLED_INSECURE("enabledInsecure");
++
++      private final ITextComponent motd;
++
++      private TlsMode(String name) {
++         this.motd = new TranslationTextComponent("addServer.tls." + name);
++      }
++
++      public ITextComponent getMotd() {
++         return this.motd;
++      }
++   }
++
+ }

--- a/patches/minecraft/net/minecraft/client/network/ServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/ServerPinger.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/network/ServerPinger.java
 +++ b/net/minecraft/client/network/ServerPinger.java
+@@ -53,7 +53,7 @@
+ 
+    public void func_147224_a(final ServerData p_147224_1_, final Runnable p_147224_2_) throws UnknownHostException {
+       ServerAddress serveraddress = ServerAddress.func_78860_a(p_147224_1_.field_78845_b);
+-      final NetworkManager networkmanager = NetworkManager.func_181124_a(InetAddress.getByName(serveraddress.func_78861_a()), serveraddress.func_78864_b(), false);
++      final NetworkManager networkmanager = NetworkManager.createNetworkManagerAndConnect(InetAddress.getByName(serveraddress.func_78861_a()), serveraddress.func_78861_a(), serveraddress.func_78864_b(), false, p_147224_1_.tlsMode);
+       this.field_147229_c.add(networkmanager);
+       p_147224_1_.field_78843_d = new TranslationTextComponent("multiplayer.status.pinging");
+       p_147224_1_.field_78844_e = -1L;
 @@ -116,6 +116,7 @@
                    p_147224_2_.run();
                 }

--- a/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
@@ -25,25 +25,70 @@
        }
  
        if (this.field_150746_k.eventLoop().inEventLoop()) {
-@@ -255,7 +257,9 @@
+@@ -255,10 +257,17 @@
  
     @OnlyIn(Dist.CLIENT)
     public static NetworkManager func_181124_a(InetAddress p_181124_0_, int p_181124_1_, boolean p_181124_2_) {
-+      if (p_181124_0_ instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
++      return createNetworkManagerAndConnect(p_181124_0_, null, p_181124_1_, p_181124_2_, net.minecraft.client.multiplayer.ServerData.TlsMode.DISABLED);
++   }
++
++   @OnlyIn(Dist.CLIENT)
++   public static NetworkManager createNetworkManagerAndConnect(InetAddress address, @Nullable String sniHost, int serverPort, boolean useNativeTransport, net.minecraft.client.multiplayer.ServerData.TlsMode tlsMode) {
++      if (address instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
        final NetworkManager networkmanager = new NetworkManager(PacketDirection.CLIENTBOUND);
 +      networkmanager.activationHandler = net.minecraftforge.fml.network.NetworkHooks::registerClientLoginChannel;
        Class<? extends SocketChannel> oclass;
        LazyValue<? extends EventLoopGroup> lazyvalue;
-       if (Epoll.isAvailable() && p_181124_2_) {
-@@ -282,6 +286,7 @@
+-      if (Epoll.isAvailable() && p_181124_2_) {
++      if (Epoll.isAvailable() && useNativeTransport) {
+          oclass = EpollSocketChannel.class;
+          lazyvalue = field_181125_e;
+       } else {
+@@ -272,16 +281,41 @@
+                p_initChannel_1_.config().setOption(ChannelOption.TCP_NODELAY, true);
+             } catch (ChannelException channelexception) {
+             }
+-
++            if (tlsMode != net.minecraft.client.multiplayer.ServerData.TlsMode.DISABLED) {
++               field_150735_g.info("Enabling SSL support");
++               p_initChannel_1_.pipeline().addLast("ssl", createSslHandler(p_initChannel_1_, tlsMode, sniHost, serverPort));
++            }
+             p_initChannel_1_.pipeline().addLast("timeout", new ReadTimeoutHandler(30)).addLast("splitter", new NettyVarint21FrameDecoder()).addLast("decoder", new NettyPacketDecoder(PacketDirection.CLIENTBOUND)).addLast("prepender", new NettyVarint21FrameEncoder()).addLast("encoder", new NettyPacketEncoder(PacketDirection.SERVERBOUND)).addLast("packet_handler", networkmanager);
+          }
+-      }).channel(oclass).connect(p_181124_0_, p_181124_1_).syncUninterruptibly();
++      }).channel(oclass).connect(address, serverPort).syncUninterruptibly();
+       return networkmanager;
+    }
+ 
     @OnlyIn(Dist.CLIENT)
++   public static io.netty.handler.ssl.SslHandler createSslHandler(Channel channel, net.minecraft.client.multiplayer.ServerData.TlsMode tlsMode, @Nullable String sniHost, int sniPort) {
++      try {
++         io.netty.handler.ssl.SslContextBuilder builder = io.netty.handler.ssl.SslContextBuilder
++                 .forClient();
++
++         if (tlsMode == net.minecraft.client.multiplayer.ServerData.TlsMode.ENABLED_INSECURE) {
++            builder.trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE);
++         }
++
++         if (sniHost != null) {
++            return builder.build().newHandler(channel.alloc(), sniHost, sniPort);
++         } else {
++            return builder.build().newHandler(channel.alloc());
++         }
++      }
++      catch (Exception e) {
++         throw new RuntimeException("Failed to initialize SSL", e);
++      }
++   }
++
++   @OnlyIn(Dist.CLIENT)
     public static NetworkManager func_150722_a(SocketAddress p_150722_0_) {
        final NetworkManager networkmanager = new NetworkManager(PacketDirection.CLIENTBOUND);
 +      networkmanager.activationHandler = net.minecraftforge.fml.network.NetworkHooks::registerClientLoginChannel;
        (new Bootstrap()).group(field_179296_e.func_179281_c()).handler(new ChannelInitializer<Channel>() {
           protected void initChannel(Channel p_initChannel_1_) throws Exception {
              p_initChannel_1_.pipeline().addLast("packet_handler", networkmanager);
-@@ -373,6 +378,14 @@
+@@ -373,6 +407,14 @@
        return this.field_211397_t;
     }
  

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -156,5 +156,10 @@
 
   "forge.container.enchant.limitedEnchantability": "Limited Enchantability",
   "attribute.name.generic.reachDistance": "Reach Distance",
-  "attribute.name.forge.swimSpeed": "Swim Speed"
+  "attribute.name.forge.swimSpeed": "Swim Speed",
+
+  "addServer.tls": "TLS",
+  "addServer.tls.disabled": "disabled",
+  "addServer.tls.enabled": "enabled",
+  "addServer.tls.enabledInsecure": "enabled (insecure)"
 }


### PR DESCRIPTION
This change allows a client to connect to Minecraft server with TLS enabled.

I don't want to argue about then necessity of the security TLS bring. To me, the main reason to enable TLS, is the use of SNI (see https://en.wikipedia.org/wiki/Server_Name_Indication). In a nutshell, it is similar to a "vhost" header, just on the TLS level.

This allows you to connect to a Minecraft server, which is running behind a load balancer/proxy. Using SNI, the load balancer can distinguish the target host, and then properly forward the connection.

So this even makes sense in the "insecure" mode. Which is not less secure than the normal Minecraft protocol. But still allows to use TLS SNI.

The changes are:

* Allow the user to enable TLS (also in insecure mode)
* Respect the TLS settings when connecting
* A new field in the "add/edit server" screen:
  ![image](https://user-images.githubusercontent.com/202474/89305210-acad3300-d66e-11ea-9c5a-1412355c116d.png)

It does not make any changes on the server side!

In order to test this, you need to run a normal Minecraft server, and e.g. an instance of `stunnel`. Assuming the minecraft server is running on port 1234:

* Install `openssl` and `stunnel`
* Create a self signed certificate:
  ~~~
  openssl req -new -x509 -days 365 -nodes -out stunnel.pem -keyout stunnel.pem
  # accept the defaults and enter some random information
  openssl gendh 2048 >> stunnel.pem
  ~~~
* Create a config file for stunnel (`mctunnel.conf`):
  ~~~
  foreground = yes
  pid=
  
  [mc]
  accept  = 5678
  connect = 1234
  cert = /home/user/stunnel.pem
  ~~~
* Run stunnel:
  ~~~
  stunnel mctunnel.conf
  ~~~

With this change, you can now connect to port `5678` if you select "insecure TLS" as an option.