### PR TITLE
[1.16] brute force way to force all configs to always retain insertion order

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml;
 
+import com.electronwill.nightconfig.core.Config;
 import com.google.common.collect.ImmutableList;
 import cpw.mods.modlauncher.TransformingClassLoader;
 import net.minecraftforge.api.distmarker.Dist;
@@ -154,6 +155,8 @@ public class ModLoader
      * @param periodicTask Optional periodic task to perform on the main thread while other activities run
      */
     public void gatherAndInitializeMods(final ModWorkManager.DrivenExecutor syncExecutor, final Executor parallelExecutor, final Runnable periodicTask) {
+        // do this here to ensure it happens before any mods are loaded
+        Config.setInsertionOrderPreserved(true);
         loadingStateValid = true;
         statusConsumer.ifPresent(c->c.accept("Waiting for scan to complete"));
         FMLLoader.backgroundScanHandler.waitForScanToComplete(periodicTask);


### PR DESCRIPTION
Night config does not inherit the map creator (and thereby the "retain insertion order" setting) for child-configs (at least with the TOML parser, see [here](https://github.com/TheElectronWill/night-config/blob/78d9b1cbfc700bacddab903576693f7b89306a80/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java#L90-L93)).
This overrides the setting for all configs created at all, ever, period.

Fixes #7489.