### PR TITLE
Fix parse results of CommandEvent being disregarded

### DIFF
--- a/patches/minecraft/net/minecraft/command/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/command/Commands.java.patch
@@ -8,10 +8,11 @@
  
        this.field_197062_b.findAmbiguities((p_201302_1_, p_201302_2_, p_201302_3_, p_201302_4_) -> {
           field_197061_a.warn("Ambiguity between arguments {} and {} with inputs: {}", this.field_197062_b.getPath(p_201302_2_), this.field_197062_b.getPath(p_201302_3_), p_201302_4_);
-@@ -205,6 +206,14 @@
+@@ -205,7 +206,15 @@
  
        try {
           try {
+-            return this.field_197062_b.execute(stringreader, p_197059_1_);
 +            ParseResults<CommandSource> parse = this.field_197062_b.parse(stringreader, p_197059_1_);
 +            net.minecraftforge.event.CommandEvent event = new net.minecraftforge.event.CommandEvent(parse);
 +            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) {
@@ -20,6 +21,7 @@
 +               }
 +               return 1;
 +            }
-             return this.field_197062_b.execute(stringreader, p_197059_1_);
++            return this.field_197062_b.execute(event.getParseResults());
           } catch (CommandException commandexception) {
              p_197059_1_.func_197021_a(commandexception.func_197003_a());
+             return 0;


### PR DESCRIPTION
One of the uses of `CommandEvent` is the ability to replace a command with another before execution by replacing the `ParseResults` in the event. This ability was present from when the event was introduced until 1.16.x, where a [missed/misplaced patch][1.14_patch] both removed that functionality, and made the dispatcher parse through commands twice (once to pass into `CommandEvent`, and another because the command was reparsed for execution).

This PR simply changes the call from `CommandDispatcher<S>#execute(StringReader, S)` to `CommandDispatcher<S>#execute(ParseResults<S>)`, and using the `ParseResults<S>` from the event.

[1.14_patch]: https://github.com/MinecraftForge/MinecraftForge/blob/a7df63e1a102363250e0d278b44442fa0f3eb8ee/patches/minecraft/net/minecraft/command/Commands.java.patch