### PR TITLE
[1.16.x] Fixed the PotentialSpawnEvent to match functionality from previous versions.

### DIFF
--- a/patches/minecraft/net/minecraft/world/spawner/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/WorldEntitySpawner.java.patch
@@ -27,7 +27,7 @@
                                return;
                             }
  
-@@ -253,6 +255,7 @@
+@@ -253,12 +255,13 @@
           return null;
        } else {
           List<MobSpawnInfo.Spawners> list = func_241463_a_(p_234977_0_, p_234977_1_, p_234977_2_, p_234977_3_, p_234977_5_, biome);
@@ -35,6 +35,13 @@
           return list.isEmpty() ? null : WeightedRandom.func_76271_a(p_234977_4_, list);
        }
     }
+ 
+    private static boolean func_234976_a_(ServerWorld p_234976_0_, StructureManager p_234976_1_, ChunkGenerator p_234976_2_, EntityClassification p_234976_3_, MobSpawnInfo.Spawners p_234976_4_, BlockPos p_234976_5_) {
+-      return func_241463_a_(p_234976_0_, p_234976_1_, p_234976_2_, p_234976_3_, p_234976_5_, (Biome)null).contains(p_234976_4_);
++      return net.minecraftforge.event.ForgeEventFactory.getPotentialSpawns(p_234976_0_, p_234976_3_, p_234976_5_, func_241463_a_(p_234976_0_, p_234976_1_, p_234976_2_, p_234976_3_, p_234976_5_, (Biome)null)).contains(p_234976_4_);
+    }
+ 
+    private static List<MobSpawnInfo.Spawners> func_241463_a_(ServerWorld p_241463_0_, StructureManager p_241463_1_, ChunkGenerator p_241463_2_, EntityClassification p_241463_3_, BlockPos p_241463_4_, @Nullable Biome p_241463_5_) {
 @@ -292,6 +295,13 @@
        if (p_209382_0_ == EntitySpawnPlacementRegistry.PlacementType.NO_RESTRICTIONS) {
           return true;

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -32,6 +32,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.biome.MobSpawnInfo;
+import net.minecraft.world.spawner.WorldEntitySpawner;
 import net.minecraft.world.storage.IServerWorldInfo;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
@@ -116,10 +117,10 @@ public class WorldEvent extends Event
     }
 
     /**
-     * Called by WorldServer to gather a list of all possible entities that can spawn at the specified location.
+     * Called by WorldEntitySpawner to gather a list of all possible entities that can spawn at the specified location.
      * If an entry is added to the list, it needs to be a globally unique instance.
-     * The event is called in {@link WorldServer#getSpawnListEntryForTypeAt(EnumCreatureType, BlockPos)} as well as
-     * {@link WorldServer#canCreatureTypeSpawnHere(EnumCreatureType, SpawnListEntry, BlockPos)}
+     * The event is called in {@link WorldEntitySpawner#func_234977_a_} as well as
+     * {@link WorldEntitySpawner#func_234976_a_}
      * where the latter checks for identity, meaning both events must add the same instance.
      * Canceling the event will result in a empty list, meaning no entity will be spawned.
      */

--- a/src/test/java/net/minecraftforge/debug/world/PotentialSpawnEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/PotentialSpawnEventTest.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.world.biome.MobSpawnInfo;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(PotentialSpawnEventTest.MODID)
+public class PotentialSpawnEventTest
+{
+    public static final String MODID = "potential_spawn_event_test";
+
+    private static final boolean ENABLED = false;
+
+    private MobSpawnInfo.Spawners ZOMBIFIED_PIGLIN_SPAWNER;
+
+    public PotentialSpawnEventTest()
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.addListener(this::potentialSpawns);
+            ZOMBIFIED_PIGLIN_SPAWNER = new MobSpawnInfo.Spawners(EntityType.ZOMBIFIED_PIGLIN, 1, 4, 4);
+        }
+    }
+
+    public void potentialSpawns(WorldEvent.PotentialSpawns event)
+    {
+        event.getList().clear();
+        event.getList().add(ZOMBIFIED_PIGLIN_SPAWNER);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -98,3 +98,5 @@ license="LGPL v2.1"
     modId="render_local_player_test"
 [[mods]]
     modId="forge_world_type_test"
+[[mods]]
+    modId="potential_spawn_event_test"


### PR DESCRIPTION
This fix is equivalent to what this part of the patch changed in 1.15.x and is missing in 1.16.x. https://github.com/MinecraftForge/MinecraftForge/blob/60eb1c25e9f01fc4ccc1c1bd9d63fbae813b037d/patches/minecraft/net/minecraft/world/spawner/WorldEntitySpawner.java.patch#L52-L57 
The doc for the event has been updated to point to where it's actually fired from now.
I've added a test for the event to verify that it works as intended, it will try to replace all spawns with zombified piglins even if the biome normally doesn't allow them to spawn there.
This fixes #7309 