### PR TITLE
Fix a few inconsistencies with capability invalidation

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -49,7 +49,7 @@
              this.field_145850_b.func_175666_e(this.field_174879_c, this.field_195045_e.func_177230_c());
           }
        }
-@@ -133,6 +140,8 @@
+@@ -133,8 +140,15 @@
  
     public void func_145843_s() {
        this.field_145846_f = true;
@@ -57,8 +57,15 @@
 +      requestModelDataUpdate();
     }
  
++   @Override
++   public void onChunkUnloaded() {
++      this.invalidateCaps();
++   }
++
     public void func_145829_t() {
-@@ -175,6 +184,13 @@
+       this.field_145846_f = false;
+    }
+@@ -175,6 +189,13 @@
        return this.field_200663_e;
     }
  

--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -318,13 +318,17 @@ public class LazyOptional<T>
      * call this, if they are covered with a microblock panel, thus cutting off pipe
      * connectivity to this side.
      * <p>
-     * Also should be called for all when a TE is invalidated, or a world/chunk
-     * unloads, or a entity dies, etc... This allows modders to keep a cache of
-     * capability objects instead of re-checking them every tick.
+     * Also should be called for all when a TE is invalidated (for example, when
+     * the TE is removed or unloaded), or a world/chunk unloads, or a entity dies,
+     * etc... This allows modders to keep a cache of capability objects instead of
+     * re-checking them every tick.
      */
     public void invalidate()
     {
-        this.isValid = false;
-        this.listeners.forEach(e -> e.accept(this));
+        if (this.isValid)
+        {
+            this.isValid = false;
+            this.listeners.forEach(e -> e.accept(this));
+        }
     }
 }


### PR DESCRIPTION
Made it so that `invalidateCaps` gets called when a tile unloads instead of only when a tile is removed, as after discussing it with Lex, it seems that it was overlooked. Adjusted the JavaDoc slightly on `LazyOptioanl#invalidate` to specify what constitutes a TE being invalidated, and also made it so that if someone calls `invalidate` on an already invalidated `LazyOptional` it doesn't fire the invalidation listeners again.