### PR TITLE
[1.16.x] [WIP] Add the ability to dynamically add worlds.

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -1,6 +1,10 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -225,7 +225,7 @@
+@@ -222,10 +222,11 @@
+    private DataPackRegistries field_195576_ac;
+    private final TemplateManager field_240765_ak_;
+    protected final IServerConfiguration field_240768_i_;
++   private IChunkStatusListener iChunkStatusListener;
  
     public static <S extends MinecraftServer> S func_240784_a_(Function<Thread, S> p_240784_0_) {
        AtomicReference<S> atomicreference = new AtomicReference<>();
@@ -9,7 +13,15 @@
           atomicreference.get().func_240802_v_();
        }, "Server thread");
        thread.setUncaughtExceptionHandler((p_240779_0_, p_240779_1_) -> {
-@@ -373,6 +373,7 @@
+@@ -302,6 +303,7 @@
+       this.func_175584_a();
+       this.field_240768_i_.func_230412_a_(this.getServerModName(), this.func_230045_q_().isPresent());
+       IChunkStatusListener ichunkstatuslistener = this.field_213220_d.create(11);
++      this.iChunkStatusListener = ichunkstatuslistener;
+       this.func_240787_a_(ichunkstatuslistener);
+       this.func_230543_p_();
+       this.func_213186_a(ichunkstatuslistener);
+@@ -373,6 +375,7 @@
              worldborder.func_177737_a(new IBorderListener.Impl(serverworld1.func_175723_af()));
              this.field_71305_c.put(registrykey1, serverworld1);
           }
@@ -17,7 +29,7 @@
        }
  
     }
