### PR TITLE
Fix food bar not rendering when non-living entities are mounted

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -112,7 +112,7 @@ public class ForgeIngameGui extends IngameGui
         this.scaledHeight = this.mc.getMainWindow().getScaledHeight();
         eventParent = new RenderGameOverlayEvent(mStack, partialTicks, this.mc.getMainWindow());
         renderHealthMount = mc.player.getRidingEntity() instanceof LivingEntity;
-        renderFood = mc.player.getRidingEntity() == null;
+        renderFood = !(mc.player.getRidingEntity() instanceof LivingEntity);
         renderJumpBar = mc.player.isRidingHorse();
 
         right_height = 39;

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -112,7 +112,7 @@ public class ForgeIngameGui extends IngameGui
         this.scaledHeight = this.mc.getMainWindow().getScaledHeight();
         eventParent = new RenderGameOverlayEvent(mStack, partialTicks, this.mc.getMainWindow());
         renderHealthMount = mc.player.getRidingEntity() instanceof LivingEntity;
-        renderFood = !(mc.player.getRidingEntity() instanceof LivingEntity);
+        renderFood = !renderHealthMount;
         renderJumpBar = mc.player.isRidingHorse();
 
         right_height = 39;


### PR DESCRIPTION
Reported [on the forums](https://forums.minecraftforge.net/topic/92896-hunger-bar-disappears-when-in-boat/).