### PR TITLE
Fix DimensionType not encode into registries in dedicated server saves

### DIFF
--- a/patches/minecraft/net/minecraft/server/Main.java.patch
+++ b/patches/minecraft/net/minecraft/server/Main.java.patch
@@ -60,7 +60,7 @@
              }
  
 +            // Forge: Deserialize the DimensionGeneratorSettings to ensure modded dims are loaded on first server load (see SimpleRegistryCodec#decode). Vanilla behaviour only loads from the server.properties and deserializes only after the 2nd server load.
-+            dimensiongeneratorsettings = DimensionGeneratorSettings.field_236201_a_.encodeStart(worldsettingsimport, dimensiongeneratorsettings).flatMap(nbt -> DimensionGeneratorSettings.field_236201_a_.parse(worldsettingsimport, nbt)).getOrThrow(false, errorMsg->{});
++            dimensiongeneratorsettings = DimensionGeneratorSettings.field_236201_a_.encodeStart(net.minecraft.util.registry.WorldGenSettingsExport.func_240896_a_(NBTDynamicOps.field_210820_a, dynamicregistries$impl), dimensiongeneratorsettings).flatMap(nbt -> DimensionGeneratorSettings.field_236201_a_.parse(worldsettingsimport, nbt)).getOrThrow(false, errorMsg->{});
              iserverconfiguration = new ServerWorldInfo(worldsettings, dimensiongeneratorsettings, Lifecycle.stable());
           }
  


### PR DESCRIPTION
This is introduced in #7445. When starting a (first run) server, the DimensionType instance in ServerWorld is not in the `DynamicRegistries`. I want to get the registry key of the dimType then find out this issue.

I print the instances in two registries with following code(breakpoint inside World.<init>, this.dimensionType is the world's type)

```java
for (Map.Entry<RegistryKey<Dimension>, Dimension> entry : ((ServerWorldInfo) info).getDimensionGeneratorSettings().func_236224_e_().getEntries()) {
     System.out.println(entry.getKey());
     System.out.println(entry.getValue());
     System.out.println(entry.getValue().getDimensionType());
}
System.out.println(this.dimensionType);
for (Map.Entry<RegistryKey<DimensionType>, DimensionType> entry : minecraftServer.func_244267_aX().func_230520_a_().getEntries()) {
     System.out.println(entry.getKey());
     System.out.println(entry.getValue());
}
```

And here are results, the first is the world copied from client saves(a valid save):
![with level.dat](https://user-images.githubusercontent.com/21029868/99932575-71f11700-2d93-11eb-981f-9454279536b1.png)
And this is from Forge 35.1.0 dedicated server:
![without level.dat](https://user-images.githubusercontent.com/21029868/99932581-76b5cb00-2d93-11eb-8fcf-b34dfad8cdcf.png)

The two different saves have different level.dat. The valid save one has encoded its dimension type to registry:
![dat1](https://user-images.githubusercontent.com/21029868/99937700-4c6b0a00-2da1-11eb-9858-48a9b7c7bf71.png)
The corrupted one has not:
![dat2](https://user-images.githubusercontent.com/21029868/99937817-863c1080-2da1-11eb-8f69-89f0f3d902f3.png)

Passing a `WorldGenSettingsExport` instead of `WorldSettingsImport` could address this, which encodes instances to registry ResourceLocation.

Seems this fix #7510