### PR TITLE
Fix ToggleableKeyBinding differences to vanilla.

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
@@ -54,7 +54,7 @@
  
     public boolean func_151470_d() {
 -      return this.field_74513_e;
-+      return this.field_74513_e && getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
++      return this.field_74513_e && isConflictContextAndModifierActive();
     }
  
     public String func_151466_e() {

--- a/patches/minecraft/net/minecraft/client/settings/ToggleableKeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/ToggleableKeyBinding.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/client/settings/ToggleableKeyBinding.java
++++ b/net/minecraft/client/settings/ToggleableKeyBinding.java
+@@ -16,7 +16,7 @@
+ 
+    public void func_225593_a_(boolean p_225593_1_) {
+       if (this.field_228053_a_.getAsBoolean()) {
+-         if (p_225593_1_) {
++         if (p_225593_1_ && isConflictContextAndModifierActive()) {
+             super.func_225593_a_(!this.func_151470_d());
+          }
+       } else {
+@@ -24,4 +24,5 @@
+       }
+ 
+    }
++   @Override public boolean func_151470_d() { return this.field_74513_e; }
+ }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeKeybinding.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeKeybinding.java
@@ -55,6 +55,11 @@ public interface IForgeKeybinding
 
     void setKeyModifierAndCode(KeyModifier keyModifier, InputMappings.Input keyCode);
 
+    default boolean isConflictContextAndModifierActive()
+    {
+        return getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
+    }
+
     /**
      * Returns true when one of the bindings' key codes conflicts with the other's modifier.
      */

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -176,6 +176,7 @@ private-f net.minecraft.client.renderer.model.ModelBakery field_217853_J # field
 protected net.minecraft.client.renderer.model.ModelBakery func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/model/BlockModel; # loadModel
 private-f net.minecraft.client.renderer.tileentity.PistonTileEntityRenderer field_178462_c # blockRenderer - it's static so we need to un-finalize in case this class loads to early.
 public net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher field_147557_n # fontRenderer - needed for rendering text in TESR items before entering world
+default net.minecraft.client.settings.KeyBinding field_74513_e # pressed
 public net.minecraft.command.arguments.EntityOptions func_202024_a(Ljava/lang/String;Lnet/minecraft/command/arguments/EntityOptions$IFilter;Ljava/util/function/Predicate;Lnet/minecraft/util/text/ITextComponent;)V # register
 public net.minecraft.command.arguments.EntitySelectorParser func_197396_n()V # updateFilter
 public net.minecraft.command.arguments.EntitySelectorParser func_197404_d()V # parseArguments


### PR DESCRIPTION
A `ToggleableKeyBinding` can be active (`isKeyDown`) even when it's conflict context or modifier are not active. Instead those must be checked when the toggle happens.

A symptom of this is the player stopping to sneak while a GUI is open when sneaking-toggle is enabled.

[Reported on the forums](https://forums.minecraftforge.net/topic/91437-sneak-takes-off-in-chat-menu/).