### PR TITLE
Fix MC-197616 (Massive log spam, lag, and invalid client biomes when using `SingleBiomeProvider` with data pack / modded biomes.)

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeContainer.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeContainer.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/biome/BiomeContainer.java
++++ b/net/minecraft/world/biome/BiomeContainer.java
+@@ -90,6 +90,13 @@
+ 
+       for(int i = 0; i < this.field_227054_f_.length; ++i) {
+          aint[i] = this.field_242704_g.func_148757_b(this.field_227054_f_[i]);
++         // FORGE: Fix MC-197616 - Data pack biomes are synchronized with -1 IDs causing massive log spam, lag, and invalid biomes on client
++         if (aint[i] == -1 && this.field_242704_g instanceof net.minecraft.util.registry.SimpleRegistry) {
++            Biome dynamicBiome = ((net.minecraft.util.registry.SimpleRegistry<Biome>)this.field_242704_g).func_82594_a(this.field_227054_f_[i].getRegistryName());
++            if (dynamicBiome != null) {
++                aint[i] = this.field_242704_g.func_148757_b(dynamicBiome);
++            }
++         }
+       }
+ 
+       return aint;


### PR DESCRIPTION
This is pretty simple. The biomes stored in the `BiomeContainer` are not the ones in the dynamic registry - when queried, they return a non-existent ID value. This then gets synchronized to clients and due to the fact vanilla logs a warning message **for every biome**, if used in `SingleBiomeProvider`, this logs an error **1024 times per chunk**. Ya - not very performant. The client side biome properties (water and foliage color for example) are also broken and F3 reports the biome as `"minecraft:ocean"`

The fix is instead of going biome -> int ID, querying first biome -> name -> biome -> ID which refreshes the biome, and thus gets the correct ID in the case of data pack biome overrides. This requires #7434 as without it, the biomes in the `BiomeContainer` do not have any indication of where they come from as they don't exist in the registry and don't store a name.

*Ideally* vanilla would fix their messy biome-copy-between-registries-and-encode-decode nonsense, but that's unlikely going to be simply doable by forge, so this is more of a "make the system not crash and burn" fix.

To test: see the process in #7433. Observe there is no log spam with this additional fix included.