### PR TITLE
Fixed container item being consumed in brewing stand. #7307

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
@@ -8,7 +8,7 @@
        if (itemstack.func_190926_b()) {
           return false;
        } else if (!PotionBrewing.func_185205_a(itemstack)) {
-@@ -163,16 +164,16 @@
+@@ -163,22 +164,22 @@
     }
  
     private void func_145940_l() {
@@ -18,18 +18,26 @@
 -      for(int i = 0; i < 3; ++i) {
 -         this.field_145945_j.set(i, PotionBrewing.func_185212_d(itemstack, this.field_145945_j.get(i)));
 -      }
+-
+-      itemstack.func_190918_g(1);
 +      net.minecraftforge.common.brewing.BrewingRecipeRegistry.brewPotions(field_145945_j, itemstack, field_145947_i);
- 
-       itemstack.func_190918_g(1);
 +      net.minecraftforge.event.ForgeEventFactory.onPotionBrewed(field_145945_j);
        BlockPos blockpos = this.func_174877_v();
 -      if (itemstack.func_77973_b().func_77634_r()) {
 -         ItemStack itemstack1 = new ItemStack(itemstack.func_77973_b().func_77668_q());
 +      if (itemstack.hasContainerItem()) {
 +         ItemStack itemstack1 = itemstack.getContainerItem();
++         itemstack.func_190918_g(1);
           if (itemstack.func_190926_b()) {
              itemstack = itemstack1;
           } else if (!this.field_145850_b.field_72995_K) {
+             InventoryHelper.func_180173_a(this.field_145850_b, (double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p(), itemstack1);
+          }
+       }
++      else itemstack.func_190918_g(1);
+ 
+       this.field_145945_j.set(3, itemstack);
+       this.field_145850_b.func_217379_c(1035, blockpos, 0);
 @@ -229,13 +230,13 @@
  
     public boolean func_94041_b(int p_94041_1_, ItemStack p_94041_2_) {

--- a/src/test/java/net/minecraftforge/debug/PotionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/PotionEventTest.java
@@ -22,10 +22,16 @@ package net.minecraftforge.debug;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
 import net.minecraftforge.event.entity.living.PotionEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("potion_event_test")
 @Mod.EventBusSubscriber
@@ -33,6 +39,16 @@ public class PotionEventTest
 {
     private static Logger LOGGER = LogManager.getLogger(PotionEventTest.class);
 
+    public PotionEventTest()
+    {
+    	FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onSetup);
+    }
+    
+    private void onSetup(FMLCommonSetupEvent event)
+    {
+    	BrewingRecipeRegistry.addRecipe(Ingredient.fromItems(Items.ICE), Ingredient.fromItems(Items.LAVA_BUCKET), new ItemStack(Items.OBSIDIAN));
+    }
+    
     @SubscribeEvent
     public static void onPotionAdded(PotionEvent.PotionAddedEvent event)
     {


### PR DESCRIPTION
It seems there was already code to support container items but decreasing the stack size before the checks would make the item empty and fail the various checks. This PR restructures how and where the stack is shrunk. 