### PR TITLE
Allow Chunk loading Tickets to opt-into forcing chunk ticks.

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/server/ServerChunkProvider.java
++++ b/net/minecraft/world/server/ServerChunkProvider.java
+@@ -353,7 +353,7 @@
+                if (optional1.isPresent()) {
+                   Chunk chunk = optional1.get();
+                   ChunkPos chunkpos = p_241099_7_.func_219277_h();
+-                  if (!this.field_217237_a.func_219243_d(chunkpos)) {
++                  if (!this.field_217237_a.func_219243_d(chunkpos) || field_217237_a.func_219246_e().shouldForceTicks(chunkpos.func_201841_a())) {
+                      chunk.func_177415_c(chunk.func_177416_w() + j);
+                      if (flag1 && (this.field_217246_l || this.field_217247_m) && this.field_73251_h.func_175723_af().func_177730_a(chunk.func_76632_l())) {
+                         WorldEntitySpawner.func_234979_a_(this.field_73251_h, chunk, worldentityspawner$entitydensitymanager, this.field_217247_m, this.field_217246_l, flag2);

--- a/patches/minecraft/net/minecraft/world/server/Ticket.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/Ticket.java.patch
@@ -20,7 +20,7 @@
        } else {
           Ticket<?> ticket = (Ticket)p_equals_1_;
 -         return this.field_219481_b == ticket.field_219481_b && Objects.equals(this.field_219480_a, ticket.field_219480_a) && Objects.equals(this.field_219482_c, ticket.field_219482_c);
-+         return this.field_219481_b == ticket.field_219481_b && Objects.equals(this.field_219480_a, ticket.field_219480_a) && Objects.equals(this.field_219482_c, ticket.field_219482_c) && this.forceTicks == forceTicks;
++         return this.field_219481_b == ticket.field_219481_b && Objects.equals(this.field_219480_a, ticket.field_219480_a) && Objects.equals(this.field_219482_c, ticket.field_219482_c) && this.forceTicks == ticket.forceTicks;
        }
     }
  

--- a/patches/minecraft/net/minecraft/world/server/Ticket.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/Ticket.java.patch
@@ -1,0 +1,49 @@
+--- a/net/minecraft/world/server/Ticket.java
++++ b/net/minecraft/world/server/Ticket.java
+@@ -9,9 +9,14 @@
+    private long field_219483_d;
+ 
+    protected Ticket(TicketType<T> p_i226095_1_, int p_i226095_2_, T p_i226095_3_) {
++      this(p_i226095_1_, p_i226095_2_, p_i226095_3_, false);
++   }
++
++   public Ticket(TicketType<T> p_i226095_1_, int p_i226095_2_, T p_i226095_3_, boolean forceTicks) {
+       this.field_219480_a = p_i226095_1_;
+       this.field_219481_b = p_i226095_2_;
+       this.field_219482_c = p_i226095_3_;
++      this.forceTicks = forceTicks;
+    }
+ 
+    public int compareTo(Ticket<?> p_compareTo_1_) {
+@@ -31,16 +36,16 @@
+          return false;
+       } else {
+          Ticket<?> ticket = (Ticket)p_equals_1_;
+-         return this.field_219481_b == ticket.field_219481_b && Objects.equals(this.field_219480_a, ticket.field_219480_a) && Objects.equals(this.field_219482_c, ticket.field_219482_c);
++         return this.field_219481_b == ticket.field_219481_b && Objects.equals(this.field_219480_a, ticket.field_219480_a) && Objects.equals(this.field_219482_c, ticket.field_219482_c) && this.forceTicks == forceTicks;
+       }
+    }
+ 
+    public int hashCode() {
+-      return Objects.hash(this.field_219480_a, this.field_219481_b, this.field_219482_c);
++      return Objects.hash(this.field_219480_a, this.field_219481_b, this.field_219482_c, forceTicks);
+    }
+ 
+    public String toString() {
+-      return "Ticket[" + this.field_219480_a + " " + this.field_219481_b + " (" + this.field_219482_c + ")] at " + this.field_219483_d;
++      return "Ticket[" + this.field_219480_a + " " + this.field_219481_b + " (" + this.field_219482_c + ")] at " + this.field_219483_d + " force ticks " + forceTicks;
+    }
+ 
+    public TicketType<T> func_219479_a() {
+@@ -59,4 +64,11 @@
+       long i = this.field_219480_a.func_223184_b();
+       return i != 0L && p_223182_1_ - this.field_219483_d > i;
+    }
++
++   /* ======================================== FORGE START =====================================*/
++   private final boolean forceTicks;
++
++   public boolean isForceTicks() {
++      return forceTicks;
++   }
+ }

