### PR TITLE
Added patch (and test mod) for creating custom boat entity types.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/client/renderer/entity/BoatRenderer.java
++++ b/net/minecraft/client/renderer/entity/BoatRenderer.java
+@@ -58,6 +58,10 @@
+    }
+ 
+    public ResourceLocation func_110775_a(BoatEntity p_110775_1_) {
+-      return field_110782_f[p_110775_1_.func_184453_r().ordinal()];
++      if(p_110775_1_.func_184453_r().ordinal() < field_110782_f.length) {
++         return field_110782_f[p_110775_1_.func_184453_r().ordinal()];
++      } else {
++         return p_110775_1_.func_184453_r().getTexture();
++      }
+    }
+ }

--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -1,6 +1,19 @@
 --- a/net/minecraft/dispenser/IDispenseItemBehavior.java
 +++ b/net/minecraft/dispenser/IDispenseItemBehavior.java
-@@ -373,8 +373,9 @@
+@@ -305,12 +305,6 @@
+             p_82485_1_.func_197524_h().func_217379_c(1018, p_82485_1_.func_180699_d(), 0);
+          }
+       });
+-      DispenserBlock.func_199774_a(Items.field_151124_az, new DispenseBoatBehavior(BoatEntity.Type.OAK));
+-      DispenserBlock.func_199774_a(Items.field_185150_aH, new DispenseBoatBehavior(BoatEntity.Type.SPRUCE));
+-      DispenserBlock.func_199774_a(Items.field_185151_aI, new DispenseBoatBehavior(BoatEntity.Type.BIRCH));
+-      DispenserBlock.func_199774_a(Items.field_185152_aJ, new DispenseBoatBehavior(BoatEntity.Type.JUNGLE));
+-      DispenserBlock.func_199774_a(Items.field_185154_aL, new DispenseBoatBehavior(BoatEntity.Type.DARK_OAK));
+-      DispenserBlock.func_199774_a(Items.field_185153_aK, new DispenseBoatBehavior(BoatEntity.Type.ACACIA));
+       IDispenseItemBehavior idispenseitembehavior1 = new DefaultDispenseItemBehavior() {
+          private final DefaultDispenseItemBehavior field_239793_b_ = new DefaultDispenseItemBehavior();
+ 
+@@ -373,8 +367,9 @@
                 world.func_175656_a(blockpos, AbstractFireBlock.func_235326_a_(world, blockpos));
              } else if (CampfireBlock.func_241470_h_(blockstate)) {
                 world.func_175656_a(blockpos, blockstate.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)));

--- a/patches/minecraft/net/minecraft/entity/item/BoatEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/BoatEntity.java.patch
@@ -1,6 +1,29 @@
 --- a/net/minecraft/entity/item/BoatEntity.java
 +++ b/net/minecraft/entity/item/BoatEntity.java
-@@ -468,7 +468,7 @@
+@@ -188,21 +188,7 @@
+    }
+ 
+    public Item func_184455_j() {
+-      switch(this.func_184453_r()) {
+-      case OAK:
+-      default:
+-         return Items.field_151124_az;
+-      case SPRUCE:
+-         return Items.field_185150_aH;
+-      case BIRCH:
+-         return Items.field_185151_aI;
+-      case JUNGLE:
+-         return Items.field_185152_aJ;
+-      case ACACIA:
+-         return Items.field_185153_aK;
+-      case DARK_OAK:
+-         return Items.field_185154_aL;
+-      }
++      return this.func_184453_r().getBoatItem();
+    }
+ 
+    @OnlyIn(Dist.CLIENT)
+@@ -468,7 +454,7 @@
                       blockpos$mutable.func_181079_c(l1, k2, i2);
                       BlockState blockstate = this.field_70170_p.func_180495_p(blockpos$mutable);
                       if (!(blockstate.func_177230_c() instanceof LilyPadBlock) && VoxelShapes.func_197879_c(blockstate.func_196952_d(this.field_70170_p, blockpos$mutable).func_197751_a((double)l1, (double)k2, (double)i2), voxelshape, IBooleanFunction.field_223238_i_)) {
@@ -9,7 +32,7 @@
                          ++k1;
                       }
                    }
-@@ -817,6 +817,16 @@
+@@ -817,6 +803,16 @@
        return this.field_184469_aF == BoatEntity.Status.UNDER_WATER || this.field_184469_aF == BoatEntity.Status.UNDER_FLOWING_WATER;
     }
  
