### PR TITLE
Bump pack version to 6

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -260,7 +260,7 @@ public class ClientModLoader
             }
         }
         final ResourcePackInfo packInfo = ResourcePackInfo.createResourcePack("mod_resources", true, () -> new DelegatingResourcePack("mod_resources", "Mod Resources",
-                new PackMetadataSection(new TranslationTextComponent("fml.resources.modresources", hiddenPacks.size()), 5),
+                new PackMetadataSection(new TranslationTextComponent("fml.resources.modresources", hiddenPacks.size()), 6),
                 hiddenPacks), factory, ResourcePackInfo.Priority.BOTTOM, IPackNameDecorator.field_232625_a_);
         consumer.accept(packInfo);
     }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack": {
-      "pack_format": 5,
+      "pack_format": 6,
       "description": "Forge resource pack"
    }
 }

--- a/src/test/resources/pack.mcmeta
+++ b/src/test/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack": {
-      "pack_format": 5,
+      "pack_format": 6,
       "description": "Forge tests resource pack"
    }
 }


### PR DESCRIPTION
1.16 changed the blockstates for walls, meaning that resource packs for 1.15 are not compatible with 1.16. However, 1.16 did not bump the version number from `5` to `6`, so 1.15 resource packs still loaded without warnings in 1.16.

An [issue was filed on Mojang's bug tracker][issue-197275], and a fix was released with 1.16.2: bumping the pack version from `5` to `6`. 
However, Forge did not update it's `pack.mcmeta` nor the internal constant used for resource pack delegation. This was eventually [reported on the Discord][discord_report].

This PR simply updates the `pack.mcmeta` and that internal constant to `6`.

_Note: I did think of maybe using `SharedConstants` directly to bypass the need of a hardcoded constant, but [as said by tterag1908 on Discord][tterag] (to which I concur), that may cause unforseen side-effects, and the resources are manually updated when needed anyway._

[issue-197275]: https://bugs.mojang.com/browse/MC-197275
[discord_report]: https://discordapp.com/channels/313125603924639766/437001959950778368/751103750180962367
[tterag]: https://discordapp.com/channels/313125603924639766/437001959950778368/751108702190305362