### PR TITLE
A possible modification to #7434 to make it a non-breaking change.

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public final class Biome {
-+public final class Biome implements net.minecraftforge.registries.IForgeRegistryEntry<Biome> {
++public final class Biome extends net.minecraftforge.registries.ForgeRegistryEntry.DynamicRegistryEntry<Biome> {
     public static final Logger field_150586_aC = LogManager.getLogger();
     public static final Codec<Biome> field_242418_b = RecordCodecBuilder.create((p_235064_0_) -> {
        return p_235064_0_.group(Biome.Climate.field_242459_a.forGetter((p_242446_0_) -> {
@@ -20,34 +20,7 @@
     });
     public static final Codec<Biome> field_242419_c = RecordCodecBuilder.create((p_242432_0_) -> {
        return p_242432_0_.group(Biome.Climate.field_242459_a.forGetter((p_242441_0_) -> {
-@@ -113,6 +115,26 @@
-       });
-    });
- 
-+   // FORGE: Since this is special (dynamic registry codec special), we have to re-implement ForgeRegistryEntry here
-+   @Nullable
-+   private ResourceLocation registryName = null;
-+   @Nullable
-+   @Override
-+   public ResourceLocation getRegistryName() {
-+      return registryName;
-+   }
-+   @Override
-+   public Biome setRegistryName(ResourceLocation registryName) {
-+      if (getRegistryName() != null)
-+         throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + registryName + " Old: " + getRegistryName());
-+      this.registryName = registryName;
-+      return this;
-+   }
-+   @Override
-+   public Class<Biome> getRegistryType() {
-+      return Biome.class;
-+   }
-+
-    private Biome(Biome.Climate p_i241927_1_, Biome.Category p_i241927_2_, float p_i241927_3_, float p_i241927_4_, BiomeAmbience p_i241927_5_, BiomeGenerationSettings p_i241927_6_, MobSpawnInfo p_i241927_7_) {
-       this.field_242423_j = p_i241927_1_;
-       this.field_242424_k = p_i241927_6_;
-@@ -200,7 +222,7 @@
+@@ -200,7 +202,7 @@
        } else {
           if (p_201850_2_.func_177956_o() >= 0 && p_201850_2_.func_177956_o() < 256 && p_201850_1_.func_226658_a_(LightType.BLOCK, p_201850_2_) < 10) {
              BlockState blockstate = p_201850_1_.func_180495_p(p_201850_2_);

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public final class Biome {
-+public final class Biome extends net.minecraftforge.registries.ForgeRegistryEntry.DynamicRegistryEntry<Biome> {
++public final class Biome extends net.minecraftforge.registries.ForgeRegistryEntry.UncheckedRegistryEntry<Biome> {
     public static final Logger field_150586_aC = LogManager.getLogger();
     public static final Codec<Biome> field_242418_b = RecordCodecBuilder.create((p_235064_0_) -> {
        return p_235064_0_.group(Biome.Climate.field_242459_a.forGetter((p_242446_0_) -> {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -60,12 +60,23 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
 
     public final Class<V> getRegistryType() { return (Class<V>)token.getRawType(); }
 
+    /**
+     * This will assert that the registry name is valid and warn about potential registry overrides
+     * It is important as it detects cases where modders unintentionally register objects with the "minecraft" namespace, leading to dangerous errors later.
+     * @param name The registry name
+     * @return A verified "correct" registry name
+     */
     ResourceLocation checkRegistryName(String name)
     {
         return GameData.checkPrefix(name, true);
     }
 
-    public abstract static class DynamicRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
+    /**
+     * This class exists for registry entries which are dynamic (e.g. loaded via data packs), and also exist in a forge registry prior to that.
+     * Due to this, the registry name will be set via the codec not during initial registration, and as a result, we want to not warn about possible overrides as the registry name will be set outside of mod context.
+     * @param <V>
+     */
+    public abstract static class UncheckedRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
     {
         @Override
         ResourceLocation checkRegistryName(String name)

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -74,7 +74,6 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
     /**
      * This class exists for registry entries which are dynamic (e.g. loaded via data packs), and also exist in a forge registry prior to that.
      * Due to this, the registry name will be set via the codec not during initial registration, and as a result, we want to not warn about possible overrides as the registry name will be set outside of mod context.
-     * @param <V>
      */
     public abstract static class UncheckedRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
     {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -42,7 +42,7 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
         if (getRegistryName() != null)
             throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryName());
 
-        this.registryName = GameData.checkPrefix(name, true);
+        this.registryName = checkRegistryName(name);
         return (V)this;
     }
 
@@ -59,4 +59,18 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
     }
 
     public final Class<V> getRegistryType() { return (Class<V>)token.getRawType(); }
+
+    ResourceLocation checkRegistryName(String name)
+    {
+        return GameData.checkPrefix(name, true);
+    }
+
+    public static class DynamicRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
+    {
+        @Override
+        ResourceLocation checkRegistryName(String name)
+        {
+            return new ResourceLocation(name);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -65,7 +65,7 @@ public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> imple
         return GameData.checkPrefix(name, true);
     }
 
-    public static class DynamicRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
+    public abstract static class DynamicRegistryEntry<V extends IForgeRegistryEntry<V>> extends ForgeRegistryEntry<V>
     {
         @Override
         ResourceLocation checkRegistryName(String name)


### PR DESCRIPTION
The gist, from discord:

> So TIL that https://github.com/MinecraftForge/MinecraftForge/pull/7434 may have included a binary compat break by changing Biome extends ForgeRegistryEntry<Biome> to Biome implements IForgeRegistryEntry<Biome>
> 
> A friend mentioned to me that code that worked pre 34.1.32 now crashes with
> 
> > java.lang.NoSuchMethodError: net.minecraft.world.Biome.setRegistryName(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraftforge/registries/IForgeRegistryEntry;
> 
> So there's two things here
> - Removing ForgeRegistryEntry accidentally involved removing two overloads of setRegistryName which take a String name or String modid, String name, respectively.
> - And (this I did not know), apparently narrowing the type of a return value actually constitutes a breaking change. (Although the only "fix" that is required would be to recompile against the new version, but that's still a binary break)

So, this is one possibility to re-implement `ForgeRegistryEntry`, and avoid the original idea using `get/set/DynamicRegistryName`, and avoid the same pitfalls that were fallen into in the original idea.

