### PR TITLE
Fix modded EntityClassifications

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -9,7 +9,16 @@
     MONSTER("monster", 70, false, false, 128),
     CREATURE("creature", 10, true, true, 128),
     AMBIENT("ambient", 15, true, false, 128),
-@@ -57,6 +57,17 @@
+@@ -14,7 +14,7 @@
+    WATER_AMBIENT("water_ambient", 20, true, false, 64),
+    MISC("misc", -1, true, true, 128);
+ 
+-   public static Codec<EntityClassification> field_233667_g_ = IStringSerializable.func_233023_a_(EntityClassification::values, EntityClassification::func_233670_a_);
++   public static Codec<EntityClassification> field_233667_g_ = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(EntityClassification::values, EntityClassification::func_233670_a_);
+    private static final Map<String, EntityClassification> field_220364_f = Arrays.stream(values()).collect(Collectors.toMap(EntityClassification::func_220363_a, (p_220362_0_) -> {
+       return p_220362_0_;
+    }));
+@@ -57,6 +57,16 @@
        return this.field_82707_i;
     }
  
@@ -21,7 +30,6 @@
 +   @Deprecated
 +   public void init() {
 +      field_220364_f.put(this.field_220365_j, this);
-+      field_233667_g_ = IStringSerializable.func_233023_a_(EntityClassification::values, EntityClassification::func_233670_a_);
 +   }
 +
     public int func_233671_f_() {

--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -9,12 +9,19 @@
     MONSTER("monster", 70, false, false, 128),
     CREATURE("creature", 10, true, true, 128),
     AMBIENT("ambient", 15, true, false, 128),
-@@ -57,6 +57,10 @@
+@@ -57,6 +57,17 @@
        return this.field_82707_i;
     }
  
 +   public static EntityClassification create(String name, String id, int maxNumberOfCreatureIn, boolean isPeacefulCreatureIn, boolean isAnimalIn, int despawnDistance) {
 +      throw new IllegalStateException("Enum not extended");
++   }
++
++   @Override
++   @Deprecated
++   public void init() {
++      field_220364_f.clear();
++      Arrays.stream(values()).forEach(v->field_220364_f.put(v.func_220363_a(),v)); //Collect values again after modded additions similar as Vanilla does statically above
 +   }
 +
     public int func_233671_f_() {

--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -29,7 +29,7 @@
 +   @Override
 +   @Deprecated
 +   public void init() {
-+      field_220364_f.put(this.field_220365_j, this);
++      field_220364_f.put(this.func_220363_a(), this);
 +   }
 +
     public int func_233671_f_() {

--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -20,8 +20,8 @@
 +   @Override
 +   @Deprecated
 +   public void init() {
-+      field_220364_f.clear();
-+      Arrays.stream(values()).forEach(v->field_220364_f.put(v.func_220363_a(),v)); //Collect values again after modded additions similar as Vanilla does statically above
++      field_220364_f.put(this.field_220365_j, this);
++      field_233667_g_ = IStringSerializable.func_233023_a_(EntityClassification::values, EntityClassification::func_233670_a_);
 +   }
 +
     public int func_233671_f_() {

--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -13,8 +13,8 @@
     WATER_AMBIENT("water_ambient", 20, true, false, 64),
     MISC("misc", -1, true, true, 128);
  
--   public static Codec<EntityClassification> field_233667_g_ = IStringSerializable.func_233023_a_(EntityClassification::values, EntityClassification::func_233670_a_);
-+   public static Codec<EntityClassification> field_233667_g_ = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(EntityClassification::values, EntityClassification::func_233670_a_);
+-   public static final Codec<EntityClassification> field_233667_g_ = IStringSerializable.func_233023_a_(EntityClassification::values, EntityClassification::func_233670_a_);
++   public static final Codec<EntityClassification> field_233667_g_ = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(EntityClassification::values, EntityClassification::func_233670_a_);
     private static final Map<String, EntityClassification> field_220364_f = Arrays.stream(values()).collect(Collectors.toMap(EntityClassification::func_220363_a, (p_220362_0_) -> {
        return p_220362_0_;
     }));

--- a/patches/minecraft/net/minecraft/world/gen/feature/jigsaw/JigsawPattern.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/jigsaw/JigsawPattern.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/gen/feature/jigsaw/JigsawPattern.java
 +++ b/net/minecraft/world/gen/feature/jigsaw/JigsawPattern.java
-@@ -104,7 +104,7 @@
+@@ -104,11 +104,11 @@
        return this.field_214953_e.size();
     }
  
@@ -9,6 +9,11 @@
        TERRAIN_MATCHING("terrain_matching", ImmutableList.of(new GravityStructureProcessor(Heightmap.Type.WORLD_SURFACE_WG, -1))),
        RIGID("rigid", ImmutableList.of());
  
+-      public static final Codec<JigsawPattern.PlacementBehaviour> field_236858_c_ = IStringSerializable.func_233023_a_(JigsawPattern.PlacementBehaviour::values, JigsawPattern.PlacementBehaviour::func_214938_a);
++      public static final Codec<JigsawPattern.PlacementBehaviour> field_236858_c_ = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(JigsawPattern.PlacementBehaviour::values, JigsawPattern.PlacementBehaviour::func_214938_a);
+       private static final Map<String, JigsawPattern.PlacementBehaviour> field_214939_c = Arrays.stream(values()).collect(Collectors.toMap(JigsawPattern.PlacementBehaviour::func_214936_a, (p_214935_0_) -> {
+          return p_214935_0_;
+       }));
 @@ -135,5 +135,15 @@
        public String func_176610_l() {
           return this.field_214940_d;

--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -19,6 +19,12 @@
 
 package net.minecraftforge.common;
 
+import com.mojang.serialization.Codec;
+import net.minecraft.util.IStringSerializable;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
  * To be implemented on vanilla enums that should be enhanced with ASM to be
  * extensible. If this is implemented on a class, the class must define a static
@@ -47,4 +53,11 @@ public interface IExtensibleEnum
      */
     @Deprecated
     default void init() {}
+
+    /**
+     * Use this instead of {@link IStringSerializable#func_233023_a_(Supplier, Function)} for extensible enums because this not cache the enum values on construction
+     */
+    static <E extends Enum<E> & IStringSerializable> Codec<E> createCodecForExtensibleEnum(Supplier<E[]> valuesSupplier, Function<? super String, ? extends E> enumValueFromNameFunction) {
+        return IStringSerializable.func_233024_a_(Enum::ordinal, (id) -> valuesSupplier.get()[id], enumValueFromNameFunction);
+    }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -316,3 +316,4 @@ private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 public net.minecraft.world.storage.FolderName <init>(Ljava/lang/String;)V # constructor
+public-f net.minecraft.entity.EntityClassification field_233667_g_ # CODEC

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -219,7 +219,6 @@ protected net.minecraft.data.loot.EntityLootTables field_218586_a # ON_FIRE
 protected net.minecraft.data.loot.EntityLootTables func_218582_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/loot/LootTable$Builder;)V # registerLootTable
 protected net.minecraft.data.loot.EntityLootTables func_218585_a(Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/loot/LootTable$Builder;)V #
 public net.minecraft.entity.Entity func_70022_Q()Ljava/lang/String; # getEntityString
-public-f net.minecraft.entity.EntityClassification field_233667_g_ # CODEC
 public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$IPlacementPredicate;)V # register
 public net.minecraft.entity.MobEntity field_70714_bg #tasks
 public net.minecraft.entity.MobEntity field_70715_bh #targetTasks

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -219,6 +219,7 @@ protected net.minecraft.data.loot.EntityLootTables field_218586_a # ON_FIRE
 protected net.minecraft.data.loot.EntityLootTables func_218582_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/loot/LootTable$Builder;)V # registerLootTable
 protected net.minecraft.data.loot.EntityLootTables func_218585_a(Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/loot/LootTable$Builder;)V #
 public net.minecraft.entity.Entity func_70022_Q()Ljava/lang/String; # getEntityString
+public-f net.minecraft.entity.EntityClassification field_233667_g_ # CODEC
 public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$IPlacementPredicate;)V # register
 public net.minecraft.entity.MobEntity field_70714_bg #tasks
 public net.minecraft.entity.MobEntity field_70715_bh #targetTasks
@@ -316,4 +317,3 @@ private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj
 public net.minecraft.world.storage.FolderName <init>(Ljava/lang/String;)V # constructor
-public-f net.minecraft.entity.EntityClassification field_233667_g_ # CODEC


### PR DESCRIPTION
The `EntityClassification` enum can be extended thanks to Forge's `IExtensibleEnum`.
However, then included `VALUES_MAP` is not updated with the new additions, which causes issues.

This PR fixes this by adding new elements to the map in the constructor.
Also updates the CODEC