### PR TITLE
Add Player context to AnvilUpdateEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RepairContainer.java.patch
@@ -26,7 +26,7 @@
 +
           if (!itemstack2.func_190926_b()) {
 -            boolean flag = itemstack2.func_77973_b() == Items.field_151134_bR && !EnchantedBookItem.func_92110_g(itemstack2).isEmpty();
-+            if (!net.minecraftforge.common.ForgeHooks.onAnvilChange(this, itemstack, itemstack2, field_234642_c_, field_82857_m, j)) return;
++            if (!net.minecraftforge.common.ForgeHooks.onAnvilChange(this, itemstack, itemstack2, field_234642_c_, field_82857_m, j, this.field_234645_f_)) return;
 +            flag = itemstack2.func_77973_b() == Items.field_151134_bR && !EnchantedBookItem.func_92110_g(itemstack2).isEmpty();
              if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2)) {
                 int l2 = Math.min(itemstack1.func_77952_i(), itemstack1.func_77958_k() / 4);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -672,9 +672,22 @@ public class ForgeHooks
         return ret;
     }
 
+    @Deprecated // TODO: Remove 1.17 - Use player-contextual version below.
     public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost)
     {
         AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, baseCost);
+        if (MinecraftForge.EVENT_BUS.post(e)) return false;
+        if (e.getOutput().isEmpty()) return true;
+
+        outputSlot.setInventorySlotContents(0, e.getOutput());
+        container.setMaximumCost(e.getCost());
+        container.materialCost = e.getMaterialCost();
+        return false;
+    }
+
+    public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost, PlayerEntity player)
+    {
+        AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, baseCost, player);
         if (MinecraftForge.EVENT_BUS.post(e)) return false;
         if (e.getOutput().isEmpty()) return true;
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -675,14 +675,7 @@ public class ForgeHooks
     @Deprecated // TODO: Remove 1.17 - Use player-contextual version below.
     public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost)
     {
-        AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, baseCost);
-        if (MinecraftForge.EVENT_BUS.post(e)) return false;
-        if (e.getOutput().isEmpty()) return true;
-
-        outputSlot.setInventorySlotContents(0, e.getOutput());
-        container.setMaximumCost(e.getCost());
-        container.materialCost = e.getMaterialCost();
-        return false;
+        return onAnvilChange(container, left, right, outputSlot, name, baseCost, null);
     }
 
     public static boolean onAnvilChange(RepairContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, IInventory outputSlot, String name, int baseCost, PlayerEntity player)

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -36,7 +36,8 @@ import javax.annotation.Nullable;
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
 @Cancelable
