### PR TITLE
Try to fix GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT error

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -16,7 +16,15 @@
        this.field_71459_aj = p_i45547_1_.field_178741_d.field_178756_a;
        this.field_238175_ae_ = !p_i45547_1_.field_178741_d.field_239099_d_;
        this.field_238176_af_ = !p_i45547_1_.field_178741_d.field_239100_e_;
-@@ -415,14 +415,15 @@
+@@ -392,6 +392,7 @@
+       this.field_152352_aC = Thread.currentThread();
+       this.field_71474_y = new GameSettings(this, this.field_71412_D);
+       this.field_191950_u = new CreativeSettings(this.field_71412_D, this.field_184131_U);
++      net.minecraftforge.fml.loading.progress.EarlyProgressVisualization.INSTANCE.stopRender();
+       field_147123_G.info("Backend library: {}", (Object)RenderSystem.getBackendDescription());
+       ScreenSize screensize;
+       if (this.field_71474_y.field_92119_C > 0 && this.field_71474_y.field_92118_B > 0) {
+@@ -415,14 +416,15 @@
  
        this.field_195558_d.func_216526_a(this.field_71474_y.field_74350_i);
        this.field_71417_B = new MouseHelper(this);
@@ -33,7 +41,7 @@
        this.field_71474_y.func_198017_a(this.field_110448_aq);
        this.field_135017_as = new LanguageManager(this.field_71474_y.field_74363_ab);
        this.field_110451_am.func_219534_a(this.field_135017_as);
-@@ -462,6 +463,7 @@
+@@ -462,6 +464,7 @@
        this.func_193986_ar();
        this.field_110451_am.func_219534_a(this.field_193995_ae);
        this.field_71452_i = new ParticleManager(this.field_71441_e, this.field_71446_o);
@@ -41,7 +49,7 @@
        this.field_110451_am.func_219534_a(this.field_71452_i);
        this.field_213272_aL = new PaintingSpriteUploader(this.field_71446_o);
        this.field_110451_am.func_219534_a(this.field_213272_aL);
-@@ -469,7 +471,8 @@
+@@ -469,7 +472,8 @@
        this.field_110451_am.func_219534_a(this.field_213273_aM);
        this.field_241557_ar_ = new GPUWarning();
        this.field_110451_am.func_219534_a(this.field_241557_ar_);
@@ -51,7 +59,7 @@
        this.field_184132_p = new DebugRenderer(this);
        RenderSystem.setErrorCallback(this::func_195545_a);
        if (this.field_71474_y.field_74353_u && !this.field_195558_d.func_198113_j()) {
-@@ -481,11 +484,6 @@
+@@ -481,11 +485,6 @@
        this.field_195558_d.func_224798_d(this.field_71474_y.field_225307_E);
        this.field_195558_d.func_227801_c_();
        this.func_213226_a();
@@ -63,7 +71,7 @@
  
        ResourceLoadProgressGui.func_212970_a(this);
        List<IResourcePack> list = this.field_110448_aq.func_232623_f_();
-@@ -494,7 +492,14 @@
+@@ -494,7 +493,14 @@
              if (SharedConstants.field_206244_b) {
                 this.func_213256_aB();
              }
@@ -79,7 +87,7 @@
           });
        }, false));
     }
-@@ -533,7 +538,7 @@
+@@ -533,7 +539,7 @@
     }
  
     private void func_229988_a_(Throwable p_229988_1_) {
@@ -88,7 +96,7 @@
           ITextComponent itextcomponent;
           if (p_229988_1_ instanceof SimpleReloadableResourceManager.FailedPackException) {
              itextcomponent = new StringTextComponent(((SimpleReloadableResourceManager.FailedPackException)p_229988_1_).func_241203_a().func_195762_a());
-@@ -621,7 +626,7 @@
+@@ -621,7 +627,7 @@
           return Stream.of(Registry.field_212630_s.func_177774_c(p_213251_0_.func_77973_b()));
        });
        SearchTreeReloadable<ItemStack> searchtreereloadable = new SearchTreeReloadable<>((p_213235_0_) -> {
@@ -97,7 +105,7 @@
        });
        NonNullList<ItemStack> nonnulllist = NonNullList.func_191196_a();
  
-@@ -691,13 +696,13 @@
+@@ -691,13 +697,13 @@
        Bootstrap.func_179870_a(p_71377_0_.func_71502_e());
        if (p_71377_0_.func_71497_f() != null) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + p_71377_0_.func_71497_f());
