### PR TITLE
[1.16.x] Environment tick event

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/server/ServerChunkProvider.java
 +++ b/net/minecraft/world/server/ServerChunkProvider.java
-@@ -353,7 +_,7 @@
+@@ -353,13 +_,15 @@
                 if (optional1.isPresent()) {
                    Chunk chunk = optional1.get();
                    ChunkPos chunkpos = p_241099_7_.func_219277_h();
@@ -9,6 +9,14 @@
                       chunk.func_177415_c(chunk.func_177416_w() + j);
                       if (flag1 && (this.field_217246_l || this.field_217247_m) && this.field_73251_h.func_175723_af().func_177730_a(chunk.func_76632_l())) {
                          WorldEntitySpawner.func_234979_a_(this.field_73251_h, chunk, worldentityspawner$entitydensitymanager, this.field_217247_m, this.field_217246_l, flag2);
+                      }
+ 
++                     net.minecraftforge.fml.hooks.BasicEventHooks.onPreEnvironmentTick(this.field_73251_h,chunk, k);
+                      this.field_73251_h.func_217441_a(chunk, k);
++                     net.minecraftforge.fml.hooks.BasicEventHooks.onPostEnvironmentTick(this.field_73251_h, chunk, k);
+                   }
+                }
+             }
 @@ -427,6 +_,14 @@
  
     public <T> void func_217222_b(TicketType<T> p_217222_1_, ChunkPos p_217222_2_, int p_217222_3_, T p_217222_4_) {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -22,13 +22,14 @@ package net.minecraftforge.event;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
 public class TickEvent extends Event
 {
     public enum Type {
-        WORLD, PLAYER, CLIENT, SERVER, RENDER;
+        WORLD, PLAYER, CLIENT, SERVER, RENDER, ENVIRONMENT;
     }
 
     public enum Phase {
@@ -66,6 +67,7 @@ public class TickEvent extends Event
             this.world = world;
         }
     }
+
     public static class PlayerTickEvent extends TickEvent {
         public final PlayerEntity player;
 
@@ -82,6 +84,24 @@ public class TickEvent extends Event
         {
             super(Type.RENDER, LogicalSide.CLIENT, phase);
             this.renderTickTime = renderTickTime;
+        }
+    }
+    
+    /**
+     * Useful for random-tick and weather based actions. 
+     */
+    public static class EnvironmentTickEvent extends TickEvent
+    {
+        public final World world;
+        public final Chunk chunk;
+        public final int randomTickSpeed;
+
+        public EnvironmentTickEvent(LogicalSide side, Phase phase, World world, Chunk chunk, int randomTickSpeed)
+        {
+            super(Type.ENVIRONMENT, side, phase);
+            this.world = world;
+            this.chunk = chunk;
+            this.randomTickSpeed = randomTickSpeed;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -25,6 +25,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.model.animation.Animation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -118,5 +119,15 @@ public class BasicEventHooks
     public static void onPostServerTick()
     {
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
+    }
+
+    public static void onPreEnvironmentTick(World world, Chunk chunk, int randomTickSpeed)
+    {
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.START, world, chunk, randomTickSpeed));
+    }
+    
+    public static void onPostEnvironmentTick(World world, Chunk chunk, int randomTickSpeed)
+    {
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.END, world, chunk, randomTickSpeed));
     }
 }

--- a/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.debug.world;
+
+import com.google.common.eventbus.Subscribe;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("environmenttickeventtest")
+public class EnvironmentTickEventTest
+{
+    private final Logger LOGGER;
+    
+    public EnvironmentTickEventTest()
+    {
+        LOGGER = LogManager.getLogger();
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void environmentTickEvent(final TickEvent.EnvironmentTickEvent event)
+    {
+        LOGGER.info(event.phase + " Environment tick event at " + event.chunk.getPos());
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -124,3 +124,5 @@ license="LGPL v2.1"
     modId="entity_teleport_event_test"
 [[mods]]
     modId="text_linear_filtering_test"
+[[mods]]
+    modId="environmenttickeventtest"


### PR DESCRIPTION
This event provides a way for mods to perform weather and random tick based actions at the same time as vanilla (not actually the same time, either just before or just after).
Test mod included.