### PR TITLE
Add an optional biome palette to chunk data.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/chunk/storage/ChunkSerializer.java
 +++ b/net/minecraft/world/chunk/storage/ChunkSerializer.java
+@@ -67,7 +67,7 @@
+          field_222658_a.error("Chunk file at {} is in the wrong location; relocating. (Expected {}, got {})", p_222656_3_, p_222656_3_, chunkpos);
+       }
+ 
+-      BiomeContainer biomecontainer = new BiomeContainer(p_222656_0_.func_241828_r().func_243612_b(Registry.field_239720_u_), p_222656_3_, biomeprovider, compoundnbt.func_150297_b("Biomes", 11) ? compoundnbt.func_74759_k("Biomes") : null);
++      BiomeContainer biomecontainer = net.minecraftforge.common.ForgeHooks.readBiomeContainer(p_222656_0_, p_222656_3_, biomeprovider, compoundnbt, () -> new BiomeContainer(p_222656_0_.func_241828_r().func_243612_b(Registry.field_239720_u_), p_222656_3_, biomeprovider, compoundnbt.func_150297_b("Biomes", 11) ? compoundnbt.func_74759_k("Biomes") : null));
+       UpgradeData upgradedata = compoundnbt.func_150297_b("UpgradeData", 10) ? new UpgradeData(compoundnbt.func_74775_l("UpgradeData")) : UpgradeData.field_196994_a;
+       ChunkPrimerTickList<Block> chunkprimerticklist = new ChunkPrimerTickList<>((p_222652_0_) -> {
+          return p_222652_0_ == null || p_222652_0_.func_176223_P().func_196958_f();
 @@ -132,6 +132,7 @@
           ichunk = new Chunk(p_222656_0_.func_201672_e(), p_222656_3_, biomecontainer, upgradedata, iticklist, iticklist1, k1, achunksection, (p_222648_1_) -> {
              func_222650_a(compoundnbt, p_222648_1_);
@@ -34,6 +43,15 @@
           return chunkprimer1;
        }
     }
+@@ -274,7 +278,7 @@
+ 
+       BiomeContainer biomecontainer = p_222645_1_.func_225549_i_();
+       if (biomecontainer != null) {
+-         compoundnbt1.func_74783_a("Biomes", biomecontainer.func_227055_a_());
++         net.minecraftforge.common.ForgeHooks.writeBiomeContainer(p_222645_0_, biomecontainer, compoundnbt1);
+       }
+ 
+       ListNBT listnbt1 = new ListNBT();
 @@ -295,12 +299,22 @@
           for(int k = 0; k < chunk.func_177429_s().length; ++k) {
              for(Entity entity : chunk.func_177429_s()[k]) {

--- a/src/test/java/net/minecraftforge/debug/world/BiomeIdOrderTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeIdOrderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeMaker;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(BiomeIdOrderTest.MOD_ID)
+public class BiomeIdOrderTest {
+    public static final boolean ENABLED = true;
+    public static final boolean REVERSED = true;
+    static final String MOD_ID = "biome_id_order_test";
+    private static final Logger LOGGER = LogManager.getLogger();
+    public BiomeIdOrderTest() {
+        if (ENABLED) FMLJavaModLoadingContext.get().getModEventBus().register(this);
+    }
+
+    @SubscribeEvent
+    public void registerBiomes(RegistryEvent.Register<Biome> event) {
+        LOGGER.info("Registering Biomes!");
+        if (REVERSED) {
+            event.getRegistry().registerAll(BiomeMaker.func_244252_r().setRegistryName(MOD_ID, "first_biome"), BiomeMaker.func_244252_r().setRegistryName(MOD_ID, "second_biome"));
+        } else {
+            event.getRegistry().registerAll(BiomeMaker.func_244252_r().setRegistryName(MOD_ID, "second_biome"), BiomeMaker.func_244252_r().setRegistryName(MOD_ID, "first_biome"));
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -92,3 +92,5 @@ license="LGPL v2.1"
     modId="player_game_mode_event_test"
 [[mods]]
     modId="structure_spawn_list_event_test"
+[[mods]]
+    modId="biome_id_order_test"


### PR DESCRIPTION
Okay, so I think the original issue here missed the point. Here is the specific impact of this issue to mods (mine, among others):

1. If a modder *changes the order of their biome registrations*, worlds created before the change may have shuffled biomes.
2. If another mod is added, or removed, worlds created before the change may have shuffled biomes.
3. If a mod adds a biome (without adding or removing mods), worlds created before the change may have shuffled biomes.

In contrast to popular opinion, you can show that this **is not** influenced by forge registry's biome ID mapping as that is done too late to matter in the dynamic registry. I have tested this several times and gotten identical results on this. If there's a better way to fix the behavior as described by the test mod and steps below, (e.g. perhaps making this mapping work?) I'm all ears.

1. Create a new world (Let's call it "First World"). Change the generation to "Single Biome", and select `biome_id_order_test:first_biome`.
2. Observe in F3, the biome is labeled as `biome_id_order_test:first_biome`
3. Quit the game and close Minecraft
4. Change the `REVERSED = false` to `REVERSED = true` in the test mod (or vice versa). All this does is change the order in which the two biomes are registered!
5. Launch the game
6. Load "First World"
7. **Without this fix**: Observe in F3, the biome is now `biome_id_order_test:second_biome`. **With this fix:** the biome is saved and restored correctly.

This addresses <https://bugs.mojang.com/browse/MC-202036>.