### PR TITLE
Fix for MacOS Shift/Scroll Issue

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
+
+import net.minecraft.client.util.NativeUtil;
++ import net.minecraft.util.Util;
+import net.minecraft.util.math.MathHelper;
+
+private final Minecraft minecraft;
++ public static final boolean IS_RUNNING_ON_MAC = Util.getOSType() == Util.OS.OSX;
+private boolean middleDown;
+
 @@ -71,6 +71,7 @@
              this.field_198042_g = -1;
           }
@@ -36,6 +45,12 @@
     }
  
 @@ -121,7 +126,9 @@
+          if (handle == Minecraft.getInstance().getMainWindow().getHandle()) {
++            if (IS_RUNNING_ON_MAC) {
++               double d0 = (this.minecraft.gameSettings.discreteMouseScroll ? Math.signum(xpffset + yoffset) : (xoffset + yoffset)) * this.minecraft.gameSettings.mouseWheelSensitivity;
++            } else {
+                double d0 = (this.minecraft.gameSettings.discreteMouseScroll ? Math.signum(yoffset) : yoffset) * this.minecraft.gameSettings.mouseWheelSensitivity;
++            }
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
                 double d2 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();

--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,86 +1,46 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
-
-import net.minecraft.client.util.NativeUtil;
-+ import net.minecraft.util.Util;
-import net.minecraft.util.math.MathHelper;
-
-private final Minecraft minecraft;
-+ public static final boolean IS_RUNNING_ON_MAC = Util.getOSType() == Util.OS.OSX;
-private boolean middleDown;
-
-@@ -71,6 +71,7 @@
-             this.field_198042_g = -1;
-          }
+@@ -1,9 +1,5 @@
+ package net.minecraft.client;
  
