### PR TITLE
[1.16] Added multi part entity support

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
@@ -36,6 +36,17 @@
     }
  
     public void func_147279_a(SAnimateHandPacket p_147279_1_) {
+@@ -854,8 +858,8 @@
+          livingentity.func_213312_b(d0, d1, d2);
+          livingentity.field_70761_aq = (float)(p_147281_1_.func_149032_n() * 360) / 256.0F;
+          livingentity.field_70759_as = (float)(p_147281_1_.func_149032_n() * 360) / 256.0F;
+-         if (livingentity instanceof EnderDragonEntity) {
+-            EnderDragonPartEntity[] aenderdragonpartentity = ((EnderDragonEntity)livingentity).func_213404_dT();
++         if (livingentity.isMultipartEntity()) {
++            net.minecraftforge.entity.PartEntity<?>[] aenderdragonpartentity = livingentity.getParts();
+ 
+             for(int i = 0; i < aenderdragonpartentity.length; ++i) {
+                aenderdragonpartentity[i].func_145769_d(i + p_147281_1_.func_149024_d());
 @@ -1004,8 +1008,10 @@
           clientplayerentity1.func_233645_dx_().func_233784_a_(clientplayerentity.func_233645_dx_());
        }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRendererManager.java.patch
@@ -11,6 +11,21 @@
        for(EntityType<?> entitytype : Registry.field_212629_r) {
           if (entitytype != EntityType.field_200729_aH && !this.field_78729_o.containsKey(entitytype)) {
              throw new IllegalStateException("No renderer registered for " + Registry.field_212629_r.func_177774_c(entitytype));
+@@ -280,12 +283,12 @@
+    private void func_229093_a_(MatrixStack p_229093_1_, IVertexBuilder p_229093_2_, Entity p_229093_3_, float p_229093_4_) {
+       float f = p_229093_3_.func_213311_cf() / 2.0F;
+       this.func_229094_a_(p_229093_1_, p_229093_2_, p_229093_3_, 1.0F, 1.0F, 1.0F);
+-      if (p_229093_3_ instanceof EnderDragonEntity) {
++      if (p_229093_3_.isMultipartEntity()) {
+          double d0 = -MathHelper.func_219803_d((double)p_229093_4_, p_229093_3_.field_70142_S, p_229093_3_.func_226277_ct_());
+          double d1 = -MathHelper.func_219803_d((double)p_229093_4_, p_229093_3_.field_70137_T, p_229093_3_.func_226278_cu_());
+          double d2 = -MathHelper.func_219803_d((double)p_229093_4_, p_229093_3_.field_70136_U, p_229093_3_.func_226281_cx_());
+ 
+-         for(EnderDragonPartEntity enderdragonpartentity : ((EnderDragonEntity)p_229093_3_).func_213404_dT()) {
++         for(net.minecraftforge.entity.PartEntity<?> enderdragonpartentity : p_229093_3_.getParts()) {
+             p_229093_1_.func_227860_a_();
+             double d3 = d0 + MathHelper.func_219803_d((double)p_229093_4_, enderdragonpartentity.field_70142_S, enderdragonpartentity.func_226277_ct_());
+             double d4 = d1 + MathHelper.func_219803_d((double)p_229093_4_, enderdragonpartentity.field_70137_T, enderdragonpartentity.func_226278_cu_());
 @@ -450,4 +453,8 @@
     public FontRenderer func_78716_a() {
        return this.field_78736_p;

--- a/patches/minecraft/net/minecraft/entity/boss/dragon/EnderDragonEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/dragon/EnderDragonEntity.java.patch
@@ -11,3 +11,18 @@
                       flag1 = this.field_70170_p.func_217377_a(blockpos, false) || flag1;
                    } else {
                       flag = true;
+@@ -842,4 +842,14 @@
+    public boolean func_184222_aU() {
+       return false;
+    }
++
++   @Override
++   public boolean isMultipartEntity() {
++      return true;
++   }
++
++   @Override
++   public net.minecraftforge.entity.PartEntity<?>[] getParts() {
++      return this.field_70977_g;
++   }
+ }

--- a/patches/minecraft/net/minecraft/entity/boss/dragon/EnderDragonPartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/dragon/EnderDragonPartEntity.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/entity/boss/dragon/EnderDragonPartEntity.java
++++ b/net/minecraft/entity/boss/dragon/EnderDragonPartEntity.java
+@@ -7,13 +7,13 @@
+ import net.minecraft.network.IPacket;
+ import net.minecraft.util.DamageSource;
+ 
+-public class EnderDragonPartEntity extends Entity {
++public class EnderDragonPartEntity extends net.minecraftforge.entity.PartEntity<EnderDragonEntity> {
+    public final EnderDragonEntity field_213852_b;
+    public final String field_213853_c;
+    private final EntitySize field_213854_d;
+ 
+    public EnderDragonPartEntity(EnderDragonEntity p_i50232_1_, String p_i50232_2_, float p_i50232_3_, float p_i50232_4_) {
+-      super(p_i50232_1_.func_200600_R(), p_i50232_1_.field_70170_p);
++      super(p_i50232_1_);
+       this.field_213854_d = EntitySize.func_220314_b(p_i50232_3_, p_i50232_4_);
+       this.func_213323_x_();
+       this.field_213852_b = p_i50232_1_;

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -210,7 +210,14 @@
                 }
  
                 f = f + f1;
-@@ -1127,8 +1160,10 @@
+@@ -1122,13 +1155,15 @@
+                   EnchantmentHelper.func_151385_b(this, p_71059_1_);
+                   ItemStack itemstack1 = this.func_184614_ca();
+                   Entity entity = p_71059_1_;
+-                  if (p_71059_1_ instanceof EnderDragonPartEntity) {
+-                     entity = ((EnderDragonPartEntity)p_71059_1_).field_213852_b;
++                  if (p_71059_1_ instanceof net.minecraftforge.entity.PartEntity) {
++                     entity = ((net.minecraftforge.entity.PartEntity<?>) p_71059_1_).getParent();
                    }
  
                    if (!this.field_70170_p.field_72995_K && !itemstack1.func_190926_b() && entity instanceof LivingEntity) {

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -143,6 +143,17 @@
        i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
        j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
+@@ -472,8 +482,8 @@
+                   p_177414_3_.add(entity);
+                }
+ 
+-               if (entity instanceof EnderDragonEntity) {
+-                  for(EnderDragonPartEntity enderdragonpartentity : ((EnderDragonEntity)entity).func_213404_dT()) {
++               if (entity.isMultipartEntity()) {
++                  for(net.minecraftforge.entity.PartEntity<?> enderdragonpartentity : entity.getParts()) {
+                      if (enderdragonpartentity != p_177414_1_ && enderdragonpartentity.func_174813_aQ().func_72326_a(p_177414_2_) && (p_177414_4_ == null || p_177414_4_.test(enderdragonpartentity))) {
+                         p_177414_3_.add(enderdragonpartentity);
+                      }
 @@ -486,8 +496,8 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -32,3 +32,12 @@
           if (p_219199_5_ && !p_219199_4_) {
              ChunkHolder chunkholder = this.func_219219_b(p_219199_2_.func_201841_a());
              if (chunkholder != null) {
+@@ -942,7 +946,7 @@
+    }
+ 
+    protected void func_219210_a(Entity p_219210_1_) {
+-      if (!(p_219210_1_ instanceof EnderDragonPartEntity)) {
++      if (!(p_219210_1_ instanceof net.minecraftforge.entity.PartEntity)) {
+          EntityType<?> entitytype = p_219210_1_.func_200600_R();
+          int i = entitytype.func_233602_m_() * 16;
+          int j = entitytype.func_220332_l();

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -61,6 +61,15 @@
           }
  
           this.func_229856_ab_();
+@@ -395,7 +400,7 @@
+             }
+ 
+             iprofiler.func_76320_a("tick");
+-            if (!entity1.field_70128_L && !(entity1 instanceof EnderDragonPartEntity)) {
++            if (!entity1.field_70128_L && !(entity1 instanceof net.minecraftforge.entity.PartEntity)) {
+                this.func_217390_a(this::func_217479_a, entity1);
+             }
+ 
 @@ -404,7 +409,7 @@
              if (entity1.field_70128_L) {
                 this.func_217454_n(entity1);
@@ -128,12 +137,14 @@
  
 +   @Deprecated //Forge: Use removeEntityComplete(entity,boolean)
     public void func_217484_g(Entity p_217484_1_) {
+-      if (p_217484_1_ instanceof EnderDragonEntity) {
+-         for(EnderDragonPartEntity enderdragonpartentity : ((EnderDragonEntity)p_217484_1_).func_213404_dT()) {
+-            enderdragonpartentity.func_70106_y();
 +      removeEntityComplete(p_217484_1_, false);
 +   }
 +   public void removeEntityComplete(Entity p_217484_1_, boolean keepData) {
-       if (p_217484_1_ instanceof EnderDragonEntity) {
-          for(EnderDragonPartEntity enderdragonpartentity : ((EnderDragonEntity)p_217484_1_).func_213404_dT()) {
--            enderdragonpartentity.func_70106_y();
++      if (p_217484_1_.isMultipartEntity()) {
++         for(net.minecraftforge.entity.PartEntity<?> enderdragonpartentity : p_217484_1_.getParts()) {
 +            enderdragonpartentity.remove(keepData);
           }
        }
@@ -150,6 +161,17 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
+@@ -905,8 +923,8 @@
+          this.field_217499_z.add(p_217465_1_);
+       } else {
+          this.field_217498_x.put(p_217465_1_.func_145782_y(), p_217465_1_);
+-         if (p_217465_1_ instanceof EnderDragonEntity) {
+-            for(EnderDragonPartEntity enderdragonpartentity : ((EnderDragonEntity)p_217465_1_).func_213404_dT()) {
++         if (p_217465_1_.isMultipartEntity()) {
++            for(net.minecraftforge.entity.PartEntity<?> enderdragonpartentity : p_217465_1_.getParts()) {
+                this.field_217498_x.put(enderdragonpartentity.func_145782_y(), enderdragonpartentity);
+             }
+          }
 @@ -918,15 +936,19 @@
           }
        }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.extensions;
 
 import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
@@ -40,6 +41,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.entity.PartEntity;
 
 public interface IForgeEntity extends ICapabilitySerializable<CompoundNBT>
 {
@@ -192,4 +194,34 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundNBT>
      * the entity to react to being revived.
      */
     void revive();
+
+
+    /**
+     * This is used to specify that your entity has multiple individual parts, such as the Vanilla Ender Dragon.
+     *
+     * See {@link net.minecraft.entity.boss.dragon.EnderDragonEntity} for an example implementation.
+     * @return true if this is a multipart entity.
+     */
+    default boolean isMultipartEntity()
+    {
+        return false;
+    }
+
+    /**
+     * Gets the individual sub parts that make up this entity.
+     *
+     * The entities returned by this method are NOT saved to the world in nay way, they exist as an extension
+     * of their host entity. The child entity does not track its server-side(or client-side) counterpart, and
+     * the host entity is responsible for moving and managing these children.
+     *
+     * Only used if {@link #isMultipartEntity()} returns true.
+     *
+     * See {@link net.minecraft.entity.boss.dragon.EnderDragonEntity} for an example implementation.
+     * @return The child parts of this entity. The value to be returned here should be cached.
+     */
+    @Nullable
+    default PartEntity<?>[] getParts()
+    {
+        return null;
+    }
 }

--- a/src/main/java/net/minecraftforge/entity/PartEntity.java
+++ b/src/main/java/net/minecraftforge/entity/PartEntity.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.network.IPacket;
+
+/**
+ * Created by brandon3055 on 16/12/20
+ */
+public abstract class PartEntity<T extends Entity> extends Entity {
+    private final T parent;
+
+    public PartEntity(T parent) {
+        super(parent.getType(), parent.world);
+        this.parent = parent;
+    }
+
+    public T getParent() {
+        return parent;
+    }
+
+    @Override
+    public IPacket<?> createSpawnPacket() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/net/minecraftforge/entity/PartEntity.java
+++ b/src/main/java/net/minecraftforge/entity/PartEntity.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.entity;
 
 import net.minecraft.entity.Entity;

--- a/src/main/java/net/minecraftforge/entity/PartEntity.java
+++ b/src/main/java/net/minecraftforge/entity/PartEntity.java
@@ -3,9 +3,6 @@ package net.minecraftforge.entity;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.IPacket;
 
-/**
- * Created by brandon3055 on 16/12/20
- */
 public abstract class PartEntity<T extends Entity> extends Entity {
     private final T parent;
 


### PR DESCRIPTION
Effectively a simplified version of #6701

This pr expands the vanilla logic used by the Ender Dragon and opens it up so other can make similar multipart entities. This is done via two new methods on `IForgeEntity` `isMultipartEntity` and `getParts`, All of the vanilla logic for handling dragons has been switched to these methods, There is now also a `PartEntity` which is extended by `EnderDragonPartEntity`.

Uses for this include creating large entities which require custom sub hit boxes. An obvious example being custom dragons as its now no longer possible to extend the vanilla dragon. 
