### PR TITLE
Fixed tile entities getting removed even when the underlying block stays the same

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -24,7 +24,7 @@
     @Deprecated
     public void func_196243_a(BlockState p_196243_1_, World p_196243_2_, BlockPos p_196243_3_, BlockState p_196243_4_, boolean p_196243_5_) {
 -      if (this.func_235695_q_() && !p_196243_1_.func_203425_a(p_196243_4_.func_177230_c())) {
-+      if (p_196243_1_.hasTileEntity() && (p_196243_1_.func_203425_a(p_196243_4_.func_177230_c()) || !p_196243_4_.hasTileEntity())) {
++      if (p_196243_1_.hasTileEntity() && (!p_196243_1_.func_203425_a(p_196243_4_.func_177230_c()) || !p_196243_4_.hasTileEntity())) {
           p_196243_2_.func_175713_t(p_196243_3_);
        }
  


### PR DESCRIPTION
In this PR I've added back the negation in an if check in AbstractBlock that was (probably accidentally) removed in https://github.com/MinecraftForge/MinecraftForge/commit/887bc372094eab7f03c1d7d8d21119947f36c080. This removal of the negation causes the tileentity to be removed even if the new block is the same as the old one, and it also caused issues where the tileentity would not get removed in some scenarios, even when it should.