### PR TITLE
[1.16.x] Readding DifficultyChangeEvent hooks

### DIFF
--- a/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
@@ -62,3 +62,11 @@
        if (p_217384_1_ == this.field_73037_M.field_71439_g) {
           this.field_73037_M.func_147118_V().func_147682_a(new EntityTickableSound(p_217384_3_, p_217384_4_, p_217384_2_));
        }
+@@ -857,6 +874,7 @@
+       }
+ 
+       public void func_239156_a_(Difficulty p_239156_1_) {
++         net.minecraftforge.common.ForgeHooks.onDifficultyChange(p_239156_1_, this.field_239153_j_);
+          this.field_239153_j_ = p_239156_1_;
+       }
+ 

--- a/patches/minecraft/net/minecraft/world/WorldSettings.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldSettings.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/WorldSettings.java
++++ b/net/minecraft/world/WorldSettings.java
+@@ -62,6 +62,7 @@
+    }
+ 
+    public WorldSettings func_234948_a_(Difficulty p_234948_1_) {
++      net.minecraftforge.common.ForgeHooks.onDifficultyChange(p_234948_1_, this.field_234944_d_);
+       return new WorldSettings(this.field_234943_a_, this.field_77172_b, this.field_77170_d, p_234948_1_, this.field_77168_f, this.field_234945_f_, this.field_234946_g_);
+    }
+ 


### PR DESCRIPTION
There isn't much of an explanation for this. Instead of checking every tick for if the difficulty changes, we use this hook instead. This PR just readds the hook back into the server and client.