### PR TITLE
Fix wrong function call in horizontalFaceBlock

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -255,7 +255,7 @@ public abstract class BlockStateProvider implements IDataProvider {
     }
 
     public void horizontalFaceBlock(Block block, Function<BlockState, ModelFile> modelFunc) {
-        horizontalBlock(block, modelFunc, DEFAULT_ANGLE_OFFSET);
+        horizontalFaceBlock(block, modelFunc, DEFAULT_ANGLE_OFFSET);
     }
 
     public void horizontalFaceBlock(Block block, Function<BlockState, ModelFile> modelFunc, int angleOffset) {


### PR DESCRIPTION
This pull request fixes a wrong function call in the `public void horizontalFaceBlock(Block block, Function<BlockState, ModelFile> modelFunc)` which called `horizontalBlock` but should call `horizontalFaceBlock` with the `DEFAULT_ANGLE_OFFSET` 