### PR TITLE
Fix MC-201374

### DIFF
--- a/patches/minecraft/net/minecraft/block/CampfireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/CampfireBlock.java.patch
@@ -9,3 +9,12 @@
           if (flag && !p_220066_2_.func_177229_b(field_220101_b) && !p_220066_2_.func_177229_b(field_220103_d)) {
              BlockPos blockpos = p_220066_3_.func_216350_a();
              p_220066_1_.func_180501_a(blockpos, p_220066_2_.func_206870_a(BlockStateProperties.field_208190_q, Boolean.valueOf(true)), 11);
+@@ -208,7 +208,7 @@
+             return true;
+          }
+ 
+-         boolean flag = VoxelShapes.func_197879_c(field_226912_f_, blockstate.func_215685_b(p_235474_0_, p_235474_1_, ISelectionContext.func_216377_a()), IBooleanFunction.field_223238_i_);
++         boolean flag = VoxelShapes.func_197879_c(field_226912_f_, blockstate.func_215685_b(p_235474_0_, blockpos, ISelectionContext.func_216377_a()), IBooleanFunction.field_223238_i_);//Forge fix: MC-201374
+          if (flag) {
+             BlockState blockstate1 = p_235474_0_.func_180495_p(blockpos.func_177977_b());
+             return func_226915_i_(blockstate1);


### PR DESCRIPTION
Adjusts CampfireBlock#isSmokingBlockAt to pass the correct position to BlockState#getCollisionShape. See [MC-201374](https://bugs.mojang.com/browse/MC-201374) for more details