### PR TITLE
[1.16.x] Add event for fabulous graphics rendering

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -87,7 +87,7 @@
           RenderState.field_239237_T_.func_228549_b_();
        } else {
           iprofiler.func_219895_b("translucent");
-@@ -1129,7 +1141,7 @@
+@@ -1129,9 +1141,12 @@
           iprofiler.func_219895_b("string");
           this.func_228441_a_(RenderType.func_241715_r_(), p_228426_1_, d0, d1, d2);
           iprofiler.func_219895_b("particles");
@@ -95,8 +95,13 @@
 +         this.field_72777_q.field_71452_i.renderParticles(p_228426_1_, irendertypebuffer$impl, p_228426_8_, p_228426_6_, p_228426_2_, clippinghelper);
        }
  
++      this.field_72777_q.func_213239_aq().func_219895_b("forge_render_framebuffer_last");
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderFramebufferLast(this.field_72777_q.field_71438_f, p_228426_1_, p_228426_2_, matrix4f, p_228426_3_);
++
        RenderSystem.pushMatrix();
-@@ -1481,6 +1493,11 @@
+       RenderSystem.multMatrix(p_228426_1_.func_227866_c_().func_227870_a_());
+       if (this.field_72777_q.field_71474_y.func_216842_e() != CloudOption.OFF) {
+@@ -1481,6 +1496,11 @@
     }
  
     public void func_228424_a_(MatrixStack p_228424_1_, float p_228424_2_) {
@@ -108,7 +113,7 @@
        if (this.field_72777_q.field_71441_e.func_239132_a_().func_241683_c_() == DimensionRenderInfo.FogType.END) {
           this.func_228444_b_(p_228424_1_);
        } else if (this.field_72777_q.field_71441_e.func_239132_a_().func_241683_c_() == DimensionRenderInfo.FogType.NORMAL) {
-@@ -1609,6 +1626,11 @@
+@@ -1609,6 +1629,11 @@
     }
  
     public void func_228425_a_(MatrixStack p_228425_1_, float p_228425_2_, double p_228425_3_, double p_228425_5_, double p_228425_7_) {
@@ -120,7 +125,7 @@
        float f = this.field_72769_h.func_239132_a_().func_239213_a_();
        if (!Float.isNaN(f)) {
           RenderSystem.disableCull();
-@@ -1792,7 +1814,7 @@
+@@ -1792,7 +1817,7 @@
  
           while(iterator.hasNext()) {
              ChunkRenderDispatcher.ChunkRender chunkrenderdispatcher$chunkrender = iterator.next();
@@ -129,7 +134,7 @@
                 this.field_174995_M.func_228902_a_(chunkrenderdispatcher$chunkrender);
              } else {
                 chunkrenderdispatcher$chunkrender.func_228929_a_(this.field_174995_M);
-@@ -2076,7 +2098,12 @@
+@@ -2076,7 +2101,12 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
@@ -142,7 +147,7 @@
        ISound isound = this.field_147593_P.get(p_184377_2_);
        if (isound != null) {
           this.field_72777_q.func_147118_V().func_147683_b(isound);
-@@ -2084,7 +2111,7 @@
+@@ -2084,7 +2114,7 @@
        }
  
        if (p_184377_1_ != null) {
@@ -151,7 +156,7 @@
           if (musicdiscitem != null) {
              this.field_72777_q.field_71456_v.func_238451_a_(musicdiscitem.func_234801_g_());
           }
-@@ -2232,7 +2259,7 @@
+@@ -2232,7 +2262,7 @@
           break;
        case 1010:
           if (Item.func_150899_d(p_180439_4_) instanceof MusicDiscItem) {
@@ -160,7 +165,7 @@
           } else {
              this.func_184377_a((SoundEvent)null, p_180439_3_);
           }
-@@ -2382,8 +2409,8 @@
+@@ -2382,8 +2412,8 @@
           break;
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
@@ -171,7 +176,7 @@
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
  
-@@ -2531,7 +2558,7 @@
+@@ -2531,7 +2561,7 @@
        } else {
           int i = p_228420_0_.func_226658_a_(LightType.SKY, p_228420_2_);
           int j = p_228420_0_.func_226658_a_(LightType.BLOCK, p_228420_2_);
@@ -180,7 +185,7 @@
           if (j < k) {
              j = k;
           }
-@@ -2570,6 +2597,11 @@
+@@ -2570,6 +2600,11 @@
        return this.field_239226_J_;
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -138,6 +138,11 @@ public class ForgeHooksClient
         }
     }
 
+    public static void dispatchRenderFramebufferLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderFramebufferLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));
+    }
+
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));

