### PR TITLE
[1.16] Fix PointOfInterestType not being added to blockstate map when registered

### DIFF
--- a/patches/minecraft/net/minecraft/village/PointOfInterestType.java.patch
+++ b/patches/minecraft/net/minecraft/village/PointOfInterestType.java.patch
@@ -9,3 +9,33 @@
     private static final Supplier<Set<PointOfInterestType>> field_234168_y_ = Suppliers.memoize(() -> {
        return Registry.field_218370_L.func_201756_e().map(VillagerProfession::func_221149_b).collect(Collectors.toSet());
     });
+@@ -36,7 +36,7 @@
+    }).filter((p_234173_0_) -> {
+       return p_234173_0_.func_177229_b(BedBlock.field_176472_a) == BedPart.HEAD;
+    }).collect(ImmutableSet.toImmutableSet());
+-   private static final Map<BlockState, PointOfInterestType> field_221073_u = Maps.newHashMap();
++   private static final Map<BlockState, PointOfInterestType> field_221073_u = net.minecraftforge.registries.GameData.getBlockStatePointOfInterestTypeMap();
+    public static final PointOfInterestType field_221054_b = func_226360_a_("unemployed", ImmutableSet.of(), 1, field_221071_s, 1);
+    public static final PointOfInterestType field_221055_c = func_226359_a_("armorer", func_221042_a(Blocks.field_222424_lM), 1, 1);
+    public static final PointOfInterestType field_221056_d = func_226359_a_("butcher", func_221042_a(Blocks.field_222423_lL), 1, 1);
+@@ -112,16 +112,14 @@
+    }
+ 
+    private static PointOfInterestType func_221052_a(PointOfInterestType p_221052_0_) {
+-      p_221052_0_.field_221075_w.forEach((p_234169_1_) -> {
+-         PointOfInterestType pointofinteresttype = field_221073_u.put(p_234169_1_, p_221052_0_);
+-         if (pointofinteresttype != null) {
+-            throw (IllegalStateException)Util.func_229757_c_(new IllegalStateException(String.format("%s is defined in too many tags", p_234169_1_)));
+-         }
+-      });
+       return p_221052_0_;
+    }
+ 
+    public static Optional<PointOfInterestType> func_221047_b(BlockState p_221047_0_) {
+       return Optional.ofNullable(field_221073_u.get(p_221047_0_));
+    }
++   
++   public ImmutableSet<BlockState> getBlockStates() {
++      return ImmutableSet.copyOf(this.field_221075_w);
++   }
+ }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -74,7 +74,6 @@ import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.world.ForgeWorldType;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.RegistryEvent.MissingMappings;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -634,19 +633,22 @@ public class GameData
             }
             obj.getBlockStates().forEach((state) -> 
             {
-                if (map.put(state, obj) != null)
+                PointOfInterestType oldType = map.put(state, obj);
+                if (oldType != null)
                 {
-                    throw Util.pauseDevMode(new IllegalStateException(String.format("%s is defined in too many tags", state)));
+                    throw new IllegalStateException(String.format("Point of interest types %s and %s both list %s in their blockstates, this is not allowed. Blockstates can only have one point of interest type each.", oldType, obj, state));
                 }
             });
         }
 
-        @Override public void onClear(IForgeRegistryInternal<PointOfInterestType> owner, RegistryManager stage)
+        @Override
+        public void onClear(IForgeRegistryInternal<PointOfInterestType> owner, RegistryManager stage)
         {
             owner.getSlaveMap(BLOCKSTATE_TO_POINT_OF_INTEREST_TYPE, Map.class).clear();
         }
 
-        @Override public void onCreate(IForgeRegistryInternal<PointOfInterestType> owner, RegistryManager stage)
+        @Override
+        public void onCreate(IForgeRegistryInternal<PointOfInterestType> owner, RegistryManager stage)
         {
             owner.setSlaveMap(BLOCKSTATE_TO_POINT_OF_INTEREST_TYPE, new HashMap<>());
         }


### PR DESCRIPTION
When vanilla registers a `PointOfInterestType`, its blockstates are added to the map that is used to find POI's in the world. The forge registry does not add blockstates to that map. This PR resolves this by making the map a slave map (as suggested by tterrag) and using callbacks to add blockstates to it.

This will (probably) not break mods currently adding POIs because the method they are (probably) using to register their POI blockstates to the map now does nothing.