### PR TITLE
Add modded biomes to overworld biome list

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/provider/OverworldBiomeProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/provider/OverworldBiomeProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/biome/provider/OverworldBiomeProvider.java
++++ b/net/minecraft/world/biome/provider/OverworldBiomeProvider.java
+@@ -35,7 +35,7 @@
+    private final Registry<Biome> field_242636_k;
+ 
+    public OverworldBiomeProvider(long p_i241958_1_, boolean p_i241958_3_, boolean p_i241958_4_, Registry<Biome> p_i241958_5_) {
+-      super(field_226847_e_.stream().map((p_242638_1_) -> {
++      super(java.util.stream.Stream.concat(field_226847_e_.stream(), net.minecraftforge.common.BiomeManager.getAdditionalOverworldBiomes().stream()).map((p_242638_1_) -> {
+          return () -> {
+             return p_i241958_5_.func_243576_d(p_242638_1_);
+          };

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -34,6 +34,7 @@ import net.minecraft.world.biome.Biome;
 public class BiomeManager
 {
     private static TrackedList<BiomeEntry>[] biomes = setupBiomes();
+    private static final List<RegistryKey<Biome>> additionalOverworldBiomes = new ArrayList<>();
 
     private static TrackedList<BiomeEntry>[] setupBiomes()
     {
@@ -97,11 +98,23 @@ public class BiomeManager
     }
     */
 
+    /**
+     * Add biomes that you add to the overworld without using {@link BiomeManager#addBiome(BiomeType, BiomeEntry)}
+     */
+    public static void addAdditionalOverworldBiomes(List<RegistryKey<Biome>> biomes){
+        additionalOverworldBiomes.addAll(biomes);
+    }
+
     public static boolean addBiome(BiomeType type, BiomeEntry entry)
     {
         int idx = type.ordinal();
         List<BiomeEntry> list = idx > biomes.length ? null : biomes[idx];
-        return list == null ? false : list.add(entry);
+        if(list != null)
+        {
+            additionalOverworldBiomes.add(entry.key);
+            return list.add(entry);
+        }
+        return false;
     }
 
     public static boolean removeBiome(BiomeType type, BiomeEntry entry)
@@ -109,6 +122,14 @@ public class BiomeManager
         int idx = type.ordinal();
         List<BiomeEntry> list = idx > biomes.length ? null : biomes[idx];
         return list == null ? false : list.remove(entry);
+    }
+
+    /**
+     * @return list of biomes that might be generated in the overworld in addition to the vanilla biomes
+     */
+    public static List<RegistryKey<Biome>> getAdditionalOverworldBiomes()
+    {
+        return additionalOverworldBiomes;
     }
 
     public static ImmutableList<BiomeEntry> getBiomes(BiomeType type)

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -101,8 +101,11 @@ public class BiomeManager
     /**
      * Add biomes that you add to the overworld without using {@link BiomeManager#addBiome(BiomeType, BiomeEntry)}
      */
-    public static void addAdditionalOverworldBiomes(List<RegistryKey<Biome>> biomes){
-        additionalOverworldBiomes.addAll(biomes);
+    public static void addAdditionalOverworldBiomes(RegistryKey<Biome> biome){
+        if (!"minecraft".equals(biome.func_240901_a_().getNamespace()) && additionalOverworldBiomes.stream().noneMatch(entry -> entry.compareTo(biome) == 0))
+        {
+            additionalOverworldBiomes.add(biome);
+        }
     }
 
     public static boolean addBiome(BiomeType type, BiomeEntry entry)

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -102,7 +102,7 @@ public class BiomeManager
      * Add biomes that you add to the overworld without using {@link BiomeManager#addBiome(BiomeType, BiomeEntry)}
      */
     public static void addAdditionalOverworldBiomes(RegistryKey<Biome> biome){
-        if (!"minecraft".equals(biome.func_240901_a_().getNamespace()) && additionalOverworldBiomes.stream().noneMatch(entry -> entry.compareTo(biome) == 0))
+        if (!"minecraft".equals(biome.func_240901_a_().getNamespace()) && additionalOverworldBiomes.stream().noneMatch(entry -> entry.func_240901_a_().equals(biome.func_240901_a_())))
         {
             additionalOverworldBiomes.add(biome);
         }


### PR DESCRIPTION
## Why?
The `BiomeProvider` class has a list containing all biomes that might be generated in the related dimension.
This list is used for several things:
- Determine if a structure might be generated in this dimension (used by the locate command)
- Determine possible surface blocks in the dimension (used e.g. when looking for a world spawn point) 
- Used for Stronghold generation
- Potentially used by mods as this list is publicly available
This use cases where deduced from code, the only thing I tested is:
A structure (that only generates in a modded biome) cannot be found using the `/locate` command unless the biome is added to the list.

Currently one has to AT that list and replace it using a modified copy (using the **sequential** mod loading queue to avoid race conditions).

## Implementation
This PR simply adds a list to Forge's `BiomeManager` that modders can add biomes to and which is merged with the vanilla biome list in the `OverworldBiomeProvider` on construction.
Biomes added as `BiomeEntry` to the `BiomeManager` are automatically added to this list as well. Additionally, one can manually add biomes in case they are generated in a different way (e.g. as hill variant of another biome).
