### PR TITLE
[1.15] Fix food bar not rendering when non-living entities are mounted

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -111,7 +111,7 @@ public class ForgeIngameGui extends IngameGui
         this.scaledHeight = this.mc.getMainWindow().getScaledHeight();
         eventParent = new RenderGameOverlayEvent(partialTicks, this.mc.getMainWindow());
         renderHealthMount = mc.player.getRidingEntity() instanceof LivingEntity;
-        renderFood = !(mc.player.getRidingEntity() instanceof LivingEntity);
+        renderFood = !renderHealthMount;
         renderJumpBar = mc.player.isRidingHorse();
 
         right_height = 39;

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -111,7 +111,7 @@ public class ForgeIngameGui extends IngameGui
         this.scaledHeight = this.mc.getMainWindow().getScaledHeight();
         eventParent = new RenderGameOverlayEvent(partialTicks, this.mc.getMainWindow());
         renderHealthMount = mc.player.getRidingEntity() instanceof LivingEntity;
-        renderFood = mc.player.getRidingEntity() == null;
+        renderFood = !(mc.player.getRidingEntity() instanceof LivingEntity);
         renderJumpBar = mc.player.isRidingHorse();
 
         right_height = 39;


### PR DESCRIPTION
LTS Backport of https://github.com/MinecraftForge/MinecraftForge/pull/7446.