### PR TITLE
Fix (NonNull)Lazy.Concurrent using a global lock

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/Lazy.java
+++ b/src/main/java/net/minecraftforge/common/util/Lazy.java
@@ -78,7 +78,7 @@ public interface Lazy<T> extends Supplier<T>
      */
     final class Concurrent<T> implements Lazy<T>
     {
-        private static final Object lock = new Object();
+        // Also used as the lock to reduce object size
         private volatile Supplier<T> supplier;
         private volatile T instance;
 
@@ -91,9 +91,12 @@ public interface Lazy<T> extends Supplier<T>
         @Override
         public final T get()
         {
-            if (supplier != null)
+            // Copy the supplier to a local variable to prevent NPEs if the supplier field is set to null between the
+            // null-check and the synchronization
+            Supplier<T> localSupplier = this.supplier;
+            if (localSupplier != null)
             {
-                synchronized (lock)
+                synchronized (localSupplier)
                 {
                     if (supplier != null)
                     {

--- a/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
@@ -20,8 +20,7 @@
 package net.minecraftforge.common.util;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.function.Supplier;
+import java.util.Objects;
 
 /**
  * Proxy object for a value that is calculated on first access.
@@ -36,7 +35,8 @@ public interface NonNullLazy<T> extends NonNullSupplier<T>
      */
     static <T> NonNullLazy<T> of(@Nonnull NonNullSupplier<T> supplier)
     {
-        return new NonNullLazy.Fast<>(supplier);
+        Lazy<T> lazy = Lazy.of(supplier::get);
+        return () -> Objects.requireNonNull(lazy.get());
     }
 
     /**
@@ -45,65 +45,7 @@ public interface NonNullLazy<T> extends NonNullSupplier<T>
      */
     static <T> NonNullLazy<T> concurrentOf(@Nonnull NonNullSupplier<T> supplier)
     {
-        return new NonNullLazy.Concurrent<>(supplier);
-    }
-
-    /**
-     * Non-thread-safe implementation.
-     */
-    final class Fast<T> implements NonNullLazy<T>
-    {
-        private NonNullSupplier<T> supplier;
-        private T instance;
-
-        private Fast(NonNullSupplier<T> supplier)
-        {
-            this.supplier = supplier;
-        }
-
-        @Nonnull
-        @Override
-        public final T get()
-        {
-            if (supplier != null)
-            {
-                instance = supplier.get();
-                supplier = null;
-            }
-            return instance;
-        }
-    }
-
-    /**
-     * Thread-safe implementation. See {@link Lazy.Concurrent} for implementation details.
-     */
-    final class Concurrent<T> implements NonNullLazy<T>
-    {
-        private volatile NonNullSupplier<T> supplier;
-        private volatile T instance;
-
-        private Concurrent(NonNullSupplier<T> supplier)
-        {
-            this.supplier = supplier;
-        }
-
-        @Nonnull
-        @Override
-        public final T get()
-        {
-            NonNullSupplier<T> localSupplier = supplier;
-            if (localSupplier != null)
-            {
-                synchronized (localSupplier)
-                {
-                    if (supplier != null)
-                    {
-                        instance = supplier.get();
-                        supplier = null;
-                    }
-                }
-            }
-            return instance;
-        }
+        Lazy<T> lazy = Lazy.concurrentOf(supplier::get);
+        return () -> Objects.requireNonNull(lazy.get());
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
@@ -75,11 +75,10 @@ public interface NonNullLazy<T> extends NonNullSupplier<T>
     }
 
     /**
-     * Thread-safe implementation.
+     * Thread-safe implementation. See {@link Lazy.Concurrent} for implementation details.
      */
     final class Concurrent<T> implements NonNullLazy<T>
     {
-        private static final Object lock = new Object();
         private volatile NonNullSupplier<T> supplier;
         private volatile T instance;
 
@@ -92,9 +91,10 @@ public interface NonNullLazy<T> extends NonNullSupplier<T>
         @Override
         public final T get()
         {
-            if (supplier != null)
+            NonNullSupplier<T> localSupplier = supplier;
+            if (localSupplier != null)
             {
-                synchronized (lock)
+                synchronized (localSupplier)
                 {
                     if (supplier != null)
                     {


### PR DESCRIPTION
This prevented multiple threads from resolving independent `Lazy`s at the same time. Implementation is as discussed in the Forge Discord yesterday, starting at [this](https://discordapp.com/channels/313125603924639766/725850371834118214/763492119313907714) message.