### PR TITLE
[1.16] Rework RenderWorldLastEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 **/.classpath
 *.project
 
+#vscode
+/.vscode
+
 #In case people make their workspace in the repo
 /eclipse/
 

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -27,7 +27,7 @@
              } catch (Throwable throwable) {
                 CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Rendering screen");
                 CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Screen render details");
-@@ -595,9 +597,16 @@
+@@ -595,6 +597,11 @@
        Matrix4f matrix4f = matrixstack.func_227866_c_().func_227870_a_();
        this.func_228379_a_(matrix4f);
        activerenderinfo.func_216772_a(this.field_78531_r.field_71441_e, (Entity)(this.field_78531_r.func_175606_aa() == null ? this.field_78531_r.field_71439_g : this.field_78531_r.func_175606_aa()), !this.field_78531_r.field_71474_y.func_243230_g().func_243192_a(), this.field_78531_r.field_71474_y.func_243230_g().func_243193_b(), p_228378_1_);
@@ -39,12 +39,7 @@
        p_228378_4_.func_227863_a_(Vector3f.field_229179_b_.func_229187_a_(activerenderinfo.func_216777_e()));
        p_228378_4_.func_227863_a_(Vector3f.field_229181_d_.func_229187_a_(activerenderinfo.func_216778_f() + 180.0F));
        this.field_78531_r.field_71438_f.func_228426_a_(p_228378_4_, p_228378_1_, p_228378_2_, flag, activerenderinfo, this, this.field_78513_d, matrix4f);
-+      this.field_78531_r.func_213239_aq().func_219895_b("forge_render_last");
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderLast(this.field_78531_r.field_71438_f, p_228378_4_, p_228378_1_, matrix4f, p_228378_2_);
-       this.field_78531_r.func_213239_aq().func_219895_b("hand");
-       if (this.field_175074_C) {
-          RenderSystem.clear(256, Minecraft.field_142025_a);
-@@ -709,4 +718,9 @@
+@@ -709,4 +716,9 @@
     public OverlayTexture func_228385_m_() {
        return this.field_228375_t_;
     }

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -137,7 +137,7 @@
        RenderSystem.disableBlend();
        RenderSystem.popMatrix();
        FogRenderer.func_228370_a_();
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldLast(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldLast(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_, p_228426_9_, p_228426_3_);
     }
  
     private void func_228423_a_(MatrixStack p_228423_1_) {

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -37,8 +37,11 @@
        iprofiler.func_219895_b("terrain_setup");
        this.func_228437_a_(p_228426_6_, clippinghelper, flag, this.field_228409_ai_++, this.field_72777_q.field_71439_g.func_175149_v());
        iprofiler.func_219895_b("updatechunks");
-@@ -942,7 +947,9 @@
+@@ -940,9 +945,12 @@
+       long k1 = j1 * 3L / 2L;
+       long l1 = MathHelper.func_226163_a_(k1, l, 33333333L);
        this.func_174967_a(p_228426_3_ + l1);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldTerrainUpdate(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_, p_228426_3_ + l1);
        iprofiler.func_219895_b("terrain");
        this.func_228441_a_(RenderType.func_228639_c_(), p_228426_1_, d0, d1, d2);
 +      this.field_72777_q.func_209506_al().func_229356_a_(AtlasTexture.field_110575_b).setBlurMipmap(false, this.field_72777_q.field_71474_y.field_151442_I > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
@@ -47,7 +50,7 @@
        this.func_228441_a_(RenderType.func_228643_e_(), p_228426_1_, d0, d1, d2);
        if (this.field_72769_h.func_239132_a_().func_239217_c_()) {
           RenderHelper.func_237533_a_(p_228426_1_.func_227866_c_().func_227870_a_());
-@@ -972,7 +979,7 @@
+@@ -972,7 +980,7 @@
        IRenderTypeBuffer.Impl irendertypebuffer$impl = this.field_228415_m_.func_228487_b_();
  
        for(Entity entity : this.field_72769_h.func_217416_b()) {
@@ -56,7 +59,15 @@
              ++this.field_72749_I;
              if (entity.field_70173_aa == 0) {
                 entity.field_70142_S = entity.func_226277_ct_();
-@@ -1010,6 +1017,7 @@
+@@ -999,6 +1007,7 @@
+          }
+       }
+ 
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldEntities(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
+       this.func_228423_a_(p_228426_1_);
+       irendertypebuffer$impl.func_228462_a_(RenderType.func_228634_a_(AtlasTexture.field_110575_b));
+       irendertypebuffer$impl.func_228462_a_(RenderType.func_228638_b_(AtlasTexture.field_110575_b));
+@@ -1010,6 +1019,7 @@
           List<TileEntity> list = worldrenderer$localrenderinformationcontainer.field_178036_a.func_178571_g().func_178485_b();
           if (!list.isEmpty()) {
              for(TileEntity tileentity1 : list) {
@@ -64,7 +75,7 @@
                 BlockPos blockpos3 = tileentity1.func_174877_v();
                 IRenderTypeBuffer irendertypebuffer1 = irendertypebuffer$impl;
                 p_228426_1_.func_227860_a_();
-@@ -1035,6 +1043,7 @@
+@@ -1035,6 +1045,7 @@
  
        synchronized(this.field_181024_n) {
           for(TileEntity tileentity : this.field_181024_n) {
@@ -72,7 +83,15 @@
              BlockPos blockpos2 = tileentity.func_174877_v();
              p_228426_1_.func_227860_a_();
              p_228426_1_.func_227861_a_((double)blockpos2.func_177958_n() - d0, (double)blockpos2.func_177956_o() - d1, (double)blockpos2.func_177952_p() - d2);
-@@ -1084,10 +1093,13 @@
+@@ -1043,6 +1054,7 @@
+          }
+       }
+ 
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldTileEntities(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
+       this.func_228423_a_(p_228426_1_);
+       irendertypebuffer$impl.func_228462_a_(RenderType.func_228639_c_());
+       irendertypebuffer$impl.func_228462_a_(Atlases.func_228782_g_());
+@@ -1084,16 +1096,20 @@
           iprofiler.func_219895_b("outline");
           BlockPos blockpos = ((BlockRayTraceResult)raytraceresult).func_216350_a();
           BlockState blockstate = this.field_72769_h.func_180495_p(blockpos);
@@ -87,7 +106,14 @@
        }
  
        RenderSystem.pushMatrix();
-@@ -1119,7 +1131,7 @@
+       RenderSystem.multMatrix(p_228426_1_.func_227866_c_().func_227870_a_());
+       this.field_72777_q.field_184132_p.func_229019_a_(p_228426_1_, irendertypebuffer$impl, d0, d1, d2);
+       RenderSystem.popMatrix();
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldEnd(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
+       irendertypebuffer$impl.func_228462_a_(Atlases.func_228785_j_());
+       irendertypebuffer$impl.func_228462_a_(Atlases.func_228768_a_());
+       irendertypebuffer$impl.func_228462_a_(Atlases.func_228776_b_());
+@@ -1119,7 +1135,7 @@
           this.field_239224_H_.func_237506_a_(this.field_72777_q.func_147110_a());
           RenderState.field_239237_T_.func_228547_a_();
           iprofiler.func_219895_b("particles");
@@ -96,16 +122,34 @@
           RenderState.field_239237_T_.func_228549_b_();
        } else {
           iprofiler.func_219895_b("translucent");
-@@ -1129,7 +1141,7 @@
+@@ -1129,8 +1145,9 @@
           iprofiler.func_219895_b("string");
           this.func_228441_a_(RenderType.func_241715_r_(), p_228426_1_, d0, d1, d2);
           iprofiler.func_219895_b("particles");
 -         this.field_72777_q.field_71452_i.func_228345_a_(p_228426_1_, irendertypebuffer$impl, p_228426_8_, p_228426_6_, p_228426_2_);
 +         this.field_72777_q.field_71452_i.renderParticles(p_228426_1_, irendertypebuffer$impl, p_228426_8_, p_228426_6_, p_228426_2_, clippinghelper);
        }
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldPreWeather(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
  
        RenderSystem.pushMatrix();
-@@ -1481,6 +1493,11 @@
+       RenderSystem.multMatrix(p_228426_1_.func_227866_c_().func_227870_a_());
+@@ -1169,6 +1186,7 @@
+       RenderSystem.disableBlend();
+       RenderSystem.popMatrix();
+       FogRenderer.func_228370_a_();
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldLast(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_, field_228415_m_);
+    }
+ 
+    private void func_228423_a_(MatrixStack p_228423_1_) {
+@@ -1239,6 +1257,7 @@
+       }
+ 
+       VertexBuffer.func_177361_b();
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderWorldBlockLayer(this, p_228441_2_, field_228415_m_, p_228441_1_, p_228441_3_, p_228441_5_, p_228441_7_);
+       RenderSystem.clearCurrentColor();
+       this.field_228408_W_.func_227895_d_();
+       this.field_72777_q.func_213239_aq().func_76319_b();
+@@ -1481,6 +1500,11 @@
     }
  
     public void func_228424_a_(MatrixStack p_228424_1_, float p_228424_2_) {
@@ -117,7 +161,7 @@
        if (this.field_72777_q.field_71441_e.func_239132_a_().func_241683_c_() == DimensionRenderInfo.FogType.END) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.func_239132_a_().func_241683_c_() == DimensionRenderInfo.FogType.NORMAL) {
-@@ -1609,6 +1626,11 @@
+@@ -1609,6 +1633,11 @@
     }
  
     public void func_228425_a_(MatrixStack p_228425_1_, float p_228425_2_, double p_228425_3_, double p_228425_5_, double p_228425_7_) {
@@ -129,7 +173,7 @@
        float f = this.field_72769_h.func_239132_a_().func_239213_a_();
        if (!Float.isNaN(f)) {
           RenderSystem.disableCull();
-@@ -1792,7 +1814,7 @@
+@@ -1792,7 +1821,7 @@
  
           while(iterator.hasNext()) {
              ChunkRenderDispatcher.ChunkRender chunkrenderdispatcher$chunkrender = iterator.next();
@@ -138,7 +182,7 @@
                 this.field_174995_M.func_228902_a_(chunkrenderdispatcher$chunkrender);
              } else {
                 chunkrenderdispatcher$chunkrender.func_228929_a_(this.field_174995_M);
-@@ -2076,7 +2098,12 @@
+@@ -2076,7 +2105,12 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
@@ -151,7 +195,7 @@
        ISound isound = this.field_147593_P.get(p_184377_2_);
        if (isound != null) {
           this.field_72777_q.func_147118_V().func_147683_b(isound);
-@@ -2084,7 +2111,7 @@
+@@ -2084,7 +2118,7 @@
        }
  
        if (p_184377_1_ != null) {
@@ -160,7 +204,7 @@
           if (musicdiscitem != null) {
              this.field_72777_q.field_71456_v.func_238451_a_(musicdiscitem.func_234801_g_());
           }
-@@ -2232,7 +2259,7 @@
+@@ -2232,7 +2266,7 @@
           break;
        case 1010:
           if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
@@ -169,7 +213,7 @@
           } else {
              this.func_184377_a((SoundEvent)null, p_180439_3_);
           }
-@@ -2382,8 +2409,8 @@
+@@ -2382,8 +2416,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -180,7 +224,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2531,7 +2558,7 @@
+@@ -2531,7 +2565,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -189,7 +233,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2570,6 +2597,11 @@
+@@ -2570,6 +2604,11 @@
        return this.field_239226_J_;
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -154,44 +154,53 @@ public class ForgeHooksClient
 
     public static void dispatchRenderWorldTerrainUpdate(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers, long finishTimeNano)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_terrain_update");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_terrain_update");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldTerrainUpdateEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers, finishTimeNano));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static void dispatchRenderWorldBlockLayer(WorldRenderer context, MatrixStack mStack, RenderTypeBuffers renderTypeBuffers, RenderType blockLayer, double cameraX, double cameraY, double cameraZ)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_block_layer_" + blockLayer.toString());
+        Minecraft.getInstance().getProfiler().startSection("forge_render_block_layer_" + blockLayer.toString());
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldBlockLayerEvent(context, mStack, renderTypeBuffers, blockLayer, cameraX, cameraY, cameraZ));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static void dispatchRenderWorldEntities(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_entities");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_entities");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldEntitiesEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static void dispatchRenderWorldTileEntities(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_tile_entities");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_tile_entities");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldTileEntitiesEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static void dispatchRenderWorldEnd(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_main_buffer_end");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_main_buffer_end");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldEndEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static void dispatchRenderWorldPreWeather(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_pre_weather");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_pre_weather");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldPreWeatherEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
-    public static void dispatchRenderWorldLast(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    // TODO: 1.17 remove projectionMatrix and finishTimeNano arguments
+    public static void dispatchRenderWorldLast(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers, Matrix4f projectionMatrix, long finishTimeNano)
     {
-        Minecraft.getInstance().getProfiler().endStartSection("forge_render_last");
+        Minecraft.getInstance().getProfiler().startSection("forge_render_last");
         MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldLastEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+        MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mStack, partialTicks, projectionMatrix, finishTimeNano));
+        Minecraft.getInstance().getProfiler().endSection();
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -37,6 +37,7 @@ import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.FogRenderer.FogType;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.ItemColors;
+import net.minecraft.client.renderer.culling.ClippingHelper;
 import net.minecraft.client.renderer.entity.model.BipedModel;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
@@ -142,9 +143,55 @@ public class ForgeHooksClient
         }
     }
 
+    /**
+     * @deprecated Use new {@link RenderWorldEvent events} - check which event suits the best your needs, TODO: remove in 1.17
+     */
+    @Deprecated
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
+    }
+
+    public static void dispatchRenderWorldTerrainUpdate(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers, long finishTimeNano)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_terrain_update");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldTerrainUpdateEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers, finishTimeNano));
+    }
+
+    public static void dispatchRenderWorldBlockLayer(WorldRenderer context, MatrixStack mStack, RenderTypeBuffers renderTypeBuffers, RenderType blockLayer, double cameraX, double cameraY, double cameraZ)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_block_layer_" + blockLayer.toString());
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldBlockLayerEvent(context, mStack, renderTypeBuffers, blockLayer, cameraX, cameraY, cameraZ));
+    }
+
+    public static void dispatchRenderWorldEntities(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_entities");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldEntitiesEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+    }
+
+    public static void dispatchRenderWorldTileEntities(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_tile_entities");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldTileEntitiesEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+    }
+
+    public static void dispatchRenderWorldEnd(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_main_buffer_end");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldEndEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+    }
+
+    public static void dispatchRenderWorldPreWeather(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_pre_weather");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldPreWeatherEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
+    }
+
+    public static void dispatchRenderWorldLast(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippinghelper, ActiveRenderInfo activeRenderInfoIn, RenderTypeBuffers renderTypeBuffers)
+    {
+        Minecraft.getInstance().getProfiler().endStartSection("forge_render_last");
+        MinecraftForge.EVENT_BUS.post(new RenderWorldEvent.RenderWorldLastEvent(context, mStack, partialTicks, clippinghelper, activeRenderInfoIn, renderTypeBuffers));
     }
 
     public static boolean renderSpecificFirstPersonHand(Hand hand, MatrixStack mat, IRenderTypeBuffer buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldEvent.java
@@ -1,0 +1,209 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypeBuffers;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.culling.ClippingHelper;
+import net.minecraftforge.common.MinecraftForge;
+
+/**
+ * Abstract class for all world rendering events.
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class RenderWorldEvent extends net.minecraftforge.eventbus.api.Event
+{
+    private final WorldRenderer context;
+    private final MatrixStack mStack;
+    private final RenderTypeBuffers renderTypeBuffers;
+
+    private RenderWorldEvent(WorldRenderer context, MatrixStack mStack, RenderTypeBuffers renderTypeBuffers)
+    {
+        this.context = context;
+        this.mStack = mStack;
+        this.renderTypeBuffers = renderTypeBuffers;
+    }
+
+    public WorldRenderer getContext()
+    {
+        return context;
+    }
+
+    public MatrixStack getMatrixStack()
+    {
+        return mStack;
+    }
+
+    public RenderTypeBuffers getRenderTypeBuffers()
+    {
+        return renderTypeBuffers;
+    }
+
+    public static class InnerRenderWorldEvent extends RenderWorldEvent
+    {
+        private final float partialTicks;
+        private final ClippingHelper clippingHelper;
+        private final ActiveRenderInfo activeRenderInfo;
+
+        private InnerRenderWorldEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, renderTypeBuffers);
+            this.partialTicks = partialTicks;
+            this.clippingHelper = clippingHelper;
+            this.activeRenderInfo = activeRenderInfo;
+        }
+
+        public float getPartialTicks()
+        {
+            return partialTicks;
+        }
+    
+        public ClippingHelper getClippingHelper()
+        {
+            return clippingHelper;
+        }
+    
+        public ActiveRenderInfo getActiveRenderInfo()
+        {
+            return activeRenderInfo;
+        }
+    }
+
+    /**
+     * Event fired before first rendering call. Can be used to check which terrain needs updating.
+     * <br>
+     * If {@link System#nanoTime} is greater than <code>finishTimeNano</code> then you should quit this event immediately.
+     */
+    public static class RenderWorldTerrainUpdateEvent extends InnerRenderWorldEvent
+    {
+        private final long finishTimeNano;
+
+        public RenderWorldTerrainUpdateEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers, long finishTimeNano)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+            this.finishTimeNano = finishTimeNano;
+        }
+
+        public long getFinishTimeNano()
+        {
+            return finishTimeNano;
+        }
+    }
+
+    /**
+     * Event fired for each block layer being rendered.
+     */
+    public static class RenderWorldBlockLayerEvent extends RenderWorldEvent
+    {
+        private final RenderType blockLayer;
+        private final double cameraX;
+        private final double cameraY;
+        private final double cameraZ;
+
+        public RenderWorldBlockLayerEvent(WorldRenderer context, MatrixStack mStack, RenderTypeBuffers renderTypeBuffers, RenderType blockLayer, double cameraX, double cameraY, double cameraZ)
+        {
+            super(context, mStack, renderTypeBuffers);
+            this.blockLayer = blockLayer;
+            this.cameraX = cameraX;
+            this.cameraY = cameraY;
+            this.cameraZ = cameraZ;
+        }
+
+        public RenderType getBlockLayer()
+        {
+            return blockLayer;
+        }
+
+        public double getCameraX()
+        {
+            return cameraX;
+        }
+
+        public double getCameraY()
+        {
+            return cameraY;
+        }
+
+        public double getCameraZ()
+        {
+            return cameraZ;
+        }
+    }
+
+    /**
+     * Event fired before end of entity rendering.
+     */
+    public static class RenderWorldEntitiesEvent extends InnerRenderWorldEvent
+    {
+        public RenderWorldEntitiesEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+        }
+    }
+
+    /**
+     * Event fired before end of tile entity rendering.
+     */
+    public static class RenderWorldTileEntitiesEvent extends InnerRenderWorldEvent
+    {
+        public RenderWorldTileEntitiesEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+        }
+    }
+
+    /**
+     * Event fired before finishing the source buffer.
+     */
+    public static class RenderWorldEndEvent extends InnerRenderWorldEvent
+    {
+        public RenderWorldEndEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+        }
+    }
+
+    /**
+     * Event fired before weather and clouds are rendered.
+     */
+    public static class RenderWorldPreWeatherEvent extends InnerRenderWorldEvent
+    {
+        public RenderWorldPreWeatherEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+        }
+    }
+
+    /**
+     * Event fired after entire World is rendered.
+     */
+    public static class RenderWorldLastEvent extends InnerRenderWorldEvent
+    {
+        public RenderWorldLastEvent(WorldRenderer context, MatrixStack mStack, float partialTicks, ClippingHelper clippingHelper, ActiveRenderInfo activeRenderInfo, RenderTypeBuffers renderTypeBuffers)
+        {
+            super(context, mStack, partialTicks, clippingHelper, activeRenderInfo, renderTypeBuffers);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -24,6 +24,10 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.util.math.vector.Matrix4f;
 
+/**
+ * @deprecated Use new {@link RenderWorldEvent events} - check which event suits the best your needs, TODO: remove in 1.17
+ */
+@Deprecated
 public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
 {
     private final WorldRenderer context;


### PR DESCRIPTION
The old way became less programmer-friendly as of recent rendering updates in vanilla code.
The new way adds events before finishing of important render buffers and creates an event for each rendered block layer. The old RenderWorldLastEvent was moved to the end of World rendering method.

I'm not sure if this PR needs a test mod since it's only event change.
~I have not carried over profiler section calls because of patch lengths. If you think it's better to separate forge events from vanilla profiling, I can add them into client forge hooks.~ done

_Sequel of #6985 as I failed to push into it_
_Superseded by and closes #7661_