### PR TITLE
Reimplement nametag distance attribute, fix attribute translation keys

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -13,3 +13,12 @@
        }
     }
  
+@@ -77,7 +79,7 @@
+ 
+    protected void func_225629_a_(T p_225629_1_, ITextComponent p_225629_2_, MatrixStack p_225629_3_, IRenderTypeBuffer p_225629_4_, int p_225629_5_) {
+       double d0 = this.field_76990_c.func_229099_b_(p_225629_1_);
+-      if (!(d0 > 4096.0D)) {
++      if (net.minecraftforge.client.ForgeHooksClient.isNameplateInRenderDistance(p_225629_1_, d0)) {
+          boolean flag = !p_225629_1_.func_226273_bm_();
+          float f = p_225629_1_.func_213302_cg() + 0.5F;
+          int i = "deadmau5".equals(p_225629_2_.getString()) ? -10 : 0;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -51,6 +51,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
@@ -77,6 +78,7 @@ import net.minecraftforge.client.event.*;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.animation.Animation;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.model.TransformationHelper;
 import net.minecraftforge.eventbus.api.Event;
@@ -745,5 +747,15 @@ public class ForgeHooksClient
             renderer.renderModel(layer, itemStackIn, combinedLightIn, combinedOverlayIn, matrixStackIn, ivertexbuilder);
         }
         net.minecraftforge.client.ForgeHooksClient.setRenderLayer(null);
+    }
+
+    public static boolean isNameplateInRenderDistance(Entity entity, double squareDistance) {
+        if (entity instanceof LivingEntity) {
+            final ModifiableAttributeInstance attribute = ((LivingEntity) entity).getAttribute(ForgeMod.NAMETAG_DISTANCE.get());
+            if (attribute != null) {
+                return !(squareDistance > (attribute.getValue() * attribute.getValue()));
+            }
+        }
+        return !(squareDistance > 4096.0f);
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -85,11 +85,11 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 
     private static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(Attribute.class, "forge");
 
-    public static final RegistryObject<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("attribute.name.forge.swim_speed", 1.0D, 0.0D, 1024.0D).func_233753_a_(true));
-    public static final RegistryObject<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("attribute.name.forge.nametag_distance", 64.0D, 0.0D, 64.0).func_233753_a_(true));
-    public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("attribute.name.forge.entity_gravity", 0.08D, -8.0D, 8.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("forge.swimSpeed", 1.0D, 0.0D, 1024.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("forge.nameTagDistance", 64.0D, 0.0D, 64.0).func_233753_a_(true));
+    public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).func_233753_a_(true));
 
-    public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("attribute.name.generic.reach_distance", 5.0D, 0.0D, 1024.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("generic.reachDistance", 5.0D, 0.0D, 1024.0D).func_233753_a_(true));
 
     private static ForgeMod INSTANCE;
     public static ForgeMod getInstance()

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -85,11 +85,11 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 
     private static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(Attribute.class, "forge");
 
-    public static final RegistryObject<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("forge.swimSpeed", 1.0D, 0.0D, 1024.0D).func_233753_a_(true));
-    public static final RegistryObject<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("forge.nameTagDistance", 64.0D, 0.0D, Float.MAX_VALUE).func_233753_a_(true));
-    public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("attribute.name.forge.swim_speed", 1.0D, 0.0D, 1024.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("attribute.name.forge.nametag_distance", 64.0D, 0.0D, 64.0).func_233753_a_(true));
+    public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("attribute.name.forge.entity_gravity", 0.08D, -8.0D, 8.0D).func_233753_a_(true));
 
-    public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute( "generic.reachDistance", 5.0D, 0.0D, 1024.0D).func_233753_a_(true));
+    public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("attribute.name.generic.reach_distance", 5.0D, 0.0D, 1024.0D).func_233753_a_(true));
 
     private static ForgeMod INSTANCE;
     public static ForgeMod getInstance()

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -159,5 +159,9 @@
   "attribute.name.forge.swim_speed": "Swim Speed",
   "attribute.name.forge.nametag_distance": "Nametag Render Distance",
   "attribute.name.forge.entity_gravity": "Entity Gravity",
-  "attribute.name.generic.reach_distance": "Reach Distance"
+  "attribute.name.generic.reach_distance": "Reach Distance",
+  "forge.swimSpeed": "Swim Speed",
+  "forge.nameTagDistance": "Nametag Render Distance",
+  "forge.entity_gravity": "Entity Gravity",
+  "generic.reachDistance": "Reach Distance"
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -156,6 +156,8 @@
   "forge.controlsgui.alt": "ALT + %s",
 
   "forge.container.enchant.limitedEnchantability": "Limited Enchantability",
-  "attribute.name.generic.reachDistance": "Reach Distance",
-  "attribute.name.forge.swimSpeed": "Swim Speed"
+  "attribute.name.forge.swim_speed": "Swim Speed",
+  "attribute.name.forge.nametag_distance": "Nametag Render Distance",
+  "attribute.name.forge.entity_gravity": "Entity Gravity",
+  "attribute.name.generic.reach_distance": "Reach Distance"
 }


### PR DESCRIPTION
_This PR closes #7372._

First, this PR addresses the lack of translation keys for the Forge-added attributes. For this, I mirrored how vanilla has their attributes and translation keys, and added the English (`en_us.json`) translation keys as a default. I do not know how Forge integrates with [Crowdin][crowdin] and the crowdsourced translations, and I have received no word from any of the Forge/Triage team on how it is setup. 
I request any member of the Forge/Triage team to contact me if there are further steps to be taken on my end to add these translation keys to the Crowdin site.


Second, this PR addresses the lack of functionality of the `forge:nametag_distance` attribute. From the name, I have presumed that this attribute controls the distance from which the nametag of a living entity can be observed from. I implemented a hook as `ForgeHooksClient#isNameplateInRenderDistance(...)`, which is patched into `EntityRender#renderName(...)`.

However, due to restrictions on entity rendering, all nameplates are not rendered if they exceed 64 blocks from the camera's position (see `Entity#isInRangeToRenderDist()`). In my opinion, the patches required to workaround that for this attribute may cause unintended consequences, so I went with the safe option of limiting the attribute's max value to 64 blocks (as any higher value functions the same as `64.0d`).

_Note: In my opinion, these changes should be considered non-breaking: for the first point, the changed string is only used (as far as my investigation led me) for translations; for the second point, any value higher than `64.0d` has the same function as that value; the changed maximum value simply ensures that it will never be some arbitrarity high number._

[crowdin]: https://crowdin.com/project/minecraft-forge