### PR TITLE
Fixed nether portal not spawning in 1.16.2

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -675,7 +675,7 @@ public class ForgeEventFactory
     public static Optional<PortalSize> onTrySpawnPortal(IWorld world, BlockPos pos, Optional<PortalSize> size)
     {
         if (!size.isPresent()) return size;
-        return MinecraftForge.EVENT_BUS.post(new BlockEvent.PortalSpawnEvent(world, pos, world.getBlockState(pos), size.get())) ? size : Optional.empty();
+        return MinecraftForge.EVENT_BUS.post(new BlockEvent.PortalSpawnEvent(world, pos, world.getBlockState(pos), size.get())) ? Optional.empty() : size;
     }
 
     public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level)


### PR DESCRIPTION
As the title says.
IEventBus#post returns true if the event is canceled. This means the return values in ForgeEventFactory#onTrySpawnPortal were swapped and thus the portal wouldn't spawn.

this also closes issue https://github.com/MinecraftForge/MinecraftForge/issues/7249