--- a/patches/minecraft/net/minecraft/world/server/TicketManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/TicketManager.java.patch
@@ -1,0 +1,48 @@
+--- a/net/minecraft/world/server/TicketManager.java
++++ b/net/minecraft/world/server/TicketManager.java
+@@ -49,6 +49,8 @@
+    private final Executor field_219388_p;
+    private long field_219389_q;
+ 
++   private final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> forcedTickets = new Long2ObjectOpenHashMap<>();
++
+    protected TicketManager(Executor p_i50707_1_, Executor p_i50707_2_) {
+       ITaskExecutor<Runnable> itaskexecutor = ITaskExecutor.func_213140_a("player ticket throttler", p_i50707_2_::execute);
+       ChunkTaskPriorityQueueSorter chunktaskpriorityqueuesorter = new ChunkTaskPriorityQueueSorter(ImmutableList.of(itaskexecutor), p_i50707_1_, 4);
+@@ -143,6 +145,10 @@
+          this.field_219378_f.func_215491_b(p_219347_1_, p_219347_3_.func_219477_b(), true);
+       }
+ 
++      if (p_219347_3_.isForceTicks()) {
++          SortedArraySet<Ticket<?>> tickets = forcedTickets.computeIfAbsent(p_219347_1_, e -> SortedArraySet.func_226172_a_(4));
++          tickets.func_226175_a_(ticket);
++      }
+    }
+ 
+    private void func_219349_b(long p_219349_1_, Ticket<?> p_219349_3_) {
+@@ -155,6 +161,13 @@
+       }
+ 
+       this.field_219378_f.func_215491_b(p_219349_1_, func_229844_a_(sortedarrayset), false);
++
++      if (p_219349_3_.isForceTicks()) {
++          SortedArraySet<Ticket<?>> tickets = forcedTickets.get(p_219349_1_);
++          if (tickets != null) {
++              tickets.remove(p_219349_3_);
++          }
++      }
+    }
+ 
+    public <T> void func_219356_a(TicketType<T> p_219356_1_, ChunkPos p_219356_2_, int p_219356_3_, T p_219356_4_) {
+@@ -242,6 +255,11 @@
+       return this.field_219384_l.func_225396_a();
+    }
+ 
++   public boolean shouldForceTicks(long chunkPos) {
++       SortedArraySet<Ticket<?>> tickets = forcedTickets.get(chunkPos);
++       return tickets != null && !tickets.isEmpty();
++   }
++
+    class ChunkTicketTracker extends ChunkDistanceGraph {
+       public ChunkTicketTracker() {
+          super(ChunkManager.field_219249_a + 2, 16, 256);


### PR DESCRIPTION
By default, vanilla only ticks chunks when players are nearby, regardless of what ticket is loading the chunk (this is true even with [/forceload](https://minecraft.gamepedia.com/Commands/forceload#Note)).

This patch simply adds an extra flag a ChunkTicket can opt-into, in order to force chunks to tick regardless of nearby players.

Tested with a modified version of [ChickenChunks](https://github.com/TheCBProject/ChickenChunks), made some crops, chunk loaded them, teleported away, set random tick speed to insane, reset random tick speed, teleported back, crops are grown.