### PR TITLE
Add getType to Capability.

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -91,7 +91,7 @@ public class Capability<T>
     public String getName() { return name; }
 
     /**
-     * @return The target interface of this capability.
+     * @return The target interface of this capability, the value of the {@link CapabilityInject} annotation.
      */
     public Class<T> getType() { return type; }
 
@@ -149,9 +149,9 @@ public class Capability<T>
 
     // INTERNAL
     private final String name;
+    private final Class<T> type;
     private final IStorage<T> storage;
     private final Callable<? extends T> factory;
-    private final Class<T> type;
 
     Capability(String name, Class<T> type, IStorage<T> storage, Callable<? extends T> factory)
     {

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -91,6 +91,11 @@ public class Capability<T>
     public String getName() { return name; }
 
     /**
+     * @return The target interface of this capability.
+     */
+    public Class<T> getType() { return type; }
+
+    /**
      * @return An instance of the default storage handler. You can safely use this store your default implementation in NBT.
      */
     public IStorage<T> getStorage() { return storage; }
@@ -146,11 +151,13 @@ public class Capability<T>
     private final String name;
     private final IStorage<T> storage;
     private final Callable<? extends T> factory;
+    private final Class<T> type;
 
-    Capability(String name, IStorage<T> storage, Callable<? extends T> factory)
+    Capability(String name, Class<T> type, IStorage<T> storage, Callable<? extends T> factory)
     {
         this.name = name;
         this.storage = storage;
         this.factory = factory;
+        this.type = type;
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -72,7 +72,7 @@ public enum CapabilityManager
                 throw new IllegalArgumentException("Cannot register a capability implementation multiple times : "+ realName);
             }
 
-            cap = new Capability<>(realName, storage, factory);
+            cap = new Capability<>(realName, type, storage, factory);
             providers.put(realName, cap);
         }
 


### PR DESCRIPTION
This PR adds a `getType` method to the `Capability` class, that returns the target class of the Capability, i.e. the parameter to the `CapabilityInject` annotation. This may be useful when the value of the capability is received from a source that cannot guarantee the correct type, for example if it's from a user-written script. This allows for checking the type safely and without causing heap pollution.

While currently the class can be retrieved by using `Class.forName(capability.getName())`, this is an awkward solution, as the name being the same as the class name is only an implementation detail.