### PR TITLE
Fix vanilla hardcoded sea level in World

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -214,7 +214,7 @@
        explosion.func_77278_a();
        explosion.func_77279_a(false);
        if (p_230546_12_ == Explosion.Mode.NONE) {
-@@ -1410,4 +1446,14 @@
+@@ -1410,4 +1446,19 @@
           p_241121_0_.func_175656_a(p_241122_1_, Blocks.field_150343_Z.func_176223_P());
        });
     }
@@ -227,5 +227,10 @@
 +
 +   public java.util.stream.Stream<Entity> getEntities() {
 +       return field_217498_x.values().stream();
++   }
++
++   @Override // FORGE: The method in World is hardcoded to 63, but here we can delegate to the chunk generator which mods can override!
++   public int func_181545_F() {
++      return func_72863_F().func_201711_g().func_230356_f_();
 +   }
  }


### PR DESCRIPTION
`World#getSeaLevel()` (`func_181545_F`) is hardcoded to return `63`. This method is called a lot within the vanilla code base, although only on logical server. This is also impossible for mods to override as it's a method in `World` if they want to change the sea level (me!).

However, mods can already change the sea level reported by `ChunkGenerator` subclasses via the `getSeaLevel` method there. And the `ServerWorld` has a reference to the chunk generator. So this just delegates the world's sea level to it's chunk generator. Horray!