### PR TITLE
[1.16] Fix Entity EyeHeight and EntityEvent.Size problems.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -31,20 +31,19 @@
        this.field_200606_g = p_i48580_1_;
        this.field_70170_p = p_i48580_2_;
        this.field_213325_aI = p_i48580_1_.func_220334_j();
-@@ -211,7 +214,11 @@
+@@ -211,7 +214,10 @@
        this.field_70180_af.func_187214_a(field_189655_aD, false);
        this.field_70180_af.func_187214_a(field_213330_X, Pose.STANDING);
        this.func_70088_a();
 -      this.field_213326_aJ = this.func_213316_a(Pose.STANDING, this.field_213325_aI);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.field_213325_aI, this.func_213316_a(Pose.STANDING, this.field_213325_aI));
-+      this.field_213325_aI = sizeEvent.getNewSize();
-+      this.field_213326_aJ = sizeEvent.getNewEyeHeight().orElse(this.func_213316_a(Pose.STANDING, this.field_213325_aI));
++      this.field_213325_aI = net.minecraftforge.event.ForgeEventFactory.onEntitySize(this, Pose.STANDING, this.field_213325_aI).getNewSize();
++      this.field_213326_aJ = net.minecraftforge.event.ForgeEventFactory.onEntityEyeHeight(this, Pose.STANDING, this.field_213325_aI, func_213316_a(Pose.STANDING, this.field_213325_aI)).getNewEyeHeight();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -317,7 +324,13 @@
+@@ -317,7 +323,13 @@
     }
  
     public void func_70106_y() {
@@ -58,7 +57,7 @@
     }
  
     public void func_213301_b(Pose p_213301_1_) {
-@@ -330,6 +343,7 @@
+@@ -330,6 +342,7 @@
  
     public boolean func_233562_a_(Entity p_233562_1_, double p_233562_2_) {
        double d0 = p_233562_1_.field_233557_ao_.field_72450_a - this.field_233557_ao_.field_72450_a;
@@ -66,7 +65,7 @@
        double d1 = p_233562_1_.field_233557_ao_.field_72448_b - this.field_233557_ao_.field_72448_b;
        double d2 = p_233562_1_.field_233557_ao_.field_72449_c - this.field_233557_ao_.field_72449_c;
        return d0 * d0 + d1 * d1 + d2 * d2 < p_233562_2_ * p_233562_2_;
-@@ -560,7 +574,7 @@
+@@ -560,7 +573,7 @@
  
              this.field_70140_Q = (float)((double)this.field_70140_Q + (double)MathHelper.func_76133_a(func_213296_b(vector3d)) * 0.6D);
              this.field_82151_R = (float)((double)this.field_82151_R + (double)MathHelper.func_76133_a(d0 * d0 + d1 * d1 + d2 * d2) * 0.6D);
@@ -75,7 +74,7 @@
                 this.field_70150_b = this.func_203009_ad();
                 if (this.func_70090_H()) {
                    Entity entity = this.func_184207_aI() && this.func_184179_bs() != null ? this.func_184179_bs() : this;
-@@ -575,7 +589,7 @@
+@@ -575,7 +588,7 @@
                 } else {
                    this.func_180429_a(blockpos, blockstate);
                 }
@@ -84,7 +83,7 @@
                 this.field_191959_ay = this.func_191954_d(this.field_82151_R);
              }
           }
-@@ -591,8 +605,9 @@
+@@ -591,8 +604,9 @@
  
           float f2 = this.func_225515_ai_();
           this.func_213317_d(this.func_213322_ci().func_216372_d((double)f2, 1.0D, (double)f2));
@@ -96,7 +95,7 @@
           }) && this.field_190534_ay <= 0) {
              this.func_241209_g_(-this.func_190531_bD());
           }
-@@ -611,11 +626,10 @@
+@@ -611,11 +625,10 @@
        int j = MathHelper.func_76128_c(this.field_233557_ao_.field_72448_b - (double)0.2F);
        int k = MathHelper.func_76128_c(this.field_233557_ao_.field_72449_c);
        BlockPos blockpos = new BlockPos(i, j, k);
@@ -110,7 +109,7 @@
              return blockpos1;
           }
        }
