### PR TITLE
[1.16] Fix Banner.toItem causing crash on server

### DIFF
--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -27,6 +27,7 @@ net/minecraft/block/Block func_185473_a(Lnet/minecraft/world/IBlockReader;Lnet/m
 	net/minecraft/block/TallSeaGrassBlock func_185473_a(Lnet/minecraft/world/IBlockReader;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Lnet/minecraft/item/ItemStack;
 # Vanilla blocks calling these sided methods in getItem
 net/minecraft/tileentity/BannerTileEntity func_190615_l(Lnet/minecraft/block/BlockState;)Lnet/minecraft/item/ItemStack;
+net/minecraft/block/BannerBlock func_196287_a(Lnet/minecraft/item/DyeColor;)Lnet/minecraft/block/Block;
 net/minecraft/block/AttachedStemBlock func_196279_O_()Lnet/minecraft/item/Item;
 net/minecraft/block/StemBlock func_176481_j()Lnet/minecraft/item/Item;
 #=====================================


### PR DESCRIPTION
Forge uses the SAS to remove @OnlyIn(Dist.CLIENT) from BannerTileEntity.getItem:
`net/minecraft/tileentity/BannerTileEntity func_190615_l(Lnet/minecraft/block/BlockState;)Lnet/minecraft/item/ItemStack;`
But that function calls BannerBlock.forColor, which is also sided.

This PR adds BannerBlock.forColor to the Forge SAS, allowing servers to call BannerTileEntity.getItem again.

NOTE: i have not run checkSAS on this yet