### PR TITLE
Add support for referencing forge's resources and specifying existing mods to data generators

### DIFF
--- a/patches/minecraft/net/minecraft/data/Main.java.patch
+++ b/patches/minecraft/net/minecraft/data/Main.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/data/Main.java
 +++ b/net/minecraft/data/Main.java
-@@ -21,8 +21,12 @@
+@@ -21,8 +21,13 @@
        OptionSpec<Void> optionspec6 = optionparser.accepts("all", "Include all generators");
        OptionSpec<String> optionspec7 = optionparser.accepts("output", "Output folder").withRequiredArg().defaultsTo("generated");
        OptionSpec<String> optionspec8 = optionparser.accepts("input", "Input folder").withRequiredArg();
 +      OptionSpec<String> existing = optionparser.accepts("existing", "Existing resource packs that generated resources can reference").withRequiredArg();
++      OptionSpec<String> existingMod = optionparser.accepts("existing-mod", "Existing mods that generated resources can reference the resource packs of").withRequiredArg();
 +      OptionSpec<java.io.File> gameDir = optionparser.accepts("gameDir").withRequiredArg().ofType(java.io.File.class).defaultsTo(new java.io.File(".")).required(); //Need by modlauncher, so lets just eat it
 +      OptionSpec<String> mod = optionparser.accepts("mod", "A modid to dump").withRequiredArg().withValuesSeparatedBy(",");
 +      OptionSpec<Void> flat = optionparser.accepts("flat", "Do not append modid prefix to output directory when generating for multiple mods");
@@ -14,7 +15,7 @@
           Path path = Paths.get(optionspec7.value(optionset));
           boolean flag = optionset.has(optionspec6);
           boolean flag1 = flag || optionset.has(optionspec2);
-@@ -30,10 +34,13 @@
+@@ -30,10 +35,14 @@
           boolean flag3 = flag || optionset.has(optionspec3);
           boolean flag4 = flag || optionset.has(optionspec4);
           boolean flag5 = flag || optionset.has(optionspec5);
@@ -24,9 +25,10 @@
 -         datagenerator.func_200392_c();
 +         Collection<Path> inputs = optionset.valuesOf(optionspec8).stream().map(Paths::get).collect(Collectors.toList());
 +         Collection<Path> existingPacks = optionset.valuesOf(existing).stream().map(Paths::get).collect(Collectors.toList());
++         java.util.Set<String> existingMods = new java.util.HashSet<>(optionset.valuesOf(existingMod));
 +         java.util.Set<String> mods = new java.util.HashSet<>(optionset.valuesOf(mod));
 +         boolean isFlat = mods.isEmpty() || optionset.has(flat);
