### PR TITLE
Do not try to get the bounding box of an empty voxel shape

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -139,7 +140,11 @@ public interface IForgeTileEntity extends ICapabilitySerializable<CompoundNBT>
              AxisAlignedBB cbb = null;
              try
              {
-                 cbb = state.getCollisionShape(getTileEntity().getWorld(), pos).getBoundingBox().offset(pos);
+                 VoxelShape collisionShape = state.getCollisionShape(getTileEntity().getWorld(), pos);
+                 if (!collisionShape.isEmpty())
+                 {
+                     cbb = collisionShape.getBoundingBox().offset(pos);
+                 }
              }
              catch (Exception e)
              {


### PR DESCRIPTION
` IForgeTileEntity#getRenderBoundingBox` currently calls `getBoundingBox` on the collision shape of the relevant block. If the block has an empty collision shape this will throw an `UnsupportedOperationException`. This doesn't crash because the call is wrapped in a try-catch related to bukkit issues, but still isn't great and, at least for me, wastes 0.5% of the render thread's time.