### PR TITLE
Fix regression in RightClickBlock

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -101,7 +101,7 @@
        } else {
           ItemStack itemstack = p_217292_1_.func_184586_b(p_217292_3_);
 +         net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
-+                 .onRightClickBlock(p_217292_1_, p_217292_3_, blockpos, p_217292_4_.func_216354_b());
++                 .onRightClickBlock(p_217292_1_, p_217292_3_, blockpos, p_217292_4_);
 +         if (event.isCanceled()) {
 +            this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
 +            return event.getCancellationResult();

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -122,7 +122,7 @@
 +            boolean flag = !p_217292_1_.func_184614_ca().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_) || !p_217292_1_.func_184592_cb().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_);
              boolean flag1 = p_217292_1_.func_226563_dT_() && flag;
 -            if (!flag1) {
-+            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
++            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1)) {
                 ActionResultType actionresulttype = p_217292_2_.func_180495_p(blockpos).func_227031_a_(p_217292_2_, p_217292_1_, p_217292_3_, p_217292_4_);
                 if (actionresulttype.func_226246_a_()) {
                    this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
@@ -133,7 +133,7 @@
 -            if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
 -               ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
++            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b()))) {
                 ActionResultType actionresulttype1;
                 if (this.field_78779_k.func_77145_d()) {
                    int i = itemstack.func_190916_E();

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -122,7 +122,7 @@
 +            boolean flag = !p_217292_1_.func_184614_ca().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_) || !p_217292_1_.func_184592_cb().doesSneakBypassUse(p_217292_2_,blockpos,p_217292_1_);
              boolean flag1 = p_217292_1_.func_226563_dT_() && flag;
 -            if (!flag1) {
-+            if (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
++            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
                 ActionResultType actionresulttype = p_217292_2_.func_180495_p(blockpos).func_227031_a_(p_217292_2_, p_217292_1_, p_217292_3_, p_217292_4_);
                 if (actionresulttype.func_226246_a_()) {
                    this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
@@ -130,9 +130,10 @@
              }
  
              this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
-             if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
+-            if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
 -               ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
++            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
++            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
                 ActionResultType actionresulttype1;
                 if (this.field_78779_k.func_77145_d()) {
                    int i = itemstack.func_190916_E();

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -125,7 +125,7 @@
     public ActionResultType func_219441_a(ServerPlayerEntity p_219441_1_, World p_219441_2_, ItemStack p_219441_3_, Hand p_219441_4_, BlockRayTraceResult p_219441_5_) {
        BlockPos blockpos = p_219441_5_.func_216350_a();
        BlockState blockstate = p_219441_2_.func_180495_p(blockpos);
-+      net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_.func_216354_b());
++      net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks.onRightClickBlock(p_219441_1_, p_219441_4_, blockpos, p_219441_5_);
 +      if (event.isCanceled()) return event.getCancellationResult();
        if (this.field_73091_c == GameType.SPECTATOR) {
           INamedContainerProvider inamedcontainerprovider = blockstate.func_215699_b(p_219441_2_, blockpos);

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -144,15 +144,17 @@
 +         boolean flag1 = (p_219441_1_.func_226563_dT_() && flag) && !(p_219441_1_.func_184614_ca().doesSneakBypassUse(p_219441_2_, blockpos, p_219441_1_) && p_219441_1_.func_184592_cb().doesSneakBypassUse(p_219441_2_, blockpos, p_219441_1_));
           ItemStack itemstack = p_219441_3_.func_77946_l();
 -         if (!flag1) {
-+         if (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
++         if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
              ActionResultType actionresulttype = blockstate.func_227031_a_(p_219441_2_, p_219441_1_, p_219441_4_, p_219441_5_);
              if (actionresulttype.func_226246_a_()) {
                 CriteriaTriggers.field_232607_M_.func_226695_a_(p_219441_1_, blockpos, itemstack);
-@@ -312,7 +343,7 @@
+@@ -311,8 +342,8 @@
+             }
           }
  
-          if (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
+-         if (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
 -            ItemUseContext itemusecontext = new ItemUseContext(p_219441_1_, p_219441_4_, p_219441_5_);
++         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
              ActionResultType actionresulttype1;
              if (this.func_73083_d()) {

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -144,7 +144,7 @@
 +         boolean flag1 = (p_219441_1_.func_226563_dT_() && flag) && !(p_219441_1_.func_184614_ca().doesSneakBypassUse(p_219441_2_, blockpos, p_219441_1_) && p_219441_1_.func_184592_cb().doesSneakBypassUse(p_219441_2_, blockpos, p_219441_1_));
           ItemStack itemstack = p_219441_3_.func_77946_l();
 -         if (!flag1) {
-+         if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1) {
++         if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1)) {
              ActionResultType actionresulttype = blockstate.func_227031_a_(p_219441_2_, p_219441_1_, p_219441_4_, p_219441_5_);
              if (actionresulttype.func_226246_a_()) {
                 CriteriaTriggers.field_232607_M_.func_226695_a_(p_219441_1_, blockpos, itemstack);
@@ -154,7 +154,7 @@
  
 -         if (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
 -            ItemUseContext itemusecontext = new ItemUseContext(p_219441_1_, p_219441_4_, p_219441_5_);
-+         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
++         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b()))) {
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
              ActionResultType actionresulttype1;
              if (this.func_73083_d()) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -772,9 +772,17 @@ public class ForgeHooks
         return evt;
     }
 
+    @Deprecated //Use RayTraceResult version.  TODO: Remove 1.17
     public static PlayerInteractEvent.RightClickBlock onRightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, Direction face)
     {
         PlayerInteractEvent.RightClickBlock evt = new PlayerInteractEvent.RightClickBlock(player, hand, pos, face);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
+    }
+
+    public static PlayerInteractEvent.RightClickBlock onRightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult hitVec)
+    {
+        PlayerInteractEvent.RightClickBlock evt = new PlayerInteractEvent.RightClickBlock(player, hand, pos, hitVec);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -20,8 +20,10 @@
 package net.minecraftforge.event.entity.player;
 
 import com.google.common.base.Preconditions;
+import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
@@ -129,16 +131,17 @@ public class PlayerInteractEvent extends PlayerEvent
     }
 
     /**
-     * This event is fired on both sides whenever the player right clicks while targeting a block.
-     * This event controls which of {@link net.minecraft.block.Block#onBlockActivated} and/or {@link net.minecraft.item.Item#onItemUse}
-     * will be called after {@link net.minecraft.item.Item#onItemUseFirst} is called.
-     * Canceling the event will cause none of the above three to be called
-     *
-     * Let result be a return value of the above three methods, or {@link #cancellationResult} if the event is cancelled.
-     * If we are on the client and result is not {@link EnumActionResult#SUCCESS}, the client will then try {@link RightClickItem}.
-     *
-     * There are various results to this event, see the getters below.
-     * Note that handling things differently on the client vs server may cause desynchronizations!
+     * This event is fired on both sides whenever the player right clicks while targeting a block. <br>
+     * This event controls which of {@link Item#onItemUseFirst}, {@link Block#onBlockActivated}, and {@link Item#onItemUse}
+     * will be called. <br>
+     * Canceling the event will cause none of the above three to be called. <br>
+     * <br>
+     * Let result be the first non-pass return value of the above three methods, or pass, if they all pass. <br>
+     * Or {@link #cancellationResult} if the event is cancelled. <br>
+     * If result equals {@link ActionResultType#PASS}, we proceed to {@link RightClickItem}.  <br>
+     * <br>
+     * There are various results to this event, see the getters below.  <br>
+     * Note that handling things differently on the client vs server may cause desynchronizations! 
      */
     @Cancelable
     public static class RightClickBlock extends PlayerInteractEvent
@@ -167,9 +170,10 @@ public class PlayerInteractEvent extends PlayerEvent
         }
 
         /**
-         * DENY: Block will never be used.
-         * DEFAULT: Default behaviour (sneak will not use block, unless all items return true in {@link net.minecraft.item.Item#doesSneakBypassUse}).
-         * ALLOW: Block will always be used, regardless of sneaking and doesSneakBypassUse.
+         * DENY: {@link Block#onBlockActivated} will never be called. <br>
+         * DEFAULT: {@link Block#onBlockActivated} will be called if {@link Item#onItemUseFirst} passes. <br>
+         * Note that default activation can be blocked if the user is sneaking and holding an item that does not return true to {@link Item#doesSneakBypassUse}. <br>
+         * ALLOW: {@link Block#onBlockActivated} will always be called, unless {@link Item#onItemUseFirst} does not pass. <br>
          */
         public void setUseBlock(Result triggerBlock)
         {
@@ -177,9 +181,9 @@ public class PlayerInteractEvent extends PlayerEvent
         }
 
         /**
-         * DENY: The item will never be used.
-         * DEFAULT: The item will be used if the block fails.
-         * ALLOW: The item will always be used.
+         * DENY: Neither {@link Item#onItemUse} or {@link Item#onItemUseFirst} will be called. <br>
+         * DEFAULT: {@link Item#onItemUseFirst} will always be called, and {@link Item#onItemUse} will be called if the block passes. <br>
+         * ALLOW: {@link Item#onItemUseFirst} will always be called, and {@link Item#onItemUse} will be called if the block passes, regardless of cooldowns or emptiness. <br>
          */
         public void setUseItem(Result triggerItem)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -29,6 +29,7 @@ import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -148,9 +149,16 @@ public class PlayerInteractEvent extends PlayerEvent
     {
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
+        private BlockRayTraceResult hitVec;
 
+        @Deprecated //Use RayTraceResult version.  TODO: Remove 1.17
         public RightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, Direction face) {
             super(player, hand, pos, face);
+        }
+
+        public RightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult hitVec) {
+            super(player, hand, pos, hitVec.getFace());
+            this.hitVec = hitVec;
         }
 
         /**
@@ -167,6 +175,14 @@ public class PlayerInteractEvent extends PlayerEvent
         public Result getUseItem()
         {
             return useItem;
+        }
+
+        /**
+         * @return The ray trace result targeting the block.
+         */
+        public BlockRayTraceResult getHitVec()
+        {
+            return hitVec;
         }
 
         /**


### PR DESCRIPTION
Somewhere between 1.12 and 1.16 (this may have happened in any version between 1.13-1.16), the patches that enabled the ALLOW results to have any purpose were lost.  This PR restores them, and additionally updates the javadocs on RightClickBlock to be a bit more descriptive on what the consequences of each result is.