### PR TITLE
Fix configuration entry order not being preserved

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -525,7 +525,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public ForgeConfigSpec build()
         {
             context.ensureEmpty();
-            Config valueCfg = Config.of(InMemoryFormat.withSupport(ConfigValue.class::isAssignableFrom));
+            Config valueCfg = Config.of(Config.getDefaultMapCreator(true, true), InMemoryFormat.withSupport(ConfigValue.class::isAssignableFrom));
             values.forEach(v -> valueCfg.set(v.getPath(), v));
 
             ForgeConfigSpec ret = new ForgeConfigSpec(storage, valueCfg, levelComments);


### PR DESCRIPTION
It was [set to be preserved when reading the file](https://github.com/MinecraftForge/MinecraftForge/blob/517bbc8b5ba282076dab9bdd8b8b86f28238080f/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java#L47), but that's not actually what is needed (although it might be useful?).
Iteration order must be preserved when creating the in-memory config.

Fixes #7224.