### PR TITLE
Don't overwrite PlayerAdvancement's player with a fake one

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -106,7 +106,16 @@
        if (flag2) {
           serverplayerentity.field_71135_a.func_147359_a(new SPlaySoundEffectPacket(SoundEvents.field_232818_ms_, SoundCategory.BLOCKS, (double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p(), 1.0F, 1.0F));
        }
-@@ -786,7 +795,7 @@
+@@ -769,6 +778,8 @@
+          this.field_192055_p.put(uuid, playeradvancements);
+       }
+ 
++      // Forge: don't overwrite active player with a fake one.
++      if (!(p_192054_1_ instanceof net.minecraftforge.common.util.FakePlayer))
+       playeradvancements.func_192739_a(p_192054_1_);
+       return playeradvancements;
+    }
+@@ -786,7 +797,7 @@
     }
  
     public List<ServerPlayerEntity> func_181057_v() {
@@ -115,7 +124,7 @@
     }
  
     @Nullable
-@@ -804,6 +813,7 @@
+@@ -804,6 +815,7 @@
        }
  
        this.func_148540_a(new STagsListPacket(this.field_72400_f.func_244266_aF()));
@@ -123,7 +132,7 @@
        SUpdateRecipesPacket supdaterecipespacket = new SUpdateRecipesPacket(this.field_72400_f.func_199529_aN().func_199510_b());
  
        for(ServerPlayerEntity serverplayerentity : this.field_72404_b) {
-@@ -816,4 +826,12 @@
+@@ -816,4 +828,12 @@
     public boolean func_206257_x() {
        return this.field_72407_n;
     }


### PR DESCRIPTION
If a FakePlayer is constructed with the same UUID/GameProfile as a currently active player, the player object within PlayerAdvancement is set to the fake player.

As fake players cannot receive advancements (see grantCriterion), this prevents the actual player from receiving any advancements until they change dimension/relog.