-@@ -801,6 +815,7 @@
+@@ -801,6 +814,7 @@
     public void func_174829_m() {
        AxisAlignedBB axisalignedbb = this.func_174813_aQ();
        this.func_226288_n_((axisalignedbb.field_72340_a + axisalignedbb.field_72336_d) / 2.0D, axisalignedbb.field_72338_b, (axisalignedbb.field_72339_c + axisalignedbb.field_72334_f) / 2.0D);
@@ -118,7 +117,7 @@
     }
  
     protected SoundEvent func_184184_Z() {
-@@ -849,7 +864,7 @@
+@@ -849,7 +863,7 @@
     protected void func_180429_a(BlockPos p_180429_1_, BlockState p_180429_2_) {
        if (!p_180429_2_.func_185904_a().func_76224_d()) {
           BlockState blockstate = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a());
@@ -127,7 +126,7 @@
           this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
        }
     }
-@@ -1056,9 +1071,10 @@
+@@ -1056,9 +1070,10 @@
        int k = MathHelper.func_76128_c(this.func_226281_cx_());
        BlockPos blockpos = new BlockPos(i, j, k);
        BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
@@ -139,7 +138,7 @@
        }
  
     }
-@@ -1377,6 +1393,7 @@
+@@ -1377,6 +1392,7 @@
           if (this.field_184238_ar) {
              p_189511_1_.func_74757_a("Glowing", this.field_184238_ar);
           }
@@ -147,7 +146,7 @@
  
           if (!this.field_184236_aF.isEmpty()) {
              ListNBT listnbt = new ListNBT();
-@@ -1388,6 +1405,10 @@
+@@ -1388,6 +1404,10 @@
              p_189511_1_.func_218657_a("Tags", listnbt);
           }
  