@@ -26,3 +49,109 @@
     public static enum Status {
        IN_WATER,
        UNDER_WATER,
+@@ -825,22 +821,52 @@
+       IN_AIR;
+    }
+ 
+-   public static enum Type {
+-      OAK(Blocks.field_196662_n, "oak"),
+-      SPRUCE(Blocks.field_196664_o, "spruce"),
+-      BIRCH(Blocks.field_196666_p, "birch"),
+-      JUNGLE(Blocks.field_196668_q, "jungle"),
+-      ACACIA(Blocks.field_196670_r, "acacia"),
+-      DARK_OAK(Blocks.field_196672_s, "dark_oak");
++   public static class Type {
++      private static final List<Type> values = new java.util.ArrayList<>();
++      public static final Type OAK = register(Blocks.field_196662_n, "oak");
++      public static final Type SPRUCE = register(Blocks.field_196664_o, "spruce");
++      public static final Type BIRCH = register(Blocks.field_196666_p, "birch");
++      public static final Type JUNGLE = register(Blocks.field_196668_q, "jungle");
++      public static final Type ACACIA = register(Blocks.field_196670_r, "acacia");
++      public static final Type DARK_OAK = register(Blocks.field_196672_s, "dark_oak");
+ 
+       private final String field_184990_g;
+       private final Block field_195934_h;
++      private final int ord;
++      private Item boatItem;
++      private net.minecraft.util.ResourceLocation texture;
+ 
+-      private Type(Block p_i48146_3_, String p_i48146_4_) {
+-         this.field_184990_g = p_i48146_4_;
++      private Type(Block p_i48146_3_, String p_i48146_4_, net.minecraft.util.ResourceLocation texture, int ord) {
+          this.field_195934_h = p_i48146_3_;
++         this.field_184990_g = p_i48146_4_;
++         this.texture = texture;
++         this.ord = ord;
+       }
+ 
++      private Type(Block p_i48146_3_, String p_i48146_4_, int ord) {
++         this(p_i48146_3_, p_i48146_4_, null, ord);
++      }
++
++      public static Type register(Block p_i48146_3_, String p_i48146_4_, net.minecraft.util.ResourceLocation texture) {
++         Type t = new Type(p_i48146_3_, p_i48146_4_, new net.minecraft.util.ResourceLocation(texture.func_110624_b(), "textures/entity/boat/" + texture.func_110623_a() + ".png"), values.size());
++         values.add(t);
++         return t;
++      }
++
++      public static Type register(Block p_i48146_3_, String p_i48146_4_) {
++         Type t = new Type(p_i48146_3_, p_i48146_4_, values.size());
++         values.add(t);
++         return t;
++      }
++
++      public static java.util.stream.Stream<Type> values() {
++         return values.stream();
++      }
++
++      public void setBoatItem(Item boatItem) {
++         this.boatItem = boatItem;
++      }
++
+       public String func_184980_a() {
+          return this.field_184990_g;
+       }
+@@ -853,25 +879,34 @@
+          return this.field_184990_g;
+       }
+ 
++      public int ordinal() {
++         return this.ord;
++      }
++
+       public static BoatEntity.Type func_184979_a(int p_184979_0_) {
+-         BoatEntity.Type[] aboatentity$type = values();
+-         if (p_184979_0_ < 0 || p_184979_0_ >= aboatentity$type.length) {
++         if (p_184979_0_ < 0 || p_184979_0_ >= values.size()) {
+             p_184979_0_ = 0;
+          }
+ 
+-         return aboatentity$type[p_184979_0_];
++         return values.get(p_184979_0_);
+       }
+ 
+       public static BoatEntity.Type func_184981_a(String p_184981_0_) {
+-         BoatEntity.Type[] aboatentity$type = values();
+-
+-         for(int i = 0; i < aboatentity$type.length; ++i) {
+-            if (aboatentity$type[i].func_184980_a().equals(p_184981_0_)) {
+-               return aboatentity$type[i];
++         for(Type type : values) {
++            if (type.func_184980_a().equals(p_184981_0_)) {
++               return type;
+             }
+          }
+ 
+-         return aboatentity$type[0];
++         return values.get(0);
+       }
++
++      public Item getBoatItem() {
++         return this.boatItem;
++      }
++
++      public net.minecraft.util.ResourceLocation getTexture() {
++         return this.texture;
++      }
+    }
+ }

--- a/patches/minecraft/net/minecraft/item/BoatItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BoatItem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/item/BoatItem.java
++++ b/net/minecraft/item/BoatItem.java
+@@ -21,6 +21,8 @@
+ 
+    public BoatItem(BoatEntity.Type p_i48526_1_, Item.Properties p_i48526_2_) {
+       super(p_i48526_2_);
++      p_i48526_1_.setBoatItem(this);
++      net.minecraft.block.DispenserBlock.func_199774_a(this, new net.minecraft.dispenser.DispenseBoatBehavior(p_i48526_1_));
+       this.field_185057_a = p_i48526_1_;
+    }
+ 

--- a/src/test/java/net/minecraftforge/debug/entity/CustomBoatTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/CustomBoatTypeTest.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.debug.entity;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.item.BoatEntity;
+import net.minecraft.item.BoatItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod("custom_boat_type_test")
+public class CustomBoatTypeTest {
+
+    public static final String MOD_ID = "custom_boat_type_test";
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+    private static final BoatEntity.Type CUSTOM_BOAT_TYPE = BoatEntity.Type
+            .register(Blocks.STONE, "custom", new ResourceLocation(MOD_ID, "custom_boat"));
+
+    static {
+        ITEMS.register("test_boat", () -> new BoatItem(CUSTOM_BOAT_TYPE,
+                new Item.Properties().maxStackSize(1).group(ItemGroup.TRANSPORTATION)));
+    }
+
+    public CustomBoatTypeTest() {
+        ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -86,3 +86,5 @@ license="LGPL v2.1"
     modId="custom_tag_types_test"
 [[mods]]
     modId="biome_loading_event_test"
+[[mods]]
+    modId="custom_boat_type_test"


### PR DESCRIPTION
This patch adds the ability to easily add a new Boat type. This means modders can easily create custom boats without having to copy the BoatEntity class or anything.