@@ -114,7 +122,7 @@
        }
  
     }
-@@ -706,6 +711,7 @@
+@@ -706,6 +712,7 @@
        return this.field_71474_y.field_211842_aO;
     }
  
@@ -122,7 +130,7 @@
     public CompletableFuture<Void> func_213237_g() {
        if (this.field_213276_aV != null) {
           return this.field_213276_aV;
-@@ -794,10 +800,6 @@
+@@ -794,10 +801,6 @@
     }
  
     public void func_147108_a(@Nullable Screen p_147108_1_) {
@@ -133,7 +141,7 @@
        if (p_147108_1_ == null && this.field_71441_e == null) {
           p_147108_1_ = new MainMenuScreen();
        } else if (p_147108_1_ == null && this.field_71439_g.func_233643_dh_()) {
-@@ -808,6 +810,14 @@
+@@ -808,6 +811,14 @@
           }
        }
  
@@ -148,7 +156,7 @@
        if (p_147108_1_ instanceof MainMenuScreen || p_147108_1_ instanceof MultiplayerScreen) {
           this.field_71474_y.field_74330_P = false;
           this.field_71456_v.func_146158_b().func_146231_a(true);
-@@ -939,11 +949,13 @@
+@@ -939,11 +950,13 @@
        RenderSystem.enableCull();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
@@ -162,7 +170,7 @@
        }
  
        if (this.field_238174_aV_ != null) {
-@@ -1042,6 +1054,7 @@
+@@ -1042,6 +1055,7 @@
  
        Framebuffer framebuffer = this.func_147110_a();
        framebuffer.func_216491_a(this.field_195558_d.func_198109_k(), this.field_195558_d.func_198091_l(), field_142025_a);
@@ -170,7 +178,7 @@
        this.field_71460_t.func_147704_a(this.field_195558_d.func_198109_k(), this.field_195558_d.func_198091_l());
        this.field_71417_B.func_198021_g();
     }
-@@ -1230,11 +1243,21 @@
+@@ -1230,11 +1244,21 @@
           if (p_147115_1_ && this.field_71476_x != null && this.field_71476_x.func_216346_c() == RayTraceResult.Type.BLOCK) {
              BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
              BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -194,7 +202,7 @@
                 }
              }
  
-@@ -1253,6 +1276,8 @@
+@@ -1253,6 +1277,8 @@
              }
  
           } else if (!this.field_71439_g.func_184838_M()) {
@@ -203,7 +211,7 @@
              switch(this.field_71476_x.func_216346_c()) {
              case ENTITY:
                 this.field_71442_b.func_78764_a(this.field_71439_g, ((EntityRayTraceResult)this.field_71476_x).func_216348_a());
-@@ -1260,7 +1285,7 @@
+@@ -1260,7 +1286,7 @@
              case BLOCK:
                 BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
                 BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -212,7 +220,7 @@
                    this.field_71442_b.func_180511_b(blockpos, blockraytraceresult.func_216354_b());
                    break;
                 }
-@@ -1270,8 +1295,10 @@
+@@ -1270,8 +1296,10 @@
                 }
  
                 this.field_71439_g.func_184821_cY();
@@ -223,7 +231,7 @@
              this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
           }
        }
