### PR TITLE
Fix small issues with loading pack.png for mods

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
@@ -79,7 +79,7 @@ public class ExplodedDirectoryLocator implements IModLocator {
         if (Files.exists(found)) return found;
         // then try left path (classes)
         return mods.get(modFile).getRight().stream().map(p->p.resolve(target)).filter(Files::exists).
-                findFirst().orElse(found.resolve(target));
+                findFirst().orElse(found);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml.packs;
 
+import net.minecraft.resources.ResourcePackFileNotFoundException;
 import net.minecraft.resources.ResourcePackInfo;
 import net.minecraft.resources.ResourcePackType;
 import net.minecraft.util.ResourceLocation;
@@ -63,6 +64,8 @@ public class ModFileResourcePack extends DelegatableResourcePack
     public InputStream getInputStream(String name) throws IOException
     {
         final Path path = modFile.getLocator().findPath(modFile, name);
+        if(!Files.exists(path))
+            throw new ResourcePackFileNotFoundException(path.toFile(), name);
         return Files.newInputStream(path, StandardOpenOption.READ);
     }
 


### PR DESCRIPTION
The locator was resolving the path twice when not finding something, which leads to an error message that make it seem like there was  a deeper error than just not finding a a file (could not find "../pack.png/pack.png" in this case. 
Also vanilla behaviour is to not log anything when the pack.png is missing. It was being logged however since only FileNotFoundExceptions are silenced when the ModFileResourcePack was throwing a NoSuchFileException.