### PR TITLE
Set WM_CLASS and WM_INSTANCE_NAME for early progress window

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -185,11 +185,12 @@ public class FMLLoader
         naming = commonLaunchHandler.getNaming();
         dist = commonLaunchHandler.getDist();
         production = commonLaunchHandler.isProduction();
-        progressWindowTick = EarlyProgressVisualization.INSTANCE.accept(dist, commonLaunchHandler.isData());
+
+        mcVersion = (String) arguments.get("mcVersion");
+        progressWindowTick = EarlyProgressVisualization.INSTANCE.accept(dist, commonLaunchHandler.isData(), mcVersion);
         StartupMessageManager.modLoaderConsumer().ifPresent(c->c.accept("Early Loading!"));
         accessTransformer.getExtension().accept(Pair.of(naming, "srg"));
 
-        mcVersion = (String) arguments.get("mcVersion");
         mcpVersion = (String) arguments.get("mcpVersion");
         forgeVersion = (String) arguments.get("forgeVersion");
         forgeGroup = (String) arguments.get("forgeGroup");

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -43,6 +43,8 @@ import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
 import static org.lwjgl.opengl.GL11.*;
@@ -60,7 +62,7 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
     private GLFWFramebufferSizeCallback framebufferSizeCallback;
     private int[] fbSize;
 
-    private void initWindow( String mcVersion) {
+    private void initWindow(@Nullable String mcVersion) {
         GLFWErrorCallback.createPrint(System.err).set();
 
         long glfwInitBegin = System.nanoTime();
@@ -82,12 +84,15 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
 
-        // this emulates what we would get without early progress window
-        // as vanilla never sets these, so GLFW uses the first window title
-        // set them explicitly to avoid it using "FML early loading progress" as the class
-        String vanillaWindowTitle = "Minecraft* " + mcVersion;
-        glfwWindowHintString(GLFW_X11_CLASS_NAME, vanillaWindowTitle);
-        glfwWindowHintString(GLFW_X11_INSTANCE_NAME, vanillaWindowTitle);
+        if (mcVersion != null)
+        {
+            // this emulates what we would get without early progress window
+            // as vanilla never sets these, so GLFW uses the first window title
+            // set them explicitly to avoid it using "FML early loading progress" as the class
+            String vanillaWindowTitle = "Minecraft* " + mcVersion;
+            glfwWindowHintString(GLFW_X11_CLASS_NAME, vanillaWindowTitle);
+            glfwWindowHintString(GLFW_X11_INSTANCE_NAME, vanillaWindowTitle);
+        }
 
         window = glfwCreateWindow(screenWidth, screenHeight, "FML early loading progress", NULL, NULL);
         if (window == NULL) {
@@ -308,7 +313,7 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
     }
 
     @Override
-    public Runnable start(String mcVersion) {
+    public Runnable start(@Nullable String mcVersion) {
         initWindow(mcVersion);
         renderThread.setDaemon(true); // Don't hang the game if it terminates before handoff (i.e. datagen)
         renderThread.start();

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -60,7 +60,7 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
     private GLFWFramebufferSizeCallback framebufferSizeCallback;
     private int[] fbSize;
 
-    private void initWindow() {
+    private void initWindow( String mcVersion) {
         GLFWErrorCallback.createPrint(System.err).set();
 
         long glfwInitBegin = System.nanoTime();
@@ -81,6 +81,13 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+
+        // this emulates what we would get without early progress window
+        // as vanilla never sets these, so GLFW uses the first window title
+        // set them explicitly to avoid it using "FML early loading progress" as the class
+        String vanillaWindowTitle = "Minecraft* " + mcVersion;
+        glfwWindowHintString(GLFW_X11_CLASS_NAME, vanillaWindowTitle);
+        glfwWindowHintString(GLFW_X11_INSTANCE_NAME, vanillaWindowTitle);
 
         window = glfwCreateWindow(screenWidth, screenHeight, "FML early loading progress", NULL, NULL);
         if (window == NULL) {
@@ -301,8 +308,8 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
     }
 
     @Override
-    public Runnable start() {
-        initWindow();
+    public Runnable start(String mcVersion) {
+        initWindow(mcVersion);
         renderThread.setDaemon(true); // Don't hang the game if it terminates before handoff (i.e. datagen)
         renderThread.start();
         return org.lwjgl.glfw.GLFW::glfwPollEvents;

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
@@ -21,18 +21,24 @@ package net.minecraftforge.fml.loading.progress;
 
 import net.minecraftforge.api.distmarker.Dist;
 
-import java.util.Locale;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
 
 public enum EarlyProgressVisualization {
     INSTANCE;
 
     private Visualization visualization;
 
-    public Runnable accept(final Dist dist, final boolean isData, String mcVersion) {
+    public Runnable accept(Dist dist, boolean isData)
+    {
+        return accept(dist, isData, null);
+    }
+
+    public Runnable accept(final Dist dist, final boolean isData, @Nullable String mcVersion) {
         visualization = !isData && dist.isClient() && Boolean.parseBoolean(System.getProperty("fml.earlyprogresswindow", "true")) ? new ClientVisualization() : new NoVisualization();
         return visualization.start(mcVersion);
     }
@@ -46,7 +52,7 @@ public enum EarlyProgressVisualization {
     }
 
     interface Visualization {
-        Runnable start(String mcVersion);
+        Runnable start(@Nullable String mcVersion);
 
         default long handOffWindow(final IntSupplier width, final IntSupplier height, final Supplier<String> title, LongSupplier monitorSupplier) {
             return new LongSupplier() {
@@ -63,7 +69,7 @@ public enum EarlyProgressVisualization {
 
     private static class NoVisualization implements Visualization {
         @Override
-        public Runnable start(String mcVersion) {
+        public Runnable start(@Nullable String mcVersion) {
             return () -> {};
         }
     }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
@@ -32,9 +32,9 @@ public enum EarlyProgressVisualization {
 
     private Visualization visualization;
 
-    public Runnable accept(final Dist dist, final boolean isData) {
+    public Runnable accept(final Dist dist, final boolean isData, String mcVersion) {
         visualization = !isData && dist.isClient() && Boolean.parseBoolean(System.getProperty("fml.earlyprogresswindow", "true")) ? new ClientVisualization() : new NoVisualization();
-        return visualization.start();
+        return visualization.start(mcVersion);
     }
 
     public long handOffWindow(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitor) {
@@ -46,7 +46,7 @@ public enum EarlyProgressVisualization {
     }
 
     interface Visualization {
-        Runnable start();
+        Runnable start(String mcVersion);
 
         default long handOffWindow(final IntSupplier width, final IntSupplier height, final Supplier<String> title, LongSupplier monitorSupplier) {
             return new LongSupplier() {
@@ -63,7 +63,7 @@ public enum EarlyProgressVisualization {
 
     private static class NoVisualization implements Visualization {
         @Override
-        public Runnable start() {
+        public Runnable start(String mcVersion) {
             return () -> {};
         }
     }


### PR DESCRIPTION
Emulate what we would get without the early progress window.
Vanilla Minecraft never sets these properties, so GLFW defaults to the first window title, which is "Minecraft* \<version\>".  Emulate this here by setting the properties explicitly to avoid GLFW using the early progress window title.

Fixes #7531.