### PR TITLE
Override invalidateCaps instead of remove for vanilla TE capability invalidation

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -481,7 +481,7 @@
     }
  
     public boolean func_70094_T() {
-@@ -3082,6 +3138,60 @@
+@@ -3082,6 +3138,58 @@
        this.func_213361_c(p_213334_1_ == Hand.MAIN_HAND ? EquipmentSlotType.MAINHAND : EquipmentSlotType.OFFHAND);
     }
  
@@ -531,12 +531,10 @@
 +   }
 +
 +   @Override
-+   public void remove(boolean keepData) {
-+      super.remove(keepData);
-+      if (!keepData) {
-+         for (int x = 0; x < handlers.length; x++)
-+            handlers[x].invalidate();
-+      }
++   protected void invalidateCaps() {
++      super.invalidateCaps();
++      for (int x = 0; x < handlers.length; x++)
++         handlers[x].invalidate();
 +   }
 +
     @OnlyIn(Dist.CLIENT)

--- a/patches/minecraft/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java
 +++ b/net/minecraft/entity/item/minecart/ContainerMinecartEntity.java
-@@ -118,17 +118,19 @@
+@@ -118,17 +118,18 @@
     }
  
     @Nullable
@@ -20,11 +20,10 @@
  
 -      super.func_70106_y();
 +      super.remove(keepData);
-+      if (!keepData) itemHandler.invalidate();
     }
  
     protected void func_213281_b(CompoundNBT p_213281_1_) {
-@@ -157,6 +159,8 @@
+@@ -157,6 +158,8 @@
     }
  
     public ActionResultType func_184230_a(PlayerEntity p_184230_1_, Hand p_184230_2_) {
@@ -33,7 +32,7 @@
        p_184230_1_.func_213829_a(this);
        if (!p_184230_1_.field_70170_p.field_72995_K) {
           PiglinTasks.func_234478_a_(p_184230_1_, true);
-@@ -185,6 +189,8 @@
+@@ -185,6 +188,8 @@
  
           this.field_184290_c = null;
           LootContext.Builder lootcontext$builder = (new LootContext.Builder((ServerWorld)this.field_70170_p)).func_216015_a(LootParameters.field_237457_g_, this.func_213303_ch()).func_216016_a(this.field_184291_d);
@@ -42,7 +41,7 @@
           if (p_184288_1_ != null) {
              lootcontext$builder.func_186469_a(p_184288_1_.func_184817_da()).func_216015_a(LootParameters.field_216281_a, p_184288_1_);
           }
-@@ -215,4 +221,17 @@
+@@ -215,4 +220,23 @@
     }
  
     protected abstract Container func_213968_a(int p_213968_1_, PlayerInventory p_213968_2_);
@@ -54,6 +53,12 @@
 +      if (this.func_70089_S() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
++   }
++
++   @Override
++   protected void invalidateCaps() {
++      super.invalidateCaps();
++      itemHandler.invalidate();
 +   }
 +
 +   public void dropContentsWhenDead(boolean value) {

--- a/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
@@ -43,9 +43,9 @@
 +   }
 +
 +   @Override
-+   public void remove(boolean keepData) {
-+      super.remove(keepData);
-+      if (!keepData && itemHandler != null) {
++   protected void invalidateCaps() {
++      super.invalidateCaps();
++      if (itemHandler != null) {
 +         itemHandler.invalidate();
 +         itemHandler = null;
 +      }

--- a/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
@@ -118,8 +118,8 @@
 +   }
 +
 +   @Override
-+   public void func_145843_s() {
-+      super.func_145843_s();
++   public void invalidateCaps() {
++      super.invalidateCaps();
 +      for (int x = 0; x < handlers.length; x++)
 +        handlers[x].invalidate();
 +   }

--- a/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
@@ -118,7 +118,7 @@
 +   }
 +
 +   @Override
-+   public void invalidateCaps() {
++   protected void invalidateCaps() {
 +      super.invalidateCaps();
 +      for (int x = 0; x < handlers.length; x++)
 +        handlers[x].invalidate();

--- a/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
@@ -76,8 +76,8 @@
 +   }
 +
 +   @Override
-+   public void func_145843_s() {
-+      super.func_145843_s();
++   public void invalidateCaps() {
++      super.invalidateCaps();
 +      for (int x = 0; x < handlers.length; x++)
 +        handlers[x].invalidate();
 +   }

--- a/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/BrewingStandTileEntity.java.patch
@@ -76,7 +76,7 @@
 +   }
 +
 +   @Override
-+   public void invalidateCaps() {
++   protected void invalidateCaps() {
 +      super.invalidateCaps();
 +      for (int x = 0; x < handlers.length; x++)
 +        handlers[x].invalidate();

--- a/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
@@ -51,7 +51,7 @@
 +   }
 +
 +   @Override
-+   public void invalidateCaps() {
++   protected void invalidateCaps() {
 +      super.invalidateCaps();
 +      if (chestHandler != null)
 +        chestHandler.invalidate();

--- a/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
@@ -51,8 +51,8 @@
 +   }
 +
 +   @Override
-+   public void func_145843_s() {
-+      super.func_145843_s();
++   public void invalidateCaps() {
++      super.invalidateCaps();
 +      if (chestHandler != null)
 +        chestHandler.invalidate();
 +   }

--- a/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
@@ -10,7 +10,7 @@
 +      return new net.minecraftforge.items.wrapper.InvWrapper(this);
 +   }
 +
-+   @javax.annotation.Nullable
++   @javax.annotation.Nonnull
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @javax.annotation.Nullable net.minecraft.util.Direction side) {
 +      if (!this.field_145846_f && cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
 +         return itemHandler.cast();
@@ -18,8 +18,8 @@
 +   }
 +
 +   @Override
-+   public void func_145843_s() {
-+      super.func_145843_s();
++   public void invalidateCaps() {
++      super.invalidateCaps();
 +      itemHandler.invalidate();
 +   }
  }

--- a/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
@@ -18,7 +18,7 @@
 +   }
 +
 +   @Override
-+   public void invalidateCaps() {
++   protected void invalidateCaps() {
 +      super.invalidateCaps();
 +      itemHandler.invalidate();
 +   }

--- a/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/LockableTileEntity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/tileentity/LockableTileEntity.java
 +++ b/net/minecraft/tileentity/LockableTileEntity.java
-@@ -81,4 +81,22 @@
+@@ -81,4 +81,21 @@
     }
  
     protected abstract Container func_213906_a(int p_213906_1_, PlayerInventory p_213906_2_);
@@ -10,7 +10,6 @@
 +      return new net.minecraftforge.items.wrapper.InvWrapper(this);
 +   }
 +
-+   @javax.annotation.Nonnull
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @javax.annotation.Nullable net.minecraft.util.Direction side) {
 +      if (!this.field_145846_f && cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
 +         return itemHandler.cast();


### PR DESCRIPTION
Addresses a small oversight of mine in https://github.com/MinecraftForge/MinecraftForge/commit/1a539ffebcbc3d9eba46cd489066c228a4e6fc2a where I did not realize that forge's patched in capabilities for vanilla TEs was hardcoded to happening in `remove` instead of in `invalidateCaps`.