-public class AnvilUpdateEvent extends Event {
+public class AnvilUpdateEvent extends Event
+{
 
     private final ItemStack left;
     private final ItemStack right;
@@ -65,7 +66,7 @@ public class AnvilUpdateEvent extends Event {
     }
 
     /**
-     * @return ihe Item in the left input (leftmost) anvil slot.
+     * @return The item in the left input (leftmost) anvil slot.
      */
     public ItemStack getLeft()
     {
@@ -92,10 +93,11 @@ public class AnvilUpdateEvent extends Event {
     }
 
     /**
-     * This is the output as a result of this event, not of the two items. <br>
+     * This is the output as determined by the event, not by the vanilla behavior between these two items. <br>
      * If you are the first receiver of this event, it is guaranteed to be empty. <br>
-     * It will only be non-empty if changed by an event handler.
-     * @return The item in the output (rightmost) anvil slot.
+     * It will only be non-empty if changed by an event handler. <br>
+     * If this event is cancelled, this output stack is discarded.
+     * @return The item to set in the output (rightmost) anvil slot.
      */
     public ItemStack getOutput() 
     {

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -131,7 +131,7 @@ public class AnvilUpdateEvent extends Event {
     }
 
     /**
-     * The material cost is how many right inputs are consumed.
+     * The material cost is how many units of the right input stack are consumed.
      * @return The material cost of this anvil operation.
      */
     public int getMaterialCost()

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -19,52 +19,146 @@
 
 package net.minecraftforge.event;
 
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.container.RepairContainer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
-import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * 
- * AnvilUpdateEvent is fired when a player places items in both the left and right slots of a anvil.
- * If the event is canceled, vanilla behavior will not run, and the output will be set to null.
- * If the event is not canceled, but the output is not null, it will set the output and not run vanilla behavior.
- * if the output is null, and the event is not canceled, vanilla behavior will execute.
+ * AnvilUpdateEvent is fired when the inputs (either input stack, or the name) to an anvil are changed. <br> 
+ * It is called from {@link RepairContainer#updateRepairOutput}. <br>
+ * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
+ * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
+ * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
 @Cancelable
-public class AnvilUpdateEvent extends Event
-{
-    @Nonnull
-    private final ItemStack left;  // The left side of the input
-    @Nonnull
-    private final ItemStack right; // The right side of the input
-    private final String name;     // The name to set the item, if the user specified one.
-    @Nonnull
-    private ItemStack output;      // Set this to set the output stack
-    private int cost;              // The base cost, set this to change it if output != null
-    private int materialCost; // The number of items from the right slot to be consumed during the repair. Leave as 0 to consume the entire stack.
+public class AnvilUpdateEvent extends Event {
 
-    public AnvilUpdateEvent(@Nonnull ItemStack left, @Nonnull ItemStack right, String name, int cost)
+    private final ItemStack left;
+    private final ItemStack right;
+    private final String name;
+    private ItemStack output;
+    private int cost;
+    private int materialCost;
+    @Nullable // TODO: Remove 1.17 - Nullable only in the instance that a mod uses the deprecated ctor.
+    private final PlayerEntity player;
+
+    @Deprecated //TODO: Remove 1.17 - Use Player-contextual constructor below.
+    public AnvilUpdateEvent(ItemStack left, ItemStack right, String name, int cost)
+    {
+        this(left, right, name, cost, null);
+    }
+
+    public AnvilUpdateEvent(ItemStack left, ItemStack right, String name, int cost, PlayerEntity player)
     {
         this.left = left;
         this.right = right;
         this.output = ItemStack.EMPTY;
         this.name = name;
+        this.player = player;
         this.setCost(cost);
         this.setMaterialCost(0);
     }
 
-    @Nonnull
-    public ItemStack getLeft() { return left; }
-    @Nonnull
-    public ItemStack getRight() { return right; }
-    public String getName() { return name; }
-    @Nonnull
-    public ItemStack getOutput() { return output; }
-    public void setOutput(@Nonnull ItemStack output) { this.output = output; }
-    public int getCost() { return cost; }
-    public void setCost(int cost) { this.cost = cost; }
-    public int getMaterialCost() { return materialCost; }
-    public void setMaterialCost(int materialCost) { this.materialCost = materialCost; }
+    /**
+     * @return ihe Item in the left input (leftmost) anvil slot.
+     */
+    public ItemStack getLeft()
+    {
+        return left;
+    }
+
+    /**
+     * @return The item in the right input (center) anvil slot.
+     */
+    public ItemStack getRight()
+    {
+        return right;
+    }
+
+    /**
+     * This is the name as sent by the client.  It may be null if none has been sent. <br>
+     * If empty, it indicates the user wishes to clear the custom name from the item.
+     * @return The name that the output item will be set to, if applicable.
+     */
+    @Nullable
+    public String getName()
+    {
+        return name;
+    }
+
+    /**
+     * This is the output as a result of this event, not of the two items. <br>
+     * If you are the first receiver of this event, it is guaranteed to be empty. <br>
+     * It will only be non-empty if changed by an event handler.
+     * @return The item in the output (rightmost) anvil slot.
+     */
+    public ItemStack getOutput() 
+    {
+        return output;
+    }
+
+    /**
+     * Sets the output slot to a specific itemstack.
+     * @param output The stack to change the output to.
+     */
+    public void setOutput(ItemStack output)
+    {
+        this.output = output;
+    }
+
+    /**
+     * This is the level cost of this anvil operation. <br> 
+     * When unchanged, it is guaranteed to be left.getRepairCost() + right.getRepairCost().
+     * @return The level cost of this anvil operation.
+     */
+    public int getCost()
+    {
+        return cost;
+    }
+
+    /**
+     * Changes the level cost of this operation.
+     * @param cost The new level cost.
+     */
+    public void setCost(int cost)
+    {
+        this.cost = cost;
+    }
+
+    /**
+     * The material cost is how many right inputs are consumed.
+     * @return The material cost of this anvil operation.
+     */
+    public int getMaterialCost()
+    {
+        return materialCost;
+    }
+
+    /**
+     * Sets how many right inputs are consumed. <br>
+     * A material cost of zero consumes the entire stack. <br>
+     * A material cost higher than the count of the right stack
+     * consumes the entire stack. <br>
+     * It does not block the operation.
+     * @param materialCost The new material cost.
+     */
+    public void setMaterialCost(int materialCost)
+    {
+        this.materialCost = materialCost;
+    }
+
+    /**
+     * Nullable in the case someone is using the deprecated constructor.
+     * @return The player using this anvil container.
+     */
+    @Nullable // TODO: Remove 1.17
+    public PlayerEntity getPlayer()
+    {
+        return this.player;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -124,7 +124,9 @@ public class AnvilUpdateEvent extends Event
     }
 
     /**
-     * Changes the level cost of this operation.
+     * Changes the level cost of this operation. <br>
+     * The level cost does prevent the output from being available.  <br>
+     * That is, a player without enough experience may not take the output.
      * @param cost The new level cost.
      */
     public void setCost(int cost)
@@ -146,7 +148,7 @@ public class AnvilUpdateEvent extends Event
      * A material cost of zero consumes the entire stack. <br>
      * A material cost higher than the count of the right stack
      * consumes the entire stack. <br>
-     * It does not block the operation.
+     * The material cost does not prevent the output from being available.
      * @param materialCost The new material cost.
      */
     public void setMaterialCost(int materialCost)


### PR DESCRIPTION
This PR adds the player using the Anvil to the context of the AnvilUpdateEvent.

It also updates the documentation of the event significantly, as it was pretty bare before.  Most of the changes involve the comments (the changes to add the player to the event were rather minor).

The old constructor and old ForgeHooks method have been deprecated as they cannot be removed without causing a breaking change.

The reason for having the player available is as follows:
I was attempting to recreate the vanilla behavior of using the anvil, but with slightly lower numbers as my mod allows for higher enchantments levels to be obtained through normal gameplay.  These higher enchantment levels make it very difficult to use the anvil, but currently, it is impossible to retain vanilla behavior for creative players and still make this modification.  The player using the anvil is required to still allow creative players to do whatever they want (such as putting enchantments on items that normally may not receive them), while still being able to change the vanilla calculations.

Another possible solution to this problem would be to add another event that fires when vanilla's implementation has completed, to allow for that result to be changed or edited.  However, I believe this solution is superior, as there are likely more uses for the player context than my scenario.