### PR TITLE
[1.16.x] Added model data to ItemStack rendering

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -1,14 +1,6 @@
 --- a/net/minecraft/client/renderer/ItemRenderer.java
 +++ b/net/minecraft/client/renderer/ItemRenderer.java
-@@ -47,6 +47,7 @@
- import net.minecraft.world.World;
- import net.minecraftforge.api.distmarker.Dist;
- import net.minecraftforge.api.distmarker.OnlyIn;
-+import net.minecraftforge.client.model.data.IModelData;
- 
- @OnlyIn(Dist.CLIENT)
- public class ItemRenderer implements IResourceManagerReloadListener {
-@@ -59,7 +60,7 @@
+@@ -59,7 +59,7 @@
  
     public ItemRenderer(TextureManager p_i46552_1_, ModelManager p_i46552_2_, ItemColors p_i46552_3_) {
        this.field_175057_n = p_i46552_1_;
@@ -17,11 +9,11 @@
  
        for(Item item : Registry.field_212630_s) {
           if (!field_195411_c.contains(item)) {
-@@ -78,13 +79,14 @@
+@@ -78,13 +78,14 @@
        Random random = new Random();
        long i = 42L;
  
-+      IModelData modelData = p_229114_2_.getModelData();
++      net.minecraftforge.client.model.data.IModelData modelData = p_229114_2_.getModelData();
        for(Direction direction : Direction.values()) {
           random.setSeed(42L);
 -         this.func_229112_a_(p_229114_5_, p_229114_6_, p_229114_1_.func_200117_a((BlockState)null, direction, random), p_229114_2_, p_229114_3_, p_229114_4_);
@@ -34,7 +26,7 @@
     }
  
     public void func_229111_a_(ItemStack p_229111_1_, ItemCameraTransforms.TransformType p_229111_2_, boolean p_229111_3_, MatrixStack p_229111_4_, IRenderTypeBuffer p_229111_5_, int p_229111_6_, int p_229111_7_, IBakedModel p_229111_8_) {
-@@ -95,7 +97,7 @@
+@@ -95,7 +96,7 @@
              p_229111_8_ = this.field_175059_m.func_178083_a().func_174953_a(new ModelResourceLocation("minecraft:trident#inventory"));
           }
  
@@ -43,7 +35,7 @@
           p_229111_4_.func_227861_a_(-0.5D, -0.5D, -0.5D);
           if (!p_229111_8_.func_188618_c() && (p_229111_1_.func_77973_b() != Items.field_203184_eO || flag)) {
              boolean flag1;
-@@ -105,7 +107,8 @@
+@@ -105,7 +106,8 @@
              } else {
                 flag1 = true;
              }
@@ -53,7 +45,7 @@
              RenderType rendertype = RenderTypeLookup.func_239219_a_(p_229111_1_, flag1);
              IVertexBuilder ivertexbuilder;
              if (p_229111_1_.func_77973_b() == Items.field_151111_aL && p_229111_1_.func_77962_s()) {
-@@ -131,8 +134,9 @@
+@@ -131,8 +133,9 @@
              }
  
              this.func_229114_a_(p_229111_8_, p_229111_1_, p_229111_6_, p_229111_7_, p_229111_4_, ivertexbuilder);
@@ -64,7 +56,7 @@
           }
  
           p_229111_4_.func_227865_b_();
-@@ -176,7 +180,7 @@
+@@ -176,7 +179,7 @@
           float f = (float)(i >> 16 & 255) / 255.0F;
           float f1 = (float)(i >> 8 & 255) / 255.0F;
           float f2 = (float)(i & 255) / 255.0F;
@@ -73,7 +65,7 @@
        }
  
     }
-@@ -267,6 +271,7 @@
+@@ -267,6 +270,7 @@
              crashreportcategory.func_189529_a("Item Type", () -> {
                 return String.valueOf((Object)p_239387_2_.func_77973_b());
              });
@@ -81,7 +73,7 @@
              crashreportcategory.func_189529_a("Item Damage", () -> {
                 return String.valueOf(p_239387_2_.func_77952_i());
              });
-@@ -298,18 +303,16 @@
+@@ -298,18 +302,16 @@
              irendertypebuffer$impl.func_228461_a_();
           }
  
@@ -104,7 +96,7 @@
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
              RenderSystem.enableBlend();
-@@ -347,4 +350,9 @@
+@@ -347,4 +349,9 @@
     public void func_195410_a(IResourceManager p_195410_1_) {
        this.field_175059_m.func_178085_b();
     }

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/client/renderer/ItemRenderer.java
 +++ b/net/minecraft/client/renderer/ItemRenderer.java
