### PR TITLE
Allows json based biomes to be loaded.

### DIFF
--- a/patches/minecraft/net/minecraft/util/registry/WorldSettingsImport.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/WorldSettingsImport.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/util/registry/WorldSettingsImport.java
 +++ b/net/minecraft/util/registry/WorldSettingsImport.java
-@@ -231,6 +231,7 @@
+@@ -190,6 +190,7 @@
+                ) {
+                   JsonParser jsonparser = new JsonParser();
+                   JsonElement jsonelement = jsonparser.parse(reader);
++                  if (jsonelement!= null) jsonelement.getAsJsonObject().addProperty("forge:registry_name", p_241879_3_.func_240901_a_().toString());
+                   return p_241879_4_.parse(p_241879_1_, jsonelement).map((p_244347_0_) -> {
+                      return Pair.of(p_244347_0_, OptionalInt.empty());
+                   });
+@@ -231,6 +232,7 @@
  
           public <E> DataResult<Pair<E, OptionalInt>> func_241879_a(DynamicOps<JsonElement> p_241879_1_, RegistryKey<? extends Registry<E>> p_241879_2_, RegistryKey<E> p_241879_3_, Decoder<E> p_241879_4_) {
              JsonElement jsonelement = this.field_244349_a.get(p_241879_3_);

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BiomeLoadingEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(BiomeLoadingEventTest.MODID)
+public class BiomeLoadingEventTest {
+    static final String MODID = "biome_loading_event_test";
+    private static final Logger LOGGER = LogManager.getLogger(MODID);
+    private static final boolean ENABLED = false;
+    public BiomeLoadingEventTest(){
+        if(ENABLED) {
+            MinecraftForge.EVENT_BUS.addListener(this::onBiomeLoading);
+        }
+    }
+    public void onBiomeLoading(BiomeLoadingEvent event){
+        ResourceLocation biome = event.getName();
+        LOGGER.info(String.format("Biome loaded: %s", biome.toString()));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -84,3 +84,5 @@ license="LGPL v2.1"
     modId="scaffolding_test"
 [[mods]]
     modId="custom_tag_types_test"
+[[mods]]
+    modId="biome_loading_event_test"

--- a/src/test/resources/data/biome_loading_event_test/worldgen/biome/desert.json
+++ b/src/test/resources/data/biome_loading_event_test/worldgen/biome/desert.json
@@ -1,0 +1,164 @@
+{
+  "scale": 0.05,
+  "effects": {
+    "mood_sound": {
+      "sound": "minecraft:ambient.cave",
+      "tick_delay": 6000,
+      "block_search_extent": 8,
+      "offset": 2.0
+    },
+    "foliage_color": 16711680,
+    "grass_color": 7348484,
+    "sky_color": 5963796,
+    "fog_color": 12638463,
+    "water_color": 0,
+    "water_fog_color": 0
+  },
+  "surface_builder": "minecraft:desert",
+  "carvers": {
+    "air": [
+      "minecraft:cave",
+      "minecraft:canyon"
+    ]
+  },
+  "features": [
+    [],
+    [
+      "minecraft:lake_lava"
+    ],
+    [],
+    [
+      "minecraft:fossil",
+      "minecraft:monster_room"
+    ],
+    [
+      "minecraft:desert_well"
+    ],
+    [],
+    [
+      "minecraft:ore_dirt",
+      "minecraft:ore_gravel",
+      "minecraft:ore_granite",
+      "minecraft:ore_diorite",
+      "minecraft:ore_andesite",
+      "minecraft:ore_coal",
+      "minecraft:ore_iron",
+      "minecraft:ore_gold",
+      "minecraft:ore_redstone",
+      "minecraft:ore_diamond",
+      "minecraft:ore_lapis",
+      "minecraft:disk_sand",
+      "minecraft:disk_clay",
+      "minecraft:disk_gravel"
+
+    ],
+    [],
+    [
+      "minecraft:flower_default",
+      "minecraft:patch_grass_badlands",
+      "minecraft:patch_dead_bush_2",
+      "minecraft:brown_mushroom_normal",
+      "minecraft:red_mushroom_normal",
+      "minecraft:patch_sugar_cane_desert",
+      "minecraft:patch_pumpkin",
+      "minecraft:patch_cactus_desert",
+      "minecraft:spring_water",
+      "minecraft:spring_lava"
+    ],
+    [
+      "minecraft:freeze_top_layer"
+    ]
+  ],
+  "starts": [
+    "minecraft:village_desert",
+    "minecraft:pillager_outpost",
+    "minecraft:desert_pyramid",
+    "minecraft:mineshaft",
+    "minecraft:stronghold",
+    "minecraft:ruined_portal_desert"
+  ],
+  "spawners": {
+    "monster": [
+      {
+        "type": "minecraft:spider",
+        "weight": 100,
+        "minCount": 4,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:zombie",
+        "weight": 19,
+        "minCount": 4,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:zombie_villager",
+        "weight": 1,
+        "minCount": 1,
+        "maxCount": 1
+      },
+      {
+        "type": "minecraft:skeleton",
+        "weight": 100,
+        "minCount": 4,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:creeper",
+        "weight": 100,
+        "minCount": 4,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:slime",
+        "weight": 100,
+        "minCount": 4,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:enderman",
+        "weight": 10,
+        "minCount": 1,
+        "maxCount": 4
+      },
+      {
+        "type": "minecraft:witch",
+        "weight": 5,
+        "minCount": 1,
+        "maxCount": 1
+      },
+      {
+        "type": "minecraft:husk",
+        "weight": 80,
+        "minCount": 4,
+        "maxCount": 4
+      }
+    ],
+    "creature": [
+      {
+        "type": "minecraft:rabbit",
+        "weight": 4,
+        "minCount": 2,
+        "maxCount": 3
+      }
+    ],
+    "ambient": [
+      {
+        "type": "minecraft:bat",
+        "weight": 10,
+        "minCount": 8,
+        "maxCount": 8
+      }
+    ],
+    "water_creature": [],
+    "water_ambient": [],
+    "misc": []
+  },
+  "spawn_costs": {},
+  "player_spawn_friendly": false,
+  "precipitation": "none",
+  "temperature": 2.0,
+  "downfall": 0.0,
+  "category": "desert",
+  "depth": 0.125
+}


### PR DESCRIPTION
This PR aims to address an issue caused by the biome loading event addition.

Datapack biomes would error because only the biomes loaded from the Biome Registry would have the `forge:registry_name` property injected into the biome json.
`Error loading registry data: No key forge:registry_name in MapLike[...]`
This is because there are 2 implementations of `WorldSettingsImport.IResourceAccess`, `RegistryAccess` which was used when you open the new world screen and loaded from the registry, and an anonymous class in `WorldSettingsImport.IResourceAccess` which is used for datapacks.
`RegistryAccess` had already been patched to inject `forge:registry_name` property into the json.
This patches the anonymous class to do the same.

Adds a test mod that when enabled will log the names of all biomes that go through the BiomeLoadedEvent and a sample json biome based on the vanilla desert biome under the mod namespace to demonstrate the differences between registry biomes and datapack biomes. The sample biome is not generated as it is not included in any dimension.
