### PR TITLE
[1.16.x] Add support for custom world generators

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screen/BiomeGeneratorTypeScreens.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/BiomeGeneratorTypeScreens.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screen/BiomeGeneratorTypeScreens.java
++++ b/net/minecraft/client/gui/screen/BiomeGeneratorTypeScreens.java
+@@ -27,7 +27,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public abstract class BiomeGeneratorTypeScreens {
++public abstract class BiomeGeneratorTypeScreens implements net.minecraftforge.client.extensions.IForgeGeneratorType {
+    public static final BiomeGeneratorTypeScreens field_239066_a_ = new BiomeGeneratorTypeScreens("default") {
+       protected ChunkGenerator func_241869_a(Registry<Biome> p_241869_1_, Registry<DimensionSettings> p_241869_2_, long p_241869_3_) {
+          return new NoiseChunkGenerator(new OverworldBiomeProvider(p_241869_3_, false, false, p_241869_1_), p_241869_3_, () -> {

--- a/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
@@ -5,7 +5,7 @@
        this.field_239035_i_.field_230693_o_ = this.field_239040_n_.isPresent();
        this.field_239036_j_ = p_239048_1_.func_230480_a_(new Button(j, 120, 150, 20, new TranslationTextComponent("selectWorld.customizeType"), (p_239044_3_) -> {
 -         BiomeGeneratorTypeScreens.IFactory biomegeneratortypescreens$ifactory = BiomeGeneratorTypeScreens.field_239069_d_.get(this.field_239040_n_);
-+         BiomeGeneratorTypeScreens.IFactory biomegeneratortypescreens$ifactory = this.field_239040_n_.map(BiomeGeneratorTypeScreens::getEditScreenFactory).orElse(BiomeGeneratorTypeScreens.field_239069_d_.get(this.field_239040_n_));
++         BiomeGeneratorTypeScreens.IFactory biomegeneratortypescreens$ifactory = this.field_239040_n_.filter(BiomeGeneratorTypeScreens::hasEditScreen).map(BiomeGeneratorTypeScreens::getEditScreenFactory).orElse(BiomeGeneratorTypeScreens.field_239069_d_.get(this.field_239040_n_));
           if (biomegeneratortypescreens$ifactory != null) {
              p_239048_2_.func_147108_a(biomegeneratortypescreens$ifactory.createEditScreen(p_239048_1_, this.field_239039_m_));
           }

--- a/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/gui/screen/WorldOptionsScreen.java
++++ b/net/minecraft/client/gui/screen/WorldOptionsScreen.java
+@@ -133,7 +133,7 @@
+       this.field_239035_i_.field_230694_p_ = false;
+       this.field_239035_i_.field_230693_o_ = this.field_239040_n_.isPresent();
+       this.field_239036_j_ = p_239048_1_.func_230480_a_(new Button(j, 120, 150, 20, new TranslationTextComponent("selectWorld.customizeType"), (p_239044_3_) -> {
+-         BiomeGeneratorTypeScreens.IFactory biomegeneratortypescreens$ifactory = BiomeGeneratorTypeScreens.field_239069_d_.get(this.field_239040_n_);
++         BiomeGeneratorTypeScreens.IFactory biomegeneratortypescreens$ifactory = this.field_239040_n_.map(BiomeGeneratorTypeScreens::getEditScreenFactory).orElse(BiomeGeneratorTypeScreens.field_239069_d_.get(this.field_239040_n_));
+          if (biomegeneratortypescreens$ifactory != null) {
+             p_239048_2_.func_147108_a(biomegeneratortypescreens$ifactory.createEditScreen(p_239048_1_, this.field_239039_m_));
+          }
+@@ -292,7 +292,7 @@
+       } else {
+          this.field_239034_h_.field_230694_p_ = p_239059_1_;
+          this.field_239027_a_.field_230694_p_ = p_239059_1_;
+-         this.field_239036_j_.field_230694_p_ = p_239059_1_ && BiomeGeneratorTypeScreens.field_239069_d_.containsKey(this.field_239040_n_);
++         this.field_239036_j_.field_230694_p_ = p_239059_1_ && this.field_239040_n_.map(BiomeGeneratorTypeScreens::hasEditScreen).orElse(BiomeGeneratorTypeScreens.field_239069_d_.containsKey(this.field_239040_n_));
+          this.field_239037_k_.field_230694_p_ = p_239059_1_;
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/WorldOptionsScreen.java.patch
@@ -14,7 +14,7 @@
           this.field_239034_h_.field_230694_p_ = p_239059_1_;
           this.field_239027_a_.field_230694_p_ = p_239059_1_;
 -         this.field_239036_j_.field_230694_p_ = p_239059_1_ && BiomeGeneratorTypeScreens.field_239069_d_.containsKey(this.field_239040_n_);
-+         this.field_239036_j_.field_230694_p_ = p_239059_1_ && this.field_239040_n_.map(BiomeGeneratorTypeScreens::hasEditScreen).orElse(BiomeGeneratorTypeScreens.field_239069_d_.containsKey(this.field_239040_n_));
++         this.field_239036_j_.field_230694_p_ = p_239059_1_ && (this.field_239040_n_.filter(BiomeGeneratorTypeScreens::hasEditScreen).isPresent() || BiomeGeneratorTypeScreens.field_239069_d_.containsKey(this.field_239040_n_));
           this.field_239037_k_.field_230694_p_ = p_239059_1_;
        }
  

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
@@ -36,7 +36,7 @@ public interface IForgeGeneratorType
 
     /**
      * Override to provide a Screen for editing this GeneratorType's settings.
-     * @return A factory for creating new instances of this GeneratorType's settings editor Screen
+     * @return A factory for creating new instances of this GeneratorType's settings editor Screen or null.
      */
     @Nullable
     default BiomeGeneratorTypeScreens.IFactory getEditScreenFactory()

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
@@ -25,11 +25,19 @@ import javax.annotation.Nullable;
 
 public interface IForgeGeneratorType
 {
+    /**
+     * Override to specify that this GeneratorType provides a Screen for editing its settings.
+     * @return True if this GeneratorType provides a Screen for editing its settings.
+     */
     default boolean hasEditScreen()
     {
         return false;
     }
 
+    /**
+     * Override to provide a Screen for editing this GeneratorType's settings.
+     * @return A factory for creating new instances of this GeneratorType's settings editor Screen
+     */
     @Nullable
     default BiomeGeneratorTypeScreens.IFactory getEditScreenFactory()
     {

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.client.extensions;
+
+import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
+
+import javax.annotation.Nullable;
+
+public interface IForgeGeneratorType
+{
+    default boolean hasEditScreen()
+    {
+        return false;
+    }
+
+    @Nullable
+    default BiomeGeneratorTypeScreens.IFactory getEditScreenFactory()
+    {
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeGeneratorType.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client.extensions;
 
 import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -144,6 +144,7 @@ public net.minecraft.client.gui.ScreenManager func_216911_a(Lnet/minecraft/inven
 public net.minecraft.client.gui.ScreenManager$IScreenFactory
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211537_g # rayTraceBlock
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211538_h # rayTraceFluid
+protected net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens <init>(Ljava/lang/String;)V
 protected net.minecraft.client.gui.widget.list.AbstractList$AbstractListEntry field_230666_a_ # list
 public net.minecraft.client.particle.ParticleManager func_199283_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/IParticleFactory;)V # registerFactory
 public net.minecraft.client.particle.ParticleManager func_215234_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/ParticleManager$IParticleMetaFactory;)V # registerFactory

--- a/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
@@ -1,0 +1,75 @@
+package net.minecraftforge.debug.client.gui;
+
+import net.minecraft.client.gui.DialogTexts;
+import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
+import net.minecraft.client.gui.screen.CreateWorldScreen;
+import net.minecraft.client.gui.screen.ErrorScreen;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.DimensionSettings;
+import net.minecraft.world.gen.FlatChunkGenerator;
+import net.minecraft.world.gen.FlatGenerationSettings;
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+@Mod(GeneratorTypeTest.MODID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class GeneratorTypeTest {
+
+    public static final String MODID = "generatortypetest";
+
+    @SubscribeEvent
+    public static void init(FMLClientSetupEvent event) {
+        TestGeneratorType testScreen = new TestGeneratorType("test_screen", TestEditScreen::new);
+        TestGeneratorType testNoScreen = new TestGeneratorType("test_no_screen", null);
+    }
+
+    private static class TestGeneratorType extends BiomeGeneratorTypeScreens {
+
+        private final BiomeGeneratorTypeScreens.IFactory factory;
+
+        private TestGeneratorType(String name, BiomeGeneratorTypeScreens.IFactory factory) {
+            super(name);
+            this.factory = factory;
+            // add to the generator types list so this shows up as an option
+            BiomeGeneratorTypeScreens.field_239068_c_.add(this);
+        }
+
+        @Override
+        protected ChunkGenerator func_241869_a(Registry<Biome> biomes, Registry<DimensionSettings> settings, long seed) {
+            return new FlatChunkGenerator(FlatGenerationSettings.func_242869_a(biomes));
+        }
+
+        @Override
+        public boolean hasEditScreen() {
+            return factory != null;
+        }
+
+        @Override
+        public IFactory getEditScreenFactory() {
+            return factory;
+        }
+    }
+
+    private static class TestEditScreen extends ErrorScreen {
+
+        private final CreateWorldScreen parent;
+
+        private TestEditScreen(CreateWorldScreen parent, DimensionGeneratorSettings settings) {
+            super(new StringTextComponent("Test"), new StringTextComponent("Not implemented!"));
+            this.parent = parent;
+        }
+
+        @Override
+        protected void func_231160_c_() {
+            this.func_230480_a_(new Button(this.field_230708_k_ / 2 - 100, 140, 200, 20, DialogTexts.field_240633_d_, button -> {
+                this.field_230706_i_.displayGuiScreen(parent);
+            }));
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client.gui;
 
 import net.minecraft.client.gui.DialogTexts;

--- a/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/gui/GeneratorTypeTest.java
@@ -40,12 +40,14 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class GeneratorTypeTest {
 
-    public static final String MODID = "generatortypetest";
+    public static final String MODID = "generator_type_test";
 
     @SubscribeEvent
     public static void init(FMLClientSetupEvent event) {
-        TestGeneratorType testScreen = new TestGeneratorType("test_screen", TestEditScreen::new);
-        TestGeneratorType testNoScreen = new TestGeneratorType("test_no_screen", null);
+        event.enqueueWork(() -> {
+            new TestGeneratorType("test_screen", TestEditScreen::new);
+            new TestGeneratorType("test_no_screen", null);
+        });
     }
 
     private static class TestGeneratorType extends BiomeGeneratorTypeScreens {

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -84,3 +84,5 @@ license="LGPL v2.1"
     modId="scaffolding_test"
 [[mods]]
     modId="custom_tag_types_test"
+[[mods]]
+    modId="generatortypetest"

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -87,4 +87,4 @@ license="LGPL v2.1"
 [[mods]]
     modId="biome_loading_event_test"
 [[mods]]
-    modId="generatortypetest"
+    modId="generator_type_test"


### PR DESCRIPTION
The BiomeGeneratorTypeScreens class defines each of the user-selectable world generator types that are available in the 'More World Options' screen (similar to the WorldType class from 1.15 and below).

The class is not extensible, so modders have no way to let users select their generator(s) when creating a world:
1. The constructor is private
2. Generator types that have an 'edit screen' are defined in an immutable map

This PR does the following:
1. Changes the constructor access to protected
2. Adds an "extension"? interface to BiomeGenTypeScreens that modders can optionally override to provide their edit screen
3. Modifies WorldOptionsScreen to make use of said interface before falling back to the immutable map for the vanilla stuff
4. Adds a test mod to demo custom generator types with & without an edit screen