### PR TITLE
mdk: add properties to disable refmaps indev

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -43,6 +43,9 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
+            // Required for mixins indev
+            property 'mixin.env.disableRefMap', 'true'
+
             mods {
                 examplemod {
                     source sourceSets.main
@@ -59,6 +62,9 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
+            // Required for mixins indev
+            property 'mixin.env.disableRefMap', 'true'
+
             mods {
                 examplemod {
                     source sourceSets.main
@@ -74,6 +80,9 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
+
+            // Required for mixins indev
+            property 'mixin.env.disableRefMap', 'true'
 
             args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
 


### PR DESCRIPTION
In the event that a modder wants to dep on a mod which uses mixins, this
is required.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>