### PR TITLE
Only apply the MC-68754 fix on Windows, closes #7546

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -223,7 +223,7 @@
              }
  
              Display.setFullscreen(this.field_71431_Q);
-+            if (!this.field_71431_Q) //Forge: Fix MC-68754, Screen is not resizeable after exiting fullscreen due to LWJGL bug https://github.com/LWJGL/lwjgl/issues/142 which is fixed, but not in the version MC ships
++            if (!this.field_71431_Q && (Util.func_110647_a() == Util.EnumOS.WINDOWS)) //Forge: Fix MC-68754, Screen is not resizeable after exiting fullscreen due to LWJGL bug https://github.com/LWJGL/lwjgl/issues/142 which is fixed, but not in the version MC ships
 +            {
 +                Display.setResizable(false);
 +                Display.setResizable(true);


### PR DESCRIPTION
MC-68754 only affects Minecraft on Windows, as per the comments on Mojang's bug tracker, and the corresponding LWJGL bug report (https://github.com/LWJGL/lwjgl/issues/142). This change simply checks if the OS running Minecraft is Windows before applying the fix. This was tested by me on Windows 10, MacOS Mojave, and Lubuntu (5.8.0-31), and all platforms allowed the window to be resized as expected after exiting fullscreen. As the MC-68754 fix was the cause of #7546, this issue is fixed by applying this patch.