### PR TITLE
Add ForgeHooks.canEntitySpawn to instances of ISpecialSpawner

### DIFF
--- a/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/spawner/CatSpawner.java
++++ b/net/minecraft/world/spawner/CatSpawner.java
+@@ -80,6 +80,7 @@
+       if (catentity == null) {
+          return 0;
+       } else {
++         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(catentity, p_221122_2_, p_221122_1_.func_177958_n(), p_221122_1_.func_177956_o(), p_221122_1_.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
+          catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
+          catentity.func_174828_a(p_221122_1_, 0.0F, 0.0F);
+          p_221122_2_.func_242417_l(catentity);

--- a/patches/minecraft/net/minecraft/world/spawner/PatrolSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/PatrolSpawner.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/spawner/PatrolSpawner.java
++++ b/net/minecraft/world/spawner/PatrolSpawner.java
+@@ -94,6 +94,7 @@
+          return false;
+       } else {
+          PatrollerEntity patrollerentity = EntityType.field_220350_aJ.func_200721_a(p_222695_1_);
++         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollerentity, p_222695_1_, p_222695_2_.func_177958_n(), p_222695_2_.func_177956_o(), p_222695_2_.func_177952_p(), null, SpawnReason.PATROL) == -1) return false;
+          if (patrollerentity != null) {
+             if (p_222695_4_) {
+                patrollerentity.func_213635_r(true);

--- a/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/spawner/PhantomSpawner.java
++++ b/net/minecraft/world/spawner/PhantomSpawner.java
+@@ -58,6 +58,7 @@
+                                  for(int i1 = 0; i1 < l; ++i1) {
+                                     PhantomEntity phantomentity = EntityType.field_203097_aH.func_200721_a(p_230253_1_);
+                                     phantomentity.func_174828_a(blockpos1, 0.0F, 0.0F);
++                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
+                                     ilivingentitydata = phantomentity.func_213386_a(p_230253_1_, difficultyinstance, SpawnReason.NATURAL, ilivingentitydata, (CompoundNBT)null);
+                                     p_230253_1_.func_242417_l(phantomentity);
+                                  }

--- a/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
@@ -1,10 +1,10 @@
 --- a/net/minecraft/world/spawner/PhantomSpawner.java
 +++ b/net/minecraft/world/spawner/PhantomSpawner.java
-@@ -58,6 +58,7 @@
+@@ -57,6 +57,7 @@
+ 
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      PhantomEntity phantomentity = EntityType.field_203097_aH.func_200721_a(p_230253_1_);
-                                     phantomentity.func_174828_a(blockpos1, 0.0F, 0.0F);
 +                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
+                                     phantomentity.func_174828_a(blockpos1, 0.0F, 0.0F);
                                      ilivingentitydata = phantomentity.func_213386_a(p_230253_1_, difficultyinstance, SpawnReason.NATURAL, ilivingentitydata, (CompoundNBT)null);
                                      p_230253_1_.func_242417_l(phantomentity);
-                                  }


### PR DESCRIPTION
This can be used to allow mods to cancel Phantom spawn events.

An example of this would be TorchMaster which dynamically blocks entity spawning if they are in range of a MegaTorch block

https://github.com/Xalcon/TorchMaster/blob/e1a5fd037fd3a1677109d7146376b01bc7f9ef9f/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java#L22-L46

No edits would need to be made to TorchMaster's code to start using this hook.

I'm not too sure if this is the best way to do this, so let me know if there's a better way.