### PR TITLE
2nd take at better license error

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml.loading;
 
+import net.minecraftforge.forgespi.language.IModInfo;
+
 import java.util.List;
 
 /**
@@ -29,10 +31,19 @@ public class EarlyLoadingException extends RuntimeException {
     public static class ExceptionData {
 
 
+        private final IModInfo modInfo;
         private final String i18message;
         private final Object[] args;
+
         public ExceptionData(final String message, Object... args) {
             this.i18message = message;
+            this.modInfo = null;
+            this.args = args;
+        }
+
+        public ExceptionData(final String message, final IModInfo modInfo, Object... args) {
+            this.i18message = message;
+            this.modInfo = modInfo;
             this.args = args;
         }
 
@@ -42,6 +53,10 @@ public class EarlyLoadingException extends RuntimeException {
 
         public Object[] getArgs() {
             return args;
+        }
+
+        public IModInfo getModInfo() {
+            return modInfo;
         }
     }
     private final List<ExceptionData> errorMessages;

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
@@ -36,9 +36,7 @@ public class EarlyLoadingException extends RuntimeException {
         private final Object[] args;
 
         public ExceptionData(final String message, Object... args) {
-            this.i18message = message;
-            this.modInfo = null;
-            this.args = args;
+            this(message, null, args);
         }
 
         public ExceptionData(final String message, final IModInfo modInfo, Object... args) {

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -191,7 +192,7 @@ public class ModSorter
         if (!dupedMods.isEmpty()) {
             final List<EarlyLoadingException.ExceptionData> duplicateModErrors = dupedMods
                     .stream()
-                    .map(dm -> new EarlyLoadingException.ExceptionData("fml.modloading.dupedmod", dm.getValue().get(0)))
+                    .map(dm -> new EarlyLoadingException.ExceptionData("fml.modloading.dupedmod", dm.getValue().get(0), Objects.toString(dm.getValue().get(0))))
                     .collect(Collectors.toList());
             throw new EarlyLoadingException("Duplicate mods found", null,  duplicateModErrors);
         }
@@ -243,7 +244,7 @@ public class ModSorter
         if (!missingVersions.isEmpty()) {
             final List<EarlyLoadingException.ExceptionData> exceptionData = missingVersions
                     .stream()
-                    .map(mv -> new EarlyLoadingException.ExceptionData("fml.modloading.missingdependency",
+                    .map(mv -> new EarlyLoadingException.ExceptionData("fml.modloading.missingdependency", mv.getOwner(),
                             mv.getModId(), mv.getOwner().getModId(), mv.getVersionRange(),
                             modVersions.getOrDefault(mv.getModId(), new DefaultArtifactVersion("null"))))
                     .collect(Collectors.toList());

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -66,7 +66,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
                 .map(MavenVersionAdapter::createFromVersionSpec)
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
         this.license = config.<String>getConfigElement("license")
-            .orElse(null);
+            .orElse("");
         this.showAsResourcePack = config.<Boolean>getConfigElement("showAsResourcePack").orElse(false);
         this.properties = config.<Map<String, Object>>getConfigElement("properties").orElse(Collections.emptyMap());
         this.modFile.setFileProperties(this.properties);
@@ -141,7 +141,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     @Override
     public String getLicense()
     {
-        return Strings.nullToEmpty(license);
+        return license;
     }
 
     public URL getIssueURL()
@@ -151,6 +151,6 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
 
     public boolean missingLicense()
     {
-        return license == null;
+        return Strings.isNullOrEmpty(license);
     }
 }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml.loading.moddiscovery;
 
+import com.google.common.base.Strings;
 import net.minecraftforge.fml.loading.StringUtils;
 import net.minecraftforge.forgespi.language.IConfigurable;
 import net.minecraftforge.forgespi.language.IModFileInfo;
@@ -65,7 +66,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
                 .map(MavenVersionAdapter::createFromVersionSpec)
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
         this.license = config.<String>getConfigElement("license")
-            .orElseThrow(()->new InvalidModFileException("Missing License, please supply a license.", this));
+            .orElse(null);
         this.showAsResourcePack = config.<Boolean>getConfigElement("showAsResourcePack").orElse(false);
         this.properties = config.<Map<String, Object>>getConfigElement("properties").orElse(Collections.emptyMap());
         this.modFile.setFileProperties(this.properties);
@@ -140,11 +141,16 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
     @Override
     public String getLicense()
     {
-        return license;
+        return Strings.nullToEmpty(license);
     }
 
     public URL getIssueURL()
     {
         return issueURL;
+    }
+
+    public boolean missingLicense()
+    {
+        return license == null;
     }
 }

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -120,6 +120,11 @@ public class ModLoader
         this.loadingWarnings = FMLLoader.getLoadingModList().
                 getBrokenFiles().stream().map(file -> new ModLoadingWarning(null, ModLoadingStage.VALIDATE,
                     InvalidModIdentifier.identifyJarProblem(file.getFilePath()).orElse("fml.modloading.brokenfile"), file.getFileName())).collect(Collectors.toList());
+        FMLLoader.getLoadingModList()
+                .getModFiles().stream().filter(ModFileInfo::missingLicense) //Search for files with missing licenses
+                .filter(modFileInfo -> modFileInfo.getMods().stream().noneMatch(thisModInfo -> this.loadingExceptions.stream().map(ModLoadingException::getModInfo).anyMatch(otherInfo -> otherInfo == thisModInfo))) //Ignore files where any other mod already encountered an error
+                .map(modFileInfo -> new ModLoadingException(null, ModLoadingStage.VALIDATE, "fml.modloading.missinglicense", null, modFileInfo.getFile()))
+                .forEach(this.loadingExceptions::add);
         LOGGER.debug(CORE, "Loading Network data for FML net version: {}", FMLNetworkConstants.init());
         CrashReportExtender.registerCrashCallable("ModLauncher", FMLLoader::getLauncherInfo);
         CrashReportExtender.registerCrashCallable("ModLauncher launch target", FMLLoader::launcherHandlerName);

--- a/src/main/java/net/minecraftforge/fml/ModLoadingException.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingException.java
@@ -61,7 +61,7 @@ public class ModLoadingException extends RuntimeException
     }
 
     static Stream<ModLoadingException> fromEarlyException(final EarlyLoadingException e) {
-        return e.getAllData().stream().map(ed->new ModLoadingException(null, ModLoadingStage.VALIDATE, ed.getI18message(), e.getCause(), ed.getArgs()));
+        return e.getAllData().stream().map(ed->new ModLoadingException(ed.getModInfo(), ModLoadingStage.VALIDATE, ed.getI18message(), e.getCause(), ed.getArgs()));
     }
 
     public String getI18NMessage() {

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -58,6 +58,7 @@
   "fml.modloading.brokenfile.optifine": "File {2} is an incompatible version of OptiFine",
   "fml.modloading.brokenfile.invalidzip": "File {2} is not a jar file",
   "fml.modloading.brokenresources": "File {2} failed to load a valid ResourcePackInfo",
+  "fml.modloading.missinglicense": "Missing License Information in file {3}",
   "fml.resources.modresources": "Resources for {0} mod files",
 
   "fml.messages.artifactversion.ornotinstalled":"{0,ornull,fml.messages.artifactversion.notinstalled}",


### PR DESCRIPTION
This is an alternative to  #7264
The main difference user-side is that it shows the correct error when the version range is not satisfied (in #7264 it would show the missing license screen, here it correctly shows the wrong version screen).
This is done by deferring the crash, so fmllauncher runs cleanly and once modloading is about to start the error is populated.
Some screenshots:
Mod for 1.15.2 running on 1.16.3 with this PR:
![java_KCeelLfykr](https://user-images.githubusercontent.com/20151702/94039292-d0b40780-fdc7-11ea-8792-d4b2d371e8c7.png)
Mod for 1.16.1, but with version range `[1.16,1.17)` running in 1.16.3 with this PR:
![java_JQAVCMFxTK](https://user-images.githubusercontent.com/20151702/94039333-e3c6d780-fdc7-11ea-995a-f87b8550ab08.png)
Both would hard-crash without any screen before, leaving most users clueless behind