### PR TITLE
Fix entity properties not being sent to vanilla clients at all

### DIFF
--- a/src/main/java/net/minecraftforge/network/VanillaConnectionNetworkFilter.java
+++ b/src/main/java/net/minecraftforge/network/VanillaConnectionNetworkFilter.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.network;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -84,7 +85,7 @@ public class VanillaConnectionNetworkFilter extends MessageToMessageEncoder<IPac
     @Nonnull
     private static SEntityPropertiesPacket filterEntityProperties(SEntityPropertiesPacket msg)
     {
-        SEntityPropertiesPacket newPacket = new SEntityPropertiesPacket();
+        SEntityPropertiesPacket newPacket = new SEntityPropertiesPacket(msg.getEntityId(), Collections.emptyList());
         msg.getSnapshots().stream()
                 .filter(snapshot -> {
                     ResourceLocation key = ForgeRegistries.ATTRIBUTES.getKey(snapshot.func_240834_a_());

--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -77,6 +77,7 @@ net/minecraft/nbt/CompressedStreamTools func_74797_a(Ljava/io/File;)Lnet/minecra
 net/minecraft/nbt/CompressedStreamTools func_74795_b(Lnet/minecraft/nbt/CompoundNBT;Ljava/io/File;)V # write
 net/minecraft/network/play/server/SCommandListPacket func_197693_a()Lcom/mojang/brigadier/tree/RootCommandNode; # getRoot
 net/minecraft/network/play/server/SEntityPropertiesPacket func_149441_d()Ljava/util/List; # getSnapshots
+net/minecraft/network/play/server/SEntityPropertiesPacket func_149442_c()I # getEntityId
 net/minecraft/potion/Effect func_220303_e()Lnet/minecraft/potion/EffectType; # getEffectType
 net/minecraft/potion/Effect func_111186_k()Ljava/util/Map; # getAttributeModifierMap
 net/minecraft/potion/Effect func_188408_i()Z # isBeneficial


### PR DESCRIPTION
Sorry, my `SEntityPropertiesPacket` filter was utterly broken and just sent out packets with a 0 entity ID.
This causes vanilla clients to not see attribute changes at all.