### PR TITLE
Add annotation-based tools for dist-based implementation of methods

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeSidedImplementor.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeSidedImplementor.java
@@ -1,0 +1,405 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.asm;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.AdvancedLogMessageAdapter;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
+
+/**
+ * Modifies specified enums to allow runtime extension by making the $VALUES field non-final and
+ * injecting constructor calls which are not valid in normal java code.
+ */
+public class RuntimeSidedImplementor implements ILaunchPluginService
+{
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Marker DISTINJECT = MarkerManager.getMarker("DISTINJECT");
+    private static String DIST;
+    private static final Type IMPLEMENT_ON = Type.getType("Lnet/minecraftforge/fml/ImplementOn;");
+
+    @Override
+    public String name()
+    {
+        return "runtimesidedimplementer";
+    }
+
+    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
+    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Consumer<Dist> getExtension()
+    {
+        return s ->
+        {
+            DIST = s.name();
+            LOGGER.debug(DISTINJECT, "Configuring for Dist {}", DIST);
+        };
+    }
+
+    @Override
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty)
+    {
+        return isEmpty ? NAY : YAY;
+    }
+
+    private boolean hasImplementOn(List<AnnotationNode> annotations)
+    {
+        return annotations != null && annotations.stream().anyMatch(annotation -> IMPLEMENT_ON.equals(Type.getType(annotation.desc)));
+    }
+
+    private AnnotationNode findImplementsOn(MethodNode node)
+    {
+        if (node.invisibleAnnotations != null)
+        {
+            AnnotationNode found = node.invisibleAnnotations.stream()
+                    .filter(annotation -> IMPLEMENT_ON.equals(Type.getType(annotation.desc)))
+                    .findFirst()
+                    .orElse(null);
+
+            if (found != null)
+                return found;
+        }
+
+        if (node.visibleAnnotations != null)
+        {
+            return node.visibleAnnotations.stream()
+                    .filter(annotation -> IMPLEMENT_ON.equals(Type.getType(annotation.desc)))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null;
+    }
+
+    private static Object getAnnotationValue(AnnotationNode annotation, String parameter)
+    {
+        List<Object> values = annotation.values;
+        for (int i = 0, l = values.size(); i < l; i += 2)
+        {
+            if (values.get(i).equals(parameter))
+                return values.get(i + 1);
+        }
+        return null;
+    }
+
+    // Scans method instructions for a call to an ImplementOn annotated method, relying on the predicate that checks that
+    private static void checkMethodCall(ClassNode owner, MethodNode method, Predicate<String> implementOnCheck)
+    {
+        for (AbstractInsnNode insn : method.instructions)
+        {
+            if (insn instanceof MethodInsnNode)
+            {
+                MethodInsnNode methodInsn = (MethodInsnNode) insn;
+
+                if (owner.name.equals(methodInsn.owner) && implementOnCheck.test(methodInsn.name + methodInsn.desc))
+                {
+                    LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                        sb.append("Found manual call to ImplementOn annotated method:\n");
+                        sb.append("  Class: ").append(owner.name).append("\n");
+                        sb.append("  In:    ").append(method.name).append(method.desc).append("\n");
+                        sb.append("  To:    ").append(methodInsn.name).append(methodInsn.desc);
+                    }));
+                    throw new IllegalStateException("Manual ImplementOn call: " + methodInsn.name + methodInsn.desc);
+                }
+            }
+        }
+    }
+
+    @Override
+    public int processClassWithFlags(final Phase phase, final ClassNode classNode, final Type classType, final String reason)
+    {
+        if((classNode.access & Opcodes.ACC_ANNOTATION) != 0)
+            return ComputeFlags.NO_REWRITE; // Skip annotation classes
+
+        // Methods by name and desc, i.e. by 'methodname(Ldescriptor;)V' like strings
+        Map<String, MethodNode> methodsByNameDesc = new HashMap<>();
+        classNode.methods.forEach(mtd -> methodsByNameDesc.put(mtd.name + mtd.desc, mtd));
+
+        // Methods with ImplementOn annotation
+        List<MethodNode> implementations = classNode.methods.stream()
+                .filter(mtd -> hasImplementOn(mtd.visibleAnnotations) || hasImplementOn(mtd.invisibleAnnotations))
+                .collect(Collectors.toList());
+
+        if (implementations.isEmpty())
+        {
+            return ComputeFlags.NO_REWRITE;
+        }
+
+        // A set of name-desc strings of all methods with ImplementOn annotation
+        // Since we strip ImplementOn methods on wrong dists, we must first precheck if any method uses them and throw an
+        // exception if so
+        Set<String> implNameDescs = implementations.stream()
+                .map(mtd -> mtd.name + mtd.desc)
+                .collect(Collectors.toSet());
+
+        // Since checking all instructions of a class on load is much work, do it only on development workspace
+        if (!FMLEnvironment.production)
+            classNode.methods.forEach(mtd -> checkMethodCall(classNode, mtd, implNameDescs::contains));
+
+        // What methods will be delegated to what other methods
+        List<Delegation> delegations = new ArrayList<>();
+        List<MethodNode> removals = new ArrayList<>();
+
+        // Targeted methods, to ensure a method is only targeted once
+        Set<String> targeted = new HashSet<>();
+
+        implementations.forEach(method ->
+        {
+            AnnotationNode annotation = findImplementsOn(method);
+            if (annotation == null)
+                return; // Annotation is never null because we filtered methods with this annotation already, still skip it so that IDE is happy
+
+            String[] distPar = (String[]) getAnnotationValue(annotation, "dist");
+            String targetName = (String) getAnnotationValue(annotation, "method");
+
+            // The nature of ImplementOn annotation already prevents these from being null
+            assert distPar != null;
+            assert targetName != null;
+
+            // Use our descriptor since they must be equal
+            String nameDesc = targetName + method.desc;
+
+            // Annotated method must be private
+            if ((method.access & Opcodes.ACC_PRIVATE) == 0)
+            {
+                LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                    sb.append("ImplementOn method must be private:\n");
+                    sb.append("  Class:  ").append(classNode.name).append("\n");
+                    sb.append("  Method: ").append(method.name).append(method.desc);
+                }));
+                throw new IllegalStateException("Non-private ImplementOn method: " + method.name + method.desc);
+            }
+
+            // Find target, error if not found
+            // This also checks if descriptors match, which is mandatory
+            MethodNode target = methodsByNameDesc.get(nameDesc);
+            if (target == null)
+            {
+                LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                    sb.append("Could not find matching ImplementOn method:\n");
+                    sb.append("  Class:  ").append(classNode.name).append("\n");
+                    sb.append("  Method: ").append(method.name).append(method.desc).append("\n");
+                    sb.append("  Target: ").append(targetName).append(method.desc).append("\n");
+                    sb.append("Ensure that the arguments and return type of the ImplementOn method match that of the target method");
+                }));
+                throw new IllegalStateException("ImplementOn target not found: " + targetName + method.desc);
+            }
+
+            // One must not implement a method that is ImplementOn itself
+            if(hasImplementOn(target.invisibleAnnotations) || hasImplementOn(target.visibleAnnotations)) {
+                LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                    sb.append("Matching ImplementOn method is an ImplementOn method itself:\n");
+                    sb.append("  Class:  ").append(classNode.name).append("\n");
+                    sb.append("  Method: ").append(method.name).append(method.desc).append("\n");
+                    sb.append("  Target: ").append(targetName).append(method.desc).append("\n");
+                    sb.append("Ensure that the arguments and return type of the ImplementOn method match that of the target method");
+                }));
+                throw new IllegalStateException("ImplementOn target not found: " + targetName + method.desc);
+            }
+
+            // Check 'static' modifiers, which must match
+            if ((target.access & Opcodes.ACC_STATIC) != (method.access & Opcodes.ACC_STATIC))
+            {
+                LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                    sb.append("'static' modifiers of ImplementOn method and target method do not match:\n");
+                    sb.append("  Class:  ").append(classNode.name).append("\n");
+                    sb.append("  Method: ").append(method.name).append(method.desc)
+                            .append(", Static: ").append((method.access & Opcodes.ACC_STATIC) != 0).append("\n");
+                    sb.append("  Target: ").append(target.name).append(target.desc)
+                            .append(", Static: ").append((target.access & Opcodes.ACC_STATIC) != 0);
+                }));
+                throw new IllegalStateException("ImplementOn target does not have same 'static' modifier: " + target.name + target.desc);
+            }
+
+            if (distPar[1].equals(DIST))
+            {
+                // Ensure only one ImplementOn matches target
+                if (targeted.contains(nameDesc))
+                {
+                    LOGGER.fatal(() -> new AdvancedLogMessageAdapter(sb -> {
+                        sb.append("Method is targeted twice by ImplementOn annotation from the same dist:\n");
+                        sb.append("  Class:  ").append(classNode.name).append("\n");
+                        sb.append("  Method: ").append(method.name).append(method.desc).append("\n");
+                        sb.append("  Target: ").append(target.name).append(target.desc).append("\n");
+                        sb.append("  Dist:   ").append(DIST);
+                    }));
+                    throw new IllegalStateException("ImplementOn target does not have same 'static' modifier: " + target.name + target.desc);
+                }
+
+                targeted.add(nameDesc);
+                delegations.add(new Delegation(classNode, target, method));
+            } else {
+                removals.add(method);
+            }
+
+        });
+
+        // Last skip if no delegations or removals were found - often does not happen but we go for perfection
+        if (delegations.isEmpty() && removals.isEmpty())
+        {
+            return ComputeFlags.NO_REWRITE;
+        }
+
+        // Inject all delegations
+        for (Delegation delegation : delegations)
+        {
+            delegation.inject();
+        }
+
+        return ComputeFlags.SIMPLE_REWRITE;
+    }
+
+    private static class Delegation
+    {
+        private final ClassNode owner;
+        private final MethodNode incidence;
+        private final MethodNode reference;
+
+        private Delegation(ClassNode owner, MethodNode incidence, MethodNode reference)
+        {
+            this.owner = owner;
+            this.incidence = incidence;
+            this.reference = reference;
+        }
+
+        public void inject()
+        {
+            LOGGER.debug(DISTINJECT, "Injecting implementation {}{} into {}{} for dist {}",
+                    reference.name, reference.desc, incidence.name, incidence.desc, DIST);
+
+            boolean iface = (owner.access & Opcodes.ACC_INTERFACE) != 0;
+            boolean virtual = (reference.access & Opcodes.ACC_STATIC) == 0;
+
+            // Remove abstract or native modifier (which might be used to strip the method body)
+            incidence.access &= ~Opcodes.ACC_ABSTRACT;
+            incidence.access &= ~Opcodes.ACC_NATIVE;
+
+            InsnList newInsns = new InsnList();
+
+            // Push arguments
+            Type[] args = Type.getArgumentTypes(incidence.desc);
+            Type ret = Type.getReturnType(incidence.desc);
+
+            int localIndex = 0;
+            if (virtual) // Push 'this'
+                newInsns.add(new VarInsnNode(Opcodes.ALOAD, localIndex++));
+
+            for (Type arg : args)
+            {
+                newInsns.add(new VarInsnNode(loadOpcode(arg), localIndex));
+                localIndex += arg.getSize();
+            }
+
+            // Call target method
+            MethodInsnNode invoke = new MethodInsnNode(
+                    virtual ? Opcodes.INVOKEVIRTUAL : Opcodes.INVOKESTATIC,
+                    owner.name, reference.name, reference.desc, iface);
+            newInsns.add(invoke);
+
+            // Return value
+            newInsns.add(new InsnNode(returnOpcode(ret)));
+
+            // Set new instructions, stripping the complete method body if one was defined
+            incidence.instructions = newInsns;
+
+            // Since localIndex counted all local variable sizes, it is now the correct value of maxLocals
+            incidence.maxLocals = localIndex;
+
+            // This amount of local variables is also the size we need for the stack, but we have to ensure
+            // that there is also space for the return value after calling the method, hence maxing it with
+            // the return value size (max is enough since the invocation will consume everything in the stack)
+            incidence.maxStack = Math.max(localIndex, ret.getSize());
+        }
+
+        // Gets the correct LOAD opcode for the given argument type
+        private static int loadOpcode(Type type)
+        {
+            switch (type.getSort())
+            {
+            case Type.BOOLEAN:
+            case Type.CHAR:
+            case Type.BYTE:
+            case Type.SHORT:
+            case Type.INT:
+                return Opcodes.ILOAD;
+            case Type.LONG:
+                return Opcodes.LLOAD;
+            case Type.FLOAT:
+                return Opcodes.FLOAD;
+            case Type.DOUBLE:
+                return Opcodes.DLOAD;
+            }
+            return Opcodes.ALOAD;
+        }
+
+        // Gets the correct RETURN opcode for the given return type
+        private static int returnOpcode(Type type)
+        {
+            switch (type.getSort())
+            {
+            case Type.VOID:
+                return Opcodes.RETURN;
+            case Type.BOOLEAN:
+            case Type.CHAR:
+            case Type.BYTE:
+            case Type.SHORT:
+            case Type.INT:
+                return Opcodes.IRETURN;
+            case Type.LONG:
+                return Opcodes.LRETURN;
+            case Type.FLOAT:
+                return Opcodes.FRETURN;
+            case Type.DOUBLE:
+                return Opcodes.DRETURN;
+            }
+            return Opcodes.ARETURN;
+        }
+    }
+}

