### PR TITLE
Re-implemented GuiUtils#drawHoveringText

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -21,18 +21,28 @@ package net.minecraftforge.fml.client.gui;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraft.util.text.ITextProperties;
+import net.minecraft.util.text.LanguageMap;
+import net.minecraft.util.text.Style;
+import net.minecraftforge.client.event.RenderTooltipEvent;
+import net.minecraftforge.common.MinecraftForge;
+
 import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class provides several methods and constants used by the Config GUI classes.
@@ -232,8 +242,7 @@ public class GuiUtils
         cachedTooltipStack = ItemStack.EMPTY;
     }
 
-    /*
-    public static void drawHoveringText(MatrixStack mStack, List<? extends IReorderingProcessor> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    public static void drawHoveringText(MatrixStack mStack, List<? extends ITextProperties> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
     {
         drawHoveringText(mStack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, DEFAULT_BACKGROUND_COLOR, DEFAULT_BORDER_COLOR_START, DEFAULT_BORDER_COLOR_END, font);
     }
@@ -256,8 +265,8 @@ public class GuiUtils
      * @param borderColorEnd The ending color of the box border. The border color will be smoothly interpolated
      *                       between the start and end values.
      * @param font the font for drawing the text in the tooltip box
-     * /
-    public static void drawHoveringText(MatrixStack mStack, List<? extends IReorderingProcessor> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight,
+     */
+    public static void drawHoveringText(MatrixStack mStack, List<? extends ITextProperties> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight,
                                         int maxTextWidth, int backgroundColor, int borderColorStart, int borderColorEnd, FontRenderer font)
     {
         drawHoveringText(cachedTooltipStack, mStack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, backgroundColor, borderColorStart, borderColorEnd, font);
@@ -272,9 +281,9 @@ public class GuiUtils
      * Use this version if calling from somewhere where ItemStack context is available.
      *
      * @see #drawHoveringText(MatrixStack, List, int, int, int, int, int, int, int, int, FontRenderer)
-     * /
+     */
     //TODO, Validate rendering is the same as the original
-    public static void drawHoveringText(@Nonnull final ItemStack stack, MatrixStack mStack, List<? extends IReorderingProcessor> textLines, int mouseX, int mouseY,
+    public static void drawHoveringText(@Nonnull final ItemStack stack, MatrixStack mStack, List<? extends ITextProperties> textLines, int mouseX, int mouseY,
                                         int screenWidth, int screenHeight, int maxTextWidth,
                                         int backgroundColor, int borderColorStart, int borderColorEnd, FontRenderer font)
     {
@@ -294,7 +303,7 @@ public class GuiUtils
             RenderSystem.disableDepthTest();
             int tooltipTextWidth = 0;
 
-            for (IReorderingProcessor textLine : textLines)
+            for (ITextProperties textLine : textLines)
             {
                 int textLineWidth = font.func_238414_a_(textLine);
                 if (textLineWidth > tooltipTextWidth)
@@ -331,7 +340,7 @@ public class GuiUtils
                 for (int i = 0; i < textLines.size(); i++)
                 {
                     ITextProperties textLine = textLines.get(i);
-                    List<ITextProperties> wrappedLine = font.func_238425_b_(textLine, tooltipTextWidth);
+                    List<ITextProperties> wrappedLine = font.func_238420_b_().func_238362_b_(textLine, tooltipTextWidth, Style.field_240709_b_);
                     if (i == 0)
                         titleLinesCount = wrappedLine.size();
 
@@ -398,7 +407,7 @@ public class GuiUtils
             {
                 ITextProperties line = textLines.get(lineNumber);
                 if (line != null)
-                    font.func_238416_a_(line, (float)tooltipX, (float)tooltipY, -1, true, mat, renderType, false, 0, 15728880);
+                    font.func_238416_a_(LanguageMap.getInstance().func_241870_a(line), (float)tooltipX, (float)tooltipY, -1, true, mat, renderType, false, 0, 15728880);
 
                 if (lineNumber + 1 == titleLinesCount)
                     tooltipY += 2;
@@ -415,7 +424,6 @@ public class GuiUtils
             RenderSystem.enableRescaleNormal();
         }
     }
-    */
 
     @SuppressWarnings("deprecation")
     public static void drawGradientRect(Matrix4f mat, int zLevel, int left, int top, int right, int bottom, int startColor, int endColor)


### PR DESCRIPTION
The `drawHoveringText` methods inside `GuiUtils` had been commented out in the update to 1.16.2 due to the addition of `IReorderingProcessor`.

I tried to make these methods use the `List<? extends IReorderingProcessor>` parameter first instead of the original `List<? extends ITextProperties>` (Lex had already done this so I assumed that's what he intended ). This was a problem because wrapping the lines would not have been possible this way.

So I just left the original `List<? extends ITextProperties>` parameter and made changes inside the method itself.
I believe this is better to do because editing the lines in the `RenderTooltipEvent` would otherwise not be possible.