### PR TITLE
Fix worldgen object lists erroring

### DIFF
--- a/patches/minecraft/net/minecraft/util/registry/RegistryKeyCodec.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/RegistryKeyCodec.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/util/registry/RegistryKeyCodec.java
++++ b/net/minecraft/util/registry/RegistryKeyCodec.java
+@@ -19,17 +19,17 @@
+    }
+ 
+    public static <E> Codec<List<Supplier<E>>> func_244328_b(RegistryKey<? extends Registry<E>> p_244328_0_, Codec<E> p_244328_1_) {
+-      return Codec.either(func_244325_a(p_244328_0_, p_244328_1_, false).listOf(), p_244328_1_.<Supplier<E>>xmap((p_244329_0_) -> {
++      return Codec.either(func_244325_a(p_244328_0_, p_244328_1_, false), p_244328_1_.<Supplier<E>>xmap((p_244329_0_) -> {
+          return () -> {
+             return p_244329_0_;
+          };
+-      }, Supplier::get).listOf()).xmap((p_244323_0_) -> {
++      }, Supplier::get)).xmap((p_244323_0_) -> {
+          return p_244323_0_.map((p_244327_0_) -> {
+             return p_244327_0_;
+          }, (p_244324_0_) -> {
+             return p_244324_0_;
+          });
+-      }, Either::left);
++      }, Either::left).listOf();
+    }
+ 
+    private static <E> RegistryKeyCodec<E> func_244325_a(RegistryKey<? extends Registry<E>> p_244325_0_, Codec<E> p_244325_1_, boolean p_244325_2_) {


### PR DESCRIPTION
This causes the "not a JSON object" error in the log, and is caused because the codec used wants a list of either ALL resource locations or ALL json objects. This PR changes the codec to have the either be applied to each individual element (instead of the whole list). From the mojang name of this function, this goes against the vanilla intention, which could have unintented consequences.

Also, the resource location decoding should happen fine as long as all objects are registered (to the vanilla registry) correctly. There have been some cases where I was not able to pinpoint the error, so this might still be needed. This fix could also hide potential problems in mod code, and not error.

The purpose of the PR is mainly to let people know the problem is known, and the fix for now is (theoretically) to register the objects. 