-+         if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
-          boolean[] aboolean = new boolean[]{false};
+-import java.nio.file.Path;
+-import java.nio.file.Paths;
+-import java.util.Arrays;
+-import java.util.List;
+ import net.minecraft.client.gui.IGuiEventListener;
+ import net.minecraft.client.gui.screen.Screen;
+ import net.minecraft.client.settings.KeyBinding;
+@@ -15,9 +11,15 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ import org.lwjgl.glfw.GLFWDropCallback;
+ 
++import java.nio.file.Path;
++import java.nio.file.Paths;
++import java.util.Arrays;
++import java.util.List;
++
+ @OnlyIn(Dist.CLIENT)
+ public class MouseHelper {
+    private final Minecraft field_198036_a;
++   public static final boolean IS_RUNNING_ON_MAC = net.minecraft.util.Util.func_110647_a() == net.minecraft.util.Util.OS.OSX;
+    private boolean field_198037_b;
+    private boolean field_198038_c;
+    private boolean field_198039_d;
+@@ -116,7 +118,12 @@
+ 
+    private void func_198020_a(long p_198020_1_, double p_198020_3_, double p_198020_5_) {
+       if (p_198020_1_ == Minecraft.func_71410_x().func_228018_at_().func_198092_i()) {
+-         double d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_5_) : p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V;
++         double d0;
++         if (IS_RUNNING_ON_MAC) {
++            d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_3_ + p_198020_5_) : (p_198020_3_ + p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V);
++         } else {
++            d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_5_) : p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V;
++         }
           if (this.field_198036_a.field_213279_p == null) {
-             if (this.field_198036_a.field_71462_r == null) {
-@@ -82,11 +83,15 @@
-                double d1 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
-                if (flag) {
-                   Screen.func_231153_a_(() -> {
--                     aboolean[0] = this.field_198036_a.field_71462_r.func_231044_a_(d0, d1, i);
-+                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPre(this.field_198036_a.field_71462_r, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.field_198036_a.field_71462_r.func_231044_a_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.field_198036_a.field_71462_r, d0, d1, i);
-                   }, "mouseClicked event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
-                } else {
-                   Screen.func_231153_a_(() -> {
--                     aboolean[0] = this.field_198036_a.field_71462_r.func_231048_c_(d0, d1, i);
-+                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPre(this.field_198036_a.field_71462_r, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.field_198036_a.field_71462_r.func_231048_c_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.field_198036_a.field_71462_r, d0, d1, i);
-                   }, "mouseReleased event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
-                }
-             }
-@@ -110,7 +115,7 @@
-                }
-             }
-          }
--
-+         net.minecraftforge.client.ForgeHooksClient.fireMouseInput(p_198023_3_, p_198023_4_, p_198023_5_);
-       }
-    }
- 
-@@ -121,7 +126,9 @@
-          if (handle == Minecraft.getInstance().getMainWindow().getHandle()) {
-+            if (IS_RUNNING_ON_MAC) {
-+               double d0 = (this.minecraft.gameSettings.discreteMouseScroll ? Math.signum(xpffset + yoffset) : (xoffset + yoffset)) * this.minecraft.gameSettings.mouseWheelSensitivity;
-+            } else {
-                double d0 = (this.minecraft.gameSettings.discreteMouseScroll ? Math.signum(yoffset) : yoffset) * this.minecraft.gameSettings.mouseWheelSensitivity;
-+            }
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
-                double d2 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
--               this.field_198036_a.field_71462_r.func_231043_a_(d1, d2, d0);
-+               if (net.minecraftforge.client.ForgeHooksClient.onGuiMouseScrollPre(this, this.field_198036_a.field_71462_r, d0)) return;
-+               if (this.field_198036_a.field_71462_r.func_231043_a_(d1, d2, d0)) return;
-+               net.minecraftforge.client.ForgeHooksClient.onGuiMouseScrollPost(this, this.field_198036_a.field_71462_r, d0);
-             } else if (this.field_198036_a.field_71439_g != null) {
-                if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
-                   this.field_200542_o = 0.0D;
-@@ -134,6 +141,7 @@
-                }
- 
-                this.field_200542_o -= (double)f1;
-+               if (net.minecraftforge.client.ForgeHooksClient.onMouseScroll(this, d0)) return;
-                if (this.field_198036_a.field_71439_g.func_175149_v()) {
-                   if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
-                      this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
-@@ -202,7 +210,9 @@
-                double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
-                double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
-                Screen.func_231153_a_(() -> {
--                  iguieventlistener.func_231045_a_(d0, d1, this.field_198042_g, d2, d3);
-+                  if (net.minecraftforge.client.ForgeHooksClient.onGuiMouseDragPre(this.field_198036_a.field_71462_r, d0, d1, this.field_198042_g, d2, d3)) return;
-+                  if (iguieventlistener.func_231045_a_(d0, d1, this.field_198042_g, d2, d3)) return;
-+                  net.minecraftforge.client.ForgeHooksClient.onGuiMouseDragPost(this.field_198036_a.field_71462_r, d0, d1, this.field_198042_g, d2, d3);
-                }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
-             }
-          }
-@@ -267,6 +277,10 @@
+@@ -267,6 +274,10 @@
        return this.field_198039_d;
     }
  
@@ -90,19 +50,4 @@ private boolean middleDown;
 +
     public double func_198024_e() {
        return this.field_198040_e;
-    }
-@@ -275,6 +289,14 @@
-       return this.field_198041_f;
-    }
- 
-+   public double getXVelocity() {
-+      return this.field_198048_m;
-+   }
-+
-+   public double getYVelocity() {
-+      return this.field_198049_n;
-+   }
-+
-    public void func_198021_g() {
-       this.field_198043_h = true;
     }


### PR DESCRIPTION
This works because A. minecraft and forge currently do not us xoffset as it relates to scrollCallback(), and B. Because the default  MAC config is to HScroll when pressing shift and scrolling at the same time. This change very simply combines them together, which will complete fix the issue.

- GLFW does in fact see and output both offsets, so this is not a GLFW problem, this is a minecraft problem.