### PR TITLE
[1.16.x] Add Spawn Egg Item Interaction to IForgeItem

### DIFF
--- a/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
@@ -50,3 +50,11 @@
           }
        } else {
           return EquipmentSlotType.HEAD;
+@@ -1055,6 +1066,7 @@
+             }
+          }
+ 
++         if(this.field_70170_p instanceof ServerWorld && itemstack.getMobToSpawn(p_233661_1_, this).map(child -> { this.func_213406_a(p_233661_1_, child); return child;}).isPresent()) return ActionResultType.SUCCESS;
+          if (itemstack.func_77973_b() instanceof SpawnEggItem) {
+             if (this.field_70170_p instanceof ServerWorld) {
+                SpawnEggItem spawneggitem = (SpawnEggItem)itemstack.func_77973_b();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -855,5 +856,20 @@ public interface IForgeItem
     default boolean isDamageable(ItemStack stack)
     {
         return this.getItem().isDamageable();
+    }
+
+    /**
+     * Used to spawn mob given a mob entity is right clicked by this item.
+     * This should handle creating and spawning the entity in the world before returning.
+     * This is called only on the logical server.
+     * 
+     * @param stack The stack being right-clicked on the entity
+     * @param player The player causing the interaction
+     * @param mob The mob being interacted with
+     * @return An optional containing the mob spawned in the world or else {@code #empty} if the process failed
+     */
+    default Optional<MobEntity> getMobToSpawn(ItemStack stack, PlayerEntity player, MobEntity mob)
+    {
+        return Optional.empty();
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -502,5 +503,19 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     default boolean elytraFlightTick(LivingEntity entity, int flightTicks)
     {
         return getStack().getItem().elytraFlightTick(getStack(), entity, flightTicks);
+    }
+
+    /**
+     * Used to spawn a mob given a mob entity is right clicked by this item.
+     * This should handle creating and spawning the entity in the world before returning.
+     * This is called only on the logical server.
+     * 
+     * @param player The player causing the interaction
+     * @param mob The mob being interacted with
+     * @return An optional containing the mob spawned in the world or else {@code #empty} if the process failed
+     */
+    default Optional<MobEntity> getMobToSpawn(PlayerEntity player, MobEntity mob)
+    {
+        return getStack().getItem().getMobToSpawn(getStack(), player, mob);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/item/ItemSpawnerTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemSpawnerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.item;
+
+import java.util.Optional;
+
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.*;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod("item_spawner_test")
+public class ItemSpawnerTest
+{
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, "item_spawner_test");
+    private static final RegistryObject<Item> ITEM_SPAWNER_TEST = ITEMS.register("item_spawner_test", () -> new Item(new Item.Properties().group(ItemGroup.MISC))
+            {
+                @Override
+                public Optional<MobEntity> getMobToSpawn(ItemStack stack, PlayerEntity player, MobEntity mob)
+                {
+                    MobEntity child = (MobEntity) mob.getType().create(mob.world);
+                    if(child == null) return Optional.empty();
+                    else
+                    {
+                        child.setChild(true);
+                        if(!child.isChild()) return Optional.empty();
+                        else
+                        {
+                            child.setLocationAndAngles(mob.getPosX(), mob.getPosY(), mob.getPosZ(), 0f, 0f);
+                            ((ServerWorld) mob.world).func_242417_l(child);
+                            return Optional.of(child);
+                        }
+                    }
+                }
+            }
+    );
+
+    public ItemSpawnerTest() { ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus()); }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -104,3 +104,5 @@ license="LGPL v2.1"
     modId="custom_sound_type_test"
 [[mods]]
     modId="item_modifier_test"
+[[mods]]
+    modId="item_spawner_test"


### PR DESCRIPTION
The spawn egg item has been problematic to users for a number of reasons, specifically its desire to rely on an IdentityHashMap making implementations of supplied entity types even more complex than it should be. Technically the spawn egg could be represented as a new Item besides for one method, `#getChildToSpawn`. This method is called within `MobEntity` to spawn a child when a mob is right clicked with its associated spawn egg. This could be handled with `PlayerInteractEvent$EntityInteract`; however, the optional supplied calls a protected method that would need to be accessed using reflection for AT.

To get around this to make spawn eggs fully implementable from the base item, a new method is added. This essentially takes in a new mob entity to create and spawns it in the world. From there, the optional is mapped to its corresponding entry and calls the protected method. Finally, if its present, it returns `SUCCESS` on the server. Note that this method is called only on the logical server similarly to the `SpawnEggItem` implementation.

As an alternative solution, I could instead make the method an interaction for all mob entities that returns an `ActionResultType` circumventing the need for the event altogether besides for vanilla items interacting with vanilla entities. This still makes it impossible for the protected method to be called without AT. However, the only method call this would be applicable to is within `FoxEntity`. It more or less depends on how much should the entity interaction with items be reliant on the event.