### PR TITLE
Print mod file name when erroring from ModFileInfo

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
@@ -27,7 +27,7 @@ public class InvalidModFileException extends RuntimeException
 
     public InvalidModFileException(String message, IModFileInfo modFileInfo)
     {
-        super(message);
+        super(String.format("%s (%s)", message, ((ModFileInfo)modFileInfo).getFile().getFileName()));
         this.modFileInfo = modFileInfo;
     }
 }


### PR DESCRIPTION
I just tried switching from 1.16.1 to 1.16.2 and in 1.16.2 a license inside a mod is being enforced. Now, when I got the error I had no idea what mod that came from. And I can imagine that probably many people will have to go through all mods before they can find a culprit. Printing the mod file name when printing the error should make this quite a lot easier. I have also added it to other errors inside of ModFileInfo.java.

If anyone has any suggestions how to make this error message better, let me know. Also, this is completely untested.

This is what the error currently looks like:
```
net.minecraftforge.fml.loading.moddiscovery.InvalidModFileException: Missing License, please supply a license.
 	at net.minecraftforge.fml.loading.moddiscovery.ModFileInfo.lambda$new$2(ModFileInfo.java:68)
[stacktrace]
```