### PR TITLE
Fix Translucent parts of MultiLayer-Models rendering as missing model during piston movement 

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -156,6 +156,9 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
                 }
                 return builder.build();
             }
+            // fix translucent layer parts in piston-moving rendering as missing model
+            if (layer == RenderType.getTranslucentMovingBlock())
+                layer = RenderType.getTranslucent();
             // support for item layer rendering
             if (state == null && convertRenderTypes)
                 layer = ITEM_RENDER_TYPE_MAPPING.inverse().getOrDefault(layer, layer);


### PR DESCRIPTION
This is a fix for an issue introduced with https://github.com/MinecraftForge/MinecraftForge/pull/7441

Due to the RenderType being set to "TranslucentMovingBlock" [when rendering Block Models as they're moved by Pistons](https://github.com/MinecraftForge/MinecraftForge/blob/830d9699e3fd8ebc4d43e5e7dc2b105465563592/src/main/java/net/minecraftforge/client/ForgeHooksClient.java#L785), obtaining the correct model-part of the MultiLayerModel for the translucent RenderType fails as the rendertype key in the map is the "Translucent" RenderType.
https://github.com/MinecraftForge/MinecraftForge/blob/830d9699e3fd8ebc4d43e5e7dc2b105465563592/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java#L163

This results in the translucent-part of a multilayer model being rendered as the missing model.

The issue is further illustrated by this example with a cutout (vanilla glass), translucent (vanilla colored glass) and a multilayer model with a translucent part ([AstralSorcery's aquamarine shale](https://github.com/HellFirePvP/AstralSorcery/blob/bb6dd45878263bd874cae37e5464b310f12c5769/src/main/resources/assets/astralsorcery/models/block/multilayer/aquamarine_sand_ore.json#L3)) showing the behavior before and after the proposted change is applied:
https://www.youtube.com/watch?v=T-SvqjdcBGU