-+         net.minecraftforge.fml.DatagenModLoader.begin(mods, path, inputs, existingPacks, flag2, flag1, flag3, flag4, flag5, isFlat);
++         net.minecraftforge.fml.DatagenModLoader.begin(mods, path, inputs, existingPacks, existingMods, flag2, flag1, flag3, flag4, flag5, isFlat);
 +         if (mods.contains("minecraft") || mods.isEmpty())
 +            func_200264_a(isFlat ? path : path.resolve("minecraft"), inputs, flag1, flag2, flag3, flag4, flag5).func_200392_c();
        } else {

--- a/src/generated_test/resources/.cache/cache
+++ b/src/generated_test/resources/.cache/cache
@@ -79,7 +79,7 @@ cf16f861eaf5815238c2278eb48bde0688cb73b7 assets/scaffolding_test/blockstates/sca
 66442c8000af9af4ba36109b3c9d09d9ffd57277 data/data_gen_test/advancements/recipes/conditional2.json
 ed4cbf1a3a2f5d8969f6346fdc9acdbe81d0c919 data/data_gen_test/recipes/conditional.json
 ca9827bff0a49957e01cf3887ef5131ad8710320 data/data_gen_test/recipes/conditional2.json
-40208299608468b044f64317995f9182ec219d90 data/data_gen_test/tags/blocks/test.json
+8831e79c8d15b1bc00eb29d354bb22b64d9ddcdd data/data_gen_test/tags/blocks/test.json
 d65c425e740dc833f29d16606a1171825876be0d data/data_gen_test/tags/blocks/thing/one.json
 1f70ed4ddc878bada5e43d3c44a34157806beda8 data/data_gen_test/tags/blocks/thing/three.json
 2c648bca262caaa826ddbbde796d35bb2ee5f03a data/data_gen_test/tags/blocks/thing/two.json

--- a/src/generated_test/resources/data/data_gen_test/tags/blocks/test.json
+++ b/src/generated_test/resources/data/data_gen_test/tags/blocks/test.json
@@ -3,6 +3,7 @@
   "values": [
     "minecraft:diamond_block",
     "#minecraft:stone_bricks",
+    "#forge:cobblestone",
     {
       "id": "chisel:marble/raw",
       "required": false

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -47,7 +47,7 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements IDataP
         private final ExistingFileHelper delegate;
 
         public ExistingFileHelperIncludingGenerated(ExistingFileHelper delegate) {
-            super(Collections.emptyList(), Collections.emptySet(), true, false);
+            super(Collections.emptyList(), Collections.emptySet(), true);
             this.delegate = delegate;
         }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -47,7 +47,7 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements IDataP
         private final ExistingFileHelper delegate;
 
         public ExistingFileHelperIncludingGenerated(ExistingFileHelper delegate) {
-            super(Collections.emptyList(), true);
+            super(Collections.emptyList(), Collections.emptySet(), true);
             this.delegate = delegate;
         }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -47,7 +47,7 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements IDataP
         private final ExistingFileHelper delegate;
 
         public ExistingFileHelperIncludingGenerated(ExistingFileHelper delegate) {
-            super(Collections.emptyList(), Collections.emptySet(), true);
+            super(Collections.emptyList(), Collections.emptySet(), true, false);
             this.delegate = delegate;
         }
 

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -56,10 +56,10 @@ public class ExistingFileHelper {
 
     @Deprecated//TODO: Remove in 1.17
     public ExistingFileHelper(Collection<Path> existingPacks, boolean enable) {
-        this(existingPacks, Collections.emptySet(), enable);
+        this(existingPacks, Collections.emptySet(), enable, true);
     }
 
-    public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable) {
+    public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable, boolean includeForge) {
         this.clientResources = new SimpleReloadableResourceManager(ResourcePackType.CLIENT_RESOURCES);
         this.serverData = new SimpleReloadableResourceManager(ResourcePackType.SERVER_DATA);
         this.clientResources.addResourcePack(new VanillaPack("minecraft", "realms"));
@@ -70,10 +70,13 @@ public class ExistingFileHelper {
             this.clientResources.addResourcePack(pack);
             this.serverData.addResourcePack(pack);
         }
-        //Always add forge's resources
-        addModResources("forge");
+        if (includeForge) {
+            addModResources("forge");
+        }
         for (String existingMod : existingMods) {
-            if (!existingMod.equals("forge")) {//Ensure forge only gets added once if someone manually specifies it
+            //Ensure forge only gets added once if someone manually specifies it or if we aren't
+            // automatically adding forge and it gets manually specified as existing
+            if (!includeForge || !existingMod.equals("forge")) {
                 addModResources(existingMod);
             }
         }

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.Collections;
+import java.util.Set;
 import net.minecraft.resources.FilePack;
 import net.minecraft.resources.FolderPack;
 import net.minecraft.resources.IResource;
@@ -35,20 +37,29 @@ import net.minecraft.resources.ResourcePackType;
 import net.minecraft.resources.SimpleReloadableResourceManager;
 import net.minecraft.resources.VanillaPack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
+import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
+import net.minecraftforge.fml.packs.ModFileResourcePack;
 
 /**
  * Enables data providers to check if other data files currently exist. The
  * instance provided in the {@link GatherDataEvent} utilizes the standard
- * resources (via {@link VanillaPack}), as well as any extra resource packs
- * passed in via the {@code --existing} argument.
+ * resources (via {@link VanillaPack}), forge's resources, as well as any
+ * extra resource packs passed in via the {@code --existing} argument,
+ * or mod resources via the {@code --existing-mod} argument.
  */
 public class ExistingFileHelper {
 
     private final SimpleReloadableResourceManager clientResources, serverData;
     private final boolean enable;
 
+    @Deprecated//TODO: Remove in 1.17
     public ExistingFileHelper(Collection<Path> existingPacks, boolean enable) {
+        this(existingPacks, Collections.emptySet(), enable);
+    }
+
+    public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable) {
         this.clientResources = new SimpleReloadableResourceManager(ResourcePackType.CLIENT_RESOURCES);
         this.serverData = new SimpleReloadableResourceManager(ResourcePackType.SERVER_DATA);
         this.clientResources.addResourcePack(new VanillaPack("minecraft", "realms"));
@@ -58,8 +69,24 @@ public class ExistingFileHelper {
             IResourcePack pack = file.isDirectory() ? new FolderPack(file) : new FilePack(file);
             this.clientResources.addResourcePack(pack);
             this.serverData.addResourcePack(pack);
-        };
+        }
+        //Always add forge's resources
+        addModResources("forge");
+        for (String existingMod : existingMods) {
+            if (!existingMod.equals("forge")) {//Ensure forge only gets added once if someone manually specifies it
+                addModResources(existingMod);
+            }
+        }
         this.enable = enable;
+    }
+
+    private void addModResources(String modid) {
+        ModFileInfo modFileInfo = ModList.get().getModFileById(modid);
+        if (modFileInfo != null) {
+            IResourcePack pack = new ModFileResourcePack(modFileInfo.getFile());
+            this.clientResources.addResourcePack(pack);
+            this.serverData.addResourcePack(pack);
+        }
     }
 
     private IResourceManager getManager(ResourcePackType type) {

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -56,10 +56,10 @@ public class ExistingFileHelper {
 
     @Deprecated//TODO: Remove in 1.17
     public ExistingFileHelper(Collection<Path> existingPacks, boolean enable) {
-        this(existingPacks, Collections.emptySet(), enable, true);
+        this(existingPacks, Collections.emptySet(), enable);
     }
 
-    public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable, boolean includeForge) {
+    public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable) {
         this.clientResources = new SimpleReloadableResourceManager(ResourcePackType.CLIENT_RESOURCES);
         this.serverData = new SimpleReloadableResourceManager(ResourcePackType.SERVER_DATA);
         this.clientResources.addResourcePack(new VanillaPack("minecraft", "realms"));
@@ -70,26 +70,15 @@ public class ExistingFileHelper {
             this.clientResources.addResourcePack(pack);
             this.serverData.addResourcePack(pack);
         }
-        if (includeForge) {
-            addModResources("forge");
-        }
         for (String existingMod : existingMods) {
-            //Ensure forge only gets added once if someone manually specifies it or if we aren't
-            // automatically adding forge and it gets manually specified as existing
-            if (!includeForge || !existingMod.equals("forge")) {
-                addModResources(existingMod);
+            ModFileInfo modFileInfo = ModList.get().getModFileById(existingMod);
+            if (modFileInfo != null) {
+                IResourcePack pack = new ModFileResourcePack(modFileInfo.getFile());
+                this.clientResources.addResourcePack(pack);
+                this.serverData.addResourcePack(pack);
             }
         }
         this.enable = enable;
-    }
-
-    private void addModResources(String modid) {
-        ModFileInfo modFileInfo = ModList.get().getModFileById(modid);
-        if (modFileInfo != null) {
-            IResourcePack pack = new ModFileResourcePack(modFileInfo.getFile());
-            this.clientResources.addResourcePack(pack);
-            this.serverData.addResourcePack(pack);
-        }
     }
 
     private IResourceManager getManager(ResourcePackType type) {

--- a/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
@@ -52,7 +52,11 @@ public class DatagenModLoader {
         Bootstrap.register();
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
         ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
-        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator, !mods.contains("forge"));
+        if (!mods.contains("forge")) {
+            //If we aren't generating data for forge, automatically add forge as an existing so mods can access forge's data
+            existingMods.add("forge");
+        }
+        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator);
         ModLoader.get().runEventGenerator(mc->new GatherDataEvent(mc, dataGeneratorConfig.makeGenerator(p->dataGeneratorConfig.isFlat() ? p : p.resolve(mc.getModId()), dataGeneratorConfig.getMods().contains(mc.getModId())), dataGeneratorConfig, existingFileHelper));
         dataGeneratorConfig.runAll();
     }

--- a/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
@@ -52,7 +52,7 @@ public class DatagenModLoader {
         Bootstrap.register();
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
         ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
-        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator);
+        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator, !mods.contains("forge"));
         ModLoader.get().runEventGenerator(mc->new GatherDataEvent(mc, dataGeneratorConfig.makeGenerator(p->dataGeneratorConfig.isFlat() ? p : p.resolve(mc.getModId()), dataGeneratorConfig.getMods().contains(mc.getModId())), dataGeneratorConfig, existingFileHelper));
         dataGeneratorConfig.runAll();
     }

--- a/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml;
 
+import java.util.Collections;
 import net.minecraft.util.registry.Bootstrap;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
@@ -39,14 +40,19 @@ public class DatagenModLoader {
         return runningDataGen;
     }
 
-    public static void begin(final Set<String> mods, final Path path, final java.util.Collection<Path> inputs, Collection<Path> existingPacks, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final boolean structureValidator, final boolean flat) {
+    @Deprecated //TODO: Remove in 1.17
+    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final boolean structureValidator, final boolean flat) {
+        begin(mods, path, inputs, existingPacks, Collections.emptySet(), serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
+    }
+
+    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final boolean structureValidator, final boolean flat) {
         if (mods.contains("minecraft") && mods.size() == 1) return;
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;
         Bootstrap.register();
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
-        existingFileHelper = new ExistingFileHelper(existingPacks, structureValidator);
         ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
+        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator);
         ModLoader.get().runEventGenerator(mc->new GatherDataEvent(mc, dataGeneratorConfig.makeGenerator(p->dataGeneratorConfig.isFlat() ? p : p.resolve(mc.getModId()), dataGeneratorConfig.getMods().contains(mc.getModId())), dataGeneratorConfig, existingFileHelper));
         dataGeneratorConfig.runAll();
     }

--- a/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
+++ b/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
@@ -214,6 +214,7 @@ public class DataGeneratorTest
             getOrCreateBuilder(BlockTags.makeWrapperTag(new ResourceLocation(MODID, "test").toString()))
                 .addItemEntry(Blocks.DIAMOND_BLOCK)
                 .addTag(BlockTags.STONE_BRICKS)
+                .addTag(net.minecraftforge.common.Tags.Blocks.COBBLESTONE)
                 .addOptional(new ResourceLocation("chisel", "marble/raw"))
                 .addOptionalTag(new ResourceLocation("forge", "storage_blocks/ruby"));
 


### PR DESCRIPTION
This PR adds support for declaring that a mod's resources should be added to the existing file helper's resource check b adding an `--existing-mod` argument that takes a modid. This PR also auto-adds forge as an existing mod so that modders can reference forge resources from their data generators without having running into errors, similar to how vanilla resources can be referenced.