### PR TITLE
Gives Item the ability to take full control over what data is included when sending over the network.

### DIFF
--- a/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
@@ -32,7 +32,7 @@
 -         if (item.func_77645_m() || item.func_77651_p()) {
 -            compoundnbt = p_150788_1_.func_77978_p();
 +         if (item.isDamageable(p_150788_1_) || item.func_77651_p()) {
-+            compoundnbt = limitedTag ? p_150788_1_.getShareTag() : p_150788_1_.func_77978_p();
++            compoundnbt = limitedTag ? p_150788_1_.getShareTag() : p_150788_1_.getFullNetworkTag();
           }
  
           this.func_150786_a(compoundnbt);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -169,19 +169,40 @@ public interface IForgeItem
      * @param stack The stack to send the NBT tag for
      * @return The NBT tag
      */
-    @Nullable
+    @Nullable //TODO 1.17 rename to getMinimalNetworkTag
     default CompoundNBT getShareTag(ItemStack stack)
     {
         return stack.getTag();
     }
 
     /**
+     * Get the NBT data to be used when sending the full item over the network.
+     *
+     * Note that this will sometimes be applied multiple times, the following MUST
+     * be supported:
+     *   Item item = stack.getItem();
+     *   NBTTagCompound nbtShare1 = item.getFullNetworkTag(stack);
+     *   stack.setTagCompound(nbtShare1);
+     *   NBTTagCompound nbtShare2 = item.getFullNetworkTag(stack);
+     *   assert nbtShare1.equals(nbtShare2);
+     *
+     * @param stack The stack to send the NBT tag for
+     * @return The NBT tag
+     */
+    @Nullable
+    default CompoundNBT getFullNetworkTag(ItemStack stack)
+    {
+        return stack.getTag();
+    }
+
+    /**
      * Override this method to decide what to do with the NBT data received from
-     * getNBTShareTag().
+     * getNBTShareTag() and getFullNetworkTag().
      *
      * @param stack The stack that received NBT
      * @param nbt   Received NBT, can be null
      */
+    //TODO 1.17 rename to readNetworkTag
     default void readShareTag(ItemStack stack, @Nullable CompoundNBT nbt)
     {
         stack.setTag(nbt);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -368,19 +368,39 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
      *
      * @return The NBT tag
      */
-    @Nullable
+    @Nullable //TODO 1.17 rename to getMinimalNetworkTag
     default CompoundNBT getShareTag()
     {
         return getStack().getItem().getShareTag(getStack());
     }
 
     /**
+     * Get the NBT data to be used when sending the full item over the network.
+     *
+     * Note that this will sometimes be applied multiple times, the following MUST
+     * be supported:
+     *   Item item = stack.getItem();
+     *   NBTTagCompound nbtShare1 = item.getFullNetworkTag(stack);
+     *   stack.setTagCompound(nbtShare1);
+     *   NBTTagCompound nbtShare2 = item.getFullNetworkTag(stack);
+     *   assert nbtShare1.equals(nbtShare2);
+     *
+     * @return The NBT tag
+     */
+    @Nullable
+    default CompoundNBT getFullNetworkTag()
+    {
+        return getStack().getItem().getFullNetworkTag(getStack());
+    }
+
+    /**
      * Override this method to decide what to do with the NBT data received from
-     * getNBTShareTag().
+     * getNBTShareTag() and getFullNetworkTag().
      *
      * @param stack The stack that received NBT
      * @param nbt   Received NBT, can be null
      */
+    //TODO 1.17 rename to readNetworkTag
     default void readShareTag(@Nullable CompoundNBT nbt)
     {
         getStack().getItem().readShareTag(getStack(), nbt);


### PR DESCRIPTION
This specifically applies when an item is being sent via `PacketBuffer.writeItemStack` where `limitedTag = false` meaning the item and its full tag is being sent. 
This allows mods to add extra data to the "full tag" as needed.