--- a/src/main/java/net/minecraftforge/client/event/RenderFramebufferLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderFramebufferLastEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraftforge.eventbus.api.Event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+/**
+ * Fired just before the fabulous shader is rendered.
+ */
+public class RenderFramebufferLastEvent extends Event
+{
+    private final WorldRenderer context;
+    private final MatrixStack mat;
+    private final float partialTicks;
+    private final Matrix4f projectionMatrix;
+    private final long finishTimeNano;
+
+    public RenderFramebufferLastEvent(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
+    {
+        this.context = context;
+        this.mat = mat;
+        this.partialTicks = partialTicks;
+        this.projectionMatrix = projectionMatrix;
+        this.finishTimeNano = finishTimeNano;
+    }
+
+    public WorldRenderer getContext()
+    {
+        return context;
+    }
+
+    public MatrixStack getMatrixStack()
+    {
+        return mat;
+    }
+
+    public float getPartialTicks()
+    {
+        return partialTicks;
+    }
+
+    public Matrix4f getProjectionMatrix()
+    {
+        return projectionMatrix;
+    }
+
+    public long getFinishTimeNano()
+    {
+        return finishTimeNano;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/FramebufferRenderLastEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/FramebufferRenderLastEventTest.java
@@ -1,0 +1,213 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import static org.lwjgl.opengl.GL11.GL_QUADS;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.RenderState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.world.World;
+import net.minecraft.world.border.BorderStatus;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderFramebufferLastEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+
+@Mod("render_framebuffers_last_event_test")
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class FramebufferRenderLastEventTest
+{
+    static final ResourceLocation BORDER = new ResourceLocation("textures/misc/forcefield.png");
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onEvent(RenderFramebufferLastEvent event)
+    {
+        if (!ENABLED)
+            return;
+
+        Minecraft mc = Minecraft.getInstance();
+        World world = mc.world;
+        BufferBuilder buffer = Tessellator.getInstance().getBuffer();
+        MatrixStack matrixStack = event.getMatrixStack();
+        Vector3d view = mc.getRenderManager().info.getProjectedView();
+
+        if (world == null)
+            return;
+
+        RenderTypes.getWeatherTarget().setupRenderState();
+        renderBorder(buffer, matrixStack, view.getX(), view.getY(), view.getZ());
+        RenderTypes.getWeatherTarget().clearRenderState();
+    }
+
+    // Example rendering something, this is a clone of the vanilla world border
+    private static void renderBorder(BufferBuilder builder, MatrixStack matrixStack, double playerX, double playerY, double playerZ)
+    {
+        Minecraft mc = Minecraft.getInstance();
+        int viewDistance = mc.gameSettings.renderDistanceChunks * 16;
+        float centerX = 0;
+        float centerZ = 0;
+        float radius = 32;
+
+        if (mc.player == null)
+            return;
+
+        BorderStatus status = BorderStatus.STATIONARY;
+
+        float minX = centerX - radius;
+        float maxX = centerX + radius;
+        float minZ = centerZ - radius;
+        float maxZ = centerZ + radius;
+
+        if (playerX >= maxX - viewDistance || playerX <= minX + viewDistance || playerZ >= maxZ - viewDistance || playerZ <= minZ + viewDistance)
+        {
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+            mc.getTextureManager().bindTexture(BORDER);
+            RenderSystem.depthMask(Minecraft.func_238218_y_());
+            matrixStack.push();
+            {
+                matrixStack.translate(-playerX, -playerY, -playerZ);
+                int borderColor = status.getColor();
+                float red = (float) (borderColor >> 16 & 255) / 255.0F;
+                float green = (float) (borderColor >> 8 & 255) / 255.0F;
+                float blue = (float) (borderColor & 255) / 255.0F;
+                RenderSystem.polygonOffset(-3.0F, -3.0F);
+                RenderSystem.enablePolygonOffset();
+                RenderSystem.defaultAlphaFunc();
+                RenderSystem.enableAlphaTest();
+                RenderSystem.disableCull();
+                float offset = (float) (Util.milliTime() % 3000L) / 3000.0F;
+
+                builder.begin(GL_QUADS, DefaultVertexFormats.POSITION_COLOR_TEX);
+                Matrix4f matrix4f = matrixStack.getLast().getMatrix();
+
+                float d8 = Math.max(MathHelper.floor(playerZ - viewDistance), minZ);
+                float d9 = Math.min(MathHelper.ceil(playerZ + viewDistance), maxZ);
+
+                if (playerX > maxX - viewDistance)
+                {
+                    float f7 = 0.0F;
+
+                    for (float d10 = d8; d10 < d9; f7 += 0.5F)
+                    {
+                        float d11 = Math.min(1.0f, d9 - d10);
+                        float f8 = d11 * 0.5F;
+                        builder.pos(matrix4f, maxX, 256.0f, d10).color(red, green, blue, 1.0f).tex(offset + f7, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, maxX, 256.0f, d10 + d11).color(red, green, blue, 1.0f).tex(offset + f8 + f7, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, maxX, 0.0f, d10 + d11).color(red, green, blue, 1.0f).tex(offset + f8 + f7, offset + 128.0F).endVertex();
+                        builder.pos(matrix4f, maxX, 0.0f, d10).color(red, green, blue, 1.0f).tex(offset + f7, offset + 128.0F).endVertex();
+                        ++d10;
+                    }
+                }
+
+                if (playerX < minX + viewDistance)
+                {
+                    float f9 = 0.0F;
+
+                    for (float d12 = d8; d12 < d9; f9 += 0.5F)
+                    {
+                        float d15 = Math.min(1.0f, d9 - d12);
+                        float f12 = d15 * 0.5F;
+                        builder.pos(matrix4f, minX, 256.0f, d12).color(red, green, blue, 1.0f).tex(offset + f9, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, minX, 256.0f, d12 + d15).color(red, green, blue, 1.0f).tex(offset + f12 + f9, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, minX, 0.0f, d12 + d15).color(red, green, blue, 1.0f).tex(offset + f12 + f9, offset + 128.0F).endVertex();
+                        builder.pos(matrix4f, minX, 0.0f, d12).color(red, green, blue, 1.0f).tex(offset + f9, offset + 128.0F).endVertex();
+                        ++d12;
+                    }
+                }
+
+                d8 = Math.max(MathHelper.floor(playerX - viewDistance), minX);
+                d9 = Math.min(MathHelper.ceil(playerX + viewDistance), maxX);
+
+                if (playerZ > maxZ - viewDistance)
+                {
+                    float f10 = 0.0F;
+
+                    for (float d13 = d8; d13 < d9; f10 += 0.5F)
+                    {
+                        float d16 = Math.min(1.0f, d9 - d13);
+                        float f13 = d16 * 0.5F;
+                        builder.pos(matrix4f, d13, 256.0f, maxZ).color(red, green, blue, 1.0f).tex(offset + f10, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, d13 + d16, 256.0f, maxZ).color(red, green, blue, 1.0f).tex(offset + f13 + f10, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, d13 + d16, 0.0f, maxZ).color(red, green, blue, 1.0f).tex(offset + f13 + f10, offset + 128.0F).endVertex();
+                        builder.pos(matrix4f, d13, 0.0f, maxZ).color(red, green, blue, 1.0f).tex(offset + f10, offset + 128.0F).endVertex();
+                        ++d13;
+                    }
+                }
+
+                if (playerZ < minZ + viewDistance)
+                {
+                    float f11 = 0.0F;
+
+                    for (float d14 = d8; d14 < d9; f11 += 0.5F)
+                    {
+                        float d17 = Math.min(1.0f, d9 - d14);
+                        float f14 = d17 * 0.5F;
+                        builder.pos(matrix4f, d14, 256.0f, minZ).color(red, green, blue, 1.0f).tex(offset + f11, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, d14 + d17, 256.0f, minZ).color(red, green, blue, 1.0f).tex(offset + f14 + f11, offset + 0.0F).endVertex();
+                        builder.pos(matrix4f, d14 + d17, 0.0f, minZ).color(red, green, blue, 1.0f).tex(offset + f14 + f11, offset + 128.0F).endVertex();
+                        builder.pos(matrix4f, d14, 0.0f, minZ).color(red, green, blue, 1.0f).tex(offset + f11, offset + 128.0F).endVertex();
+                        ++d14;
+                    }
+                }
+
+                Tessellator.getInstance().draw();
+
+                RenderSystem.enableCull();
+                RenderSystem.disableAlphaTest();
+                RenderSystem.polygonOffset(0.0F, 0.0F);
+                RenderSystem.disablePolygonOffset();
+                RenderSystem.enableAlphaTest();
+                RenderSystem.disableBlend();
+            }
+            matrixStack.pop();
+            RenderSystem.depthMask(true);
+        }
+    }
+
+    private static final class RenderTypes extends RenderType
+    {
+        private RenderTypes(String nameIn, VertexFormat formatIn, int drawModeIn, int bufferSizeIn, boolean useDelegateIn, boolean needsSortingIn, Runnable setupTaskIn, Runnable clearTaskIn)
+        {
+            super(nameIn, formatIn, drawModeIn, bufferSizeIn, useDelegateIn, needsSortingIn, setupTaskIn, clearTaskIn);
+        }
+
+        private static RenderState getWeatherTarget()
+        {
+            return field_239238_U_;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -90,3 +90,5 @@ license="LGPL v2.1"
     modId="biome_loading_event_test"
 [[mods]]
     modId="structure_spawn_list_event_test"
+[[mods]]
+    modId="render_framebuffers_last_event_test"


### PR DESCRIPTION
**The problem at hand**
After the introduction of the Fabulous Graphics setting, it has been near impossible to use the `RenderLastEvent` without experiencing some sort of visual issues. This is due to the fabulous shader being rendered before the event is fired so new render changes are never drawn to the screen.
**This PR adds:**
- A new event for rendering that allows rendering into fabulous frame buffers
- Patches WorldRenderer
- A test mod

I considered just moving `RenderLastEvent`, but that could have unintended consequences so I opted to make a new event. Technically `RenderLastEvent` _can_ be moved but it would have the chance of breaking mods that use it.