### PR TITLE
Add a ChunkGeneratorLoadEvent to allow modification/addition/removal of structure se…

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGenerator.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/gen/ChunkGenerator.java
++++ b/net/minecraft/world/gen/ChunkGenerator.java
+@@ -58,9 +58,11 @@
+    }
+ 
+    public ChunkGenerator(BiomeProvider p_i231887_1_, BiomeProvider p_i231887_2_, DimensionStructuresSettings p_i231887_3_, long p_i231887_4_) {
++      net.minecraftforge.event.world.ChunkGeneratorLoadEvent loadEvent = new net.minecraftforge.event.world.ChunkGeneratorLoadEvent(p_i231887_1_, p_i231887_3_, p_i231887_4_);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(loadEvent);
+       this.field_222542_c = p_i231887_1_;
+       this.field_235949_c_ = p_i231887_2_;
+-      this.field_222543_d = p_i231887_3_;
++      this.field_222543_d = new DimensionStructuresSettings(java.util.Optional.ofNullable(loadEvent.getStructureSpreadSettings()), loadEvent.getStructureSeparationSettings());
+       this.field_235950_e_ = p_i231887_4_;
+    }
+ 

--- a/src/main/java/net/minecraftforge/event/world/ChunkGeneratorLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkGeneratorLoadEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.world;
+
+import net.minecraft.world.biome.provider.BiomeProvider;
+import net.minecraft.world.gen.feature.structure.Structure;
+import net.minecraft.world.gen.settings.DimensionStructuresSettings;
+import net.minecraft.world.gen.settings.StructureSeparationSettings;
+import net.minecraft.world.gen.settings.StructureSpreadSettings;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * This event fires whenever a new instance of a chunk generator is created.
+ * It allows mods to edit the structure separation settings and the structure spread settings.
+ *
+ * To maintain the most possible compatibility with other mods' changes,
+ * the event should be assigned a {@link net.minecraftforge.eventbus.api.EventPriority}:
+ *
+ * - Additions to the separation settings: {@link net.minecraftforge.eventbus.api.EventPriority#HIGH}
+ * - Removals from the separation settings: {@link net.minecraftforge.eventbus.api.EventPriority#NORMAL}
+ * - Other modifications: {@link net.minecraftforge.eventbus.api.EventPriority#LOW}
+ *
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ */
+
+public class ChunkGeneratorLoadEvent extends Event
+{
+    private final BiomeProvider biomeProvider;
+    private final Map<Structure<?>, StructureSeparationSettings> structureSeparationSettings;
+    private StructureSpreadSettings structureSpreadSettings;
+    private final long seed;
+
+    public ChunkGeneratorLoadEvent(BiomeProvider biomeProvider, DimensionStructuresSettings settings, long seed)
+    {
+        this.biomeProvider = biomeProvider;
+        this.structureSeparationSettings = settings.func_236195_a_();
+        this.structureSpreadSettings = settings.func_236199_b_();
+        this.seed = seed;
+    }
+
+    public BiomeProvider getBiomeProvider()
+    {
+        return biomeProvider;
+    }
+
+    public Map<Structure<?>, StructureSeparationSettings> getStructureSeparationSettings()
+    {
+        return structureSeparationSettings;
+    }
+
+    @Nullable
+    public StructureSpreadSettings getStructureSpreadSettings()
+    {
+        return structureSpreadSettings;
+    }
+
+    public long getSeed()
+    {
+        return seed;
+    }
+
+    public void setStructureSpreadSettings(StructureSpreadSettings structureSpreadSettings)
+    {
+        this.structureSpreadSettings = structureSpreadSettings;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/ChunkGeneratorLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkGeneratorLoadEventTest.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.world.gen.feature.structure.Structure;
+import net.minecraft.world.gen.settings.StructureSeparationSettings;
+import net.minecraft.world.gen.settings.StructureSpreadSettings;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ChunkGeneratorLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(ChunkGeneratorLoadEventTest.MODID)
+public class ChunkGeneratorLoadEventTest
+{
+    public static final String MODID = "chunk_generator_load_event_test";
+    private static final Logger LOGGER = LogManager.getLogger(MODID);
+    private static final boolean ENABLED = false;
+
+    public ChunkGeneratorLoadEventTest()
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.addListener(this::onChunkGeneratorLoading);
+        }
+    }
+
+    public void onChunkGeneratorLoading(ChunkGeneratorLoadEvent event)
+    {
+        LOGGER.info("Seed: {}", event.getSeed());
+        if (event.getStructureSeparationSettings().containsKey(Structure.field_236370_f_))
+        {
+            event.getStructureSeparationSettings().put(Structure.field_236370_f_, new StructureSeparationSettings(3, 1, 12345));
+        }
+        if (event.getStructureSeparationSettings().containsKey(Structure.field_236369_e_))
+        {
+            event.getStructureSeparationSettings().put(Structure.field_236369_e_, new StructureSeparationSettings(3, 0, 54321));
+        }
+        event.setStructureSpreadSettings(new StructureSpreadSettings(5, 5, 256)); // This makes strongholds pretty common.
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -86,3 +86,5 @@ license="LGPL v2.1"
     modId="custom_tag_types_test"
 [[mods]]
     modId="biome_loading_event_test"
+[[mods]]
+    modId="chunk_generator_load_event_test"


### PR DESCRIPTION
…paration settings and structure spread settings. This is an alternative to #7232 

Since Minecraft Version 1.16.2, every structure needs to have structure separation settings in order to get placed by a chunk generator.
Because of this, there is no proper way to add custom structures since the list of default settings in DimensionStructuresSettings is immutable and gets copied and used way before modloading even begins.

The new event gets fired whenever a new instance of ChunkGenerator is created and grants mods to access the map of structure separation settings and the structure spread settings (used for the stronghold only) before they are passed over to the ChunkGenerator, allowing them to add separation settings for their structures or to overwrite existing ones.

The biome provider and the world seed are passed over in the event as well to provide some extra information.