@@ -158,7 +157,7 @@
           this.func_213281_b(p_189511_1_);
           if (this.func_184207_aI()) {
              ListNBT listnbt1 = new ListNBT();
-@@ -1458,6 +1479,9 @@
+@@ -1458,6 +1478,9 @@
                 this.func_174810_b(p_70020_1_.func_74767_n("Silent"));
                 this.func_189654_d(p_70020_1_.func_74767_n("NoGravity"));
                 this.func_184195_f(p_70020_1_.func_74767_n("Glowing"));
@@ -168,7 +167,7 @@
                 if (p_70020_1_.func_150297_b("Tags", 9)) {
                    this.field_184236_aF.clear();
                    ListNBT listnbt3 = p_70020_1_.func_150295_c("Tags", 8);
-@@ -1546,6 +1570,8 @@
+@@ -1546,6 +1569,8 @@
        } else {
           ItemEntity itementity = new ItemEntity(this.field_70170_p, this.func_226277_ct_(), this.func_226278_cu_() + (double)p_70099_2_, this.func_226281_cx_(), p_70099_1_);
           itementity.func_174869_p();
@@ -177,7 +176,7 @@
           this.field_70170_p.func_217376_c(itementity);
           return itementity;
        }
-@@ -1582,6 +1608,7 @@
+@@ -1582,6 +1607,7 @@
  
     public void func_70098_U() {
        this.func_213317_d(Vector3d.field_186680_a);
@@ -185,7 +184,7 @@
        this.func_70071_h_();
        if (this.func_184218_aH()) {
           this.func_184187_bx().func_184232_k(this);
-@@ -1627,6 +1654,7 @@
+@@ -1627,6 +1653,7 @@
           }
        }
  
@@ -193,7 +192,7 @@
        if (p_184205_2_ || this.func_184228_n(p_184205_1_) && p_184205_1_.func_184219_q(this)) {
           if (this.func_184218_aH()) {
              this.func_184210_p();
-@@ -1659,6 +1687,7 @@
+@@ -1659,6 +1686,7 @@
     public void func_233575_bb_() {
        if (this.field_184239_as != null) {
           Entity entity = this.field_184239_as;
@@ -201,7 +200,7 @@
           this.field_184239_as = null;
           entity.func_184225_p(this);
        }
-@@ -1816,6 +1845,7 @@
+@@ -1816,6 +1844,7 @@
        return !this.func_184188_bt().isEmpty();
     }
  
@@ -209,7 +208,7 @@
     public boolean func_205710_ba() {
        return true;
     }
-@@ -2032,7 +2062,7 @@
+@@ -2032,7 +2061,7 @@
     }
  
     protected ITextComponent func_225513_by_() {
@@ -218,7 +217,7 @@
     }
  
     public boolean func_70028_i(Entity p_70028_1_) {
-@@ -2087,14 +2117,19 @@
+@@ -2087,14 +2116,19 @@
  
     @Nullable
     public Entity func_241206_a_(ServerWorld p_241206_1_) {
@@ -239,7 +238,7 @@
              this.field_70170_p.func_217381_Z().func_219895_b("reloading");
              Entity entity = this.func_200600_R().func_200721_a(p_241206_1_);
              if (entity != null) {
-@@ -2102,17 +2137,19 @@
+@@ -2102,17 +2136,19 @@
                 entity.func_70012_b(portalinfo.field_222505_a.field_72450_a, portalinfo.field_222505_a.field_72448_b, portalinfo.field_222505_a.field_72449_c, portalinfo.field_242960_c, entity.field_70125_A);
                 entity.func_213317_d(portalinfo.field_222506_b);
                 p_241206_1_.func_217460_e(entity);
@@ -261,20 +260,19 @@
           }
        } else {
           return null;
-@@ -2320,9 +2357,10 @@
+@@ -2320,9 +2356,9 @@
     public void func_213323_x_() {
        EntitySize entitysize = this.field_213325_aI;
        Pose pose = this.func_213283_Z();
 -      EntitySize entitysize1 = this.func_213305_a(pose);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, this.func_213305_a(pose), this.func_213316_a(pose, entitysize));
-+      EntitySize entitysize1 = sizeEvent.getNewSize();
++      EntitySize entitysize1 = net.minecraftforge.event.ForgeEventFactory.onEntitySize(this, pose, this.func_213305_a(pose)).getNewSize();
        this.field_213325_aI = entitysize1;
 -      this.field_213326_aJ = this.func_213316_a(pose, entitysize1);
-+      this.field_213326_aJ = sizeEvent.getNewEyeHeight().orElse(this.func_213316_a(pose, entitysize1));
++      this.field_213326_aJ = net.minecraftforge.event.ForgeEventFactory.onEntityEyeHeight(this, pose, entitysize1, func_213316_a(pose, entitysize1)).getNewEyeHeight();
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.func_226277_ct_() - d0, this.func_226278_cu_(), this.func_226281_cx_() - d0, this.func_226277_ct_() + d0, this.func_226278_cu_() + (double)entitysize1.field_220316_b, this.func_226281_cx_() + d0));
-@@ -2796,6 +2834,7 @@
+@@ -2796,6 +2832,7 @@
  
           this.field_233555_aA_ = true;
        }
@@ -282,7 +280,7 @@
  
     }
  
-@@ -2811,4 +2850,63 @@
+@@ -2811,4 +2848,63 @@
     public interface IMoveCallback {
        void accept(Entity p_accept_1_, double p_accept_2_, double p_accept_4_, double p_accept_6_);
     }

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -36,7 +36,7 @@
        this.field_70180_af.func_187214_a(field_213330_X, Pose.STANDING);
        this.func_70088_a();
 -      this.field_213326_aJ = this.func_213316_a(Pose.STANDING, this.field_213325_aI);
-+      this.field_213325_aI = net.minecraftforge.event.ForgeEventFactory.onEntitySize(this, Pose.STANDING, this.field_213325_aI).getNewSize();
++      this.field_213325_aI = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.field_213325_aI, 0.0F).getNewSize();
 +      this.field_213326_aJ = net.minecraftforge.event.ForgeEventFactory.onEntityEyeHeight(this, Pose.STANDING, this.field_213325_aI, func_213316_a(Pose.STANDING, this.field_213325_aI)).getNewEyeHeight();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
@@ -265,7 +265,7 @@
        EntitySize entitysize = this.field_213325_aI;
        Pose pose = this.func_213283_Z();
 -      EntitySize entitysize1 = this.func_213305_a(pose);
