### PR TITLE
Deprecate Forge's setdimension command

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -19,13 +19,6 @@
 
 package net.minecraftforge.server.command;
 
-import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.context.ParsedCommandNode;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import com.mojang.brigadier.tree.ArgumentCommandNode;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
 import net.minecraft.command.arguments.BlockPosArgument;
@@ -34,11 +27,18 @@ import net.minecraft.command.arguments.EntityArgument;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponentUtils;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.util.text.event.ClickEvent;
 import net.minecraft.world.server.ServerWorld;
+
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedCommandNode;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
 
 import java.util.Collection;
 

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -19,6 +19,13 @@
 
 package net.minecraftforge.server.command;
 
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedCommandNode;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
 import net.minecraft.command.arguments.BlockPosArgument;
@@ -26,18 +33,17 @@ import net.minecraft.command.arguments.DimensionArgument;
 import net.minecraft.command.arguments.EntityArgument;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentUtils;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.util.text.event.ClickEvent;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraftforge.common.util.ITeleporter;
-
-import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 
 import java.util.Collection;
-import java.util.function.Function;
 
+/** @deprecated For removal in 1.17, superseded by {@code /execute in <dim> run tp <targets>} */
+@Deprecated
 public class CommandSetDimension
 {
     private static final SimpleCommandExceptionType NO_ENTITIES = new SimpleCommandExceptionType(new TranslationTextComponent("commands.forge.setdim.invalid.entity"));
@@ -49,34 +55,37 @@ public class CommandSetDimension
             .then(Commands.argument("targets", EntityArgument.entities())
                 .then(Commands.argument("dim", DimensionArgument.getDimension())
                     .then(Commands.argument("pos", BlockPosArgument.blockPos())
-                        .executes(ctx -> execute(ctx.getSource(), EntityArgument.getEntitiesAllowingNone(ctx, "targets"), DimensionArgument.getDimensionArgument(ctx, "dim"), BlockPosArgument.getBlockPos(ctx, "pos")))
+                        .executes(ctx -> execute(ctx, EntityArgument.getEntitiesAllowingNone(ctx, "targets"), DimensionArgument.getDimensionArgument(ctx, "dim"), BlockPosArgument.getBlockPos(ctx, "pos")))
                     )
-                    .executes(ctx -> execute(ctx.getSource(), EntityArgument.getEntitiesAllowingNone(ctx, "targets"), DimensionArgument.getDimensionArgument(ctx, "dim"), new BlockPos(ctx.getSource().getPos())))
+                    .executes(ctx -> execute(ctx, EntityArgument.getEntitiesAllowingNone(ctx, "targets"), DimensionArgument.getDimensionArgument(ctx, "dim"), new BlockPos(ctx.getSource().getPos())))
                 )
             );
     }
 
-    private static int execute(CommandSource sender, Collection<? extends Entity> entities, ServerWorld dim, BlockPos pos) throws CommandSyntaxException
+    private static int execute(CommandContext<CommandSource> ctx, Collection<? extends Entity> entities, ServerWorld dim, BlockPos pos) throws CommandSyntaxException
     {
         entities.removeIf(e -> !canEntityTeleport(e));
         if (entities.isEmpty())
             throw NO_ENTITIES.create();
 
+        String cmdTarget = "@s";
+        for (ParsedCommandNode<CommandSource> parsed : ctx.getNodes())
+        {
+            if (parsed.getNode() instanceof ArgumentCommandNode && "targets".equals(parsed.getNode().getName()))
+            {
+                cmdTarget = parsed.getRange().get(ctx.getInput());
+                break;
+            }
+        }
+
+        final String dimName = dim.getDimensionKey().getLocation().toString();
+        final String finalCmdTarget = cmdTarget;
+        ITextComponent suggestion = new TranslationTextComponent("/execute in %s run tp %s", dimName, cmdTarget)
+                .modifyStyle((style) -> style.setFormatting(TextFormatting.GREEN).setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget)));
+        ctx.getSource().sendFeedback(new TranslationTextComponent("commands.forge.setdim.deprecated", suggestion), true);
+
         //if (!DimensionManager.isDimensionRegistered(dim))
         //    throw INVALID_DIMENSION.create(dim);
-
-        entities.stream().filter(e -> e.world == dim).forEach(e -> sender.sendFeedback(new TranslationTextComponent("commands.forge.setdim.invalid.nochange", e.getDisplayName().getString(), dim), true));
-        entities.stream().filter(e -> e.world != dim).forEach(e ->  e.changeDimension(dim , new ITeleporter()
-        {
-            @Override
-            public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
-            {
-                Entity repositionedEntity = repositionEntity.apply(false);
-                repositionedEntity.setPositionAndUpdate(pos.getX(), pos.getY(), pos.getZ());
-                return repositionedEntity;
-            }
-        }));
-
 
         return 0;
     }

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -93,9 +93,6 @@ public class CommandSetDimension
                 .modifyStyle((style) -> style.setFormatting(TextFormatting.GREEN).setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget + finalPosTarget)));
         ctx.getSource().sendFeedback(new TranslationTextComponent("commands.forge.setdim.deprecated", suggestion), true);
 
-        //if (!DimensionManager.isDimensionRegistered(dim))
-        //    throw INVALID_DIMENSION.create(dim);
-
         return 0;
     }
 

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -39,6 +39,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.Collection;
 
@@ -69,19 +70,27 @@ public class CommandSetDimension
             throw NO_ENTITIES.create();
 
         String cmdTarget = "@s";
