### PR TITLE
Fix toggleable keybindings still being active while in GUI

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/ToggleableKeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/ToggleableKeyBinding.java.patch
@@ -13,5 +13,5 @@
        }
  
     }
-+   @Override public boolean func_151470_d() { return this.field_74513_e; }
++   @Override public boolean func_151470_d() { return this.field_74513_e && (isConflictContextAndModifierActive() || field_228053_a_.getAsBoolean()); }
  }

--- a/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
@@ -1,4 +1,3 @@
-  
 /*
  * Minecraft Forge
  * Copyright (c) 2016-2020.

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.util.ResourceLocation;


### PR DESCRIPTION
_This PR fixes #7370._

An [earlier PR by diesieben07][earlier_pr] fixed the issue of the player's sneak stopping when the player opens a GUI and the sneak toggle is on. However, this led to another issue, as described by the linked issue: when the sneak keybind is set to hold, and a GUI is open, the sneak keybind still takes effect.

This PR fixes that by requiring a toggleable keybind to be active if it's pressed down, and either the key confilict context is active or the keybind is set to toggle.
This PR also includes a cleanup commit to fix the license headers of `SkyRenderHandler` and `BiomeLoadingEventTest`, so the `checkLicenses` task does not error.

[earlier_pr]: https://github.com/MinecraftForge/MinecraftForge/pull/7338