### PR TITLE
WIP: Fix forge light pipeline applying block offsets twice

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -51,8 +51,6 @@ public class BlockInfo
 
     private boolean full;
 
-    private float shx = 0, shy = 0, shz = 0;
-
     private int cachedTint = -1;
     private int cachedMultiplier = -1;
 
@@ -69,12 +67,9 @@ public class BlockInfo
         return cachedMultiplier;
     }
 
+    @Deprecated
     public void updateShift()
     {
-        Vector3d offset = state.getOffset(world, blockPos);
-        shx = (float) offset.x;
-        shy = (float) offset.y;
-        shz = (float) offset.z;
     }
 
     public void setWorld(IBlockDisplayReader world)
@@ -96,7 +91,6 @@ public class BlockInfo
         this.blockPos = blockPos;
         cachedTint = -1;
         cachedMultiplier = -1;
-        shx = shy = shz = 0;
     }
 
     public void reset()
@@ -106,7 +100,6 @@ public class BlockInfo
         this.blockPos = null;
         cachedTint = -1;
         cachedMultiplier = -1;
-        shx = shy = shz = 0;
     }
 
     private float combine(int c, int s1, int s2, int s3, boolean t0, boolean t1, boolean t2, boolean t3)
@@ -251,19 +244,22 @@ public class BlockInfo
         return full;
     }
 
+    @Deprecated
     public float getShx()
     {
-        return shx;
+        return 0;
     }
 
+    @Deprecated
     public float getShy()
     {
-        return shy;
+        return 0;
     }
 
+    @Deprecated
     public float getShz()
     {
-        return shz;
+        return 0;
     }
 
     public int getCachedTint()

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -190,10 +190,6 @@ public class VertexLighterFlat extends QuadGatheringTransformer
 
         for(int v = 0; v < 4; v++)
         {
-            position[v][0] += blockInfo.getShx();
-            position[v][1] += blockInfo.getShy();
-            position[v][2] += blockInfo.getShz();
-
             float x = position[v][0] - .5f;
             float y = position[v][1] - .5f;
             float z = position[v][2] - .5f;
@@ -335,7 +331,6 @@ public class VertexLighterFlat extends QuadGatheringTransformer
 
     public void updateBlockInfo()
     {
-        blockInfo.updateShift();
         blockInfo.updateFlatLighting();
     }
 }


### PR DESCRIPTION
Fixes #7321.

In 1.15 vanilla switched from applying block offsets individually to each quad in `renderQuadsSmooth`/`renderQuadsFlat` to simply doing a matrix transform in `renderModel`. Forge's pipeline still applies the offset to every quad again though, causing models to be shifted twice.

I have marked this WIP because I do not know if this is the proper fix or if instead the matrix transform needs to be disabled when the forge pipeline is enabled.