### PR TITLE
Fix Deadlock when adding Entities during Chunk Load (#7519)

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -8,11 +8,20 @@
                 }
  
                 this.func_219229_a(p_219185_5_);
-@@ -601,6 +_,7 @@
+@@ -582,6 +_,7 @@
+             if (this.field_219254_h.add(chunkpos.func_201841_a())) {
+                chunk.func_177417_c(true);
+                this.field_219255_i.func_147448_a(chunk.func_177434_r().values());
++               p_219200_1_.func_219276_a(ChunkStatus.field_222617_m, this).thenRun(() -> { //Forge: Delay EntityJoinWorld events until chunk is available to prevent deadlocks
+                List<Entity> list = null;
+                ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = chunk.func_177429_s();
+                int i = aclassinheritancemultimap.length;
+@@ -601,6 +_,8 @@
                 if (list != null) {
                    list.forEach(chunk::func_76622_b);
                 }
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Load(chunk));
++               });
              }
  
              return chunk;

--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -8,14 +8,14 @@
                 }
  
                 this.func_219229_a(p_219185_5_);
-@@ -582,6 +_,7 @@
+@@ -581,6 +_,7 @@
+             chunk.func_217318_w();
              if (this.field_219254_h.add(chunkpos.func_201841_a())) {
                 chunk.func_177417_c(true);
++               p_219200_1_.func_219276_a(ChunkStatus.field_222617_m, this).thenRun(() -> { //Forge: Delay until the chunk is available to prevent deadlocks
                 this.field_219255_i.func_147448_a(chunk.func_177434_r().values());
-+               p_219200_1_.func_219276_a(ChunkStatus.field_222617_m, this).thenRun(() -> { //Forge: Delay EntityJoinWorld events until chunk is available to prevent deadlocks
                 List<Entity> list = null;
                 ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = chunk.func_177429_s();
-                int i = aclassinheritancemultimap.length;
 @@ -601,6 +_,8 @@
                 if (list != null) {
                    list.forEach(chunk::func_76622_b);

--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -8,20 +8,11 @@
                 }
  
                 this.func_219229_a(p_219185_5_);
-@@ -581,6 +_,7 @@
-             chunk.func_217318_w();
-             if (this.field_219254_h.add(chunkpos.func_201841_a())) {
-                chunk.func_177417_c(true);
-+               p_219200_1_.func_219276_a(ChunkStatus.field_222617_m, this).thenRun(() -> { //Forge: Delay until the chunk is available to prevent deadlocks
-                this.field_219255_i.func_147448_a(chunk.func_177434_r().values());
-                List<Entity> list = null;
-                ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = chunk.func_177429_s();
-@@ -601,6 +_,8 @@
+@@ -601,6 +_,7 @@
                 if (list != null) {
                    list.forEach(chunk::func_76622_b);
                 }
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Load(chunk));
-+               });
              }
  
              return chunk;

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -24,6 +24,8 @@ import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.concurrent.ThreadTaskExecutor;
+import net.minecraft.util.concurrent.TickDelayedTask;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.loot.LootModifierManager;
 import net.minecraftforge.common.util.FakePlayerFactory;
@@ -40,6 +42,8 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.TickEvent.ClientTickEvent;
 import net.minecraftforge.event.TickEvent.Phase;
 import net.minecraftforge.event.TickEvent.ServerTickEvent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.LogicalSidedProvider;
 import net.minecraftforge.server.command.ForgeCommand;
 import net.minecraftforge.server.command.ConfigCommand;
 
@@ -60,7 +64,8 @@ public class ForgeInternalHandler
                 {
                     entity.remove();
                     event.setCanceled(true);
-                    event.getWorld().addFreshEntity(newEntity);
+                    ThreadTaskExecutor<Runnable> executor = LogicalSidedProvider.WORKQUEUE.get(event.getWorld().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER);
+                    executor.tell(new TickDelayedTask(0, () -> event.getWorld().addFreshEntity(newEntity)));
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
@@ -30,6 +30,7 @@ import java.util.Collection;
  * EntityJoinWorldEvent is fired when an Entity joins the world. <br>
  * This event is fired whenever an Entity is added to the world in 
  * {@link World#loadEntities(Collection)}, {@link net.minecraft.world.ServerWorld#loadEntities(Collection)} {@link World#joinEntityInSurroundings(Entity)}, and {@link World#spawnEntity(Entity)}. <br>
+ * <strong>Note:</strong> This event may be called before the underlying {@link net.minecraft.world.chunk.Chunk} is promoted to {@link net.minecraft.world.chunk.ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
  * <br>
  * {@link #world} contains the world in which the entity is to join.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -58,6 +58,7 @@ public class ChunkEvent extends WorldEvent
      * This event is fired during chunk loading in <br>
      * {@link ChunkProviderClient#loadChunk(int, int)}, <br>
      * Chunk.onChunkLoad(). <br>
+     * <strong>Note:</strong> This event may be called before the underlying {@link net.minecraft.world.chunk.Chunk} is promoted to {@link net.minecraft.world.chunk.ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>


### PR DESCRIPTION
NOTE: This PR was changed to only target the issues in forge's `IForgeItem`, this does not fix mods.

Original below:
---

Delays the firing of `EntityJoinWorldEvent` during chunk load until after the chunk is available.
This prevent deadlocks if a listener of the event tries to add an entity to the chunk being loaded.

- `ChunkEvent.Load` I've moved this so it still fires after Entity Removal (I'm not sure if this change is right).

Tested via https://github.com/MinecraftForge/MinecraftForge/issues/7519#issuecomment-735419698.

Seeing as we just saw someone have an issue with this in production (On Forge Discord), thought it was worth moving this to a PR.

A second look by someone who's had more experience with the `ChunkManager`'s code (and the mess of completablefutures) is probably worthwhile.
There's still probably a better fix available but this seems to work.