### PR TITLE
Fix crash when beehive is broken by fake player

### DIFF
--- a/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
@@ -4,7 +4,7 @@
        List<BeeEntity> list = p_226881_1_.func_217357_a(BeeEntity.class, (new AxisAlignedBB(p_226881_2_)).func_72314_b(8.0D, 6.0D, 8.0D));
        if (!list.isEmpty()) {
           List<PlayerEntity> list1 = p_226881_1_.func_217357_a(PlayerEntity.class, (new AxisAlignedBB(p_226881_2_)).func_72314_b(8.0D, 6.0D, 8.0D));
-+         if (list.isEmpty()) return; //Forge: Prevent Error when no players are around.
++         if (list1.isEmpty()) return; //Forge: Prevent Error when no players are around.
           int i = list1.size();
  
           for(BeeEntity beeentity : list) {

--- a/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BeehiveBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BeehiveBlock.java
++++ b/net/minecraft/block/BeehiveBlock.java
+@@ -87,6 +87,8 @@
+          List<PlayerEntity> list1 = p_226881_1_.func_217357_a(PlayerEntity.class, (new AxisAlignedBB(p_226881_2_)).func_72314_b(8.0D, 6.0D, 8.0D));
+          int i = list1.size();
+ 
++         // Forge: Fix crash when there are no nearby players.
++         if (i > 0)
+          for(BeeEntity beeentity : list) {
+             if (beeentity.func_70638_az() == null) {
+                beeentity.func_70624_b(list1.get(p_226881_1_.field_73012_v.nextInt(i)));


### PR DESCRIPTION
When a beehive is broken, every nearby bee targets a random player. However, if there are no nearby players, the game crashes.

This should not occur under normal (vanilla) conditions. However, if a beehive is broken by a fake player (or potentially, a player with an extended reach attribute), there are no players in range and so we see a crash.

**Edit:** Apologies for the force-push spam. Used the wrong git config to commit.