### PR TITLE
Add hook to allow modders to more easily control if endermen can place blocks on top of their blocks

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -59,7 +59,7 @@
  
        private boolean func_220836_a(World p_220836_1_, BlockPos p_220836_2_, BlockState p_220836_3_, BlockState p_220836_4_, BlockState p_220836_5_, BlockPos p_220836_6_) {
 -         return p_220836_4_.func_196958_f() && !p_220836_5_.func_196958_f() && !p_220836_5_.func_203425_a(Blocks.field_150357_h) && p_220836_5_.func_235785_r_(p_220836_1_, p_220836_6_) && p_220836_3_.func_196955_c(p_220836_1_, p_220836_2_) && p_220836_1_.func_72839_b(this.field_179475_a, AxisAlignedBB.func_241549_a_(Vector3d.func_237491_b_(p_220836_2_))).isEmpty();
-+         return p_220836_4_.isAir(p_220836_1_, p_220836_2_) && !p_220836_5_.isAir(p_220836_1_, p_220836_6_) && !p_220836_5_.func_203425_a(Blocks.field_150357_h) && p_220836_5_.func_235785_r_(p_220836_1_, p_220836_6_) && p_220836_3_.func_196955_c(p_220836_1_, p_220836_2_) && p_220836_1_.func_72839_b(this.field_179475_a, AxisAlignedBB.func_241549_a_(Vector3d.func_237491_b_(p_220836_2_))).isEmpty();
++         return p_220836_4_.isAir(p_220836_1_, p_220836_2_) && !p_220836_5_.isAir(p_220836_1_, p_220836_6_) && !p_220836_5_.func_203425_a(Blocks.field_150357_h) && !p_220836_5_.func_235714_a_(net.minecraftforge.common.Tags.Blocks.ENDERMAN_PLACE_ON_BLACKLIST) && p_220836_5_.func_235785_r_(p_220836_1_, p_220836_6_) && p_220836_3_.func_196955_c(p_220836_1_, p_220836_2_) && p_220836_1_.func_72839_b(this.field_179475_a, AxisAlignedBB.func_241549_a_(Vector3d.func_237491_b_(p_220836_2_))).isEmpty();
        }
     }
  

--- a/src/generated/resources/data/forge/tags/blocks/enderman_place_on_blacklist.json
+++ b/src/generated/resources/data/forge/tags/blocks/enderman_place_on_blacklist.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": []
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -49,6 +49,7 @@ public class Tags
         public static final IOptionalNamedTag<Block> COBBLESTONE = tag("cobblestone");
         public static final IOptionalNamedTag<Block> DIRT = tag("dirt");
         public static final IOptionalNamedTag<Block> END_STONES = tag("end_stones");
+        public static final IOptionalNamedTag<Block> ENDERMAN_PLACE_ON_BLACKLIST = tag("enderman_place_on_blacklist");
         public static final IOptionalNamedTag<Block> FENCE_GATES = tag("fence_gates");
         public static final IOptionalNamedTag<Block> FENCE_GATES_WOODEN = tag("fence_gates/wooden");
         public static final IOptionalNamedTag<Block> FENCES = tag("fences");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -53,6 +53,7 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
         getOrCreateBuilder(COBBLESTONE).add(Blocks.COBBLESTONE, Blocks.INFESTED_COBBLESTONE, Blocks.MOSSY_COBBLESTONE);
         getOrCreateBuilder(DIRT).add(Blocks.DIRT, Blocks.GRASS_BLOCK, Blocks.COARSE_DIRT, Blocks.PODZOL, Blocks.MYCELIUM);
         getOrCreateBuilder(END_STONES).add(Blocks.END_STONE);
+        getOrCreateBuilder(ENDERMAN_PLACE_ON_BLACKLIST);
         getOrCreateBuilder(FENCE_GATES).addTags(FENCE_GATES_WOODEN);
         getOrCreateBuilder(FENCE_GATES_WOODEN).add(Blocks.OAK_FENCE_GATE, Blocks.SPRUCE_FENCE_GATE, Blocks.BIRCH_FENCE_GATE, Blocks.JUNGLE_FENCE_GATE, Blocks.ACACIA_FENCE_GATE, Blocks.DARK_OAK_FENCE_GATE, Blocks.CRIMSON_FENCE_GATE, Blocks.WARPED_FENCE_GATE);
         getOrCreateBuilder(FENCES).addTags(FENCES_NETHER_BRICK, FENCES_WOODEN);


### PR DESCRIPTION
This PR exposes a method in `IForgeBlock` to control if an Enderman can place a given block on top of a modder's block. My use case is to be able to deny Endermen from placing blocks on some of my blocks without having to listen to the full on block place event of all entities, though another thing this PR makes possible is for modders to relax the place requirements on their blocks to allow Endermen to place blocks on top of theirs even if it is "air" or opaque.