+        String posTarget = "";
         for (ParsedCommandNode<CommandSource> parsed : ctx.getNodes())
         {
-            if (parsed.getNode() instanceof ArgumentCommandNode && "targets".equals(parsed.getNode().getName()))
+            final CommandNode<CommandSource> node = parsed.getNode();
+            if (parsed.getNode() instanceof ArgumentCommandNode)
             {
-                cmdTarget = parsed.getRange().get(ctx.getInput());
-                break;
+                if ("target".equals(parsed.getNode().getName()))
+                {
+                    cmdTarget = parsed.getRange().get(ctx.getInput());
+                }
+                else if ("pos".equals(parsed.getNode().getName()))
+                {
+                    posTarget = " " + parsed.getRange().get(ctx.getInput());
+                }
             }
         }
-
         final String dimName = dim.getDimensionKey().getLocation().toString();
         final String finalCmdTarget = cmdTarget;
-        ITextComponent suggestion = new TranslationTextComponent("/execute in %s run tp %s", dimName, cmdTarget)
-                .modifyStyle((style) -> style.setFormatting(TextFormatting.GREEN).setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget)));
+        final String finalPosTarget = posTarget;
+        ITextComponent suggestion = new TranslationTextComponent("/execute in %s run tp %s%s", dimName, cmdTarget, finalPosTarget)
+                .modifyStyle((style) -> style.setFormatting(TextFormatting.GREEN).setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget + finalPosTarget)));
         ctx.getSource().sendFeedback(new TranslationTextComponent("commands.forge.setdim.deprecated", suggestion), true);
 
         //if (!DimensionManager.isDimensionRegistered(dim))

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -96,6 +96,7 @@
   "commands.forge.setdim.invalid.entity": "The entity selected ({0}) is not valid.",
   "commands.forge.setdim.invalid.dim": "The dimension ID specified ({0}) is not valid.",
   "commands.forge.setdim.invalid.nochange": "The entity selected ({0}) is already in the dimension specified ({1}).",
+  "commands.forge.setdim.deprecated": "This command is deprecated for removal in 1.17, use %s instead.",
   "commands.forge.tps.invalid": "Invalid dimension {0} Possible values: {1}",
   "commands.forge.tps.summary.all": "Overall: Mean tick time: {0} ms. Mean TPS: {1}",
   "commands.forge.mods.list": "Mod List: {0}",


### PR DESCRIPTION
The `/forge setdimension <targets> <dim> [pos]` has some issues previously, as described in issue #7254, which meant that it was effectively unusable. It was found that an alternative way was using `/execute in <dim> run tp <targets> [pos]`, and it was the temporary workaround until a fix was in place for `/forge setdimension`.

Although the issue is now fixed, it raises the question of whether `/forge setdimension` should still exist, as it has a better replacement in the form of the given `/execute` command, which only uses vanilla commands, and is more flexible (such as using the other capabilities of the `/execute` command).

PR #7457 was made to remove the `/forge setdimension` command in 1.17, but it did not address the current situation of `/forge setdimension` in 1.16 (as it was deemed by the author to be outside the scope of the PR _to which I agree_). If the command was to be removed without warning, users and server admins who are used to using that command will be confused in 1.17 when the command is removed.

Therefore, to remedy this problem, this PR does the following:
  * Marks `CommandSetDimension` as **deprecated**, for removal in 1.17 by the previously linked PR.
  * Modifies the behavior of `CommandSetDimension` to instead print a message to chat about the command's deprecation and removal in 1.17, and the new alternative in the form of `/execute in <dim> run tp <targets> [position]`.
    ![image of the message in chat](https://media.discordapp.net/attachments/540691915373412393/773149931212111922/unknown.png)
    * The command shown in the message is dynamically adjusted according to the parameters given to the `/forge setdimension` command. _(the image is a bit outdated, ignore the brackets surrounding the command)_
    ![image of the three messages in chat, each with different commands shown](https://media.discordapp.net/attachments/540691915373412393/773147674413105152/unknown.png)
    * The command shown in the message can also be clicked to insert the command into the client's chat window automatically, to allow ease of transitioning to the new command.
    ![image of the command shown in the message, now in the client's chat bar](https://media.discordapp.net/attachments/540691915373412393/773150440081981450/unknown.png)

_Notes:_
  * The translation entry (`commands.forge.setdim.deprecated`) uses `%s` instead of `{0}`, because the Forge formatting using `{0}` does not correctly output the result of the TranslationTextComponent to chat, instead outputting a semi-garbled message.
<details>
<summary>Output of the command when using <code>{0}</code> in the translation entry</summary>
<code>
This command is deprecated for removal in 1.17, use TranslatableComponent{key='chat.square_brackets', args=[TranslatableComponent{key='/execute in %s run tp %s', args=[minecraft:overworld, @s], siblings=[], style=Style{ color=null, bold=null, italic=null, underlined=null, strikethrough=null, obfuscated=null, clickEvent=null, hoverEvent=null, insertion=null, font=minecraft:default}}], siblings=[], style=Style{ color=green, bold=null, italic=null, underlined=null, strikethrough=null, obfuscated=null, clickEvent=ClickEvent{action=SUGGEST_COMMAND, value='/execute in minecraft:overworld run tp @s'}, hoverEvent=null, insertion=null, font=minecraft:default}} instead.
</code>
</details>

  * The method signature in `CommandSetDimension` was altered to pass in the `CommandContext<CommandSource>` instead of the `CommandSource` directly, to implement the dynamically-adjusted shown command. As this is in a `private static` method, this should not cause any issues with binary compatibility.
  * The original translation keys are kept in the language files for now, since older versions use these keys too. I do not know when to remove these translation keys, as that is linked with Crowdin; this matter should be consulted with Forge's Triage team first.