### PR TITLE
Removed sidedness from PacketBuffer methods.

### DIFF
--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -72,6 +72,10 @@ net/minecraft/item/crafting/IRecipe func_193358_e()Ljava/lang/String; # getGroup
 	net/minecraft/item/crafting/ShapedRecipe func_193358_e()Ljava/lang/String;
 	net/minecraft/item/crafting/ShapelessRecipe func_193358_e()Ljava/lang/String;
 	net/minecraft/item/crafting/SingleItemRecipe func_193358_e()Ljava/lang/String;
+net/minecraft/network/PacketBuffer func_186873_b([J)[J
+net/minecraft/network/PacketBuffer func_189423_a([JI)[J
+net/minecraft/network/PacketBuffer func_218666_n()Ljava/lang/String;
+net/minecraft/network/PacketBuffer func_218667_g()Lnet/minecraft/util/math/SectionPos;
 net/minecraft/nbt/CompressedStreamTools func_74797_a(Ljava/io/File;)Lnet/minecraft/nbt/CompoundNBT; # read
 net/minecraft/nbt/CompressedStreamTools func_74795_b(Lnet/minecraft/nbt/CompoundNBT;Ljava/io/File;)V # write
 net/minecraft/potion/Effect func_220303_e()Lnet/minecraft/potion/EffectType; # getEffectType


### PR DESCRIPTION
Affected methods:
* readLongArray (x2)
* readSectionPos
* readString (no-arg variant)