### PR TITLE
Allow mods to use custom LootParameter when querying existing loot tables (e.g. blocks).

### DIFF
--- a/patches/minecraft/net/minecraft/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/loot/LootContext.java.patch
@@ -48,6 +48,15 @@
        public LootContext.Builder func_216023_a(Random p_216023_1_) {
           this.field_216027_d = p_216023_1_;
           return this;
+@@ -177,7 +207,7 @@
+ 
+       public LootContext func_216022_a(LootParameterSet p_216022_1_) {
+          Set<LootParameter<?>> set = Sets.difference(this.field_216025_b.keySet(), p_216022_1_.func_216276_b());
+-         if (!set.isEmpty()) {
++         if (false && !set.isEmpty()) { // Forge: Allow mods to pass custom loot parameters (not part of the vanilla loot table) to the loot context.
+             throw new IllegalArgumentException("Parameters not allowed in this parameter set: " + set);
+          } else {
+             Set<LootParameter<?>> set1 = Sets.difference(p_216022_1_.func_216277_a(), this.field_216025_b.keySet());
 @@ -190,7 +220,7 @@
                 }
  


### PR DESCRIPTION
I had recently encountered a situation upon which I wanted to break a block via code, but not drop the normal drops (in this case, drop something different entirely). Now, I could just set the block state, don't cause vanilla drops, and spawn my custom drops manually. However this goes against the benefits of having all block drops being done via loot tables. So the obvious answer is to make add some form of condition onto the loot table that is aware of this particular case. And vanilla has a perfectly usable system for this! Introduce `LootParameter`:

- This is already used to pass a number of objects, such as the block state, position, player, or harvesting tool as part of the `LootContext`, which is then available to any code-defined `LootFunction`s, or `LootCondition`s.
- This seems like the ideal solution for my use case: define a new `LootParameter` (basically a marker), pass it into the `LootContext` builder, trigger block drops manually, and then using my new `LootCondition`, I am able to check for the existence of this parameter on the loot table itself! Fantastic!

Except there's a problem. Vanilla has a set of allowed and required `LootParameters`, and won't let you create a loot table with parameters that aren't already hardcoded in a predefined list for each loot table.

This PR simply removes the "allowed" limit, letting mods add new parameters to the loot context.