### PR TITLE
Fix dirty cast preventing game launch

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
@@ -50,7 +50,6 @@ public enum ModLoadingStage
     ERROR(),
     VALIDATE(),
     CONSTRUCT(FMLConstructModEvent.class),
-    @SuppressWarnings({ "unchecked", "rawtypes" }) //Eclipse compiler generics issue. Sorry cpw, your nested generics can't be inferred
     CREATE_REGISTRIES(()->Stream.of(EventGenerator.fromFunction(RegistryEvent.NewRegistry::new)), EventDispatcher.identity()),
     LOAD_REGISTRIES(GameData::generateRegistryEvents, GameData.buildRegistryEventDispatch()),
     COMMON_SETUP(FMLCommonSetupEvent.class),

--- a/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
@@ -51,7 +51,7 @@ public enum ModLoadingStage
     VALIDATE(),
     CONSTRUCT(FMLConstructModEvent.class),
     @SuppressWarnings({ "unchecked", "rawtypes" }) //Eclipse compiler generics issue. Sorry cpw, your nested generics can't be inferred
-    CREATE_REGISTRIES((Supplier)()->Stream.of((Function<ModContainer, IModBusEvent>)RegistryEvent.NewRegistry::new), EventDispatcher.identity()),
+    CREATE_REGISTRIES(()->Stream.of(EventGenerator.fromFunction(RegistryEvent.NewRegistry::new)), EventDispatcher.identity()),
     LOAD_REGISTRIES(GameData::generateRegistryEvents, GameData.buildRegistryEventDispatch()),
     COMMON_SETUP(FMLCommonSetupEvent.class),
     SIDED_SETUP(DistExecutor.unsafeRunForDist(()->()->FMLClientSetupEvent.class, ()->()->FMLDedicatedServerSetupEvent.class)),


### PR DESCRIPTION
_This PR fixes #7297._

The most recent [commit][dirtycasts] by Lex added a cast, because the Eclipse compiler refused to compile the previous commit due to two errors:
`(54:5) The constructor net.minecraftforge.fml.ModLoadingStage(() -> Stream.of(RegistryEvent.NewRegistry::new), EventDispatcher.identity()) is undefined`, and
`(54:23) The target type of this expression must be a functional interface`.

The dirty cast silenced the compiler. However, the cast made the supplier into a `Supplier<Stream<Function<ModContainer, IModBusEvent>>>`, while the constructor expects a `Supplier<Stream<EventGenerator<?>>>`.

This PR simply removes the dirty cast, and replaces it with a call to `EventGenerator.fromFunction`, which does the casting safely.
I have tested this compiles with the Eclipse compiler on IntelliJ. _(The errors given in the previous paragraph came from trying to compile the previous commit before Lex's, to verify what Lex fixed was reproducible)_

[dirtycasts]: https://github.com/MinecraftForge/MinecraftForge/commit/3820d1b66f38a56c08359b6c51fc33b457a4af76#diff-6963550da39455758336775329e604e7