### PR TITLE
[1.16] Added a Hunger System API

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -48,6 +48,15 @@
     public float func_149638_a() {
        return this.field_235689_au_;
     }
+@@ -300,7 +_,7 @@
+ 
+    public void func_180657_a(World p_180657_1_, PlayerEntity p_180657_2_, BlockPos p_180657_3_, BlockState p_180657_4_, @Nullable TileEntity p_180657_5_, ItemStack p_180657_6_) {
+       p_180657_2_.func_71029_a(Stats.field_188065_ae.func_199076_b(this));
+-      p_180657_2_.func_71020_j(0.005F);
++      p_180657_2_.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(p_180657_2_, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.HARVEST_BLOCK, 0.005F));
+       func_220054_a(p_180657_4_, p_180657_1_, p_180657_3_, p_180657_5_, p_180657_2_, p_180657_6_);
+    }
+ 
 @@ -332,6 +_,7 @@
        p_176216_2_.func_213317_d(p_176216_2_.func_213322_ci().func_216372_d(1.0D, 0.0D, 1.0D));
     }

--- a/patches/minecraft/net/minecraft/block/CakeBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/CakeBlock.java.patch
@@ -1,0 +1,40 @@
+--- a/net/minecraft/block/CakeBlock.java
++++ b/net/minecraft/block/CakeBlock.java
+@@ -19,7 +_,7 @@
+ import net.minecraft.world.IWorldReader;
+ import net.minecraft.world.World;
+ 
+-public class CakeBlock extends Block {
++public class CakeBlock extends Block implements net.minecraftforge.common.hunger.IEdible {
+    public static final IntegerProperty field_176589_a = BlockStateProperties.field_208173_Z;
+    protected static final VoxelShape[] field_196402_b = new VoxelShape[]{Block.func_208617_a(1.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(3.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(5.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(7.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(9.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(11.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D), Block.func_208617_a(13.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D)};
+ 
+@@ -48,11 +_,11 @@
+    }
+ 
+    private ActionResultType func_226911_a_(IWorld p_226911_1_, BlockPos p_226911_2_, BlockState p_226911_3_, PlayerEntity p_226911_4_) {
+-      if (!p_226911_4_.func_71043_e(false)) {
++      if (!p_226911_4_.func_71043_e(this.canAlwaysEat())) {
+          return ActionResultType.PASS;
+       } else {
+          p_226911_4_.func_195066_a(Stats.field_188076_J);
+-         p_226911_4_.func_71024_bL().func_75122_a(2, 0.1F);
++         p_226911_4_.func_71024_bL().func_221410_a(this.func_199767_j(), new ItemStack(this));
+          int i = p_226911_3_.func_177229_b(field_176589_a);
+          if (i < 6) {
+             p_226911_1_.func_180501_a(p_226911_2_, p_226911_3_.func_206870_a(field_176589_a, Integer.valueOf(i + 1)), 3);
+@@ -87,4 +_,14 @@
+    public boolean func_196266_a(BlockState p_196266_1_, IBlockReader p_196266_2_, BlockPos p_196266_3_, PathType p_196266_4_) {
+       return false;
+    }
++
++   /* ============================== FORGE START ============================== */
++   public net.minecraftforge.common.hunger.FoodValues getFoodValues(ItemStack stack) {
++      return new net.minecraftforge.common.hunger.FoodValues(2, 0.1F);
++   }
++
++   public boolean canAlwaysEat() {
++      return false;
++   }
++   /* =============================== FORGE END =============================== */
+ }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -8,6 +8,15 @@
     public static final EntitySize field_213835_bs = EntitySize.func_220314_b(0.6F, 1.8F);
     private static final Map<Pose, EntitySize> field_213836_b = ImmutableMap.<Pose, EntitySize>builder().put(Pose.STANDING, field_213835_bs).put(Pose.SLEEPING, field_213377_as).put(Pose.FALL_FLYING, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.SWIMMING, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.SPIN_ATTACK, EntitySize.func_220314_b(0.6F, 0.6F)).put(Pose.CROUCHING, EntitySize.func_220314_b(0.6F, 1.5F)).put(Pose.DYING, EntitySize.func_220311_c(0.2F, 0.2F)).build();
     private static final DataParameter<Float> field_184829_a = EntityDataManager.func_187226_a(PlayerEntity.class, DataSerializers.field_187193_c);
+@@ -123,7 +_,7 @@
+    protected EnderChestInventory field_71078_a = new EnderChestInventory();
+    public final PlayerContainer field_71069_bz;
+    public Container field_71070_bA;
+-   protected FoodStats field_71100_bB = new FoodStats();
++   protected FoodStats field_71100_bB = new FoodStats(this);
+    protected int field_71101_bC;
+    public float field_71107_bF;
+    public float field_71109_bG;
 @@ -150,6 +_,9 @@
     private final CooldownTracker field_184832_bU = this.func_184815_l();
     @Nullable
@@ -63,6 +72,22 @@
        if (this.func_213298_c(Pose.SWIMMING)) {
           Pose pose;
           if (this.func_184613_cA()) {
+@@ -466,11 +_,13 @@
+ 
+       if (this.field_70170_p.func_175659_aa() == Difficulty.PEACEFUL && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223606_i)) {
+          if (this.func_110143_aJ() < this.func_110138_aP() && this.field_70173_aa % 20 == 0) {
+-            this.func_70691_i(1.0F);
++            net.minecraftforge.event.hunger.HealthRegenEvent.PeacefulRegen peacefulHealthRegenEvent = net.minecraftforge.event.ForgeEventFactory.onPeacefulHealthRegen(this);
++            if (!peacefulHealthRegenEvent.isCanceled()) this.func_70691_i(peacefulHealthRegenEvent.getDeltaHealth());
+          }
+ 
+          if (this.field_71100_bB.func_75121_c() && this.field_70173_aa % 10 == 0) {
+-            this.field_71100_bB.func_75114_a(this.field_71100_bB.func_75116_a() + 1);
++            net.minecraftforge.event.hunger.HungerRegenEvent.PeacefulRegen peacefulHungerRegenEvent = net.minecraftforge.event.ForgeEventFactory.onPeacefulHungerRegen(this);
++            if (!peacefulHungerRegenEvent.isCanceled()) this.field_71100_bB.func_75114_a(this.field_71100_bB.func_75116_a() + peacefulHungerRegenEvent.getDeltaHunger());
+          }
+       }
+ 
 @@ -550,6 +_,7 @@
     }
  
@@ -149,7 +174,7 @@
              });
              if (this.field_184627_bm.func_190926_b()) {
                 if (hand == Hand.MAIN_HAND) {
-@@ -847,10 +_,13 @@
+@@ -847,20 +_,23 @@
  
     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_) {
        if (!this.func_180431_b(p_70665_1_)) {
@@ -163,9 +188,11 @@
           float f = p_70665_2_ - f2;
           if (f > 0.0F && f < 3.4028235E37F) {
              this.func_195067_a(Stats.field_212738_J, Math.round(f * 10.0F));
-@@ -859,8 +_,8 @@
+          }
+ 
           if (f2 != 0.0F) {
-             this.func_71020_j(p_70665_1_.func_76345_d());
+-            this.func_71020_j(p_70665_1_.func_76345_d());
++            this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.DAMAGE_TAKEN, p_70665_1_.func_76345_d()));
              float f1 = this.func_110143_aJ();
 -            this.func_70606_j(this.func_110143_aJ() - f2);
              this.func_110142_aN().func_94547_a(p_70665_1_, f1, f2);
@@ -247,6 +274,15 @@
                          this.func_184611_a(Hand.MAIN_HAND, ItemStack.field_190927_a);
                       }
                    }
+@@ -1146,7 +_,7 @@
+                      }
+                   }
+ 
+-                  this.func_71020_j(0.1F);
++                  this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.ATTACK_ENTITY, 0.1F));
+                } else {
+                   this.field_70170_p.func_184148_a((PlayerEntity)null, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), SoundEvents.field_187724_dU, this.func_184176_by(), 1.0F, 1.0F);
+                   if (flag4) {
 @@ -1170,7 +_,7 @@
        }
  
@@ -285,6 +321,58 @@
        } else {
           boolean flag = block.func_181623_g();
           boolean flag1 = p_242374_0_.func_180495_p(p_242374_1_.func_177984_a()).func_177230_c().func_181623_g();
+@@ -1297,9 +_,9 @@
+       super.func_70664_aZ();
+       this.func_195066_a(Stats.field_75953_u);
+       if (this.func_70051_ag()) {
+-         this.func_71020_j(0.2F);
++         this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.SPRINTING_JUMP, 0.2F));
+       } else {
+-         this.func_71020_j(0.05F);
++         this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.NORMAL_JUMP, 0.05F));
+       }
+ 
+    }
+@@ -1357,19 +_,19 @@
+             int i = Math.round(MathHelper.func_76133_a(p_71000_1_ * p_71000_1_ + p_71000_3_ * p_71000_3_ + p_71000_5_ * p_71000_5_) * 100.0F);
+             if (i > 0) {
+                this.func_195067_a(Stats.field_75946_m, i);
+-               this.func_71020_j(0.01F * (float)i * 0.01F);
++               this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_SWIM, 0.01F * (float)i * 0.01F));
+             }
+          } else if (this.func_208600_a(FluidTags.field_206959_a)) {
+             int j = Math.round(MathHelper.func_76133_a(p_71000_1_ * p_71000_1_ + p_71000_3_ * p_71000_3_ + p_71000_5_ * p_71000_5_) * 100.0F);
+             if (j > 0) {
+                this.func_195067_a(Stats.field_211756_w, j);
+-               this.func_71020_j(0.01F * (float)j * 0.01F);
++               this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_UNDERWATER, 0.01F * (float)j * 0.01F));
+             }
+          } else if (this.func_70090_H()) {
+             int k = Math.round(MathHelper.func_76133_a(p_71000_1_ * p_71000_1_ + p_71000_5_ * p_71000_5_) * 100.0F);
+             if (k > 0) {
+                this.func_195067_a(Stats.field_211755_s, k);
+-               this.func_71020_j(0.01F * (float)k * 0.01F);
++               this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_ONWATER, 0.01F * (float)k * 0.01F));
+             }
+          } else if (this.func_70617_f_()) {
+             if (p_71000_3_ > 0.0D) {
+@@ -1380,13 +_,13 @@
+             if (l > 0) {
+                if (this.func_70051_ag()) {
+                   this.func_195067_a(Stats.field_188102_l, l);
+-                  this.func_71020_j(0.1F * (float)l * 0.01F);
++                  this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_SPRINT, 0.1F * (float)l * 0.01F));
+                } else if (this.func_213453_ef()) {
+                   this.func_195067_a(Stats.field_188101_k, l);
+-                  this.func_71020_j(0.0F * (float)l * 0.01F);
++                  this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_CROUCH, 0.0F * (float)l * 0.01F));
+                } else {
+                   this.func_195067_a(Stats.field_188100_j, l);
+-                  this.func_71020_j(0.0F * (float)l * 0.01F);
++                  this.func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_ONLAND, 0.0F * (float)l * 0.01F));
+                }
+             }
+          } else if (this.func_184613_cA()) {
 @@ -1425,6 +_,7 @@
  
     public boolean func_225503_b_(float p_225503_1_, float p_225503_2_) {

--- a/patches/minecraft/net/minecraft/potion/Effect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Effect.java.patch
@@ -9,3 +9,12 @@
     private final Map<Attribute, AttributeModifier> field_111188_I = Maps.newHashMap();
     private final EffectType field_220305_b;
     private final int field_76414_N;
+@@ -51,7 +_,7 @@
+       } else if (this == Effects.field_82731_v) {
+          p_76394_1_.func_70097_a(DamageSource.field_82727_n, 1.0F);
+       } else if (this == Effects.field_76438_s && p_76394_1_ instanceof PlayerEntity) {
+-         ((PlayerEntity)p_76394_1_).func_71020_j(0.005F * (float)(p_76394_2_ + 1));
++         ((PlayerEntity)p_76394_1_).func_71020_j(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded((PlayerEntity)p_76394_1_, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.EFFECT_HUNGER, 0.005F * (float)(p_76394_2_ + 1)));
+       } else if (this == Effects.field_76443_y && p_76394_1_ instanceof PlayerEntity) {
+          if (!p_76394_1_.field_70170_p.field_72995_K) {
+             ((PlayerEntity)p_76394_1_).func_71024_bL().func_75122_a(p_76394_2_ + 1, 1.0F);

--- a/patches/minecraft/net/minecraft/util/FoodStats.java.patch
+++ b/patches/minecraft/net/minecraft/util/FoodStats.java.patch
@@ -1,0 +1,145 @@
+--- a/net/minecraft/util/FoodStats.java
++++ b/net/minecraft/util/FoodStats.java
+@@ -14,64 +_,95 @@
+    private float field_75126_c;
+    private int field_75123_d;
+    private int field_75124_e = 20;
++   // FORGE START
++   private PlayerEntity player;
++   private int starveTimer;
++   // FORGE END
+ 
++   @Deprecated // Forge: Provided for backwards compatibility. Use the Player-specific constructor instead.
+    public FoodStats() {
++      this(null);
++   }
++
++   public FoodStats(PlayerEntity player) {
+       this.field_75125_b = 5.0F;
++      this.player = player;
+    }
+ 
++   @Deprecated // Forge: Don't call this unless the player is not consuming food. Use consume() instead.
+    public void func_75122_a(int p_75122_1_, float p_75122_2_) {
+-      this.field_75127_a = Math.min(p_75122_1_ + this.field_75127_a, 20);
++      if (net.minecraftforge.event.ForgeEventFactory.onFoodStatsAddition(this.player, new net.minecraftforge.common.hunger.FoodValues(p_75122_1_, p_75122_2_))) return;
++      this.field_75127_a = Math.min(p_75122_1_ + this.field_75127_a, net.minecraftforge.event.ForgeEventFactory.getMaxHunger(this.player));
+       this.field_75125_b = Math.min(this.field_75125_b + (float)p_75122_1_ * p_75122_2_ * 2.0F, (float)this.field_75127_a);
+    }
+ 
+    public void func_221410_a(Item p_221410_1_, ItemStack p_221410_2_) {
+-      if (p_221410_1_.func_219971_r()) {
+-         Food food = p_221410_1_.func_219967_s();
+-         this.func_75122_a(food.func_221466_a(), food.func_221469_b());
++      net.minecraftforge.common.hunger.FoodValues modifiedFoodValues = net.minecraftforge.common.hunger.FoodValues.get(p_221410_2_, this.player);
++      if (modifiedFoodValues != null) {
++         int prevFoodLevel = this.field_75127_a;
++         float prevSaturationLevel = this.field_75125_b;
++         this.func_75122_a(modifiedFoodValues.getHunger(), modifiedFoodValues.getSaturationModifier());
++         net.minecraftforge.event.ForgeEventFactory.onFoodEaten(modifiedFoodValues, this.field_75127_a - prevFoodLevel, this.field_75125_b - prevSaturationLevel, p_221410_2_, this.player);
+       }
+ 
+    }
+ 
+    public void func_75118_a(PlayerEntity p_75118_1_) {
+-      Difficulty difficulty = p_75118_1_.field_70170_p.func_175659_aa();
++      if (this.player == null) this.player = p_75118_1_; // Safety-check, in-case the class was constructed without the player-specific constructor
+       this.field_75124_e = this.field_75127_a;
+-      if (this.field_75126_c > 4.0F) {
+-         this.field_75126_c -= 4.0F;
+-         if (this.field_75125_b > 0.0F) {
+-            this.field_75125_b = Math.max(this.field_75125_b - 1.0F, 0.0F);
+-         } else if (difficulty != Difficulty.PEACEFUL) {
+-            this.field_75127_a = Math.max(this.field_75127_a - 1, 0);
++      net.minecraftforge.eventbus.api.Event.Result allowExhaustionResult = net.minecraftforge.event.ForgeEventFactory.fireAllowExhaustionEvent(p_75118_1_);
++      float maxExhaustion = net.minecraftforge.event.ForgeEventFactory.getMaxExhaustion(p_75118_1_);
++      if (allowExhaustionResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowExhaustionResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && this.field_75126_c > maxExhaustion)) {
++         net.minecraftforge.event.hunger.ExhaustionEvent.Exhausted exhaustedEvent = net.minecraftforge.event.ForgeEventFactory.onExhausted(p_75118_1_, maxExhaustion, this.field_75126_c);
++         this.field_75126_c += exhaustedEvent.getDeltaExhaustion();
++         if (!exhaustedEvent.isCanceled()) {
++            this.field_75125_b = Math.max(this.field_75125_b + exhaustedEvent.getDeltaSaturation(), 0.0F);
++            this.field_75127_a = Math.max(this.field_75127_a + exhaustedEvent.getDeltaHunger(), 0);
+          }
+       }
+ 
+       boolean flag = p_75118_1_.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223606_i);
+-      if (flag && this.field_75125_b > 0.0F && p_75118_1_.func_70996_bM() && this.field_75127_a >= 20) {
+-         ++this.field_75123_d;
+-         if (this.field_75123_d >= 10) {
+-            float f = Math.min(this.field_75125_b, 6.0F);
+-            p_75118_1_.func_70691_i(f / 6.0F);
+-            this.func_75113_a(f);
+-            this.field_75123_d = 0;
+-         }
+-      } else if (flag && this.field_75127_a >= 18 && p_75118_1_.func_70996_bM()) {
+-         ++this.field_75123_d;
+-         if (this.field_75123_d >= 80) {
+-            p_75118_1_.func_70691_i(1.0F);
+-            this.func_75113_a(6.0F);
+-            this.field_75123_d = 0;
+-         }
+-      } else if (this.field_75127_a <= 0) {
+-         ++this.field_75123_d;
+-         if (this.field_75123_d >= 80) {
+-            if (p_75118_1_.func_110143_aJ() > 10.0F || difficulty == Difficulty.HARD || p_75118_1_.func_110143_aJ() > 1.0F && difficulty == Difficulty.NORMAL) {
+-               p_75118_1_.func_70097_a(DamageSource.field_76366_f, 1.0F);
+-            }
+-
++      net.minecraftforge.eventbus.api.Event.Result allowSaturatedRegenResult = net.minecraftforge.event.ForgeEventFactory.fireAllowSaturatedRegenEvent(p_75118_1_);
++      boolean shouldDoSaturatedRegen = allowSaturatedRegenResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowSaturatedRegenResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && flag && this.field_75125_b > 0.0F && p_75118_1_.func_70996_bM() && this.field_75127_a >= 20);
++      net.minecraftforge.eventbus.api.Event.Result allowRegenResult = shouldDoSaturatedRegen ? net.minecraftforge.eventbus.api.Event.Result.DENY : net.minecraftforge.event.ForgeEventFactory.fireAllowRegenEvent(p_75118_1_);
++      boolean shouldDoRegen = allowRegenResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowRegenResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && flag && this.field_75127_a >= 18 && p_75118_1_.func_70996_bM());
++      if (shouldDoSaturatedRegen) {
++         ++this.field_75123_d;
++         if (this.field_75123_d >= net.minecraftforge.event.ForgeEventFactory.getSaturatedRegenTickPeriod(p_75118_1_)) {
++            net.minecraftforge.event.hunger.HealthRegenEvent.SaturatedRegen saturatedRegenEvent = net.minecraftforge.event.ForgeEventFactory.onSaturatedRegen(p_75118_1_);
++            if (!saturatedRegenEvent.isCanceled()) {
++               p_75118_1_.func_70691_i(saturatedRegenEvent.getDeltaHealth());
++               this.func_75113_a(saturatedRegenEvent.getDeltaExhaustion());
++            }
++            this.field_75123_d = 0;
++         }
++      } else if (shouldDoRegen) {
++         ++this.field_75123_d;
++         if (this.field_75123_d >= net.minecraftforge.event.ForgeEventFactory.getHealthRegenTickPeriod(p_75118_1_)) {
++            net.minecraftforge.event.hunger.HealthRegenEvent.Regen regenEvent = net.minecraftforge.event.ForgeEventFactory.onHealthRegen(p_75118_1_);
++            if (!regenEvent.isCanceled()) {
++               p_75118_1_.func_70691_i(regenEvent.getDeltaHealth());
++               this.func_75113_a(regenEvent.getDeltaExhaustion());
++            }
+             this.field_75123_d = 0;
+          }
+       } else {
+          this.field_75123_d = 0;
+       }
++      net.minecraftforge.eventbus.api.Event.Result allowStarvationResult = net.minecraftforge.event.ForgeEventFactory.fireAllowStarvationEvent(p_75118_1_);
++      if (allowStarvationResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowStarvationResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && this.field_75127_a <= 0)) {
++         ++this.starveTimer;
++         if (this.starveTimer >= net.minecraftforge.event.ForgeEventFactory.getStarveTickPeriod(p_75118_1_)) {
++            net.minecraftforge.event.hunger.StarvationEvent.Starve starveEvent = net.minecraftforge.event.ForgeEventFactory.onStarvation(p_75118_1_);
++            if (!starveEvent.isCanceled()) {
++               p_75118_1_.func_70097_a(DamageSource.field_76366_f, starveEvent.getStarveDamage());
++            }
++
++            this.starveTimer = 0;
++         }
++      } else {
++         this.starveTimer = 0;
++      }
+ 
+    }
+ 
+@@ -97,11 +_,11 @@
+    }
+ 
+    public boolean func_75121_c() {
+-      return this.field_75127_a < 20;
++      return this.field_75127_a < net.minecraftforge.event.ForgeEventFactory.getMaxHunger(this.player);
+    }
+ 
+    public void func_75113_a(float p_75113_1_) {
+-      this.field_75126_c = Math.min(this.field_75126_c + p_75113_1_, 40.0F);
++      this.field_75126_c = Math.min(this.field_75126_c + p_75113_1_, net.minecraftforge.event.ForgeEventFactory.getExhaustionCap(this.player));
+    }
+ 
+    public float func_75115_e() {

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -54,6 +54,7 @@ import net.minecraft.world.GameType;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 
 import org.lwjgl.opengl.GL11;
 
@@ -511,7 +512,24 @@ public class ForgeIngameGui extends IngameGui
         boolean unused = false;// Unused flag in vanilla, seems to be part of a 'fade out' mechanic
 
         FoodStats stats = minecraft.player.getFoodData();
-        int level = stats.getFoodLevel();
+        // Account for changes in max hunger here
+        int realHunger = stats.getFoodLevel();
+        int level;
+        // Only set level to 0 if the real hunger value is 0
+        if (realHunger == 0)
+        {
+            level = 0;
+        }
+        else
+        {
+            // Return a scaled value so that the HUD can still use the same logic as if the max was 20.
+            float scale = 20.0F / ForgeEventFactory.getMaxHunger(minecraft.player);
+            // Floor here so that full hunger is only drawn when it's actually maxed
+            int scaledHunger = MathHelper.floor(realHunger * scale);
+            // Hunger is always some non-zero value here, so set level to at least 1 to make sure we don't draw 0 hunger
+            // when we're not actually starving
+            level = Math.max(scaledHunger, 1);
+        }
 
         for (int i = 0; i < 10; ++i)
         {

--- a/src/main/java/net/minecraftforge/common/hunger/FoodValues.java
+++ b/src/main/java/net/minecraftforge/common/hunger/FoodValues.java
@@ -1,0 +1,166 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Food;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.ForgeEventFactory;
+
+import javax.annotation.Nonnull;
+
+/**
+ * FoodValues is a utility class used to retrieve and hold food values.
+ *
+ * To get food values for any given food, use any of the static {@link #get} methods.
+ *
+ * <pre>
+ * {@code
+ * FoodValues appleFoodValues = FoodValues.get(new ItemStack(Items.APPLE));
+ * }
+ * </pre>
+ */
+public class FoodValues
+{
+    private final int hunger;
+    private final float saturationModifier;
+
+    public FoodValues(int hunger, float saturationModifier)
+    {
+        this.hunger = hunger;
+        this.saturationModifier = saturationModifier;
+    }
+
+    public FoodValues(FoodValues other)
+    {
+        this(other.hunger, other.saturationModifier);
+    }
+
+    public int getHunger()
+    {
+        return hunger;
+    }
+
+    public float getSaturationModifier()
+    {
+        return saturationModifier;
+    }
+
+    /**
+     * @return The amount of saturation that the food values would provide, ignoring any limits.
+     */
+    public float getUnboundedSaturationIncrement()
+    {
+        return hunger * saturationModifier * 2f;
+    }
+
+    /**
+     * @return The bounded amount of saturation that the food values would provide to this player,
+     * taking their max hunger level into account.
+     */
+    public float getSaturationIncrement(PlayerEntity player)
+    {
+        return Math.min(ForgeEventFactory.getMaxHunger(player), getUnboundedSaturationIncrement());
+    }
+
+    /**
+     * Get unmodified (vanilla) food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues getUnmodified(@Nonnull ItemStack stack)
+    {
+        if (stack != ItemStack.EMPTY)
+        {
+            if (stack.isEdible())
+            {
+                Food food = stack.getItem().getFoodProperties();
+                return new FoodValues(food.getNutrition(), food.getSaturationModifier());
+            }
+            else if (stack.getItem() instanceof IEdible)
+            {
+                return ((IEdible)stack.getItem()).getFoodValues(stack);
+            }
+            else if (stack.getItem() instanceof BlockItem)
+            {
+                BlockItem blockItem = (BlockItem)stack.getItem();
+                if (blockItem.getBlock() instanceof IEdible)
+                {
+                    return ((IEdible)blockItem.getBlock()).getFoodValues(stack);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get player-agnostic food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues get(@Nonnull ItemStack stack)
+    {
+        return get(stack, null);
+    }
+
+    /**
+     * Get player-specific food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues get(@Nonnull ItemStack stack, PlayerEntity player)
+    {
+        FoodValues foodValues = getUnmodified(stack);
+        if (foodValues != null)
+        {
+            return ForgeEventFactory.getFoodValues(foodValues, stack, player);
+        }
+        return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + hunger;
+        result = prime * result + Float.floatToIntBits(saturationModifier);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FoodValues other = (FoodValues) obj;
+        if (hunger != other.hunger)
+            return false;
+        if (Float.floatToIntBits(saturationModifier) != Float.floatToIntBits(other.saturationModifier))
+            return false;
+        return true;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/hunger/IEdible.java
+++ b/src/main/java/net/minecraftforge/common/hunger/IEdible.java
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.hunger;
+
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Interface to be applied to non-standard food items or blocks that are edible, in order to obtain their food values.
+ * For example, Forge implements this interface on {@link net.minecraft.block.CakeBlock}.
+ * It is recommended to add a {@link net.minecraft.item.Food} object to your item and not use this interface.
+ */
+public interface IEdible
+{
+    /**
+     * Obtain the FoodValues for this object
+     * @param stack The ItemStack containing this edible object
+     * @return The FoodValues for the object.
+     */
+    FoodValues getFoodValues(@Nonnull ItemStack stack);
+
+    /**
+     * @return true if this edible object can be eaten even when the player's hunger is full
+     * @see net.minecraft.item.Food#canAlwaysEat()
+     */
+    boolean canAlwaysEat();
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -97,6 +97,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ToolType;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.hunger.FoodValues;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
@@ -134,6 +135,7 @@ import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
+import net.minecraftforge.event.hunger.*;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
@@ -839,5 +841,143 @@ public class ForgeEventFactory
         EntityTeleportEvent.ChorusFruit event = new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
+    }
+
+    public static int getMaxHunger(PlayerEntity player)
+    {
+        HungerEvent.GetMaxHunger event = new HungerEvent.GetMaxHunger(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMaxHunger();
+    }
+
+    public static FoodValues getFoodValues(FoodValues originalFoodValues, ItemStack stack, PlayerEntity player)
+    {
+        FoodEvent.GetFoodValues event = new FoodEvent.GetFoodValues(originalFoodValues, stack, player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getFoodValues();
+    }
+
+    public static boolean onFoodStatsAddition(PlayerEntity player, FoodValues foodValuesToBeAdded)
+    {
+        FoodEvent.FoodStatsAddition event = new FoodEvent.FoodStatsAddition(foodValuesToBeAdded, player);
+        return MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    public static void onFoodEaten(FoodValues foodValues, int hungerAdded, float saturationAdded, ItemStack stack, PlayerEntity player)
+    {
+        FoodEvent.FoodEaten event = new FoodEvent.FoodEaten(foodValues, hungerAdded, saturationAdded, stack, player);
+        MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    public static float getExhaustionCap(PlayerEntity player)
+    {
+        ExhaustionEvent.GetExhaustionCap event = new ExhaustionEvent.GetExhaustionCap(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getExhaustionLevelCap();
+    }
+
+    public static Result fireAllowExhaustionEvent(PlayerEntity player)
+    {
+        ExhaustionEvent.AllowExhaustion event = new ExhaustionEvent.AllowExhaustion(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static float getMaxExhaustion(PlayerEntity player)
+    {
+        ExhaustionEvent.GetMaxExhaustion event = new ExhaustionEvent.GetMaxExhaustion(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMaxExhaustionLevel();
+    }
+
+    public static ExhaustionEvent.Exhausted onExhausted(PlayerEntity player, float exhaustionToRemove, float currentExhaustionLevel)
+    {
+        ExhaustionEvent.Exhausted event = new ExhaustionEvent.Exhausted(player, exhaustionToRemove, currentExhaustionLevel);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static Result fireAllowSaturatedRegenEvent(PlayerEntity player)
+    {
+        HealthRegenEvent.AllowSaturatedRegen event = new HealthRegenEvent.AllowSaturatedRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static Result fireAllowRegenEvent(PlayerEntity player)
+    {
+        HealthRegenEvent.AllowRegen event = new HealthRegenEvent.AllowRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static int getSaturatedRegenTickPeriod(PlayerEntity player)
+    {
+        HealthRegenEvent.GetSaturatedRegenTickPeriod event = new HealthRegenEvent.GetSaturatedRegenTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRegenTickPeriod();
+    }
+
+    public static HealthRegenEvent.SaturatedRegen onSaturatedRegen(PlayerEntity player)
+    {
+        HealthRegenEvent.SaturatedRegen event = new HealthRegenEvent.SaturatedRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static int getHealthRegenTickPeriod(PlayerEntity player)
+    {
+        HealthRegenEvent.GetRegenTickPeriod event = new HealthRegenEvent.GetRegenTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRegenTickPeriod();
+    }
+
+    public static HealthRegenEvent.Regen onHealthRegen(PlayerEntity player)
+    {
+        HealthRegenEvent.Regen event = new HealthRegenEvent.Regen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static Result fireAllowStarvationEvent(PlayerEntity player)
+    {
+        StarvationEvent.AllowStarvation event = new StarvationEvent.AllowStarvation(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static int getStarveTickPeriod(PlayerEntity player)
+    {
+        StarvationEvent.GetStarveTickPeriod event = new StarvationEvent.GetStarveTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getStarveTickPeriod();
+    }
+
+    public static StarvationEvent.Starve onStarvation(PlayerEntity player)
+    {
+        StarvationEvent.Starve event = new StarvationEvent.Starve(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static HealthRegenEvent.PeacefulRegen onPeacefulHealthRegen(PlayerEntity player)
+    {
+        HealthRegenEvent.PeacefulRegen event = new HealthRegenEvent.PeacefulRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static HungerRegenEvent.PeacefulRegen onPeacefulHungerRegen(PlayerEntity player)
+    {
+        HungerRegenEvent.PeacefulRegen event = new HungerRegenEvent.PeacefulRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static float onExhaustionAdded(PlayerEntity player, ExhaustionEvent.ExhaustingActions action, float deltaExhaustion)
+    {
+        ExhaustionEvent.ExhaustionAdded event = new ExhaustionEvent.ExhaustionAdded(player, action, deltaExhaustion);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getDeltaExhaustion();
     }
 }

--- a/src/main/java/net/minecraftforge/event/hunger/ExhaustionEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/ExhaustionEvent.java
@@ -1,0 +1,256 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.Difficulty;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all ExhaustionEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class ExhaustionEvent extends Event
+{
+    private final PlayerEntity player;
+
+    protected ExhaustionEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not exhaustion is allowed for the {@link #player}.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow exhaustion without condition.
+     * {@link Result#DENY} will deny exhaustion without condition.
+     */
+    @HasResult
+    public static class AllowExhaustion extends ExhaustionEvent
+    {
+        public AllowExhaustion(PlayerEntity player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Enumeration of actions that cause exhaustion in vanilla Minecraft
+     * @see ExhaustionAdded
+     */
+    public enum ExhaustingActions
+    {
+        HARVEST_BLOCK,
+        NORMAL_JUMP,
+        SPRINTING_JUMP,
+        ATTACK_ENTITY,
+        DAMAGE_TAKEN,
+        EFFECT_HUNGER,
+        MOVEMENT_SWIM,
+        MOVEMENT_WALK_UNDERWATER,
+        MOVEMENT_WALK_ONWATER,
+        MOVEMENT_SPRINT,
+        MOVEMENT_CROUCH,
+        MOVEMENT_WALK_ONLAND
+    }
+
+    /**
+     * Fired each time a {@link #player} does something that changes exhaustion in vanilla Minecraft
+     * (i.e. jumping, sprinting, etc; see {@link ExhaustingActions} for the full list of possible sources)
+     *
+     * This event is fired whenever {@link PlayerEntity#causeFoodExhaustion} is called from within Minecraft code.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class ExhaustionAdded extends ExhaustionEvent
+    {
+        private final ExhaustingActions action;
+        private float deltaExhaustion;
+
+        public ExhaustionAdded(PlayerEntity player, ExhaustingActions action, float deltaExhaustion)
+        {
+            super(player);
+            this.action = action;
+            this.deltaExhaustion = deltaExhaustion;
+        }
+
+        public ExhaustingActions getAction()
+        {
+            return action;
+        }
+
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+
+    /**
+     * Fired every time max exhaustion level is retrieved to allow control over its value.
+     *
+     * {@link #maxExhaustionLevel} contains the exhaustion level that will trigger a hunger/saturation decrement.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetMaxExhaustion extends ExhaustionEvent
+    {
+        private float maxExhaustionLevel;
+
+        public GetMaxExhaustion(PlayerEntity player)
+        {
+            super(player);
+            this.maxExhaustionLevel = 4.0F;
+        }
+
+        public float getMaxExhaustionLevel()
+        {
+            return maxExhaustionLevel;
+        }
+
+        public void setMaxExhaustionLevel(float maxExhaustionLevel)
+        {
+            this.maxExhaustionLevel = maxExhaustionLevel;
+        }
+    }
+
+    /**
+     * Fired once exhaustionLevel exceeds maxExhaustionLevel (see {@link GetMaxExhaustion}),
+     * in order to control how exhaustion affects hunger/saturation.
+     *
+     * {@link #currentExhaustionLevel} contains the exhaustion level of the {@link #player}.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level (default: {@link GetMaxExhaustion#maxExhaustionLevel}).
+     * {@link #deltaHunger} contains the delta to be applied to hunger.
+     * {@link #deltaSaturation} contains the delta to be applied to saturation.
+     *
+     * Note: {@link #deltaHunger} and {@link #deltaSaturation} will vary depending on their vanilla conditionals.
+     * For example, deltaHunger will be 0 when this event is fired in Peaceful difficulty.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to hunger and saturation.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    @Cancelable
+    public static class Exhausted extends ExhaustionEvent
+    {
+        private final float currentExhaustionLevel;
+        private float deltaExhaustion;
+        private int deltaHunger;
+        private float deltaSaturation;
+
+        public Exhausted(PlayerEntity player, float exhaustionToRemove, float currentExhaustionLevel)
+        {
+            super(player);
+            this.currentExhaustionLevel = currentExhaustionLevel;
+            this.deltaExhaustion = -exhaustionToRemove;
+
+            boolean shouldDecreaseSaturationLevel = player.getFoodData().getSaturationLevel() > 0.0F;
+            this.deltaSaturation = shouldDecreaseSaturationLevel ? -1.0F : 0.0F;
+
+            boolean shouldDecreaseFoodLevel = !shouldDecreaseSaturationLevel && player.level.getDifficulty() != Difficulty.PEACEFUL;
+            this.deltaHunger = shouldDecreaseFoodLevel ? -1 : 0;
+        }
+
+        public float getCurrentExhaustionLevel()
+        {
+            return currentExhaustionLevel;
+        }
+
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+
+        public int getDeltaHunger()
+        {
+            return deltaHunger;
+        }
+
+        public void setDeltaHunger(int deltaHunger)
+        {
+            this.deltaHunger = deltaHunger;
+        }
+
+        public float getDeltaSaturation()
+        {
+            return deltaSaturation;
+        }
+
+        public void setDeltaSaturation(float deltaSaturation)
+        {
+            this.deltaSaturation = deltaSaturation;
+        }
+    }
+
+    /**
+     * Fired every time the exhaustion level is capped to allow control over the cap.
+     *
+     * {@link #exhaustionLevelCap} contains the exhaustion level that will be used to cap the exhaustion level.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetExhaustionCap extends ExhaustionEvent
+    {
+        private float exhaustionLevelCap;
+
+        public GetExhaustionCap(PlayerEntity player)
+        {
+            super(player);
+            this.exhaustionLevelCap = 40.0F;
+        }
+
+        public float getExhaustionLevelCap()
+        {
+            return exhaustionLevelCap;
+        }
+
+        public void setExhaustionLevelCap(float exhaustionLevelCap)
+        {
+            this.exhaustionLevelCap = exhaustionLevelCap;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/FoodEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/FoodEvent.java
@@ -1,0 +1,161 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all FoodEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class FoodEvent extends Event
+{
+    private final PlayerEntity player;
+
+    protected FoodEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired every time food values are retrieved to allow control over their values.
+     * For this event, player can be null, which would indicate that the values should be player-independent.
+     *
+     * {@link #foodValues} contains the food values of the food associated with the {@link #itemstack}.
+     * {@link #originalFoodValues} contains the food values of the food associated with the {@link #itemstack} before the GetFoodValues event was fired.
+     * {@link #itemstack} contains the food in question.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetFoodValues extends FoodEvent
+    {
+        private FoodValues foodValues;
+        private final FoodValues originalFoodValues;
+        private final ItemStack itemstack;
+
+        public GetFoodValues(FoodValues originalFoodValues, ItemStack itemstack, PlayerEntity player)
+        {
+            super(player);
+            this.foodValues = originalFoodValues;
+            this.originalFoodValues = originalFoodValues;
+            this.itemstack = itemstack;
+        }
+
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+
+        public void setFoodValues(FoodValues foodValues)
+        {
+            this.foodValues = foodValues;
+        }
+
+        public FoodValues getOriginalFoodValues()
+        {
+            return originalFoodValues;
+        }
+
+        public ItemStack getItemStack()
+        {
+            return itemstack;
+        }
+    }
+
+    /**
+     * Fired after {@link net.minecraft.util.FoodStats#eat(Item, ItemStack)}, containing the effects and context for the food that was eaten.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class FoodEaten extends FoodEvent
+    {
+        private final FoodValues foodValues;
+        private final int hungerAdded;
+        private final float saturationAdded;
+        private final ItemStack food;
+
+        public FoodEaten(FoodValues foodValues, int hungerAdded, float saturationAdded, ItemStack food, PlayerEntity player)
+        {
+            super(player);
+            this.foodValues = foodValues;
+            this.hungerAdded = hungerAdded;
+            this.saturationAdded = saturationAdded;
+            this.food = food;
+        }
+
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+
+        public int getHungerAdded()
+        {
+            return hungerAdded;
+        }
+
+        public float getSaturationAdded()
+        {
+            return saturationAdded;
+        }
+
+        public ItemStack getItemStack() {
+            return food;
+        }
+    }
+
+    /**
+     * Fired when hunger/saturation is added to a player's FoodStats.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, the hunger and saturation of the FoodStats will not change.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    @Cancelable
+    public static class FoodStatsAddition extends FoodEvent
+    {
+        private final FoodValues foodValues;
+
+        public FoodStatsAddition(FoodValues foodValues, PlayerEntity player)
+        {
+            super(player);
+            this.foodValues = foodValues;
+        }
+
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HealthRegenEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HealthRegenEvent.java
@@ -1,0 +1,275 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HealthRegenEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HealthRegenEvent extends Event
+{
+    private final PlayerEntity player;
+
+    protected HealthRegenEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not health regen from food is allowed for the {@link #player}.
+     * However, this event will not be fired if saturated regen occurs, as saturated health regen will take precedence
+     * over normal health regen (see {@link AllowSaturatedRegen}).
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow regen without condition.
+     * {@link Result#DENY} will deny regen without condition.
+     */
+    @HasResult
+    public static class AllowRegen extends HealthRegenEvent
+    {
+        public AllowRegen(PlayerEntity player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the regen tick period is retrieved to allow control over its value.
+     *
+     * {@link #regenTickPeriod} contains the number of ticks between each regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetRegenTickPeriod extends HealthRegenEvent
+    {
+        private int regenTickPeriod;
+
+        public GetRegenTickPeriod(PlayerEntity player)
+        {
+            super(player);
+            this.regenTickPeriod = 80;
+        }
+
+        public int getRegenTickPeriod()
+        {
+            return regenTickPeriod;
+        }
+
+        public void setRegenTickPeriod(int regenTickPeriod)
+        {
+            this.regenTickPeriod = regenTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the ticks since last regen reaches regenTickPeriod (see {@link GetRegenTickPeriod}),
+     * in order to control how regen affects health/exhaustion.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to health and exhaustion.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class Regen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+        private float deltaExhaustion;
+
+        public Regen(PlayerEntity player)
+        {
+            super(player);
+            this.deltaHealth = 1.0F;
+            this.deltaExhaustion = 6.0F;
+        }
+
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+
+    /**
+     * Fired every second for each player while in Peaceful difficulty,
+     * in order to control how much health to passively regenerate.
+     *
+     * This event is never fired if the game rule "naturalRegeneration" is false.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip healing the player.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class PeacefulRegen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+
+        public PeacefulRegen(PlayerEntity player)
+        {
+            super(player);
+            this.deltaHealth = 1.0F;
+        }
+
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or health regen from full hunger + saturation is allowed for the {@link #player}.
+     *
+     * Saturated health regen will take precedence over normal health regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow regen without condition.
+     * {@link Result#DENY} will deny regen without condition.
+     */
+    @HasResult
+    public static class AllowSaturatedRegen extends HealthRegenEvent
+    {
+        public AllowSaturatedRegen(PlayerEntity player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the saturated regen tick period is retrieved to allow control over its value.
+     *
+     * {@link #regenTickPeriod} contains the number of ticks between each saturated regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetSaturatedRegenTickPeriod extends HealthRegenEvent
+    {
+        private int regenTickPeriod;
+
+        public GetSaturatedRegenTickPeriod(PlayerEntity player)
+        {
+            super(player);
+            this.regenTickPeriod = 10;
+        }
+
+        public int getRegenTickPeriod()
+        {
+            return regenTickPeriod;
+        }
+
+        public void setRegenTickPeriod(int regenTickPeriod)
+        {
+            this.regenTickPeriod = regenTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the ticks since last regen reaches regenTickPeriod (see {@link GetSaturatedRegenTickPeriod}),
+     * in order to control how regen affects health/exhaustion.
+     *
+     * By default, the amount of health restored depends on the player's current saturation level.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to health and exhaustion.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class SaturatedRegen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+        private float deltaExhaustion;
+
+        public SaturatedRegen(PlayerEntity player)
+        {
+            super(player);
+            this.deltaExhaustion = Math.min(player.getFoodData().getSaturationLevel(), 6.0F);
+            this.deltaHealth = deltaExhaustion / 6.0F;
+        }
+
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HungerEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HungerEvent.java
@@ -1,0 +1,78 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HungerEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HungerEvent extends Event
+{
+    private final PlayerEntity player;
+
+    public HungerEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired every time max hunger level is retrieved to allow control over its value.
+     *
+     * Note: This also affects max saturation, as saturation is bounded by the player's
+     * current hunger level (that is, a max of 40 hunger would also mean a max of 40
+     * saturation).
+     *
+     * {@link #maxHunger} contains the max hunger of the player.
+     * {@link #player} contains the player.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetMaxHunger extends HungerEvent
+    {
+        private int maxHunger;
+
+        public GetMaxHunger(PlayerEntity player)
+        {
+            super(player);
+            this.maxHunger = 20;
+        }
+
+        public int getMaxHunger()
+        {
+            return maxHunger;
+        }
+
+        public void setMaxHunger(int maxHunger)
+        {
+            this.maxHunger = maxHunger;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HungerRegenEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HungerRegenEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HealthRegenEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HungerRegenEvent extends Event
+{
+    private final PlayerEntity player;
+
+    public HungerRegenEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired twice every second for each player while in Peaceful difficulty,
+     * in order to control how much hunger to passively regenerate.
+     *
+     * This event is never fired if the game rule "naturalRegeneration" is false.
+     *
+     * {@link #deltaHunger} contains the delta to be applied to hunger.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip adding hunger to the player.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class PeacefulRegen extends HungerRegenEvent
+    {
+        private int deltaHunger;
+
+        public PeacefulRegen(PlayerEntity player)
+        {
+            super(player);
+            this.deltaHunger = 1;
+        }
+
+        public int getDeltaHunger()
+        {
+            return deltaHunger;
+        }
+
+        public void setDeltaHunger(int deltaHunger)
+        {
+            this.deltaHunger = deltaHunger;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/StarvationEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/StarvationEvent.java
@@ -1,0 +1,130 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.Difficulty;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all StarvationEvent events.
+ * 
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class StarvationEvent extends Event
+{
+    private final PlayerEntity player;
+
+    public StarvationEvent(PlayerEntity player)
+    {
+        this.player = player;
+    }
+
+    public PlayerEntity getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not starvation is allowed for the {@link #player}.
+     * 
+     * This event is not {@link Cancelable}.
+     * 
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow starvation without condition.
+     * {@link Result#DENY} will deny starvation without condition.
+     */
+    @HasResult
+    public static class AllowStarvation extends StarvationEvent
+    {
+        public AllowStarvation(PlayerEntity player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the starve tick period is retrieved to allow control over its value.
+     * 
+     * {@link #starveTickPeriod} contains the number of ticks between starvation damage being done.
+     * 
+     * This event is not {@link Cancelable}.
+     * 
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetStarveTickPeriod extends StarvationEvent
+    {
+        private int starveTickPeriod;
+
+        public GetStarveTickPeriod(PlayerEntity player)
+        {
+            super(player);
+            this.starveTickPeriod = 80;
+        }
+
+        public int getStarveTickPeriod()
+        {
+            return starveTickPeriod;
+        }
+
+        public void setStarveTickPeriod(int starveTickPeriod)
+        {
+            this.starveTickPeriod = starveTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the time since last starvation damage reaches starveTickPeriod (see {@link GetStarveTickPeriod}),
+     * in order to control how much starvation damage to do.
+     * 
+     * {@link #starveDamage} contains the amount of damage to deal from starvation.
+     * 
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip dealing starvation damage.
+     * 
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class Starve extends StarvationEvent
+    {
+        private float starveDamage;
+
+        public Starve(PlayerEntity player)
+        {
+            super(player);
+
+            Difficulty difficulty = player.level.getDifficulty();
+            boolean shouldDoDamage = player.getHealth() > 10.0F || difficulty == Difficulty.HARD || player.getHealth() > 1.0F && difficulty == Difficulty.NORMAL;
+            this.starveDamage = shouldDoDamage ? 1.0F : 0.0F;
+        }
+
+        public float getStarveDamage()
+        {
+            return starveDamage;
+        }
+
+        public void setStarveDamage(float starveDamage)
+        {
+            this.starveDamage = starveDamage;
+        }
+    }
+}

--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -97,6 +97,7 @@ net/minecraft/resources/IResourceManager func_219533_b(Lnet/minecraft/util/Resou
 net/minecraft/tags/ITagCollection func_199913_a(Ljava/lang/Object;)Ljava/util/Collection; # getOwningTags
 net/minecraft/util/Direction func_176739_a(Ljava/lang/String;)Lnet/minecraft/util/Direction; # byName
 net/minecraft/util/Direction$Axis func_176717_a(Ljava/lang/String;)Lnet/minecraft/util/Direction$Axis; # byName
+net/minecraft/util/FoodStats func_75119_b(F)V # setFoodSaturationLevel
 net/minecraft/util/math/vector/Vector3d func_216371_e()Lnet/minecraft/util/math/vector/Vector3d;
 net/minecraft/util/math/vector/Vector3d func_189984_a(Lnet/minecraft/util/math/vector/Vector2f;)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw
 net/minecraft/util/math/vector/Vector3d func_189986_a(FF)Lnet/minecraft/util/math/vector/Vector3d; # fromPitchYaw

--- a/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.block.*;

--- a/src/test/java/net/minecraftforge/debug/hunger/EdibleBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/EdibleBlockTest.java
@@ -1,0 +1,110 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.world.World;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.common.hunger.IEdible;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ObjectHolder;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Tests that implementing IEdible on a block works as expected.
+ * Creates a block that when right-clicked rewards 10 hunger points and 10 saturation.
+ */
+@Mod(EdibleBlockTest.MODID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class EdibleBlockTest
+{
+    private static final boolean ENABLED = false;
+    static final String MODID = "edible_block_test";
+    private static final String BLOCKID = "forge_edible_block";
+
+    @ObjectHolder(BLOCKID)
+    private static Block EDIBLE_BLOCK;
+
+    @SubscribeEvent
+    public static void registerBlocks(RegistryEvent.Register<Block> event)
+    {
+        if (ENABLED) event.getRegistry().register(new ForgeEdibleBlock(AbstractBlock.Properties.of(Material.CAKE).strength(0.5F).sound(SoundType.WOOL)));
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if (ENABLED) event.getRegistry().register(new BlockItem(EDIBLE_BLOCK, new Item.Properties()).setRegistryName(MODID, BLOCKID));
+    }
+
+    public static class ForgeEdibleBlock extends Block implements IEdible
+    {
+        public ForgeEdibleBlock(Properties properties)
+        {
+            super(properties);
+            setRegistryName(EdibleBlockTest.MODID, EdibleBlockTest.BLOCKID);
+        }
+
+        @Override
+        public ActionResultType use(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit)
+        {
+            if (!player.canEat(this.canAlwaysEat()))
+            {
+                return ActionResultType.PASS;
+            }
+            else
+            {
+                if (!worldIn.isClientSide)
+                {
+                    player.getFoodData().eat(this.asItem(), new ItemStack(this));
+                    worldIn.removeBlock(pos, false);
+                }
+                return ActionResultType.SUCCESS;
+            }
+        }
+
+        @Override
+        public FoodValues getFoodValues(@Nonnull ItemStack stack)
+        {
+            return new FoodValues(10, 10F);
+        }
+
+        @Override
+        public boolean canAlwaysEat()
+        {
+            return true;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/ExhaustionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/ExhaustionEventTest.java
@@ -1,0 +1,97 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.ExhaustionEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Tests all of the {@link ExhaustionEvent}s.
+ * Changes made by this mod to test for:
+ * - Maximum exhaustion level a player can have increased from 4.0 -> 30.0
+ * - Maximum exhaustion addition at one time increased from 40.0 -> 90.0
+ * - Non-sprinting jumps should apply a random amount of exhaustion each time
+ * - Sprinting jumps should apply 90 exhaustion each time
+ * - All other exhausting actions should be 1.5x their normal rate
+ * - Hunger loss should occur in peaceful difficulty
+ */
+@Mod("exhaustion_event_test")
+@Mod.EventBusSubscriber
+public class ExhaustionEventTest
+{
+    private static final boolean ENABLED = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    public static void onGetMaxExhaustion(ExhaustionEvent.GetMaxExhaustion event)
+    {
+        // Increase the maximum exhaustion level to 30
+        if (ENABLED) event.setMaxExhaustionLevel(30.0F);
+    }
+
+    @SubscribeEvent
+    public static void onExhausted(ExhaustionEvent.Exhausted event)
+    {
+        // This will enable hunger loss in peaceful difficulty
+        if (ENABLED)
+        {
+            if (event.getPlayer().getFoodData().getSaturationLevel() <= 0)
+            {
+                event.setDeltaHunger(-1);
+            }
+            LOGGER.info("onExhausted exhaustion=" + event.getCurrentExhaustionLevel());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onExhaustionAdded(ExhaustionEvent.ExhaustionAdded event)
+    {
+        if (ENABLED)
+        {
+            // Randomize exhaustion for each normal jump
+            if (event.getAction() == ExhaustionEvent.ExhaustingActions.NORMAL_JUMP)
+            {
+                event.setDeltaExhaustion((float)Math.random());
+            }
+            // Apply a large amount of exhaustion for each sprinting jump
+            // Note: This is over the default addition cap of 40, but also over the modified cap of 90 below.
+            //       So in theory, this should actually only do 90 units of exhaustion
+            else if (event.getAction() == ExhaustionEvent.ExhaustingActions.SPRINTING_JUMP)
+            {
+                event.setDeltaExhaustion(100.0F);
+            }
+            // Otherwise, scale all exhaustion additions by 1.5x
+            else
+            {
+                event.setDeltaExhaustion(event.getDeltaExhaustion() * 1.5F);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onGetExhaustionCap(ExhaustionEvent.GetExhaustionCap event)
+    {
+        // Increase the max exhaustion addition cap to 90
+        if (ENABLED) event.setExhaustionLevelCap(90.0F);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/FoodEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/FoodEventTest.java
@@ -1,0 +1,88 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraft.item.Items;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.hunger.FoodEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Tests all of the {@link FoodEvent}s.
+ * Changes made by this mod to test for:
+ * - Apple's FoodValues are changed to 19 hunger and 1 saturation
+ * - All other foods have their food values changed to be (20 - playerFoodLevel) / 8, with 1 saturation
+ * - The player should not be allowed to increase their hunger or saturation if their hunger is already over halfway filled
+ * - If the player just ate food that healed at least 1 hunger point, heal the player half a heart
+ */
+@Mod("food_event_test")
+@Mod.EventBusSubscriber
+public class FoodEventTest
+{
+    private static final boolean ENABLED = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    public static void onGetFoodValues(FoodEvent.GetFoodValues event)
+    {
+        // Apples should now restore 19 hunger and provide 1 saturation.
+        // All other foods will have their hunger points scaled based on the current player's food level.
+        if (ENABLED && event.getPlayer() != null)
+        {
+            if (event.getItemStack().getItem() == Items.APPLE)
+            {
+                event.setFoodValues(new FoodValues(19, 1.0F));
+            }
+            else
+            {
+                event.setFoodValues(new FoodValues((20 - event.getPlayer().getFoodData().getFoodLevel()) / 8, 1.0F));
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onFoodStatsAddition(FoodEvent.FoodStatsAddition event)
+    {
+        // If the player's hunger level is over halfway filled, cancel the food stats addition
+        if (ENABLED && event.getPlayer().getFoodData().getFoodLevel() > ForgeEventFactory.getMaxHunger(event.getPlayer()) / 2)
+        {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onFoodEaten(FoodEvent.FoodEaten event)
+    {
+        // Log what was eaten
+        // If it added more than 1 hunger point, heal the player one half of a heart
+        if (ENABLED)
+        {
+            LOGGER.info(event.getPlayer().getDisplayName().getString() + " ate " + event.getItemStack().toString());
+            if (event.getHungerAdded() >= 1)
+            {
+                event.getPlayer().heal(1.0F);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HealthRegenEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HealthRegenEventTest.java
@@ -1,0 +1,106 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HealthRegenEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HealthRegenEvent}s.
+ * Changes made by this mod to test for:
+ * - Normal health regen (unsaturated)
+ *   - Should occur no matter the food level or the state of the "naturalRegeneration" gamerule
+ *   - Tick period reduced from 80 -> 10
+ *   - Should always heal one full heart at a time
+ *   - Exhaustion added halved from 6.0 -> 3.0
+ * - Health regeneration in peaceful difficulty should not occur
+ * - Saturated health regen
+ *   - Should be allowed under the default vanilla logic
+ *   - Tick period doubled from 10 -> 20
+ *   - Should always heal half a heart at a time
+ *   - Exhaustion added held constant at 1.0
+ */
+@Mod("health_regen_event_test")
+@Mod.EventBusSubscriber
+public class HealthRegenEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAllowHealthRegen(HealthRegenEvent.AllowRegen event)
+    {
+        // Allow health regen at all times, unless the player is already fully healed. Meaning:
+        // - ignore food level
+        // - ignore naturalRegeneration gamerule
+        if (ENABLED && event.getPlayer().isHurt()) event.setResult(Event.Result.ALLOW);
+    }
+
+    @SubscribeEvent
+    public static void onGetRegenTickPeriod(HealthRegenEvent.GetRegenTickPeriod event)
+    {
+        // Reduce health regen tick period to 10 ticks
+        if (ENABLED) event.setRegenTickPeriod(10);
+    }
+
+    @SubscribeEvent
+    public static void onRegen(HealthRegenEvent.Regen event)
+    {
+        // Heal a whole heart at a time, and halve the amount of exhaustion added
+        if (ENABLED)
+        {
+            event.setDeltaHealth(2.0F);
+            event.setDeltaExhaustion(3.0F);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPeacefulRegen(HealthRegenEvent.PeacefulRegen event)
+    {
+        // Disable health regen in peaceful
+        if (ENABLED) event.setDeltaHealth(0.0F);
+    }
+
+    @SubscribeEvent
+    public static void onAllowSaturatedRegen(HealthRegenEvent.AllowSaturatedRegen event)
+    {
+        // Use the default vanilla logic
+        if (ENABLED) event.setResult(Event.Result.DEFAULT);
+    }
+
+    @SubscribeEvent
+    public static void onGetSaturatedRegenTickPeriod(HealthRegenEvent.GetSaturatedRegenTickPeriod event)
+    {
+        // Double the normal saturated regen tick period
+        if (ENABLED) event.setRegenTickPeriod(20);
+    }
+
+    @SubscribeEvent
+    public static void onSaturatedRegen(HealthRegenEvent.SaturatedRegen event)
+    {
+        // Always heal half a heart, and only add 1 exhaustion each time
+        if (ENABLED)
+        {
+            event.setDeltaHealth(1);
+            event.setDeltaExhaustion(1.0F);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HungerEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HungerEventTest.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HungerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HungerEvent}s.
+ * Changes made by this mod to test for:
+ * - Maximum hunger is increased from 20 -> 60.
+ *   - It should look visually the same on the HUD, but you should notice it visually changes less often.
+ */
+@Mod("hunger_event_test")
+@Mod.EventBusSubscriber
+public class HungerEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onGetMaxHunger(HungerEvent.GetMaxHunger event)
+    {
+        // Increase maximum hunger to 60
+        if (ENABLED) event.setMaxHunger(60);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HungerRegenEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HungerRegenEventTest.java
@@ -1,0 +1,43 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HungerRegenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HungerRegenEvent}s.
+ * Changes made by this mod to test for:
+ * - On peaceful difficulty, hunger should regen until it is over 10 points
+ */
+@Mod("hunger_regen_event_test")
+@Mod.EventBusSubscriber
+public class HungerRegenEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onPeacefulRegen(HungerRegenEvent.PeacefulRegen event)
+    {
+        // Peaceful regen of hunger will occur until it is over 10 hunger points filled
+        if (ENABLED) event.setDeltaHunger(event.getPlayer().getFoodData().getFoodLevel() <= 10 ? 1 : 0);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/StarvationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/StarvationEventTest.java
@@ -1,0 +1,60 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.StarvationEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link StarvationEvent}s.
+ * Changes made by this mod to test for:
+ * - Starvation should occur at all times, even when food level is greater than 0
+ * - Starvation tick period doubled from 80 -> 160
+ * - Starvation damage will always be half a heart. Even when half a heart is left.
+ */
+@Mod("starvation_event_test")
+@Mod.EventBusSubscriber
+public class StarvationEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAllowStarvation(StarvationEvent.AllowStarvation event)
+    {
+        // Starvation should occur at all times
+        if (ENABLED) event.setResult(Event.Result.ALLOW);
+    }
+
+    @SubscribeEvent
+    public static void onGetStarveTickPeriod(StarvationEvent.GetStarveTickPeriod event)
+    {
+        // Double the default starvation tick period
+        if (ENABLED) event.setStarveTickPeriod(160);
+    }
+
+    @SubscribeEvent
+    public static void onStarve(StarvationEvent.Starve event)
+    {
+        // Always deal half a heart of damage
+        if (ENABLED) event.setStarveDamage(1);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package net.minecraftforge.debug.hunger;
+
+import mcp.MethodsReturnNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -136,3 +136,17 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="edible_block_test"
+[[mods]]
+    modId="exhaustion_event_test"
+[[mods]]
+    modId="food_event_test"
+[[mods]]
+    modId="health_regen_event_test"
+[[mods]]
+    modId="hunger_event_test"
+[[mods]]
+    modId="hunger_regen_event_test"
+[[mods]]
+    modId="starvation_event_test"


### PR DESCRIPTION
**This is an event-driven API that allows for control of the hunger system in the game. Things like food, health regen, hunger regen, exhaustion, starvation, etc. This was actually a PR I had made 5 years ago (#1758), but broke and never fixed. Until now!**

The goal of this system is to allow modders to change values/behaviors that were previously hard-coded in the game. Some examples include:

* Changing the hunger and saturation values of foods eaten
* Allow foods to have different hunger and saturation values per-player
* Change the amount of exhaustion added for each exhausting action the player does
* Control how and when health and hunger regeneration occurs
* Control how and when starvation occurs
* and more!

There is a lot that is allowed by this system. A good overview of everything would be to check the test mods that are included with this PR.

Other more technical things that this PR does include:

* `FoodStats` now takes a `PlayerEntity` upon construction that is used throughout the class when querying values. This allows `FoodStats` to operate more player-dependently than before, allowing for operations to occur based on what player is trying to perform them.
* The `foodTimer` in `FoodStats` has been separated into the `foodTimer` and `starveTimer`. This allows starvation to happen independently from the exhaustion/regeneration timer.
* A `FoodValues` class is provided to allow for easy use of hunger and saturation values for food objects.
* An `IEdible` interface is provided that can be applied to non-standard food objects so that they can be included in the system. For a vanilla example, Cake now implements this interface. It is still recommended and preferred to include a `Food` object when constructing your item over implementing this interface.
  * The original author of this system, @squeek502, notes that he was never completely satisfied with this approach of including non-standard food items and wonders if there is a better solution. If you have an idea, please let me know!
* Fire events while in peaceful mode to allow modders to control how health/hunger regen happens in peaceful
* Removes an `OnlyIn` annotation over a simple setter for the saturation level
  * ~~Was unsure if I should leave the imports for that or not. I seem to remember an exception for this one specific case. Or maybe I'm crazy.~~ EDIT: Found the new-ish (at least to me) SAS system. Kinda cool. This comment is no longer relevant.

---

This system would be used by mods such as [Hunger Overhaul](https://www.curseforge.com/minecraft/mc-mods/hunger-overhaul) and [The Spice Of Life](https://www.curseforge.com/minecraft/mc-mods/the-spice-of-life) to fundamentally change how the hunger system works in the game.

This system was originally written by @squeek502 for [AppleCore](https://www.curseforge.com/minecraft/mc-mods/applecore), and was first attempted to be upstreamed by me way back in the 1.7.10/1.8 days (as noted above). He has offered his code into the [Public Domain](https://github.com/squeek502/AppleCore/blob/1.12.2/LICENSE), and as such I am re-attempting to put this system into Forge! Since this code was originally written for a different Minecraft version, there is a good chance that there are better ways to do some of what we are trying to do. If that is the case, please let me know and I will gladly learn the new systems and how best to be doing what we are attempting. (I haven't really been actively modding Minecraft since the 1.8 days, haha)