### PR TITLE
Revert "Fix dims on servers not loading the first run (#7445)" And fix Ender dragon bug

### DIFF
--- a/patches/minecraft/net/minecraft/server/Main.java.patch
+++ b/patches/minecraft/net/minecraft/server/Main.java.patch
@@ -55,16 +55,7 @@
           SaveFormat saveformat = SaveFormat.func_237269_a_(file1.toPath());
           SaveFormat.LevelSave saveformat$levelsave = saveformat.func_237274_c_(s);
           MinecraftServer.func_240777_a_(saveformat$levelsave);
-@@ -142,6 +149,8 @@
-                dimensiongeneratorsettings = optionset.has(optionspec3) ? serverproperties.field_241082_U_.func_236230_k_() : serverproperties.field_241082_U_;
-             }
- 
-+            // Forge: Deserialize the DimensionGeneratorSettings to ensure modded dims are loaded on first server load (see SimpleRegistryCodec#decode). Vanilla behaviour only loads from the server.properties and deserializes only after the 2nd server load.
-+            dimensiongeneratorsettings = DimensionGeneratorSettings.field_236201_a_.encodeStart(worldsettingsimport, dimensiongeneratorsettings).flatMap(nbt -> DimensionGeneratorSettings.field_236201_a_.parse(worldsettingsimport, nbt)).getOrThrow(false, errorMsg->{});
-             iserverconfiguration = new ServerWorldInfo(worldsettings, dimensiongeneratorsettings, Lifecycle.stable());
-          }
- 
-@@ -169,6 +178,7 @@
+@@ -169,6 +176,7 @@
           Thread thread = new Thread("Server Shutdown Thread") {
              public void run() {
                 dedicatedserver.func_71263_m(true);


### PR DESCRIPTION
Serializing and deserializing the dimension types caused the end dimension to not have `hasEnderFight` = true. This is because it is not in the Codec and defaults to false. I can not submit a proper fix currently, and since this is a pretty big bug I think it best to just revert temporarily. If this is not okay, I'll be submitting a proper fix in the week.

Fixes #7510 