### PR TITLE
Fix forge registry types that have private constructors (BlockStateProviderType, BlockPlacerType, FoliagePlacerType, TreeDecoratorType)

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -318,8 +318,11 @@ public net.minecraft.world.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minec
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177462_b #GRID_WIDTH
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177464_a #ALL_VALID_STATES
 private-f net.minecraft.world.gen.DebugChunkGenerator field_181039_c #GRID_HEIGHT
+public net.minecraft.world.gen.blockplacer.BlockPlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.gen.blockstateprovider.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+public net.minecraft.world.gen.foliageplacer.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.gen.layer.LayerUtil func_202829_a(JLnet/minecraft/world/gen/layer/traits/IAreaTransformer1;Lnet/minecraft/world/gen/area/IAreaFactory;ILjava/util/function/LongFunction;)Lnet/minecraft/world/gen/area/IAreaFactory; # repeat
+public net.minecraft.world.gen.treedecorator.TreeDecoratorType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator
 public net.minecraft.world.server.ServerChunkProvider field_73251_h # worldObj

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -318,6 +318,7 @@ public net.minecraft.world.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minec
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177462_b #GRID_WIDTH
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177464_a #ALL_VALID_STATES
 private-f net.minecraft.world.gen.DebugChunkGenerator field_181039_c #GRID_HEIGHT
+public net.minecraft.world.gen.blockstateprovider.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.gen.layer.LayerUtil func_202829_a(JLnet/minecraft/world/gen/layer/traits/IAreaTransformer1;Lnet/minecraft/world/gen/area/IAreaFactory;ILjava/util/function/LongFunction;)Lnet/minecraft/world/gen/area/IAreaFactory; # repeat
 private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator


### PR DESCRIPTION
This is pretty simple. `BlockStateProviderType` is a forge registry type with a private constructor. There exists a register method but it directly invokes `Registry.register()` (perish the thought). So to help every mod that wants to make a new `BlockStateProvider` (probably exactly one but ignore that *world gen is a mess sometimes okay?*), let's just AT this in Forge shall we?