### PR TITLE
Expanded EarlyLoaderGUI and moved LoadingErrorScreen initialization to allow for flexibility in rendering and potential future upgrades.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -27,7 +27,7 @@
        this.field_147124_at = new Framebuffer(this.field_195558_d.func_198109_k(), this.field_195558_d.func_198091_l(), true, field_142025_a);
        this.field_147124_at.func_147604_a(0.0F, 0.0F, 0.0F, 0.0F);
        this.field_110451_am = new SimpleReloadableResourceManager(ResourcePackType.CLIENT_RESOURCES);
-+      net.minecraftforge.fml.client.ClientModLoader.begin(this, this.field_110448_aq, this.field_110451_am, this.field_195554_ax);
++      net.minecraftforge.fml.client.ClientModLoader.begin(this, this.field_110448_aq, this.field_110451_am, this.field_195554_ax, () -> new net.minecraftforge.fml.client.EarlyLoaderGUI(this.field_195558_d));
        this.field_110448_aq.func_198983_a();
        this.field_71474_y.func_198017_a(this.field_110448_aq);
        this.field_135017_as = new LanguageManager(this.field_71474_y.field_74363_ab);
@@ -66,7 +66,7 @@
                 this.func_213256_aB();
              }
 -
-+            if (net.minecraftforge.fml.client.ClientModLoader.completeModLoading()) return; // Do not overwrite the error screen
++            if (net.minecraftforge.fml.client.ClientModLoader.completeModLoading(net.minecraftforge.fml.client.gui.screen.LoadingErrorScreen::new)) return; // Do not overwrite the error screen
 +            // FORGE: Move opening initial screen to after startup and events are enabled.
 +            // Also Fixes MC-145102
 +            if (s != null) {

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -38,8 +38,8 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 public class EarlyLoaderGUI {
-    private final MainWindow window;
-    private boolean handledElsewhere;
+    protected final MainWindow window;
+    protected boolean handledElsewhere;
 
     public EarlyLoaderGUI(final MainWindow window) {
         this.window = window;
@@ -60,12 +60,12 @@ public class EarlyLoaderGUI {
         this.handledElsewhere = true;
     }
 
-    void renderFromGUI() {
+    protected void renderFromGUI() {
         renderMessages();
     }
 
     @SuppressWarnings("deprecation")
-    void renderTick() {
+    protected void renderTick() {
         if (handledElsewhere) return;
         int guiScale = window.calcGuiScale(0, false);
         window.setGuiScale(guiScale);

--- a/src/main/java/net/minecraftforge/fml/util/TriFunction.java
+++ b/src/main/java/net/minecraftforge/fml/util/TriFunction.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.fml.util;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts three arguments and produces a result.
+ * This is the three-arity specialization of {@link Function}.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a>
+ * whose functional method is {@link #apply(Object, Object, Object)}.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <V> the type of the third argument to the function
+ * @param <R> the type of the result of the function
+ *
+ * @see Function
+ * @since 1.8
+ */
+@FunctionalInterface
+public interface TriFunction <T, U, V, R> {
+
+    R apply(T t, U u, V v);
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <W> the type of output of the {@code after} function, and of the
+     *           composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @Nonnull
+    default <W> TriFunction<T, U, V, W> andThen(Function<? super R, ? extends W> after) {
+        Objects.requireNonNull(after);
+        return (T t, U u, V v) -> after.apply(apply(t, u, v));
+    }
+}


### PR DESCRIPTION
Abstracting out the definition of the EarlyLoaderGUI and allowing for protected access to critical methods and fields allows for flexibility in the rendering pipeline. For example, running on hardware that may require specific opengl calls can now be handled with a subclass of EarlyLoaderGUI instead of having to do context checks in the EarlyLoaderGUI itself. 

This also applies to LoadingErrorScreen, however, this can be expanded more in the future if conditional ErrorScreen's were to be implemented. For example, a warning screen that displays warnings but does not kill the game (registry warnings, missing textures), or a verbose version of the LoadingErrorScreen. 

An argument could be made for implementing these features primarily in ClientModLoader but that could end up creating a large number of unnecessary parameters to begin and completeModLoading. 