### PR TITLE
Make UnboundedMapCodec more lenient in decoding dimensions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -949,6 +949,7 @@ project(':forge') {
         exclude 'net/minecraftforge/fml/common/versioning/InvalidVersionSpecificationException.java'
         exclude 'net/minecraftforge/fml/common/versioning/Restriction.java'
         exclude 'net/minecraftforge/fml/common/versioning/VersionRange.java'
+        exclude 'net/minecraftforge/common/LenientUnboundedMapCodec.java'
 
         tasks {
             main {

--- a/patches/minecraft/net/minecraft/util/registry/SimpleRegistry.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/SimpleRegistry.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/util/registry/SimpleRegistry.java
++++ b/net/minecraft/util/registry/SimpleRegistry.java
+@@ -212,7 +212,8 @@
+    }
+ 
+    public static <T> Codec<SimpleRegistry<T>> func_241745_c_(RegistryKey<? extends Registry<T>> p_241745_0_, Lifecycle p_241745_1_, Codec<T> p_241745_2_) {
+-      return Codec.unboundedMap(ResourceLocation.field_240908_a_.xmap(RegistryKey.func_240902_a_(p_241745_0_), RegistryKey::func_240901_a_), p_241745_2_).xmap((p_239656_2_) -> {
++      // FORGE: Fix MC-197860
++      return new net.minecraftforge.common.LenientUnboundedMapCodec<>(ResourceLocation.field_240908_a_.xmap(RegistryKey.func_240902_a_(p_241745_0_), RegistryKey::func_240901_a_), p_241745_2_).xmap((p_239656_2_) -> {
+          SimpleRegistry<T> simpleregistry = new SimpleRegistry<>(p_241745_0_, p_241745_1_);
+          p_239656_2_.forEach((p_239653_2_, p_239653_3_) -> {
+             simpleregistry.func_218381_a(p_239653_2_, p_239653_3_, p_241745_1_);

--- a/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
+++ b/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
@@ -1,0 +1,113 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.datafixers.util.Unit;
+import com.mojang.serialization.*;
+import com.mojang.serialization.codecs.BaseMapCodec;
+
+/**
+ * This is a copy of {@link com.mojang.serialization.codecs.UnboundedMapCodec} but with one key modification: record ALL results that successfully parse, not only the first up until it errors.
+ */
+public class LenientUnboundedMapCodec<K, V> implements BaseMapCodec<K, V>, Codec<Map<K, V>>
+{
+    private final Codec<K> keyCodec;
+    private final Codec<V> elementCodec;
+
+    public LenientUnboundedMapCodec(final Codec<K> keyCodec, final Codec<V> elementCodec) {
+        this.keyCodec = keyCodec;
+        this.elementCodec = elementCodec;
+    }
+
+    @Override
+    public Codec<K> keyCodec() {
+        return keyCodec;
+    }
+
+    @Override
+    public Codec<V> elementCodec() {
+        return elementCodec;
+    }
+
+    @Override
+    public <T> DataResult<Map<K, V>> decode(DynamicOps<T> ops, MapLike<T> input)
+    {
+        final ImmutableMap.Builder<K, V> read = ImmutableMap.builder();
+        final ImmutableList.Builder<Pair<T, T>> failed = ImmutableList.builder();
+
+        final DataResult<Unit> result = input.entries().reduce(
+                DataResult.success(Unit.INSTANCE, Lifecycle.stable()),
+                (r, pair) -> {
+                    final DataResult<K> k = keyCodec().parse(ops, pair.getFirst());
+                    final DataResult<V> v = elementCodec().parse(ops, pair.getSecond());
+
+                    final DataResult<Pair<K, V>> entry = k.apply2stable(Pair::of, v);
+                    entry.error().ifPresent(e -> failed.add(pair));
+                    entry.result().ifPresent(e -> read.put(e.getFirst(), e.getSecond())); // This line moved outside the below apply2stable condition
+                    return r.apply2stable((u, p) -> u, entry);
+                },
+                (r1, r2) -> r1.apply2stable((u1, u2) -> u1, r2)
+        );
+
+        final Map<K, V> elements = read.build();
+        final T errors = ops.createMap(failed.build().stream());
+
+        return result.map(unit -> elements).setPartial(elements).mapError(e -> e + " missed input: " + errors);
+    }
+
+    @Override
+    public <T> DataResult<Pair<Map<K, V>, T>> decode(final DynamicOps<T> ops, final T input) {
+        return ops.getMap(input).setLifecycle(Lifecycle.stable()).flatMap(map -> decode(ops, map)).map(r -> Pair.of(r, input));
+    }
+
+    @Override
+    public <T> DataResult<T> encode(final Map<K, V> input, final DynamicOps<T> ops, final T prefix) {
+        return encode(input, ops, ops.mapBuilder()).build(prefix);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final LenientUnboundedMapCodec<?, ?> that = (LenientUnboundedMapCodec<?, ?>) o;
+        return Objects.equals(keyCodec, that.keyCodec) && Objects.equals(elementCodec, that.elementCodec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyCodec, elementCodec);
+    }
+
+    @Override
+    public String toString() {
+        return "LenientUnboundedMapCodec[" + keyCodec + " -> " + elementCodec + ']';
+    }
+}

--- a/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
+++ b/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
@@ -1,50 +1,23 @@
-/*
- * Minecraft Forge
- * Copyright (c) 2020.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 package net.minecraftforge.common;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.datafixers.util.Unit;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Lifecycle;
+import com.mojang.serialization.MapLike;
+import com.mojang.serialization.codecs.BaseMapCodec;
 
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
-import com.mojang.datafixers.util.Pair;
-import com.mojang.datafixers.util.Unit;
-import com.mojang.serialization.*;
-import com.mojang.serialization.codecs.BaseMapCodec;
-
 /**
- * This is a copy of {@link com.mojang.serialization.codecs.UnboundedMapCodec} but with one key modification: record ALL results that successfully parse, not only the first up until it errors.
- *
- * This file was originally part of Data Fixer Upper (https://github.com/Mojang/DataFixerUpper)
- * It is used and modified here as per the MIT license, the text of which is included as per the license requirements:
- *
- * MIT License
- *
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Key and value decoded independently, unknown set of keys
  */
 public class LenientUnboundedMapCodec<K, V> implements BaseMapCodec<K, V>, Codec<Map<K, V>>
 {
@@ -66,7 +39,7 @@ public class LenientUnboundedMapCodec<K, V> implements BaseMapCodec<K, V>, Codec
         return elementCodec;
     }
 
-    @Override
+    @Override // FORGE: Modified from decode() in BaseMapCodec
     public <T> DataResult<Map<K, V>> decode(DynamicOps<T> ops, MapLike<T> input)
     {
         final ImmutableMap.Builder<K, V> read = ImmutableMap.builder();
@@ -80,7 +53,7 @@ public class LenientUnboundedMapCodec<K, V> implements BaseMapCodec<K, V>, Codec
 
                     final DataResult<Pair<K, V>> entry = k.apply2stable(Pair::of, v);
                     entry.error().ifPresent(e -> failed.add(pair));
-                    entry.result().ifPresent(e -> read.put(e.getFirst(), e.getSecond())); // This line moved outside the below apply2stable condition
+                    entry.result().ifPresent(e -> read.put(e.getFirst(), e.getSecond())); // FORGE: This line moved outside the below apply2stable condition
                     return r.apply2stable((u, p) -> u, entry);
                 },
                 (r1, r2) -> r1.apply2stable((u1, u2) -> u1, r2)

--- a/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
+++ b/src/main/java/net/minecraftforge/common/LenientUnboundedMapCodec.java
@@ -32,6 +32,19 @@ import com.mojang.serialization.codecs.BaseMapCodec;
 
 /**
  * This is a copy of {@link com.mojang.serialization.codecs.UnboundedMapCodec} but with one key modification: record ALL results that successfully parse, not only the first up until it errors.
+ *
+ * This file was originally part of Data Fixer Upper (https://github.com/Mojang/DataFixerUpper)
+ * It is used and modified here as per the MIT license, the text of which is included as per the license requirements:
+ *
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 public class LenientUnboundedMapCodec<K, V> implements BaseMapCodec<K, V>, Codec<Map<K, V>>
 {


### PR DESCRIPTION
This may not be the shortest fix, but in lieu of actually patching something in DFU (e.g. see https://github.com/Mojang/DataFixerUpper/pull/55), this is (I think) the best solution to be had here. I have tested this with the example data pack TelepathicGrunt posted in the vanilla issue tracker and removing a datapack dimension removed the dimension, and only that dimension (the nether and end were still intact.)

Inspecting the call path for codec construction you can see that the `SimpleRegistry` patch is only invoked from the codec in `DimensionGeneratorSettings`.

Having a copy of `UnboundedMapCodec` was basically necessary as the class is `final`, and this is the simplest way to get at the actual underlying issue. Dealing with this after is impossible as the errors have already been discarded, and dealing with it before (i.e. as outlined in the issue report) is very painful, as the `Dynamic` as input to the codec will have to be initially parsed and understood without actually using the codec of which it's designed to do, erroring entries (read: can't just remove dimensions that don't exist, have to remove any entry that may error which basically involves parsing it via the codec, but without that.) So yeah, a lot of code that has potential for issue or other effect. (see: enderdragon not spawning :P )

Fixes #7526 / [MC-197860](https://bugs.mojang.com/browse/MC-197860)