-@@ -59,7 +59,7 @@
+@@ -47,6 +47,7 @@
+ import net.minecraft.world.World;
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
++import net.minecraftforge.client.model.data.IModelData;
+ 
+ @OnlyIn(Dist.CLIENT)
+ public class ItemRenderer implements IResourceManagerReloadListener {
+@@ -59,7 +60,7 @@
  
     public ItemRenderer(TextureManager p_i46552_1_, ModelManager p_i46552_2_, ItemColors p_i46552_3_) {
        this.field_175057_n = p_i46552_1_;
@@ -9,7 +17,24 @@
  
        for(Item item : Registry.field_212630_s) {
           if (!field_195411_c.contains(item)) {
-@@ -95,7 +95,7 @@
+@@ -78,13 +79,14 @@
+       Random random = new Random();
+       long i = 42L;
+ 
++      IModelData modelData = p_229114_2_.getModelData();
+       for(Direction direction : Direction.values()) {
+          random.setSeed(42L);
+-         this.func_229112_a_(p_229114_5_, p_229114_6_, p_229114_1_.func_200117_a((BlockState)null, direction, random), p_229114_2_, p_229114_3_, p_229114_4_);
++         this.func_229112_a_(p_229114_5_, p_229114_6_, p_229114_1_.getQuads((BlockState)null, direction, random, modelData), p_229114_2_, p_229114_3_, p_229114_4_);
+       }
+ 
+       random.setSeed(42L);
+-      this.func_229112_a_(p_229114_5_, p_229114_6_, p_229114_1_.func_200117_a((BlockState)null, (Direction)null, random), p_229114_2_, p_229114_3_, p_229114_4_);
++      this.func_229112_a_(p_229114_5_, p_229114_6_, p_229114_1_.getQuads((BlockState)null, (Direction)null, random, modelData), p_229114_2_, p_229114_3_, p_229114_4_);
+    }
+ 
+    public void func_229111_a_(ItemStack p_229111_1_, ItemCameraTransforms.TransformType p_229111_2_, boolean p_229111_3_, MatrixStack p_229111_4_, IRenderTypeBuffer p_229111_5_, int p_229111_6_, int p_229111_7_, IBakedModel p_229111_8_) {
+@@ -95,7 +97,7 @@
              p_229111_8_ = this.field_175059_m.func_178083_a().func_174953_a(new ModelResourceLocation("minecraft:trident#inventory"));
           }
  
@@ -18,7 +43,7 @@
           p_229111_4_.func_227861_a_(-0.5D, -0.5D, -0.5D);
           if (!p_229111_8_.func_188618_c() && (p_229111_1_.func_77973_b() != Items.field_203184_eO || flag)) {
              boolean flag1;
-@@ -105,7 +105,8 @@
+@@ -105,7 +107,8 @@
              } else {
                 flag1 = true;
              }
@@ -28,7 +53,7 @@
              RenderType rendertype = RenderTypeLookup.func_239219_a_(p_229111_1_, flag1);
              IVertexBuilder ivertexbuilder;
              if (p_229111_1_.func_77973_b() == Items.field_151111_aL && p_229111_1_.func_77962_s()) {
-@@ -131,8 +132,9 @@
+@@ -131,8 +134,9 @@
              }
  
              this.func_229114_a_(p_229111_8_, p_229111_1_, p_229111_6_, p_229111_7_, p_229111_4_, ivertexbuilder);
@@ -39,7 +64,7 @@
           }
  
           p_229111_4_.func_227865_b_();
-@@ -176,7 +178,7 @@
+@@ -176,7 +180,7 @@
           float f = (float)(i >> 16 & 255) / 255.0F;
           float f1 = (float)(i >> 8 & 255) / 255.0F;
           float f2 = (float)(i & 255) / 255.0F;
@@ -48,7 +73,7 @@
        }
  
     }
-@@ -267,6 +269,7 @@
+@@ -267,6 +271,7 @@
              crashreportcategory.func_189529_a("Item Type", () -> {
                 return String.valueOf((Object)p_239387_2_.func_77973_b());
              });
@@ -56,7 +81,7 @@
              crashreportcategory.func_189529_a("Item Damage", () -> {
                 return String.valueOf(p_239387_2_.func_77952_i());
              });
-@@ -298,18 +301,16 @@
+@@ -298,18 +303,16 @@
              irendertypebuffer$impl.func_228461_a_();
           }
  
@@ -79,7 +104,7 @@
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
              RenderSystem.enableBlend();
