### PR TITLE
Don't process packets sent by dead players

### DIFF
--- a/patches/minecraft/net/minecraft/network/PacketThreadUtil.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketThreadUtil.java.patch
@@ -1,0 +1,40 @@
+--- a/net/minecraft/network/PacketThreadUtil.java
++++ b/net/minecraft/network/PacketThreadUtil.java
+@@ -16,6 +16,7 @@
+       if (!p_218797_2_.func_213162_bc()) {
+          p_218797_2_.execute(() -> {
+             if (p_218797_1_.func_147298_b().func_150724_d()) {
++               if (shouldProcess(p_218797_0_, p_218797_1_)) // Fix: MC-164255 (Duplicate of private)
+                p_218797_0_.func_148833_a(p_218797_1_);
+             } else {
+                field_225384_a.debug("Ignoring packet due to disconnection: " + p_218797_0_);
+@@ -25,4 +26,29 @@
+          throw ThreadQuickExitException.field_179886_a;
+       }
+    }
++
++   public static <T extends INetHandler> boolean shouldProcess(IPacket<T> packetIn, T processor) {
++      if (processor instanceof net.minecraft.network.play.ServerPlayNetHandler) {
++         net.minecraft.entity.player.ServerPlayerEntity player = ((net.minecraft.network.play.ServerPlayNetHandler) processor).field_147369_b;
++         if (!player.func_70089_S()) {
++            // Allow CustomPayloads as mods communicate here
++            if (packetIn instanceof net.minecraft.network.play.client.CCustomPayloadPacket) {
++               packetIn.func_148833_a(processor);
++               return true;
++            }
++
++            // Allow the player to respawn
++            if (packetIn instanceof net.minecraft.network.play.client.CClientStatusPacket && ((net.minecraft.network.play.client.CClientStatusPacket) packetIn).func_149435_c() == net.minecraft.network.play.client.CClientStatusPacket.State.PERFORM_RESPAWN) {
++               packetIn.func_148833_a(processor);
++               return true;
++            }
++
++            // Deny anything else
++            return false;
++         }
++      }
++
++      // Anything else is valid
++      return true;
++   }
+ }

--- a/patches/minecraft/net/minecraft/network/PacketThreadUtil.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketThreadUtil.java.patch
@@ -8,25 +8,23 @@
                 p_218797_0_.func_148833_a(p_218797_1_);
              } else {
                 field_225384_a.debug("Ignoring packet due to disconnection: " + p_218797_0_);
-@@ -25,4 +26,29 @@
+@@ -25,4 +26,27 @@
           throw ThreadQuickExitException.field_179886_a;
        }
     }
 +
-+   public static <T extends INetHandler> boolean shouldProcess(IPacket<T> packetIn, T processor) {
++   private static <T extends INetHandler> boolean shouldProcess(IPacket<T> packetIn, T processor) {
 +      if (processor instanceof net.minecraft.network.play.ServerPlayNetHandler) {
 +         net.minecraft.entity.player.ServerPlayerEntity player = ((net.minecraft.network.play.ServerPlayNetHandler) processor).field_147369_b;
 +         if (!player.func_70089_S()) {
 +            // Allow CustomPayloads as mods communicate here
 +            if (packetIn instanceof net.minecraft.network.play.client.CCustomPayloadPacket) {
-+               packetIn.func_148833_a(processor);
 +               return true;
 +            }
 +
 +            // Allow the player to respawn
-+            if (packetIn instanceof net.minecraft.network.play.client.CClientStatusPacket && ((net.minecraft.network.play.client.CClientStatusPacket) packetIn).func_149435_c() == net.minecraft.network.play.client.CClientStatusPacket.State.PERFORM_RESPAWN) {
-+               packetIn.func_148833_a(processor);
-+               return true;
++            if (packetIn instanceof net.minecraft.network.play.client.CClientStatusPacket) {
++               return ((net.minecraft.network.play.client.CClientStatusPacket) packetIn).func_149435_c() == net.minecraft.network.play.client.CClientStatusPacket.State.PERFORM_RESPAWN;
 +            }
 +
 +            // Deny anything else


### PR DESCRIPTION
The Minecraft server doesn't check the players health when processing packets, A modified client can exploit this to perform certain actions while the player is dead which includes:
- Moving (Includes loading chunks)
- Block Interaction (Includes breaking, placing and inventory transactions with chests)
- Item Interaction (Includes damaging entities)
- Using Portals
- Using Commands

While the player is dead they are invisible to all other entities including players, this also prevents them from picking up Item or XP Orbs.

I reported this issue to Mojang (MC-164255) back in October 2019 but it was closed as a duplicate of MC-87170 (Because the issue ids are sequential I was able to find that this has been known since August 2015), I then submitted a PR to Sponge to fix the issue https://github.com/SpongePowered/SpongeCommon/pull/2401

The fix I've implemented for Forge is pretty much the same as Sponge, I added logic to check if the player is alive in `PacketThreadUtil` as all the packets (KeepAlive Packet being an exception) at this point are being processed on the Main Thread, The fix allows `CCustomPayloadPacket` for mods and the `CClientStatusPacket` for respawning, Everything else is ignored as when the player dies the only options they have are to respawn or rage quit.

It should also be noted that this issue has been fixed in Bukkit / Spigot for years now and was fixed in Sponge last year.