### PR TITLE
[1.15.x] Post EntityJoinWorldEvent when Lightning is added in ServerWorld.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/effect/LightningBoltEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/effect/LightningBoltEntity.java.patch
@@ -1,6 +1,29 @@
 --- a/net/minecraft/entity/effect/LightningBoltEntity.java
 +++ b/net/minecraft/entity/effect/LightningBoltEntity.java
-@@ -80,6 +80,7 @@
+@@ -38,11 +38,6 @@
+       this.field_70264_a = this.field_70146_Z.nextLong();
+       this.field_70263_c = this.field_70146_Z.nextInt(3) + 1;
+       this.field_184529_d = p_i46780_8_;
+-      Difficulty difficulty = p_i46780_1_.func_175659_aa();
+-      if (difficulty == Difficulty.NORMAL || difficulty == Difficulty.HARD) {
+-         this.func_195053_a(4);
+-      }
+-
+    }
+ 
+    public SoundCategory func_184176_by() {
+@@ -58,6 +53,10 @@
+       if (this.field_70262_b == 2) {
+          this.field_70170_p.func_184148_a((PlayerEntity)null, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), SoundEvents.field_187754_de, SoundCategory.WEATHER, 10000.0F, 0.8F + this.field_70146_Z.nextFloat() * 0.2F);
+          this.field_70170_p.func_184148_a((PlayerEntity)null, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), SoundEvents.field_187752_dd, SoundCategory.WEATHER, 2.0F, 0.5F + this.field_70146_Z.nextFloat() * 0.2F);
++         Difficulty difficulty = this.field_70170_p.func_175659_aa();
++         if (difficulty == Difficulty.NORMAL || difficulty == Difficulty.HARD) {
++            this.func_195053_a(4);
++         }
+       }
+ 
+       --this.field_70262_b;
+@@ -80,6 +79,7 @@
              List<Entity> list = this.field_70170_p.func_175674_a(this, new AxisAlignedBB(this.func_226277_ct_() - 3.0D, this.func_226278_cu_() - 3.0D, this.func_226281_cx_() - 3.0D, this.func_226277_ct_() + 3.0D, this.func_226278_cu_() + 6.0D + 3.0D, this.func_226281_cx_() + 3.0D), Entity::func_70089_S);
  
              for(Entity entity : list) {

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -278,7 +278,12 @@
        this.func_72854_c();
     }
  
-@@ -1010,10 +1043,20 @@
+    public void func_217468_a(LightningBoltEntity p_217468_1_) {
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityJoinWorldEvent(p_217468_1_, this))) return;
+       this.field_217497_w.add(p_217468_1_);
+       this.field_73061_a.func_184103_al().func_148543_a((PlayerEntity)null, p_217468_1_.func_226277_ct_(), p_217468_1_.func_226278_cu_(), p_217468_1_.func_226281_cx_(), 512.0D, this.field_73011_w.func_186058_p(), new SSpawnGlobalEntityPacket(p_217468_1_));
+    }
+@@ -1010,10 +1044,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {


### PR DESCRIPTION
The EntityJoinWorldEvent for Lightning isn't posted in addLightningBolt. EntityConstructing is posted, however at that time the LightningBoltEntity isn't fully initialized and eg. position is missing.