### PR TITLE
Fix/Replace player visibility event

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -71,6 +71,15 @@
           this.func_82142_c(this.func_70644_a(Effects.field_76441_p));
        }
  
+@@ -747,7 +752,7 @@
+             d0 *= 0.5D;
+          }
+       }
+-
++      d0 = net.minecraftforge.common.ForgeHooks.getEntityVisibilityMultiplier(this, p_213340_1_, d0);
+       return d0;
+    }
+ 
 @@ -782,7 +787,9 @@
  
           boolean flag;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -137,6 +137,7 @@ import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
@@ -383,12 +384,23 @@ public class ForgeHooks
         return event.getLootingLevel();
     }
 
+    /**
+     * TODO 1.17 remove
+     * Unused
+     */
+    @Deprecated
     public static double getPlayerVisibilityDistance(PlayerEntity player, double xzDistance, double maxXZDistance)
     {
         PlayerEvent.Visibility event = new PlayerEvent.Visibility(player);
         MinecraftForge.EVENT_BUS.post(event);
         double value = event.getVisibilityModifier() * xzDistance;
         return value >= maxXZDistance ? maxXZDistance : value;
+    }
+
+    public static double getEntityVisibilityMultiplier(LivingEntity entity, Entity lookingEntity, double originalMultiplier){
+        LivingEvent.LivingVisibilityEvent event = new LivingEvent.LivingVisibilityEvent(entity, lookingEntity, originalMultiplier);
+        MinecraftForge.EVENT_BUS.post(event);
+        return Math.max(0,event.getVisibilityModifier());
     }
 
     public static boolean isLivingOnLadder(@Nonnull BlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -19,11 +19,14 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.entity.Entity;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityEvent;
+
+import javax.annotation.Nullable;
 
 /**
  * LivingEvent is fired whenever an event involving Living entities occurs.<br>
@@ -83,5 +86,44 @@ public class LivingEvent extends EntityEvent
     public static class LivingJumpEvent extends LivingEvent
     {
         public LivingJumpEvent(LivingEntity e){ super(e); }
+    }
+
+    public static class LivingVisibilityEvent extends LivingEvent
+    {
+        private double visibilityModifier;
+        @Nullable
+        private final Entity lookingEntity;
+
+        public LivingVisibilityEvent(LivingEntity livingEntity, @Nullable Entity lookingEntity, double originalMultiplier)
+        {
+            super(livingEntity);
+            this.visibilityModifier = originalMultiplier;
+            this.lookingEntity = lookingEntity;
+        }
+
+        /**
+         * @param mod Is multiplied with the current modifier
+         */
+        public void modifyVisibility(double mod)
+        {
+            visibilityModifier *= mod;
+        }
+
+        /**
+         * @return The current modifier
+         */
+        public double getVisibilityModifier()
+        {
+            return visibilityModifier;
+        }
+
+        /**
+         * @return The entity trying to see this LivingEntity, if available
+         */
+        @Nullable
+        public Entity getLookingEntity()
+        {
+            return lookingEntity;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -361,10 +361,12 @@ public class PlayerEvent extends LivingEvent
     }
 
     /**
+     * TODO 1.17 remove, unused
      * Fired when the world checks if a player is near enough to be attacked by an entity.
      * The resulting visibility modifier is multiplied by the one calculated by Minecraft (based on sneaking and more) and used to calculate the radius a player has to be in (targetDistance*modifier).
      * This can also be used to increase the visibility of a player, if it was decreased by Minecraft or other mods. But the resulting value cannot be higher than the standard target distance.
      */
+    @Deprecated
     public static class Visibility extends PlayerEvent
     {
 


### PR DESCRIPTION
The player visibility event introduced with https://github.com/MinecraftForge/MinecraftForge/commit/f0d9bf7886e53fc02d8b9c445086eb1e343c2420 back in 1.10/12 has stopped working in 1.14+ because the vanilla code changed and the respective patch hasn't been adjusted/replaced.

Changes in Vanilla (from 1.12 to 1.16):
- Visiblity can be checked for any `LivingEntity` instead of just `PlayerEntity` now
- The check is no longer directly tied to `World#getNearestAttackablePlayer` or its successors. Instead it is part of `LivingEntity`

Changes made by this PR:
- migrate the event from `PlayerEvent` to `LivingEvent` and modified it to suit the new vanilla functionality.
- deprecate and mark old `PlayerEvent.Visiblity` with `//TODO 1.17 remove`, it did and does not have any effect.
-   deprecate the relevant `ForgeHooks` method, even though it can probably be removed right away.