### PR TITLE
Fix Minecart speed cap on rail being initialized to 0

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
@@ -207,7 +207,7 @@
 +   private boolean canUseRail = true;
 +   @Override public boolean canUseRail() { return canUseRail; }
 +   @Override public void setCanUseRail(boolean value) { this.canUseRail = value; }
-+   private float currentSpeedCapOnRail = Float.MAX_VALUE;
++   private float currentSpeedCapOnRail = getMaxCartSpeedOnRail();
 +   @Override public float getCurrentCartSpeedCapOnRail() { return currentSpeedCapOnRail; }
 +   @Override public void setCurrentCartSpeedCapOnRail(float value) { currentSpeedCapOnRail = Math.min(value, getMaxCartSpeedOnRail()); }
 +   private float maxSpeedAirLateral = DEFAULT_MAX_SPEED_AIR_LATERAL;

--- a/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
@@ -207,9 +207,9 @@
 +   private boolean canUseRail = true;
 +   @Override public boolean canUseRail() { return canUseRail; }
 +   @Override public void setCanUseRail(boolean value) { this.canUseRail = value; }
-+   private float currentSpeedOnRail;
-+   @Override public float getCurrentCartSpeedCapOnRail() { return currentSpeedOnRail; }
-+   @Override public void setCurrentCartSpeedCapOnRail(float value) { currentSpeedOnRail = Math.min(value, getMaxCartSpeedOnRail()); }
++   private float currentSpeedCapOnRail = Float.MAX_VALUE;
++   @Override public float getCurrentCartSpeedCapOnRail() { return currentSpeedCapOnRail; }
++   @Override public void setCurrentCartSpeedCapOnRail(float value) { currentSpeedCapOnRail = Math.min(value, getMaxCartSpeedOnRail()); }
 +   private float maxSpeedAirLateral = DEFAULT_MAX_SPEED_AIR_LATERAL;
 +   @Override public float getMaxSpeedAirLateral() { return maxSpeedAirLateral; }
 +   @Override public void setMaxSpeedAirLateral(float value) { maxSpeedAirLateral = value; }


### PR DESCRIPTION
This causes Minecarts to never move on rails, because their speed is being capped at 0.
This was not an issue pre-1.16, because in 1.15 `getCurrentCartSpeedCapOnRail` was completely ignored due to a different bug in `getCurrentRailPosition`, which was fixed in 1.16.