-@@ -347,4 +348,9 @@
+@@ -347,4 +350,9 @@
     public void func_195410_a(IResourceManager p_195410_1_) {
        this.field_175059_m.func_178085_b();
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.extensions;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableMap;
@@ -59,6 +60,8 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.model.data.EmptyModelData;
+import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.ToolType;
 import net.minecraftforge.common.animation.ITimeValue;
@@ -858,5 +861,16 @@ public interface IForgeItem
     default boolean isDamageable(ItemStack stack)
     {
         return this.getItem().isDamageable();
+    }
+
+    /**
+     * Allows you to return additional model data.
+     * This data can be used to provide additional functionality in your {@link net.minecraft.client.renderer.model.IBakedModel}
+     * @param stack       The ItemStack to get the additional model data from
+     * @return Your model data
+     */
+    default @Nonnull IModelData getModelData(ItemStack stack)
+    {
+        return EmptyModelData.INSTANCE;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -21,6 +21,7 @@ package net.minecraftforge.common.extensions;
 
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.monster.EndermanEntity;
@@ -43,6 +44,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.IFormattableTextComponent;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
+import net.minecraftforge.client.model.data.EmptyModelData;
+import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.common.ToolType;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 
@@ -503,5 +506,15 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     default boolean elytraFlightTick(LivingEntity entity, int flightTicks)
     {
         return getStack().getItem().elytraFlightTick(getStack(), entity, flightTicks);
+    }
+
+    /**
+     * Allows you to return additional model data.
+     * This data can be used to provide additional functionality in your {@link net.minecraft.client.renderer.model.IBakedModel}
+     * @return Your model data
+     */
+    default @Nonnull IModelData getModelData()
+    {
+        return getStack().getItem().getModelData(getStack());
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/model/ItemModelDataTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/ItemModelDataTest.java
@@ -1,0 +1,119 @@
+package net.minecraftforge.debug.client.model;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.model.ItemOverrideList;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.item.*;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.vector.Quaternion;
+import net.minecraft.util.math.vector.TransformationMatrix;
+import net.minecraft.util.math.vector.Vector3f;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ModelBakeEvent;
+import net.minecraftforge.client.model.data.IDynamicBakedModel;
+import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.data.ModelDataMap;
+import net.minecraftforge.client.model.data.ModelProperty;
+import net.minecraftforge.client.model.pipeline.BakedQuadBuilder;
+import net.minecraftforge.client.model.pipeline.TRSRTransformer;
+import net.minecraftforge.common.model.TransformationHelper;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Random;
+
+@Mod(ItemModelDataTest.MODID)
+public class ItemModelDataTest {
+
+    public static final String MODID = "item_model_data";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+
+    private static final ModelProperty<ItemStack> ITEM_PROPERTY = new ModelProperty<>();
+
+    private static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().group(ItemGroup.MISC)){
+        @Nonnull
+        @Override
+        public IModelData getModelData(ItemStack stack) {
+            return new ModelDataMap.Builder().withInitial(ITEM_PROPERTY, new ItemStack(Items.BAMBOO)).build();
+        }
+    });
+
+    public ItemModelDataTest() {
+        final IEventBus mod = FMLJavaModLoadingContext.get().getModEventBus();
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> mod.addListener(this::onModelBake));
+        ITEMS.register(mod);
+    }
+
+    public void onModelBake(ModelBakeEvent e) {
+        for (ResourceLocation id : e.getModelRegistry().keySet()) {
+            if (MODID.equals(id.getNamespace()) && "test".equals(id.getPath())) {
+                e.getModelRegistry().put(id, new ItemModelDataTest.MyBakedModel(e.getModelRegistry().get(id)));
+            }
+        }
+    }
+
+    public class MyBakedModel implements IDynamicBakedModel {
+
+        private final IBakedModel base;
+
+        public MyBakedModel(IBakedModel base) {
+            this.base = base;
+        }
+
+        @Override
+        public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, IModelData extraData) {
+            if (extraData.hasProperty(ITEM_PROPERTY)) {
+                ItemStack stack = extraData.getData(ITEM_PROPERTY);
+                return Minecraft.getInstance().getItemRenderer().getItemModelMesher().getItemModel(stack).getQuads(state, side, rand, extraData);
+            }
+            return this.base.getQuads(state, side, rand, extraData);
+        }
+
+        @Override
+        public boolean isAmbientOcclusion() {
+            return base.isAmbientOcclusion();
+        }
+
+        @Override
+        public boolean isGui3d() {
+            return base.isGui3d();
+        }
+
+        @Override
+        public boolean func_230044_c_() {
+            return base.func_230044_c_();
+        }
+
+        @Override
+        public boolean isBuiltInRenderer() {
+            return base.isBuiltInRenderer();
+        }
+
+        @Override
+        public TextureAtlasSprite getParticleTexture() {
+            return base.getParticleTexture();
+        }
+
+        @Override
+        public ItemOverrideList getOverrides() {
+            return base.getOverrides();
+        }
+
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/model/ItemModelDataTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/ItemModelDataTest.java
@@ -1,29 +1,42 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client.model;
 
-import com.google.common.collect.ImmutableList;
-import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
-import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.model.ItemOverrideList;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.vector.Quaternion;
-import net.minecraft.util.math.vector.TransformationMatrix;
-import net.minecraft.util.math.vector.Vector3f;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.model.data.IDynamicBakedModel;
 import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.data.ModelDataMap;
 import net.minecraftforge.client.model.data.ModelProperty;
-import net.minecraftforge.client.model.pipeline.BakedQuadBuilder;
-import net.minecraftforge.client.model.pipeline.TRSRTransformer;
-import net.minecraftforge.common.model.TransformationHelper;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.RegistryObject;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -80,3 +80,5 @@ license="LGPL v2.1"
     modId="custom_elytra_test"
 [[mods]]
     modId="finite_water_test"
+[[mods]]
+    modId="item_model_data"


### PR DESCRIPTION
As the title suggests I have added functionality so that items can provide `IModelData` to pass onto the `getQuads` method of the `IBakedModel` for that item using the provided ItemStack.
This allows items to specify model data properties using NBT data and other information provided by the ItemStack parameter.
I have also provided a relevant test which allows an item to use another item's model by specifying that item in the model data object