### PR TITLE
Re-implement part of pull 6091 - Fixed entity navigation to stop entities spinning

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/pathfinding/PathNavigator.java
 +++ b/net/minecraft/pathfinding/PathNavigator.java
-@@ -208,9 +208,9 @@
+@@ -208,9 +208,10 @@
        Vector3d vector3d = this.func_75502_i();
        this.field_188561_o = this.field_75515_a.func_213311_cf() > 0.75F ? this.field_75515_a.func_213311_cf() / 2.0F : 0.75F - this.field_75515_a.func_213311_cf() / 2.0F;
        Vector3i vector3i = this.field_75514_c.func_242948_g();
 -      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + 0.5D));
++      //Forge: Fix MC-94054
 +      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + (this.field_75515_a.func_213311_cf() + 1) / 2D));
        double d1 = Math.abs(this.field_75515_a.func_226278_cu_() - (double)vector3i.func_177956_o());
 -      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + 0.5D));

--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
@@ -1,15 +1,14 @@
 --- a/net/minecraft/pathfinding/PathNavigator.java
 +++ b/net/minecraft/pathfinding/PathNavigator.java
-@@ -208,9 +208,10 @@
+@@ -208,9 +208,9 @@
        Vector3d vector3d = this.func_75502_i();
        this.field_188561_o = this.field_75515_a.func_213311_cf() > 0.75F ? this.field_75515_a.func_213311_cf() / 2.0F : 0.75F - this.field_75515_a.func_213311_cf() / 2.0F;
        Vector3i vector3i = this.field_75514_c.func_242948_g();
 -      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + 0.5D));
-+      //Forge: Fix MC-94054
-+      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + (this.field_75515_a.func_213311_cf() + 1) / 2D));
++      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + (this.field_75515_a.func_213311_cf() + 1) / 2D)); //Forge: Fix MC-94054
        double d1 = Math.abs(this.field_75515_a.func_226278_cu_() - (double)vector3i.func_177956_o());
 -      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + 0.5D));
-+      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + (this.field_75515_a.func_213311_cf() + 1) / 2D));
++      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + (this.field_75515_a.func_213311_cf() + 1) / 2D)); //Forge: Fix MC-94054
        boolean flag = d0 < (double)this.field_188561_o && d2 < (double)this.field_188561_o && d1 < 1.0D;
        if (flag || this.field_75515_a.func_233660_b_(this.field_75514_c.func_237225_h_().field_186287_m) && this.func_234112_b_(vector3d)) {
           this.field_75514_c.func_75875_a();

--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/pathfinding/PathNavigator.java
++++ b/net/minecraft/pathfinding/PathNavigator.java
+@@ -208,9 +208,9 @@
+       Vector3d vector3d = this.func_75502_i();
+       this.field_188561_o = this.field_75515_a.func_213311_cf() > 0.75F ? this.field_75515_a.func_213311_cf() / 2.0F : 0.75F - this.field_75515_a.func_213311_cf() / 2.0F;
+       Vector3i vector3i = this.field_75514_c.func_242948_g();
+-      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + 0.5D));
++      double d0 = Math.abs(this.field_75515_a.func_226277_ct_() - ((double)vector3i.func_177958_n() + (this.field_75515_a.func_213311_cf() + 1) / 2D));
+       double d1 = Math.abs(this.field_75515_a.func_226278_cu_() - (double)vector3i.func_177956_o());
+-      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + 0.5D));
++      double d2 = Math.abs(this.field_75515_a.func_226281_cx_() - ((double)vector3i.func_177952_p() + (this.field_75515_a.func_213311_cf() + 1) / 2D));
+       boolean flag = d0 < (double)this.field_188561_o && d2 < (double)this.field_188561_o && d1 < 1.0D;
+       if (flag || this.field_75515_a.func_233660_b_(this.field_75514_c.func_237225_h_().field_186287_m) && this.func_234112_b_(vector3d)) {
+          this.field_75514_c.func_75875_a();


### PR DESCRIPTION
https://github.com/MinecraftForge/MinecraftForge/pull/6091

The issue persists in 1.16.4 with entities of a larger AABB (tested 1.0 width). Updated Wyn-Prices fix for the land path following part factoring in the minor changes to the vanilla code.

The vanilla water path following (SwimmerPathNavigator) seems to be taking a different approach in 1.16.4 now so I left that part out, though I am unsure if water path following still has the issue still or not.

https://bugs.mojang.com/browse/MC-94054