### PR TITLE
[1.16] Fix #7285 - Game crash on startup when Dualshock 4 controller

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.loading.progress;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.*;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GL11;
@@ -38,6 +39,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
@@ -72,6 +74,9 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         if (glfwInitEnd - glfwInitBegin > 1e9) {
             LogManager.getLogger().fatal("WARNING : glfwInit took {} seconds to start.", (glfwInitEnd-glfwInitBegin) / 1.0e9);
         }
+
+        // Clear the Last Exception (#7285 - Prevent Vanilla throwing an IllegalStateException due to invalid controller mappings)
+        handleLastGLFWError((error, description) -> LogManager.getLogger().error(String.format("Suppressing Last GLFW error: [0x%X]%s", error, description)));
 
         glfwDefaultWindowHints();
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
@@ -227,9 +232,22 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         glVertex2f(screenWidth, 0);
         glEnd();
     }
+
     private void fbResize(long window, int width, int height) {
         if (window == this.window && width != 0 && height != 0) {
             fbSize = new int[] {width, height};
+        }
+    }
+
+    private void handleLastGLFWError(BiConsumer<Integer, String> handler) {
+        try (MemoryStack memorystack = MemoryStack.stackPush()) {
+            PointerBuffer pointerbuffer = memorystack.mallocPointer(1);
+            int error = GLFW.glfwGetError(pointerbuffer);
+            if (error != GLFW_NO_ERROR) {
+                long pDescription = pointerbuffer.get();
+                String description = pDescription == 0L ? "" : MemoryUtil.memUTF8(pDescription);
+                handler.accept(error, description);
+            }
         }
     }
 


### PR DESCRIPTION
See https://gist.github.com/AterAnimAvis/18ffab8266ae619a32d26eced456cd8d for an expanded patch with a couple of additional features (Mainly the reduction of log spam for glfwInit errors).

Trying to keep this original pull request as simple as possible.

Vanilla:
- `GLX#_initGLFW`
  - Crash if any GLFW Errors
  - Set error callback
  - `gflwInit` <-- Raises GLFW Errors [0x10004] Invalid buttons for gamepad mapping
  - Report Errors caught by error callback
  - Continue Loading

Forge:
- `ClientVisualization#initWindow`
  - `glfwInit` <-- Raises GLFW Errors [0x10004] Invalid buttons for gamepad mapping
- `GLX#_initGLFW`
  - Crash if any GLFW Errors <-- Crash

Patch:
- `ClientVisualization#initWindow`
  - `glfwInit` <-- Raises GLFW Errors [0x10004] Invalid buttons for gamepad mapping
  - `glfwGetError` <-- Consume the Error
- `GLX#_initGLFW`
  - Crash if any GLFW Errors
  - Set error callback
  - `gflwInit` <-- NO-OP due to GLFW being initialized
  - Report Errors caught by error callback <-- Should be none
  - Continue Loading

Thanks to @RedstoneLP2 for help in diagnosing / testing the pr.

Fixes #7285 - See issue for logs