-+      EntitySize entitysize1 = net.minecraftforge.event.ForgeEventFactory.onEntitySize(this, pose, this.func_213305_a(pose)).getNewSize();
++      EntitySize entitysize1 = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, this.func_213305_a(pose), 0.0F).getNewSize();
        this.field_213325_aI = entitysize1;
 -      this.field_213326_aJ = this.func_213316_a(pose, entitysize1);
 +      this.field_213326_aJ = net.minecraftforge.event.ForgeEventFactory.onEntityEyeHeight(this, pose, entitysize1, func_213316_a(pose, entitysize1)).getNewEyeHeight();

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -38,7 +38,7 @@
 -      this.field_213326_aJ = this.func_213316_a(Pose.STANDING, this.field_213325_aI);
 +      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.field_213325_aI, this.func_213316_a(Pose.STANDING, this.field_213325_aI));
 +      this.field_213325_aI = sizeEvent.getNewSize();
-+      this.field_213326_aJ = sizeEvent.getNewEyeHeight();
++      this.field_213326_aJ = sizeEvent.getNewEyeHeight().orElse(this.func_213316_a(Pose.STANDING, this.field_213325_aI));
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
@@ -270,7 +270,7 @@
 +      EntitySize entitysize1 = sizeEvent.getNewSize();
        this.field_213325_aI = entitysize1;
 -      this.field_213326_aJ = this.func_213316_a(pose, entitysize1);
-+      this.field_213326_aJ = sizeEvent.getNewEyeHeight();
++      this.field_213326_aJ = sizeEvent.getNewEyeHeight().orElse(this.func_213316_a(pose, entitysize1));
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.func_226277_ct_() - d0, this.func_226278_cu_(), this.func_226281_cx_() - d0, this.func_226277_ct_() + d0, this.func_226278_cu_() + (double)entitysize1.field_220316_b, this.func_226281_cx_() + d0));

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -742,10 +742,17 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
     }
 
