### PR TITLE
Make shear interactions extend to subclasses

### DIFF
--- a/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BeehiveBlock.java
++++ b/net/minecraft/block/BeehiveBlock.java
+@@ -105,7 +105,7 @@
+       int i = p_225533_1_.func_177229_b(field_226873_c_);
+       boolean flag = false;
+       if (i >= 5) {
+-         if (itemstack.func_77973_b() == Items.field_151097_aZ) {
++         if (itemstack.func_77973_b() instanceof net.minecraft.item.ShearsItem) {
+             p_225533_2_.func_184148_a(p_225533_4_, p_225533_4_.func_226277_ct_(), p_225533_4_.func_226278_cu_(), p_225533_4_.func_226281_cx_(), SoundEvents.field_226133_ah_, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+             func_226878_a_(p_225533_2_, p_225533_3_);
+             itemstack.func_222118_a(1, p_225533_4_, (p_226874_1_) -> {

--- a/patches/minecraft/net/minecraft/block/PumpkinBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/PumpkinBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/PumpkinBlock.java
++++ b/net/minecraft/block/PumpkinBlock.java
+@@ -20,7 +20,7 @@
+ 
+    public ActionResultType func_225533_a_(BlockState p_225533_1_, World p_225533_2_, BlockPos p_225533_3_, PlayerEntity p_225533_4_, Hand p_225533_5_, BlockRayTraceResult p_225533_6_) {
+       ItemStack itemstack = p_225533_4_.func_184586_b(p_225533_5_);
+-      if (itemstack.func_77973_b() == Items.field_151097_aZ) {
++      if (itemstack.func_77973_b() instanceof net.minecraft.item.ShearsItem) {
+          if (!p_225533_2_.field_72995_K) {
+             Direction direction = p_225533_6_.func_216354_b();
+             Direction direction1 = direction.func_176740_k() == Direction.Axis.Y ? p_225533_4_.func_174811_aO().func_176734_d() : direction;

--- a/patches/minecraft/net/minecraft/block/TripWireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TripWireBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/TripWireBlock.java
++++ b/net/minecraft/block/TripWireBlock.java
+@@ -67,7 +67,7 @@
+    }
+ 
+    public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
+-      if (!p_176208_1_.field_72995_K && !p_176208_4_.func_184614_ca().func_190926_b() && p_176208_4_.func_184614_ca().func_77973_b() == Items.field_151097_aZ) {
++      if (!p_176208_1_.field_72995_K && !p_176208_4_.func_184614_ca().func_190926_b() && p_176208_4_.func_184614_ca().func_77973_b() instanceof net.minecraft.item.ShearsItem) {
+          p_176208_1_.func_180501_a(p_176208_2_, p_176208_3_.func_206870_a(field_176295_N, Boolean.valueOf(true)), 4);
+       }
+ 

--- a/patches/minecraft/net/minecraft/enchantment/EfficiencyEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EfficiencyEnchantment.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/enchantment/EfficiencyEnchantment.java
++++ b/net/minecraft/enchantment/EfficiencyEnchantment.java
+@@ -22,6 +22,6 @@
+    }
+ 
+    public boolean func_92089_a(ItemStack p_92089_1_) {
+-      return p_92089_1_.func_77973_b() == Items.field_151097_aZ ? true : super.func_92089_a(p_92089_1_);
++      return p_92089_1_.func_77973_b() instanceof net.minecraft.item.ShearsItem ? true : super.func_92089_a(p_92089_1_);
+    }
+ }


### PR DESCRIPTION
Makes it so less code has to be replicated in onItemUse checking the block used against to make custom shears function properly with some of the custom interactions vanilla has.