### PR TITLE
[1.16.x] Fix Recipe Providers Throwing NPE for Non-Grouped Items

### DIFF
--- a/patches/minecraft/net/minecraft/data/CookingRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/CookingRecipeBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/CookingRecipeBuilder.java
++++ b/net/minecraft/data/CookingRecipeBuilder.java
+@@ -68,7 +68,7 @@
+    public void func_218635_a(Consumer<IFinishedRecipe> p_218635_1_, ResourceLocation p_218635_2_) {
+       this.func_218634_a(p_218635_2_);
+       this.field_218640_e.func_200272_a(new ResourceLocation("recipes/root")).func_200275_a("has_the_recipe", RecipeUnlockedTrigger.func_235675_a_(p_218635_2_)).func_200271_a(AdvancementRewards.Builder.func_200280_c(p_218635_2_)).func_200270_a(IRequirementsStrategy.field_223215_b_);
+-      p_218635_1_.accept(new CookingRecipeBuilder.Result(p_218635_2_, this.field_218641_f == null ? "" : this.field_218641_f, this.field_218637_b, this.field_218636_a, this.field_218638_c, this.field_218639_d, this.field_218640_e, new ResourceLocation(p_218635_2_.func_110624_b(), "recipes/" + this.field_218636_a.func_77640_w().func_200300_c() + "/" + p_218635_2_.func_110623_a()), this.field_218642_g));
++      p_218635_1_.accept(new CookingRecipeBuilder.Result(p_218635_2_, this.field_218641_f == null ? "" : this.field_218641_f, this.field_218637_b, this.field_218636_a, this.field_218638_c, this.field_218639_d, this.field_218640_e, net.minecraftforge.common.ForgeHooks.createRecipeAdvancementId(p_218635_2_, this.field_218636_a.func_77640_w()), this.field_218642_g));
+    }
+ 
+    private void func_218634_a(ResourceLocation p_218634_1_) {

--- a/patches/minecraft/net/minecraft/data/ShapedRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/ShapedRecipeBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/ShapedRecipeBuilder.java
++++ b/net/minecraft/data/ShapedRecipeBuilder.java
+@@ -102,7 +102,7 @@
+    public void func_200467_a(Consumer<IFinishedRecipe> p_200467_1_, ResourceLocation p_200467_2_) {
+       this.func_200463_a(p_200467_2_);
+       this.field_200479_f.func_200272_a(new ResourceLocation("recipes/root")).func_200275_a("has_the_recipe", RecipeUnlockedTrigger.func_235675_a_(p_200467_2_)).func_200271_a(AdvancementRewards.Builder.func_200280_c(p_200467_2_)).func_200270_a(IRequirementsStrategy.field_223215_b_);
+-      p_200467_1_.accept(new ShapedRecipeBuilder.Result(p_200467_2_, this.field_200475_b, this.field_200476_c, this.field_200480_g == null ? "" : this.field_200480_g, this.field_200477_d, this.field_200478_e, this.field_200479_f, new ResourceLocation(p_200467_2_.func_110624_b(), "recipes/" + this.field_200475_b.func_77640_w().func_200300_c() + "/" + p_200467_2_.func_110623_a())));
++      p_200467_1_.accept(new ShapedRecipeBuilder.Result(p_200467_2_, this.field_200475_b, this.field_200476_c, this.field_200480_g == null ? "" : this.field_200480_g, this.field_200477_d, this.field_200478_e, this.field_200479_f, net.minecraftforge.common.ForgeHooks.createRecipeAdvancementId(p_200467_2_, this.field_200475_b.func_77640_w())));
+    }
+ 
+    private void func_200463_a(ResourceLocation p_200463_1_) {

--- a/patches/minecraft/net/minecraft/data/ShapelessRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/ShapelessRecipeBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/ShapelessRecipeBuilder.java
++++ b/net/minecraft/data/ShapelessRecipeBuilder.java
+@@ -96,7 +96,7 @@
+    public void func_200485_a(Consumer<IFinishedRecipe> p_200485_1_, ResourceLocation p_200485_2_) {
+       this.func_200481_a(p_200485_2_);
+       this.field_200497_e.func_200272_a(new ResourceLocation("recipes/root")).func_200275_a("has_the_recipe", RecipeUnlockedTrigger.func_235675_a_(p_200485_2_)).func_200271_a(AdvancementRewards.Builder.func_200280_c(p_200485_2_)).func_200270_a(IRequirementsStrategy.field_223215_b_);
+-      p_200485_1_.accept(new ShapelessRecipeBuilder.Result(p_200485_2_, this.field_200494_b, this.field_200495_c, this.field_200498_f == null ? "" : this.field_200498_f, this.field_200496_d, this.field_200497_e, new ResourceLocation(p_200485_2_.func_110624_b(), "recipes/" + this.field_200494_b.func_77640_w().func_200300_c() + "/" + p_200485_2_.func_110623_a())));
++      p_200485_1_.accept(new ShapelessRecipeBuilder.Result(p_200485_2_, this.field_200494_b, this.field_200495_c, this.field_200498_f == null ? "" : this.field_200498_f, this.field_200496_d, this.field_200497_e, net.minecraftforge.common.ForgeHooks.createRecipeAdvancementId(p_200485_2_, this.field_200494_b.func_77640_w())));
+    }
+ 
+    private void func_200481_a(ResourceLocation p_200481_1_) {

--- a/patches/minecraft/net/minecraft/data/SingleItemRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/SingleItemRecipeBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/SingleItemRecipeBuilder.java
++++ b/net/minecraft/data/SingleItemRecipeBuilder.java
+@@ -55,7 +55,7 @@
+    public void func_218647_a(Consumer<IFinishedRecipe> p_218647_1_, ResourceLocation p_218647_2_) {
+       this.func_218646_a(p_218647_2_);
+       this.field_218652_d.func_200272_a(new ResourceLocation("recipes/root")).func_200275_a("has_the_recipe", RecipeUnlockedTrigger.func_235675_a_(p_218647_2_)).func_200271_a(AdvancementRewards.Builder.func_200280_c(p_218647_2_)).func_200270_a(IRequirementsStrategy.field_223215_b_);
+-      p_218647_1_.accept(new SingleItemRecipeBuilder.Result(p_218647_2_, this.field_218654_f, this.field_218653_e == null ? "" : this.field_218653_e, this.field_218650_b, this.field_218649_a, this.field_218651_c, this.field_218652_d, new ResourceLocation(p_218647_2_.func_110624_b(), "recipes/" + this.field_218649_a.func_77640_w().func_200300_c() + "/" + p_218647_2_.func_110623_a())));
++      p_218647_1_.accept(new SingleItemRecipeBuilder.Result(p_218647_2_, this.field_218654_f, this.field_218653_e == null ? "" : this.field_218653_e, this.field_218650_b, this.field_218649_a, this.field_218651_c, this.field_218652_d, net.minecraftforge.common.ForgeHooks.createRecipeAdvancementId(p_218647_2_, this.field_218649_a.func_77640_w())));
+    }
+ 
+    private void func_218646_a(ResourceLocation p_218646_1_) {

--- a/patches/minecraft/net/minecraft/data/SmithingRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/SmithingRecipeBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/SmithingRecipeBuilder.java
++++ b/net/minecraft/data/SmithingRecipeBuilder.java
+@@ -44,7 +44,7 @@
+    public void func_240505_a_(Consumer<IFinishedRecipe> p_240505_1_, ResourceLocation p_240505_2_) {
+       this.func_240506_a_(p_240505_2_);
+       this.field_240500_d_.func_200272_a(new ResourceLocation("recipes/root")).func_200275_a("has_the_recipe", RecipeUnlockedTrigger.func_235675_a_(p_240505_2_)).func_200271_a(AdvancementRewards.Builder.func_200280_c(p_240505_2_)).func_200270_a(IRequirementsStrategy.field_223215_b_);
+-      p_240505_1_.accept(new SmithingRecipeBuilder.Result(p_240505_2_, this.field_240501_e_, this.field_240497_a_, this.field_240498_b_, this.field_240499_c_, this.field_240500_d_, new ResourceLocation(p_240505_2_.func_110624_b(), "recipes/" + this.field_240499_c_.func_77640_w().func_200300_c() + "/" + p_240505_2_.func_110623_a())));
++      p_240505_1_.accept(new SmithingRecipeBuilder.Result(p_240505_2_, this.field_240501_e_, this.field_240497_a_, this.field_240498_b_, this.field_240499_c_, this.field_240500_d_, net.minecraftforge.common.ForgeHooks.createRecipeAdvancementId(p_240505_2_, this.field_240499_c_.func_77640_w())));
+    }
+ 
+    private void func_240506_a_(ResourceLocation p_240506_1_) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -66,6 +66,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.inventory.container.RepairContainer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
 import net.minecraft.item.AxeItem;
 import net.minecraft.item.BucketItem;
 import net.minecraft.item.EnchantedBookItem;
@@ -1165,6 +1166,20 @@ public class ForgeHooks
             list = mod.apply(list, context);
         }
         return list;
+    }
+
+    /**
+     * Creates a recipe advancement id based on the current item group.
+     * Fixes an issue with regular groups that prevents creating recipes 
+     * with items without an ItemGroup.
+     * 
+     * @param recipeId The current recipe id
+     * @param group The result's group
+     * @return The id of the recipe advancement.
+     * */
+    public static ResourceLocation createRecipeAdvancementId(ResourceLocation recipeId, @Nullable ItemGroup group)
+    {
+        return new ResourceLocation(recipeId.getNamespace(), "recipes/" + (group != null ? group.getPath() + "/" : "") + recipeId.getPath());
     }
 
     public static List<String> getModPacks()


### PR DESCRIPTION
If an item is not in an `ItemGroup`, the data provider results in an NPE as it tries to pull the group path for the advancement location. To get around this, a null check has been added before constructing the advancement id that returns an empty string if null now. Since all the recipes use the same advancement id creator, I just generalized the id into a single forge hook and passed in the required information there.