-    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity player, Pose pose, EntitySize size, float eyeHeight)
+    public static EntityEvent.Size onEntitySize(Entity entity, Pose pose, EntitySize size)
     {
-        EntityEvent.Size evt = new EntityEvent.Size(player, pose, size, eyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
+        EntityEvent.Size event = new EntityEvent.Size(entity, pose, size);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+    
+    public static EntityEvent.EyeHeight onEntityEyeHeight(Entity entity, Pose pose, EntitySize size, float eyeHeight)
+    {
+        EntityEvent.EyeHeight event = new EntityEvent.EyeHeight(entity, pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -742,9 +742,10 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
     }
 
-    public static EntityEvent.Size onEntitySize(Entity entity, Pose pose, EntitySize size)
+    //TODO remove float parameter
+    public static EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntitySize size, float eyeHeight)
     {
-        EntityEvent.Size event = new EntityEvent.Size(entity, pose, size);
+        EntityEvent.Size event = new EntityEvent.Size(entity, pose, size, eyeHeight);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -154,19 +154,55 @@ public class EntityEvent extends Event
         private final Pose pose;
         private final EntitySize oldSize;
         private EntitySize newSize;
+        /**
+         * @deprecated Use {@link EyeHeight}
+         * <br>
+         * TODO remove this field
+         */
+        @Deprecated
+        private final float oldEyeHeight;
+        /**
+         * @deprecated Use {@link EyeHeight}
+         * <br>
+         * TODO remove this field
+         */
+        private float newEyeHeight;
 
-        public Size(Entity entity, Pose pose, EntitySize size)
+        public Size(Entity entity, Pose pose, EntitySize size, float defaultEyeHeight)
         {
             super(entity);
             this.pose = pose;
             this.oldSize = size;
             this.newSize = size;
+            this.oldEyeHeight = defaultEyeHeight;
+            this.newEyeHeight = defaultEyeHeight;
         }
         
         public Pose getPose() { return pose; }
         public EntitySize getOldSize() { return oldSize; }
         public EntitySize getNewSize() { return newSize; }
         public void setNewSize(EntitySize size) { this.newSize = size; }
+        /**
+         * @deprecated Use {@link EyeHeight}
+         * <br>
+         * TODO remove this method
+         */
+        @Deprecated
+        public float getOldEyeHeight() { return oldEyeHeight; }
+        /**
+         * @deprecated Use {@link EyeHeight}
+         * <br>
+         * TODO remove this method
+         */
+        @Deprecated
+        public float getNewEyeHeight() { return newEyeHeight; }
+        /**
+         * @deprecated Use {@link EyeHeight}
+         * <br>
+         * TODO remove this method
+         */
+        @Deprecated
+        public void setNewEyeHeight(float newHeight) { this.newEyeHeight = newHeight; }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -28,8 +28,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
-import java.util.Optional;
-
 /**
  * EntityEvent is fired when an event involving any Entity occurs.<br>
  * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -28,6 +28,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+import java.util.Optional;
+
 /**
  * EntityEvent is fired when an event involving any Entity occurs.<br>
  * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
@@ -155,7 +157,7 @@ public class EntityEvent extends Event
         private final EntitySize oldSize;
         private EntitySize newSize;
         private final float oldEyeHeight;
-        private float newEyeHeight;
+        private Optional<Float> newEyeHeight;
 
         public Size(Entity entity, Pose pose, EntitySize size, float defaultEyeHeight)
         {
@@ -164,7 +166,7 @@ public class EntityEvent extends Event
             this.oldSize = size;
             this.newSize = size;
             this.oldEyeHeight = defaultEyeHeight;
-            this.newEyeHeight = defaultEyeHeight;
+            this.newEyeHeight = Optional.empty();
         }
 
 
@@ -173,7 +175,7 @@ public class EntityEvent extends Event
         public EntitySize getNewSize() { return newSize; }
         public void setNewSize(EntitySize size) { this.newSize = size; }
         public float getOldEyeHeight() { return oldEyeHeight; }
-        public float getNewEyeHeight() { return newEyeHeight; }
-        public void setNewEyeHeight(float newHeight) { this.newEyeHeight = newHeight; }
+        public Optional<Float> getNewEyeHeight() { return newEyeHeight; }
+        public void setNewEyeHeight(Optional<Float> newHeight) { this.newEyeHeight = newHeight; }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -141,9 +141,9 @@ public class EntityEvent extends Event
     }
 
     /**
-     * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios.<br>
+     * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios, before {@link EyeHeight} is fired.<br>
      * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
-     * If you change the player's size, you probably want to set the eye height accordingly as well<br>
+     * If you change the player's size, you probably want to set the eye height accordingly as well via {@link EyeHeight}<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -156,26 +156,50 @@ public class EntityEvent extends Event
         private final Pose pose;
         private final EntitySize oldSize;
         private EntitySize newSize;
-        private final float oldEyeHeight;
-        private Optional<Float> newEyeHeight;
 
-        public Size(Entity entity, Pose pose, EntitySize size, float defaultEyeHeight)
+        public Size(Entity entity, Pose pose, EntitySize size)
         {
             super(entity);
             this.pose = pose;
             this.oldSize = size;
             this.newSize = size;
-            this.oldEyeHeight = defaultEyeHeight;
-            this.newEyeHeight = Optional.empty();
         }
-
-
+        
         public Pose getPose() { return pose; }
         public EntitySize getOldSize() { return oldSize; }
         public EntitySize getNewSize() { return newSize; }
         public void setNewSize(EntitySize size) { this.newSize = size; }
+    }
+
+    /**
+     * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios, after {@link Size} is fired.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class EyeHeight extends EntityEvent
+    {
+        private final Pose pose;
+        private final EntitySize size;
+        private final float oldEyeHeight;
+        private float newEyeHeight;
+        
+        public EyeHeight(Entity entity, Pose pose, EntitySize size, float eyeHeight){
+            super(entity);
+            this.pose = pose;
+            this.size = size;
+            this.oldEyeHeight = eyeHeight;
+            this.newEyeHeight = eyeHeight;
+        }
+        
+        public Pose getPose() { return pose; }
+        public EntitySize getSize() { return size; }
         public float getOldEyeHeight() { return oldEyeHeight; }
-        public Optional<Float> getNewEyeHeight() { return newEyeHeight; }
-        public void setNewEyeHeight(Optional<Float> newHeight) { this.newEyeHeight = newHeight; }
+        public float getNewEyeHeight() { return newEyeHeight; }
+        public void setNewEyeHeight(float eyeHeight) {newEyeHeight = eyeHeight; }
     }
 }


### PR DESCRIPTION
Fixes #7399.

Fixes the new eye height from the event being incorrect by splitting the event into 2 pieces, a size event and a separate eye height event. This allows the eye height passed to the event to be the actual vanilla eye height, instead of a best guess eye height.