### PR TITLE
Fix compound ingredient in shapeless recipes

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -136,6 +136,12 @@ public class CompoundIngredient extends Ingredient
        }
     }
 
+    @Override
+    public boolean hasNoMatchingItems()
+    {
+        return getMatchingStacks().length == 0;
+    }
+
     public static class Serializer implements IIngredientSerializer<CompoundIngredient>
     {
         public static final Serializer INSTANCE = new Serializer();


### PR DESCRIPTION
_This PR fixes #7530._

As described in the linked issue, compound ingredients do not work in shapeless recipes due to `CompoundIngredient` not overriding `Ingredient#hasNoMatchingItems()`, which is used by shapeless recipes to filter out useless/empty ingredient. Because it does not override the method, and `CompoundIngredient` passes an empty stream to the superclass construtor, it will always return `false`, therefore always making sure that shapeless recipes filter out compound ingredients.

This PR fixes that by overriding `Ingredient#hasNoMatchingItems()` in `CompoundIngredient`, therefore allowing non-compound ingredients to work in shapeless recipes. I have tested my change with the datapack provided in the linked issue, and verified that the crafting operation of `Dirt, Dirt, Water Bottle` does work (i.e. result in the output of `Diamond`s).

The use of `getMatchingStack()` is deliberate, as it takes advantage of the pre-existing calculation and invalidation mechanisms for the stored `ItemStack[]`, and follows as close as possible to the contract of `Ingredient#hasNoMatchingItems()` (returning `true` if no matching items exist for the ingredient).