--- a/src/fmllauncher/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
+++ b/src/fmllauncher/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
@@ -1,4 +1,5 @@
 net.minecraftforge.fml.loading.RuntimeDistCleaner
 net.minecraftforge.common.asm.RuntimeEnumExtender
+net.minecraftforge.common.asm.RuntimeSidedImplementor
 net.minecraftforge.common.asm.ObjectHolderDefinalize
 net.minecraftforge.common.asm.CapabilityInjectDefinalize

--- a/src/main/java/net/minecraftforge/fml/ImplementOn.java
+++ b/src/main/java/net/minecraftforge/fml/ImplementOn.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.fml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.minecraftforge.api.distmarker.Dist;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface ImplementOn {
+    Dist dist();
+    String method();
+}

--- a/src/test/java/net/minecraftforge/debug/misc/ImplementOnTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/ImplementOnTest.java
@@ -1,0 +1,90 @@
+package net.minecraftforge.debug.misc;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.ImplementOn;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(ImplementOnTest.MODID)
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class ImplementOnTest
+{
+    public static final String MODID = "implement_on_test";
+
+    public ImplementOnTest() {
+        method1();
+        method2();
+        System.out.println("method3: result = " + method3());
+        System.out.println("method4: result = " + method4(5, 10));
+    }
+
+
+    // TEST virtual WITH void RETURN TYPE AND no ARGUMENTS
+
+    public void method1() {
+
+    }
+
+    @ImplementOn(dist = Dist.CLIENT, method = "method1")
+    private void method1_client() {
+        System.out.println("method1: Client implementation");
+    }
+
+    @ImplementOn(dist = Dist.DEDICATED_SERVER, method = "method1")
+    private void method1_server() {
+        System.out.println("method1: Server implementation");
+    }
+
+
+
+    // TEST static WITH void RETURN TYPE AND no ARGUMENTS
+
+    public static void method2() {
+
+    }
+
+    @ImplementOn(dist = Dist.CLIENT, method = "method2")
+    private static void method2_client() {
+        System.out.println("method2: Client implementation");
+    }
+
+    @ImplementOn(dist = Dist.DEDICATED_SERVER, method = "method2")
+    private static void method2_server() {
+        System.out.println("method2: Server implementation");
+    }
+
+
+
+    // TEST static WITH int RETURN TYPE AND no ARGUMENTS
+
+    public static int method3() {
+        return 0;
+    }
+
+    @ImplementOn(dist = Dist.CLIENT, method = "method3")
+    private static int method3_client() {
+        return 3;
+    }
+
+    @ImplementOn(dist = Dist.DEDICATED_SERVER, method = "method3")
+    private static int method3_server() {
+        return 6;
+    }
+
+
+
+    // TEST virtual WITH int RETURN TYPE AND 2 ARGUMENTS
+
+    public int method4(int a, int b) {
+        return 0;
+    }
+
+    @ImplementOn(dist = Dist.CLIENT, method = "method4")
+    private int method4_client(int a, int b) {
+        return a + b;
+    }
+
+    @ImplementOn(dist = Dist.DEDICATED_SERVER, method = "method4")
+    private int method4_server(int a, int b) {
+        return a * b;
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -92,3 +92,11 @@ license="LGPL v2.1"
     modId="player_game_mode_event_test"
 [[mods]]
     modId="structure_spawn_list_event_test"
+[[mods]]
+    modId="implement_on_test"
+[[dependencies.implement_on_test]]
+    modId="forge"
+    mandatory=true
+    versionRange="[1,)"
+    ordering="AFTER"
+    side="BOTH"


### PR DESCRIPTION
Today I ran into the annoying coding style issue that you have to create a complete new class just for calling a client-only method if available. Because this makes code very very ugly I created a different approach:

A new `@ImplementOn` annotation can specify a method in the same class to be overwritten by another method when on a specific `Dist`. For example:

```java
    public void myMethod() {

    }

    @ImplementOn(dist = Dist.CLIENT, method = "myMethod")
    private void myMethod_client() {
        System.out.println("Client implementation");
    }

    @ImplementOn(dist = Dist.DEDICATED_SERVER, method = "myMethod")
    private void myMethod_server() {
        System.out.println("Server implementation");
    }
```

Then, upon loading of this class, an ASM transformer (`net.minecraftforge.common.asm.RuntimeDistImplementor` to be precise) injects either `myMethod_client` or `myMethod_server` into the method `myMethod` and strips unused `@ImplementOn` methods so that they won't get loaded. The above example will, on `Dist.CLIENT` become:

```java
    public void myMethod() {
        this.myMethod_client();
    }

    @ImplementOn(dist = Dist.CLIENT, method = "myMethod")
    private void myMethod_client() {
        System.out.println("Client implementation");
    }
```

Note how the method is directly delegated: this keeps line numbers and debug info understandable in stack traces. The system works for methods with or without return values, static and virtual methods, and any set of arguments. For `@ImplementOn` to work properly, the following conditions are checked, with the intentions specified:

- The return types of the target method and the injected method must match **exactly**. This is because it finds the target method based on the name specified and the descriptor (including return type) of the injector method.
- The argument lists of the target method and the injected method must match **exactly**. This is because it finds the target method based on the name specified and the descriptor of the injector method.
- The `static` modifier must either be specified on both the target and injected method, or must be omitted on both methods. When one is static and the other isn't, the injection fails. This is because a static method can not reference an instance method. An instance method can access a static method but for the semantics of 'replacing the method' I forced the `static` modifiers to match exactly.
- The injected method **must** be private. This prevents overriding which can cause strange issues as unused injected methods are stripped (subclasses might be unable to load if they call `super`). This also prevents them being called from within another class (even inner classes can't call them - this goes via a bridge method).
- The injected method may never be called (only checked in a development environment, since it checks all instructions in a class and might drop performance a lot). This filters the cases where a method of the same class accesses the injector (including bridge methods), which must not happen either.
- There must be, for each separate `Dist`, only one injected method: you can specify injections for the same method but for different dists. This rule is obvious: you should not inject into a method twice because you will then overwrite your own injection.

Note that this works with method overloading: an `@ImplementOn` annotated method will be injected into the method with the name specified in the annotation's `method` parameter and the descriptor of the injected method. Hence this will work:

```java
    public void myMethod() {
        System.out.println("Common implementation");
    }

    @ImplementOn(dist = Dist.CLIENT, method = "myMethod")
    private void myMethod_client() {
        System.out.println("Client implementation");
    }

    public void myMethod(int argument) {
        System.out.println("Common implementation, argument = " + argument);
    }

    @ImplementOn(dist = Dist.CLIENT, method = "myMethod")
    private void myMethod_client(int argument) {
        System.out.println("Client implementation, argument = " + argument);
    }
```

What's also notable here is that an `@ImplementOn` method is only injected when the `dist` parameter matches the `Dist` of the environment. When the `Dist`s don't match, the target method is left untouched and the injected method is stripped from the class, if the `Dist`s _do_ match, the contents of the target method are stripped **completely** and are overwritten by the necessary bytecode.

---

As an alternative suggestion to the semantics I've implemented in the current pull request, it's also possible to make a `@DelegateOn` annotation which is put above the target method and using the `@OnlyIn` annotations for stripping sided methods. It would then look like this:

```java
    @DelegateOn(client = "myMethod_client", server = "myMethod_server")
    public void myMethod() {

    }

    @OnlyIn(Dist.CLIENT)
    private void myMethod_client() {
        System.out.println("Client implementation");
    }

    @OnlyIn(Dist.DEDICATED_SERVER)
    private void myMethod_server() {
        System.out.println("Server implementation");
    }
```

Drawback is here: the `myMethod_client` and `myMethod_server` render as unused and don't have an annotation indicating they are dynamically being injected, nor is there any visual reason not to call them.

---

I think this is a well-working alternative to `DistExecutor.safeCallWhenOn`, since it doesn't require the targeted method to be in a separate class, it allows the use of arguments and it works with return types.

---

Things that might still be necessary and which are missing now:

- Checking the signatures of the methods (so that generic types and `throws` clauses do match). This is only a semantical issue though, in bytecode it's perfectly safe if a checked exception is thrown without having it in the `throws` clause and due to type erasure generics will work.