-@@ -1286,6 +1313,11 @@
+@@ -1286,6 +1314,11 @@
              }
  
              for(Hand hand : Hand.values()) {
@@ -235,7 +243,7 @@
                 ItemStack itemstack = this.field_71439_g.func_184586_b(hand);
                 if (this.field_71476_x != null) {
                    switch(this.field_71476_x.func_216346_c()) {
-@@ -1299,6 +1331,7 @@
+@@ -1299,6 +1332,7 @@
  
                       if (actionresulttype.func_226246_a_()) {
                          if (actionresulttype.func_226247_b_()) {
@@ -243,7 +251,7 @@
                             this.field_71439_g.func_184609_a(hand);
                          }
  
-@@ -1311,6 +1344,7 @@
+@@ -1311,6 +1345,7 @@
                       ActionResultType actionresulttype1 = this.field_71442_b.func_217292_a(this.field_71439_g, this.field_71441_e, hand, blockraytraceresult);
                       if (actionresulttype1.func_226246_a_()) {
                          if (actionresulttype1.func_226247_b_()) {
@@ -251,7 +259,7 @@
                             this.field_71439_g.func_184609_a(hand);
                             if (!itemstack.func_190926_b() && (itemstack.func_190916_E() != i || this.field_71442_b.func_78758_h())) {
                                this.field_71460_t.field_78516_c.func_187460_a(hand);
-@@ -1326,6 +1360,9 @@
+@@ -1326,6 +1361,9 @@
                    }
                 }
  
@@ -261,7 +269,7 @@
                 if (!itemstack.func_190926_b()) {
                    ActionResultType actionresulttype2 = this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, hand);
                    if (actionresulttype2.func_226246_a_()) {
-@@ -1352,6 +1389,8 @@
+@@ -1352,6 +1390,8 @@
           --this.field_71467_ac;
        }
  
@@ -270,7 +278,7 @@
        this.field_71424_I.func_76320_a("gui");
        if (!this.field_71445_n) {
           this.field_71456_v.func_73831_a();
-@@ -1468,6 +1507,8 @@
+@@ -1468,6 +1508,8 @@
        this.field_71424_I.func_219895_b("keyboard");
        this.field_195559_v.func_204870_b();
        this.field_71424_I.func_76319_b();
@@ -279,7 +287,7 @@
     }
  
     private void func_184117_aA() {
-@@ -1697,7 +1738,12 @@
+@@ -1697,7 +1739,12 @@
           networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_229998_0_) -> {
           }));
           networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -293,7 +301,7 @@
           this.field_71453_ak = networkmanager;
        } else {
           this.func_241559_a_(p_238195_6_, p_238195_1_, flag, () -> {
-@@ -1771,6 +1817,7 @@
+@@ -1771,6 +1818,7 @@
     }
  
     public void func_71403_a(ClientWorld p_71403_1_) {
@@ -301,7 +309,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1802,10 +1849,12 @@
+@@ -1802,10 +1850,12 @@
        IntegratedServer integratedserver = this.field_71437_Z;
        this.field_71437_Z = null;
        this.field_71460_t.func_190564_k();
@@ -314,7 +322,7 @@
           if (integratedserver != null) {
              this.field_71424_I.func_76320_a("waitForServer");
  
-@@ -1820,6 +1869,7 @@
+@@ -1820,6 +1870,7 @@
           this.field_71456_v.func_181029_i();
           this.field_71422_O = null;
           this.field_71455_al = false;
@@ -322,7 +330,7 @@
           this.field_213274_aO.func_216815_b();
        }
  
-@@ -1850,6 +1900,7 @@
+@@ -1850,6 +1901,7 @@
        this.field_71452_i.func_78870_a(p_213257_1_);
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
        this.func_230150_b_();
@@ -330,7 +338,7 @@
     }
  
     public boolean func_238216_r_() {
-@@ -1895,112 +1946,9 @@
+@@ -1895,112 +1947,9 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -446,7 +454,7 @@
        }
     }
  
-@@ -2090,6 +2038,7 @@
+@@ -2090,6 +2039,7 @@
        return field_71432_P;
     }
  
@@ -454,7 +462,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_229993_0_) -> {
           return p_229993_0_;
-@@ -2397,7 +2346,7 @@
+@@ -2397,7 +2347,7 @@
           supplier = func_228022_c_(supplier);
        }
  
@@ -463,7 +471,7 @@
     }
  
     private static Supplier<IResourcePack> func_228021_b_(Supplier<IResourcePack> p_228021_0_) {
-@@ -2416,6 +2365,14 @@
+@@ -2416,6 +2366,14 @@
        this.field_175617_aL.func_229355_a_(p_228020_1_);
     }
  

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
@@ -40,6 +40,10 @@ public enum EarlyProgressVisualization {
         return visualization.handOffWindow(width, height, title, monitor);
     }
 
+    public void stopRender() {
+        visualization.stopRender();
+    }
+
     interface Visualization {
         Runnable start();
 
@@ -51,12 +55,19 @@ public enum EarlyProgressVisualization {
                 }
             }.getAsLong();
         }
+
+        void stopRender();
     }
 
     private static class NoVisualization implements Visualization {
         @Override
         public Runnable start() {
             return () -> {};
+        }
+
+        @Override
+        public void stopRender() {
+
         }
     }
 


### PR DESCRIPTION
- Only allow polling events if the render thread is currently not rerendering
- Stop the render thread and poll events before any other GLFW code is run on the main thread

Could be a possible fix for #6692, as it looks like some kind of race condition, but it's hard to tell if this fixes it as it's hard to reproduce.
The issue definitly exists in 1.16.2 as well: https://pastebin.com/gyJpbbg7