-@@ -384,6 +385,7 @@
+@@ -384,6 +387,7 @@
        } else if (p_240786_3_) {
           p_240786_1_.func_176143_a(BlockPos.field_177992_a.func_177984_a(), 0.0F);
        } else {
@@ -25,7 +37,7 @@
           BiomeProvider biomeprovider = chunkgenerator.func_202090_b();
           Random random = new Random(p_240786_0_.func_72905_C());
           BlockPos blockpos = biomeprovider.func_225531_a_(0, p_240786_0_.func_181545_F(), 0, 256, (p_244265_0_) -> {
-@@ -563,6 +565,7 @@
+@@ -563,6 +567,7 @@
        for(ServerWorld serverworld1 : this.func_212370_w()) {
           if (serverworld1 != null) {
              try {
@@ -33,7 +45,7 @@
                 serverworld1.close();
              } catch (IOException ioexception1) {
                 field_147145_h.error("Exception closing the level", (Throwable)ioexception1);
-@@ -611,6 +614,7 @@
+@@ -611,6 +616,7 @@
     protected void func_240802_v_() {
        try {
           if (this.func_71197_b()) {
@@ -41,7 +53,7 @@
              this.field_211151_aa = Util.func_211177_b();
              this.field_147147_p.func_151315_a(new StringTextComponent(this.field_71286_C));
              this.field_147147_p.func_151321_a(new ServerStatusResponse.Version(SharedConstants.func_215069_a().getName(), SharedConstants.func_215069_a().getProtocolVersion()));
-@@ -640,7 +644,10 @@
+@@ -640,7 +646,10 @@
                 this.func_240795_b_(longtickdetector);
                 this.field_71296_Q = true;
              }
@@ -52,7 +64,7 @@
              this.func_71228_a((CrashReport)null);
           }
        } catch (Throwable throwable1) {
-@@ -659,6 +666,7 @@
+@@ -659,6 +668,7 @@
              field_147145_h.error("We were unable to save this crash report to disk.");
           }
  
@@ -60,7 +72,7 @@
           this.func_71228_a(crashreport);
        } finally {
           try {
-@@ -667,6 +675,7 @@
+@@ -667,6 +677,7 @@
           } catch (Throwable throwable) {
              field_147145_h.error("Exception stopping the server", throwable);
           } finally {
@@ -68,7 +80,7 @@
              this.func_71240_o();
           }
  
-@@ -768,6 +777,7 @@
+@@ -768,6 +779,7 @@
  
     protected void func_71217_p(BooleanSupplier p_71217_1_) {
        long i = Util.func_211178_c();
@@ -76,7 +88,7 @@
        ++this.field_71315_w;
        this.func_71190_q(p_71217_1_);
        if (i - this.field_147142_T >= 5000000000L) {
-@@ -782,6 +792,7 @@
+@@ -782,6 +794,7 @@
  
           Collections.shuffle(Arrays.asList(agameprofile));
           this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -84,7 +96,7 @@
        }
  
        if (this.field_71315_w % 6000 == 0) {
-@@ -809,6 +820,7 @@
+@@ -809,6 +822,7 @@
        long i1 = Util.func_211178_c();
        this.field_213215_ap.func_181747_a(i1 - i);
        this.field_71304_b.func_76319_b();
@@ -92,7 +104,7 @@
     }
  
     protected void func_71190_q(BooleanSupplier p_71190_1_) {
-@@ -816,7 +828,8 @@
+@@ -816,7 +830,8 @@
        this.func_193030_aL().func_73660_a();
        this.field_71304_b.func_219895_b("levels");
  
@@ -102,7 +114,7 @@
           this.field_71304_b.func_194340_a(() -> {
              return serverworld + " " + serverworld.func_234923_W_().func_240901_a_();
           });
-@@ -827,6 +840,7 @@
+@@ -827,6 +842,7 @@
           }
  
           this.field_71304_b.func_76320_a("tick");
@@ -110,7 +122,7 @@
  
           try {
              serverworld.func_72835_b(p_71190_1_);
-@@ -835,9 +849,11 @@
+@@ -835,9 +851,11 @@
              serverworld.func_72914_a(crashreport);
              throw new ReportedException(crashreport);
           }
@@ -122,7 +134,7 @@
        }
  
        this.field_71304_b.func_219895_b("connection");
-@@ -912,7 +928,7 @@
+@@ -912,7 +930,7 @@
     }
  
     public String getServerModName() {
@@ -131,7 +143,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -925,6 +941,7 @@
+@@ -925,6 +943,7 @@
        p_71230_1_.func_85056_g().func_189529_a("Data Packs", () -> {
           StringBuilder stringbuilder = new StringBuilder();
  
@@ -139,7 +151,7 @@
           for(ResourcePackInfo resourcepackinfo : this.field_195577_ad.func_198980_d()) {
              if (stringbuilder.length() > 0) {
                 stringbuilder.append(", ");
-@@ -1271,6 +1288,7 @@
+@@ -1271,6 +1290,7 @@
           this.func_184103_al().func_193244_w();
           this.field_200258_al.func_240946_a_(this.field_195576_ac.func_240960_a_());
           this.field_240765_ak_.func_195410_a(this.field_195576_ac.func_240970_h_());
@@ -147,7 +159,7 @@
        }, this);
        if (this.func_213162_bc()) {
           this.func_213161_c(completablefuture::isDone);
-@@ -1280,10 +1298,13 @@
+@@ -1280,10 +1300,13 @@
     }
  
     public static DatapackCodec func_240772_a_(ResourcePackList p_240772_0_, DatapackCodec p_240772_1_, boolean p_240772_2_) {
@@ -163,7 +175,7 @@
        } else {
           Set<String> set = Sets.newLinkedHashSet();
  
-@@ -1433,6 +1454,31 @@
+@@ -1433,6 +1456,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  
@@ -195,7 +207,7 @@
     public void func_223711_a(Path p_223711_1_) throws IOException {
        Path path = p_223711_1_.resolve("levels");
  
-@@ -1561,6 +1607,10 @@
+@@ -1561,7 +1609,33 @@
        return this.field_240768_i_;
     }
  
@@ -206,3 +218,26 @@
     public DynamicRegistries func_244267_aX() {
        return this.field_240767_f_;
     }
++   
++   public void addWorld(RegistryKey<Dimension> dimensionKey, Dimension dimension){
++      boolean isDebugChunkGenerator = this.field_240768_i_.func_230418_z_().func_236227_h_();
++      long seed = BiomeManager.func_235200_a_(this.field_240768_i_.func_230418_z_().func_236221_b_());
++      RegistryKey<World> worldKey = RegistryKey.func_240903_a_(Registry.field_239699_ae_, dimensionKey.func_240901_a_());
++      DimensionType dimensionType = dimension.func_236063_b_();
++      ChunkGenerator chunkGenerator = dimension.func_236064_c_();
++      DerivedWorldInfo derivedWorldInfo =
++              new DerivedWorldInfo(this.field_240768_i_, this.field_240768_i_.func_230407_G_());
++      ServerWorld serverWorld =
++              new ServerWorld(this, this.field_213217_au, this.field_71310_m, derivedWorldInfo,
++                      worldKey, dimensionType, this.iChunkStatusListener, chunkGenerator, isDebugChunkGenerator, seed,
++                      ImmutableList.of(), false);
++      this.forgeGetWorldMap()
++              .get(World.field_234918_g_)
++              .func_175723_af()
++              .func_177737_a(new IBorderListener.Impl(serverWorld.func_175723_af()));
++      this.forgeGetWorldMap().put(worldKey, serverWorld);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(
++              new net.minecraftforge.event.world.WorldEvent.Load(this.forgeGetWorldMap().get(dimensionKey)));
++      this.markWorldsDirty();
++   }
+ }


### PR DESCRIPTION
Currently all this does is add a method that allows worlds to be added to a server (integrated or dedicated) using a `RegistryKey<Dimension>` and a `Dimension` object. 

The current problem is that worlds added in this manner are not loaded automatically by vanilla on startup, these worlds have to be added in this way every time the game restarts. If you have ideas on a way to fix this, please share!

Feel free to provide suggestions on how this could be done better or things that are missing, etc. 