### PR TITLE
Fix invalid license headers

### DIFF
--- a/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
@@ -1,4 +1,3 @@
-  
 /*
  * Minecraft Forge
  * Copyright (c) 2016-2020.

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.util.ResourceLocation;


### PR DESCRIPTION
These files have missing or incorrect license headers and are causing my builds to fail.