### PR TITLE
Added accessors and remove leftover immutability on BiomeGenerationSettingsBuilder

### DIFF
--- a/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
@@ -20,17 +20,43 @@
 package net.minecraftforge.common.world;
 
 import net.minecraft.world.biome.BiomeGenerationSettings;
+import net.minecraft.world.gen.GenerationStage;
+import net.minecraft.world.gen.carver.ConfiguredCarver;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+import net.minecraft.world.gen.feature.StructureFeature;
+import net.minecraft.world.gen.surfacebuilders.ConfiguredSurfaceBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class BiomeGenerationSettingsBuilder extends BiomeGenerationSettings.Builder
 {
     public BiomeGenerationSettingsBuilder(BiomeGenerationSettings orig)
     {
         field_242504_a = Optional.of(orig.func_242500_d());
-        orig.getCarvingStages().forEach(k -> field_242505_b.put(k, orig.func_242489_a(k)));
+        orig.getCarvingStages().forEach(k -> field_242505_b.put(k, new ArrayList<>(orig.func_242489_a(k))));
         orig.func_242498_c().forEach(l -> field_242506_c.add(new ArrayList<>(l)));
         field_242507_d.addAll(orig.func_242487_a());
+    }
+
+    public List<Supplier<ConfiguredFeature<?, ?>>> getFeatures(GenerationStage.Decoration stage) {
+        func_242509_a(stage.ordinal());
+        return field_242506_c.get(stage.ordinal());
+    }
+
+    public Optional<Supplier<ConfiguredSurfaceBuilder<?>>> getSurfaceBuilder() {
+        return field_242504_a;
+    }
+
+    public List<Supplier<ConfiguredCarver<?>>> getCarvers(GenerationStage.Carving stage) {
+        return field_242505_b.computeIfAbsent(stage, key -> new ArrayList<>());
+    }
+
+    public List<Supplier<StructureFeature<?, ?>>> getStructures() {
+        return field_242507_d;
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -308,6 +308,7 @@ protected net.minecraft.world.biome.BiomeGenerationSettings$Builder field_242504
 protected net.minecraft.world.biome.BiomeGenerationSettings$Builder field_242505_b
 protected net.minecraft.world.biome.BiomeGenerationSettings$Builder field_242506_c
 protected net.minecraft.world.biome.BiomeGenerationSettings$Builder field_242507_d
+protected net.minecraft.world.biome.BiomeGenerationSettings$Builder func_242509_a(I)V # populateStageEntries
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242567_a
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242568_b
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242569_c


### PR DESCRIPTION
This PR does two things:

- The `Map<GenerationStage.Carving, List<Supplier<ConfiguredCarver<?>>>>` in the builder was being built with immutable lists, which meant any builder methods weren't usable.
- There was no way to access any of the existing builder fields in order to mods to make decisions, or remove features. Sensible accessors have been added (e.g. getting features by decoration stage, or carvers by carving stage)

This makes the builder usable for mods to be able to remove features, or inspect for existing features. It also allows mods to be able to add, remove, or modify carvers at all.

*This fixes #7345*