### PR TITLE
Improve RegistryKeyCodec decoding + add extra debug info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -950,6 +950,7 @@ project(':forge') {
         exclude 'net/minecraftforge/fml/common/versioning/Restriction.java'
         exclude 'net/minecraftforge/fml/common/versioning/VersionRange.java'
         exclude 'net/minecraftforge/common/LenientUnboundedMapCodec.java'
+        exclude 'net/minecraftforge/common/util/ImprovedListCodec.java'
 
         tasks {
             main {

--- a/patches/minecraft/net/minecraft/util/registry/DynamicRegistries.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/DynamicRegistries.java.patch
@@ -9,3 +9,12 @@
        MutableRegistry<E> mutableregistry = p_243607_0_.func_243612_b(registrykey);
  
        for(Entry<RegistryKey<E>, E> entry : registry.func_239659_c_()) {
+@@ -141,7 +143,7 @@
+       });
+       DataResult<SimpleRegistry<E>> dataresult = p_243610_0_.func_241797_a_(simpleregistry, p_243610_2_.func_243622_a(), p_243610_2_.func_243623_b());
+       dataresult.error().ifPresent((p_243603_0_) -> {
+-         field_243598_a.error("Error loading registry data: {}", (Object)p_243603_0_.message());
++         field_243598_a.error("Error loading registry ({}) [{}]", registrykey.func_240901_a_(), p_243603_0_.message());
+       });
+    }
+ 

--- a/patches/minecraft/net/minecraft/util/registry/RegistryKeyCodec.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/RegistryKeyCodec.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/util/registry/RegistryKeyCodec.java
++++ b/net/minecraft/util/registry/RegistryKeyCodec.java
+@@ -19,17 +19,7 @@
+    }
+ 
+    public static <E> Codec<List<Supplier<E>>> func_244328_b(RegistryKey<? extends Registry<E>> p_244328_0_, Codec<E> p_244328_1_) {
+-      return Codec.either(func_244325_a(p_244328_0_, p_244328_1_, false).listOf(), p_244328_1_.<Supplier<E>>xmap((p_244329_0_) -> {
+-         return () -> {
+-            return p_244329_0_;
+-         };
+-      }, Supplier::get).listOf()).xmap((p_244323_0_) -> {
+-         return p_244323_0_.map((p_244327_0_) -> {
+-            return p_244327_0_;
+-         }, (p_244324_0_) -> {
+-            return p_244324_0_;
+-         });
+-      }, Either::left);
++      return net.minecraftforge.common.ForgeHooks.fixRegistryKeyCodec(func_244325_a(p_244328_0_, p_244328_1_, false), p_244328_1_, p_244328_0_.func_240901_a_());
+    }
+ 
+    private static <E> RegistryKeyCodec<E> func_244325_a(RegistryKey<? extends Registry<E>> p_244325_0_, Codec<E> p_244325_1_, boolean p_244325_2_) {

--- a/patches/minecraft/net/minecraft/util/registry/WorldSettingsImport.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/WorldSettingsImport.java.patch
@@ -1,6 +1,31 @@
 --- a/net/minecraft/util/registry/WorldSettingsImport.java
 +++ b/net/minecraft/util/registry/WorldSettingsImport.java
-@@ -190,6 +190,7 @@
+@@ -91,6 +91,7 @@
+       Collection<ResourceLocation> collection = this.field_244332_c.func_241880_a(p_241797_2_);
+       DataResult<SimpleRegistry<E>> dataresult = DataResult.success(p_241797_1_, Lifecycle.stable());
+       String s = p_241797_2_.func_240901_a_().func_110623_a() + "/";
++      org.apache.commons.lang3.mutable.MutableObject<String> error = new org.apache.commons.lang3.mutable.MutableObject<>("");
+ 
+       for(ResourceLocation resourcelocation : collection) {
+          String s1 = resourcelocation.func_110623_a();
+@@ -104,12 +105,15 @@
+             dataresult = dataresult.flatMap((p_240885_4_) -> {
+                return this.func_241805_a_(p_241797_2_, p_240885_4_, p_241797_3_, resourcelocation1).map((p_240877_1_) -> {
+                   return p_240885_4_;
++               }).mapError(msg -> {
++                  error.setValue(error.getValue() + "[" + resourcelocation1 + " -> ( " + msg + ")] ");
++                  return msg;
+                });
+             });
+          }
+       }
+ 
+-      return dataresult.setPartial(p_241797_1_);
++      return dataresult.setPartial(p_241797_1_).mapError(msg -> error.getValue());
+    }
+ 
+    private <E> DataResult<Supplier<E>> func_241805_a_(RegistryKey<? extends Registry<E>> p_241805_1_, MutableRegistry<E> p_241805_2_, Codec<E> p_241805_3_, ResourceLocation p_241805_4_) {
+@@ -190,6 +194,7 @@
                 ) {
                    JsonParser jsonparser = new JsonParser();
                    JsonElement jsonelement = jsonparser.parse(reader);
@@ -8,7 +33,7 @@
                    return p_241879_4_.parse(p_241879_1_, jsonelement).map((p_244347_0_) -> {
                       return Pair.of(p_244347_0_, OptionalInt.empty());
                    });
-@@ -231,6 +232,7 @@
+@@ -231,6 +236,7 @@
  
           public <E> DataResult<Pair<E, OptionalInt>> func_241879_a(DynamicOps<JsonElement> p_241879_1_, RegistryKey<? extends Registry<E>> p_241879_2_, RegistryKey<E> p_241879_3_, Decoder<E> p_241879_4_) {
              JsonElement jsonelement = this.field_244349_a.get(p_241879_3_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1317,7 +1317,7 @@ public class ForgeHooks
                     return inlinedObj;
                 //Promote the partial here, so that any registered objects in the list are not nuked for
                 // the presence of an unregistered one.
-                return registeredObj.promotePartial(s -> LOGGER.warn("Error decoding object list: " + input.toString() + " (" + s + ")"));
+                return registeredObj.promotePartial(err -> LOGGER.warn("Error decoding object list: " + input.toString() + " (" + err + ")"));
             }
 
             /**

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1294,7 +1294,7 @@ public class ForgeHooks
 
     public static <O> Codec<List<Supplier<O>>> fixRegistryKeyCodec(Codec<Supplier<O>> registeredCodec, Codec<O> objectCodec, ResourceLocation registryName)
     {
-        Codec<List<Supplier<O>>> improvedListCodec = ImprovedListCodec.createNoPartials(registeredCodec);
+        Codec<List<Supplier<O>>> improvedListCodec = new ImprovedListCodec<>(registeredCodec);
         Codec<List<Supplier<O>>> inlinedCodec = objectCodec.<Supplier<O>>xmap(o -> () -> o, Supplier::get).listOf();
         return new Codec<List<Supplier<O>>>()
         {

--- a/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
+++ b/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
@@ -1,87 +1,51 @@
-/*
- * Minecraft Forge
- * Copyright (c) 2016-2020.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 package net.minecraftforge.common.util;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.datafixers.util.Unit;
-import com.mojang.serialization.*;
-import com.mojang.serialization.codecs.ListCodec;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Lifecycle;
+import com.mojang.serialization.ListBuilder;
 import org.apache.commons.lang3.mutable.MutableObject;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-/**
- * This is a copy of {@link ListCodec}, but it conserves all successfully decoded elements, not only the ones before an element errors.
- * It also provides an option to include/exclude partial results of individual elements in the list partial result.
- *
- * This file was originally part of Data Fixer Upper (https://github.com/Mojang/DataFixerUpper)
- * It is used and modified here as per the MIT license, the text of which is included as per the license requirements:
- *
- * MIT License
- *
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-public class ImprovedListCodec<A> implements Codec<List<A>>
-{
+public final class ImprovedListCodec<A> implements Codec<List<A>> {
     private final Codec<A> elementCodec;
-    private final boolean withPartials;
 
-    public static <A> Codec<List<A>> create(Codec<A> codec)
-    {
-        return new ImprovedListCodec<>(codec, true);
-    }
-
-    public static <A> Codec<List<A>> createNoPartials(Codec<A> codec)
-    {
-        return new ImprovedListCodec<>(codec, false);
-    }
-
-    private ImprovedListCodec(Codec<A> codec, boolean withPartials)
-    {
-        this.elementCodec = codec;
-        this.withPartials = withPartials;
+    public ImprovedListCodec(final Codec<A> elementCodec) {
+        this.elementCodec = elementCodec;
     }
 
     @Override
-    public <T> DataResult<Pair<List<A>, T>> decode(DynamicOps<T> ops, T input)
-    {
+    public <T> DataResult<T> encode(final List<A> input, final DynamicOps<T> ops, final T prefix) {
+        final ListBuilder<T> builder = ops.listBuilder();
+
+        for (final A a : input) {
+            builder.add(elementCodec.encodeStart(ops, a));
+        }
+
+        return builder.build(prefix);
+    }
+
+    @Override
+    public <T> DataResult<Pair<List<A>, T>> decode(final DynamicOps<T> ops, final T input) {
         return ops.getList(input).setLifecycle(Lifecycle.stable()).flatMap(stream -> {
             final ImmutableList.Builder<A> read = ImmutableList.builder();
             final Stream.Builder<T> failed = Stream.builder();
+            // TODO: AtomicReference.getPlain/setPlain in java9+
             final MutableObject<DataResult<Unit>> result = new MutableObject<>(DataResult.success(Unit.INSTANCE, Lifecycle.stable()));
 
             stream.accept(t -> {
                 final DataResult<Pair<A, T>> element = elementCodec.decode(ops, t);
                 element.error().ifPresent(e -> failed.add(t));
-                if (withPartials || element.result().isPresent())
-                    element.resultOrPartial(s->{}).ifPresent(p -> read.add(p.getFirst()));
+                element.result().ifPresent(r -> read.add(r.getFirst())); // FORGE: This line moved outside the below apply2stable condition
                 result.setValue(result.getValue().apply2stable((r, v) -> r, element));
             });
 
@@ -95,36 +59,24 @@ public class ImprovedListCodec<A> implements Codec<List<A>>
     }
 
     @Override
-    public <T> DataResult<T> encode(List<A> input, DynamicOps<T> ops, T prefix) 
-    {
-        final ListBuilder<T> builder = ops.listBuilder();
-
-        for (final A a : input)
-            builder.add(elementCodec.encodeStart(ops, a));
-
-        return builder.build(prefix);
-    }
-
-    @Override
-    public boolean equals(final Object o)
-    {
-        if (this == o)
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
-        final ImprovedListCodec<?> other = (ImprovedListCodec<?>) o;
-        return Objects.equals(elementCodec, other.elementCodec) && Objects.equals(withPartials, other.withPartials);
+        }
+        final ImprovedListCodec<?> listCodec = (ImprovedListCodec<?>) o;
+        return Objects.equals(elementCodec, listCodec.elementCodec);
     }
 
     @Override
-    public int hashCode()
-    {
-        return Objects.hash(elementCodec, withPartials);
+    public int hashCode() {
+        return Objects.hash(elementCodec);
     }
 
     @Override
-    public String toString()
-    {
-        return "BetterListCodec[withPartials=" + withPartials + ", " + elementCodec +"]";
+    public String toString() {
+        return "ImprovedListCodec[" + elementCodec + ']';
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
+++ b/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
@@ -1,12 +1,29 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.util;
 
+import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
-import com.mojang.serialization.DynamicOps;
-import com.mojang.serialization.ListBuilder;
+import com.mojang.datafixers.util.Unit;
+import com.mojang.serialization.*;
 import com.mojang.serialization.codecs.ListCodec;
-import net.minecraft.util.Unit;
 import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.util.ArrayList;
@@ -15,10 +32,21 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
- * ListCodec that provides a correct partial result.
- * The normal {@link ListCodec} will stop collecting results after the first complete error.
+ * This is a copy of {@link ListCodec}, but it conserves all successfully decoded elements, not only the ones before an element errors.
+ * It also provides an option to include/exclude partial results of individual elements in the list partial result.
  *
- * This also gives the option to not include the partial results of individual elements to the partial result list.
+ * This file was originally part of Data Fixer Upper (https://github.com/Mojang/DataFixerUpper)
+ * It is used and modified here as per the MIT license, the text of which is included as per the license requirements:
+ *
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 public class ImprovedListCodec<A> implements Codec<List<A>>
 {
@@ -44,30 +72,25 @@ public class ImprovedListCodec<A> implements Codec<List<A>>
     @Override
     public <T> DataResult<Pair<List<A>, T>> decode(DynamicOps<T> ops, T input)
     {
-        return ops.getList(input).flatMap(list ->
-        {
-            MutableObject<DataResult<Pair<List<A>, Stream.Builder<T>>>> ret =
-                    new MutableObject<>(DataResult.success(Pair.of(new ArrayList<>(), Stream.builder())));
-            MutableObject<DataResult<Unit>> errorAccumulator = new MutableObject<>(DataResult.success(Unit.INSTANCE));
+        return ops.getList(input).setLifecycle(Lifecycle.stable()).flatMap(stream -> {
+            final ImmutableList.Builder<A> read = ImmutableList.builder();
+            final Stream.Builder<T> failed = Stream.builder();
+            final MutableObject<DataResult<Unit>> result = new MutableObject<>(DataResult.success(Unit.INSTANCE, Lifecycle.stable()));
 
-            list.accept(t ->
-            {
-                DataResult<A> dr = elementCodec.parse(ops, t);
-                ret.setValue(ret.getValue().map(p ->
-                        p.mapFirst(l ->
-                        {
-                            if (withPartials || dr.result().isPresent())
-                                dr.map(l::add);
-                            return l;
-                        }).mapSecond(pre -> dr.result().isPresent() ? pre : pre.add(t)) // Add the json to the errors.
-                ));
-                errorAccumulator.setValue(errorAccumulator.getValue()
-                        .flatMap(u -> dr)
-                        .map(o -> Unit.INSTANCE)
-                        .setPartial(Unit.INSTANCE)); // Set partial, to be able to always concatenate the error. This is also what sets the partial for the ret list.
+            stream.accept(t -> {
+                final DataResult<Pair<A, T>> element = elementCodec.decode(ops, t);
+                element.error().ifPresent(e -> failed.add(t));
+                if (withPartials || element.result().isPresent())
+                    element.resultOrPartial(s->{}).ifPresent(p -> read.add(p.getFirst()));
+                result.setValue(result.getValue().apply2stable((r, v) -> r, element));
             });
 
-            return errorAccumulator.getValue().flatMap(u -> ret.getValue()).map(dr -> dr.mapSecond(sb -> ops.createList(sb.build())));
+            final ImmutableList<A> elements = read.build();
+            final T errors = ops.createList(failed.build());
+
+            final Pair<List<A>, T> pair = Pair.of(elements, errors);
+
+            return result.getValue().map(unit -> pair).setPartial(pair);
         });
     }
 

--- a/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
+++ b/src/main/java/net/minecraftforge/common/util/ImprovedListCodec.java
@@ -1,0 +1,107 @@
+package net.minecraftforge.common.util;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.ListBuilder;
+import com.mojang.serialization.codecs.ListCodec;
+import net.minecraft.util.Unit;
+import org.apache.commons.lang3.mutable.MutableObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * ListCodec that provides a correct partial result.
+ * The normal {@link ListCodec} will stop collecting results after the first complete error.
+ *
+ * This also gives the option to not include the partial results of individual elements to the partial result list.
+ */
+public class ImprovedListCodec<A> implements Codec<List<A>>
+{
+    private final Codec<A> elementCodec;
+    private final boolean withPartials;
+
+    public static <A> Codec<List<A>> create(Codec<A> codec)
+    {
+        return new ImprovedListCodec<>(codec, true);
+    }
+
+    public static <A> Codec<List<A>> createNoPartials(Codec<A> codec)
+    {
+        return new ImprovedListCodec<>(codec, false);
+    }
+
+    private ImprovedListCodec(Codec<A> codec, boolean withPartials)
+    {
+        this.elementCodec = codec;
+        this.withPartials = withPartials;
+    }
+
+    @Override
+    public <T> DataResult<Pair<List<A>, T>> decode(DynamicOps<T> ops, T input)
+    {
+        return ops.getList(input).flatMap(list ->
+        {
+            MutableObject<DataResult<Pair<List<A>, Stream.Builder<T>>>> ret =
+                    new MutableObject<>(DataResult.success(Pair.of(new ArrayList<>(), Stream.builder())));
+            MutableObject<DataResult<Unit>> errorAccumulator = new MutableObject<>(DataResult.success(Unit.INSTANCE));
+
+            list.accept(t ->
+            {
+                DataResult<A> dr = elementCodec.parse(ops, t);
+                ret.setValue(ret.getValue().map(p ->
+                        p.mapFirst(l ->
+                        {
+                            if (withPartials || dr.result().isPresent())
+                                dr.map(l::add);
+                            return l;
+                        }).mapSecond(pre -> dr.result().isPresent() ? pre : pre.add(t)) // Add the json to the errors.
+                ));
+                errorAccumulator.setValue(errorAccumulator.getValue()
+                        .flatMap(u -> dr)
+                        .map(o -> Unit.INSTANCE)
+                        .setPartial(Unit.INSTANCE)); // Set partial, to be able to always concatenate the error. This is also what sets the partial for the ret list.
+            });
+
+            return errorAccumulator.getValue().flatMap(u -> ret.getValue()).map(dr -> dr.mapSecond(sb -> ops.createList(sb.build())));
+        });
+    }
+
+    @Override
+    public <T> DataResult<T> encode(List<A> input, DynamicOps<T> ops, T prefix) 
+    {
+        final ListBuilder<T> builder = ops.listBuilder();
+
+        for (final A a : input)
+            builder.add(elementCodec.encodeStart(ops, a));
+
+        return builder.build(prefix);
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final ImprovedListCodec<?> other = (ImprovedListCodec<?>) o;
+        return Objects.equals(elementCodec, other.elementCodec) && Objects.equals(withPartials, other.withPartials);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(elementCodec, withPartials);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BetterListCodec[withPartials=" + withPartials + ", " + elementCodec +"]";
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.event;
 
 import com.google.common.collect.HashMultimap;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("stencil_enable_test")
 public class StencilEnableTest {
-    public static boolean ENABLED = true;
+    public static boolean ENABLED = false;
 
     public StencilEnableTest() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);

--- a/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.entity.ai.attributes.AttributeModifier;


### PR DESCRIPTION
The current problem is that when the list is a mix of registered objects and inlined objects, the error is not descriptive and misleading. 
It also leads to the list (in some cases) to contain only the unregistered/inlined features (otherwise it is empty). 

The fix is quite annoying, because the problem is the mix of behaviour between `EitherCodec`, `ListCodec` and `#promotePartial`.

The `EitherCodec` tries its first codec then fallsback to the second. However this means that any partial result is that of the 2nd codec at all times. This is important since the list of `ConfiguredFeature`s in `BiomeGenerationSettings` has `#promotePartial` on it. The result is that only the inlined objects are added to the list. 
Another issue is that the `ListCodec` stops adding results (partial or not) after the first encountered complete error (no partial result).
This means that the order of the list will change the returned partial result.
So switching the `EitherCodec` is not sufficient (also encoding relies on the current order).
So to remedy this, another list codec was needed with improved decoding logic to get a better partial result.
Then if the registered list codec errored, check first with the inlined codec and if that errored too, discard it and return the registered list codec with a promoted partial. This makes it so that a mixed list of registered and unregistered objects will always result in a decoded list with only the registered objects.

I have also added a few patch lines to improve some error messages, I think they can be extremely helpful but if it's not wanted I will remove them.

Current hold: I have not yet tested with a unregistered object added by the `BiomeLoadingEvent` as I could not get it to work easily. Once that is done, the pr will no longer be a draft