### PR TITLE
Fix Forge 1.16.2 Server connection

### DIFF
--- a/patches/minecraft/net/minecraft/util/registry/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/Bootstrap.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/util/registry/Bootstrap.java
 +++ b/net/minecraft/util/registry/Bootstrap.java
-@@ -46,6 +46,7 @@
-                PotionBrewing.func_185207_a();
-                EntityOptions.func_197445_a();
+@@ -48,6 +48,7 @@
                 IDispenseItemBehavior.func_218401_c();
-+               if (false) // skip redirectOutputToLog, Forge already redirects stdout and stderr output to log so that they print with more context
                 ArgumentTypes.func_197483_a();
                 TagRegistryManager.func_242197_b();
++               if (false) // skip redirectOutputToLog, Forge already redirects stdout and stderr output to log so that they print with more context
                 func_179868_d();
+             }
+          }
 @@ -103,7 +104,6 @@
              Commands.func_242986_b();
           }


### PR DESCRIPTION
Misapplied patch skipped brigadier argument registration. And tag registry creation seemingly.