### PR TITLE
Improve startup time by caching the manifest data for mod jars

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -56,9 +56,8 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     private final Map<String,Object> properties;
     private final String license;
     // Caches the manifest of the mod jar as parsing the manifest can be expensive for
-    // signed jars. The manifest needs to be an Optional<Manifest>, so a nullable Optional
-    // is probably the best option.
-    private volatile Optional<Manifest> manifest = null;
+    // signed jars.
+    private final Optional<Manifest> manifest;
 
     ModFileInfo(final ModFile modFile, final IConfigurable config)
     {
@@ -88,6 +87,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
                 this.modFile::getFileName,
                 () -> this.mods.stream().map(IModInfo::getModId).collect(Collectors.joining(",", "{", "}")),
                 () -> this.mods.stream().map(IModInfo::getVersion).map(Objects::toString).collect(Collectors.joining(",", "{", "}")));
+        this.manifest = modFile.getLocator().findManifest(modFile.getFilePath());
     }
 
     @Override
@@ -121,13 +121,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
 
     public Optional<Manifest> getManifest()
     {
-        Optional<Manifest> result = manifest;
-        if (result == null)
-        {
-            result = modFile.getLocator().findManifest(modFile.getFilePath());
-            manifest = result;
-        }
-        return result;
+        return manifest;
     }
 
     @Override

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -77,7 +77,8 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
         this.modFile.setFileProperties(this.properties);
         this.issueURL = config.<String>getConfigElement("issueTrackerURL").map(StringUtils::toURL).orElse(null);
         final List<? extends IConfigurable> modConfigs = config.getConfigList("mods");
-        if (modConfigs.isEmpty()) {
+        if (modConfigs.isEmpty())
+        {
             throw new InvalidModFileException("Missing mods list", this);
         }
         this.mods = modConfigs.stream()
@@ -113,13 +114,16 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     }
 
     @Override
-    public Map<String, Object> getFileProperties() {
+    public Map<String, Object> getFileProperties()
+    {
         return this.properties;
     }
 
-    public Optional<Manifest> getManifest() {
+    public Optional<Manifest> getManifest()
+    {
         Optional<Manifest> result = manifest;
-        if (result == null) {
+        if (result == null)
+        {
             result = modFile.getLocator().findManifest(modFile.getFilePath());
             manifest = result;
         }
@@ -127,22 +131,26 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     }
 
     @Override
-    public boolean showAsResourcePack() {
+    public boolean showAsResourcePack()
+    {
         return this.showAsResourcePack;
     }
 
     @Override
-    public <T> Optional<T> getConfigElement(final String... key) {
+    public <T> Optional<T> getConfigElement(final String... key)
+    {
         return this.config.getConfigElement(key);
     }
 
     @Override
-    public List<? extends IConfigurable> getConfigList(final String... key) {
+    public List<? extends IConfigurable> getConfigList(final String... key)
+    {
         return this.config.getConfigList(key);
     }
 
     @Override
-    public String getLicense() {
+    public String getLicense()
+    {
         return license;
     }
 }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
@@ -54,6 +55,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     private final List<IModInfo> mods;
     private final Map<String,Object> properties;
     private final String license;
+    private final AtomicReference<Optional<Optional<Manifest>>> manifest = new AtomicReference<>(Optional.empty());
 
     ModFileInfo(final ModFile modFile, final IConfigurable config)
     {
@@ -113,7 +115,12 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     }
 
     public Optional<Manifest> getManifest() {
-        return modFile.getLocator().findManifest(modFile.getFilePath());
+        Optional<Optional<Manifest>> manifest = this.manifest.get();
+        if (!manifest.isPresent()) {
+            manifest = Optional.of(modFile.getLocator().findManifest(modFile.getFilePath()));
+            this.manifest.set(manifest);
+        }
+        return manifest.get();
     }
 
     @Override

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -55,7 +55,10 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     private final List<IModInfo> mods;
     private final Map<String,Object> properties;
     private final String license;
-    private final AtomicReference<Optional<Optional<Manifest>>> manifest = new AtomicReference<>(Optional.empty());
+    // Caches the manifest of the mod jar as parsing the manifest can be expensive for
+    // signed jars. The manifest needs to be an Optional<Manifest>, so a nullable Optional
+    // is probably the best option.
+    private volatile Optional<Manifest> manifest = null;
 
     ModFileInfo(final ModFile modFile, final IConfigurable config)
     {
@@ -115,12 +118,12 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     }
 
     public Optional<Manifest> getManifest() {
-        Optional<Optional<Manifest>> manifest = this.manifest.get();
-        if (!manifest.isPresent()) {
-            manifest = Optional.of(modFile.getLocator().findManifest(modFile.getFilePath()));
-            this.manifest.set(manifest);
+        Optional<Manifest> result = manifest;
+        if (result == null) {
+            result = modFile.getLocator().findManifest(modFile.getFilePath());
+            manifest = result;
         }
-        return manifest.get();
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Fixes cpw/modlauncher#55

 - I originally thought this was a ModLauncher issue because I didn't look at the stack in detail after it entered ModLauncher. Looking at it again the time I thought was in ModLauncher is actually in the method I'm changing in this PR.
 - I'm using `AtomicReference` since a) it needs to be thread safe (the method is called in classloading), b) AFAIK accessing an atomic is faster than acquiring and releasing a lock and c) parsing the manifest on multiple threads will not cause any issues and can only happen once per mod.
 - I'll happily accept suggestions for getting rid of the `Optional<Optional<…>>`. IntelliJ puts out a warning when comparing an `Optional` to null and I agree that nullable `Optional`s are bad design, but I'm not sure this is better. This is in `fmllauncher`, so using `Lazy<T>` is not an option.

The table below shows launch time in seconds with patch applied to Forge 106. The setup is slightly different from the one I used in the ModLauncher issue, but is mostly similar. I'm using three launches for each configuration to get more reliable values. The Forge builds for both tests are unsigned (didn't set up signing for Forge). With the official 106 Forge build start time without mods is ~50 s, which would probably also be reduced by my changes.
|With PR|Mods|First launch|Second launch|Third launch|
|---|---|---|---|---|
|No|Immersive Engineering, signed|77|73|73|
|Yes|Immersive Engineering, signed|52|48|49|
|No|Immersive Engineering, unsigned|51|55|56|
|Yes|Immersive Engineering, unsigned|51|56|52|
|No|None|38|39|43|
|Yes|None|38|39|38|
