### PR TITLE
Fixed crash with zip paths

### DIFF
--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -27,6 +27,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -66,7 +67,7 @@ public class ModFileResourcePack extends ResourcePack
     {
         final Path path = modFile.getLocator().findPath(modFile, name);
         if(!Files.exists(path))
-            throw new ResourcePackFileNotFoundException(path.toFile(), name);
+            throw new FileNotFoundException(String.format("'%s' in ResourcePack '%s'", path, name));
         return Files.newInputStream(path, StandardOpenOption.READ);
     }
 

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -67,7 +67,7 @@ public class ModFileResourcePack extends ResourcePack
     {
         final Path path = modFile.getLocator().findPath(modFile, name);
         if(!Files.exists(path))
-            throw new FileNotFoundException(String.format("'%s' in ResourcePack '%s'", path, name));
+            throw new ResourcePackFileNotFoundException(modFile.getFilePath().toFile(), name);
         return Files.newInputStream(path, StandardOpenOption.READ);
     }
 

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -27,7 +27,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;


### PR DESCRIPTION
path.toFile() throws for a ZipPath before the ResourcePackFileNotFoundException is thrown which is just ignored silently afterward