### PR TITLE
Add supplier variant to `AbstractBlock.Properties#lootFrom`

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -144,7 +144,7 @@
        public AbstractBlock.Properties func_200941_a(float p_200941_1_) {
           this.field_200961_i = p_200941_1_;
           return this;
-@@ -933,7 +971,7 @@
+@@ -933,10 +971,15 @@
        }
  
        public AbstractBlock.Properties func_222379_b(Block p_222379_1_) {
@@ -153,3 +153,11 @@
           return this;
        }
  
++      public AbstractBlock.Properties lootFrom(java.util.function.Supplier<? extends Block> blockIn) {
++          this.lootTableSupplier = () -> blockIn.get().func_220068_i();
++          return this;
++      }
++
+       public AbstractBlock.Properties func_235859_g_() {
+          this.field_235813_o_ = true;
+          return this;

--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -144,9 +144,11 @@
        public AbstractBlock.Properties func_200941_a(float p_200941_1_) {
           this.field_200961_i = p_200941_1_;
           return this;
-@@ -933,10 +971,15 @@
+@@ -932,11 +970,17 @@
+          return this;
        }
  
++      @Deprecated // FORGE: Use the variant that takes a Supplier below
        public AbstractBlock.Properties func_222379_b(Block p_222379_1_) {
 -         this.field_222381_j = p_222379_1_.func_220068_i();
 +         this.lootTableSupplier = () -> p_222379_1_.delegate.get().func_220068_i();


### PR DESCRIPTION
Forge patches `Block` / `AbstractBlock`s loot table handling to use a supplier of the loot table name. However, there's no way to directly set this through the properties a. la. vanilla - even though `lootFrom` internally uses a supplier, you have to pass a `Block` into it.

This adds a proper overload of `lootFrom` which takes a `Supplier<? extends Block>` and lazily maps it to a `Supplier<ResourceLocation>` as is required for the loot table, so modders can now use `lootFrom` without having to worry about creating a registration order dependency.