### PR TITLE
Fixes MACOS SHIFT SCROLL converting to HSCROLL

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,71 +1,20 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
-@@ -71,6 +71,7 @@
-             this.field_198042_g = -1;
-          }
+@@ -116,7 +116,12 @@
  
-+         if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
-          boolean[] aboolean = new boolean[]{false};
+    private void func_198020_a(long p_198020_1_, double p_198020_3_, double p_198020_5_) {
+       if (p_198020_1_ == Minecraft.func_71410_x().func_228018_at_().func_198092_i()) {
+-         double d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_5_) : p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V;
++         double d0;
++         if (Minecraft.field_142025_a) {
++            d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_3_ + p_198020_5_) : (p_198020_3_ + p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V);
++         } else {
++            d0 = (this.field_198036_a.field_71474_y.field_216843_O ? Math.signum(p_198020_5_) : p_198020_5_) * this.field_198036_a.field_71474_y.field_208033_V;
++         }
           if (this.field_198036_a.field_213279_p == null) {
-             if (this.field_198036_a.field_71462_r == null) {
-@@ -82,11 +83,15 @@
-                double d1 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
-                if (flag) {
-                   Screen.func_231153_a_(() -> {
--                     aboolean[0] = this.field_198036_a.field_71462_r.func_231044_a_(d0, d1, i);
-+                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPre(this.field_198036_a.field_71462_r, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.field_198036_a.field_71462_r.func_231044_a_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.field_198036_a.field_71462_r, d0, d1, i);
-                   }, "mouseClicked event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
-                } else {
-                   Screen.func_231153_a_(() -> {
--                     aboolean[0] = this.field_198036_a.field_71462_r.func_231048_c_(d0, d1, i);
-+                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPre(this.field_198036_a.field_71462_r, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.field_198036_a.field_71462_r.func_231048_c_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.field_198036_a.field_71462_r, d0, d1, i);
-                   }, "mouseReleased event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
-                }
-             }
-@@ -110,7 +115,7 @@
-                }
-             }
-          }
--
-+         net.minecraftforge.client.ForgeHooksClient.fireMouseInput(p_198023_3_, p_198023_4_, p_198023_5_);
-       }
-    }
- 
-@@ -121,7 +126,9 @@
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
-                double d2 = this.field_198041_f * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
--               this.field_198036_a.field_71462_r.func_231043_a_(d1, d2, d0);
-+               if (net.minecraftforge.client.ForgeHooksClient.onGuiMouseScrollPre(this, this.field_198036_a.field_71462_r, d0)) return;
-+               if (this.field_198036_a.field_71462_r.func_231043_a_(d1, d2, d0)) return;
-+               net.minecraftforge.client.ForgeHooksClient.onGuiMouseScrollPost(this, this.field_198036_a.field_71462_r, d0);
-             } else if (this.field_198036_a.field_71439_g != null) {
-                if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
-                   this.field_200542_o = 0.0D;
-@@ -134,6 +141,7 @@
-                }
- 
-                this.field_200542_o -= (double)f1;
-+               if (net.minecraftforge.client.ForgeHooksClient.onMouseScroll(this, d0)) return;
-                if (this.field_198036_a.field_71439_g.func_175149_v()) {
-                   if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
-                      this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
-@@ -202,7 +210,9 @@
-                double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.func_228018_at_().func_198107_o() / (double)this.field_198036_a.func_228018_at_().func_198105_m();
-                double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.func_228018_at_().func_198087_p() / (double)this.field_198036_a.func_228018_at_().func_198083_n();
-                Screen.func_231153_a_(() -> {
--                  iguieventlistener.func_231045_a_(d0, d1, this.field_198042_g, d2, d3);
-+                  if (net.minecraftforge.client.ForgeHooksClient.onGuiMouseDragPre(this.field_198036_a.field_71462_r, d0, d1, this.field_198042_g, d2, d3)) return;
-+                  if (iguieventlistener.func_231045_a_(d0, d1, this.field_198042_g, d2, d3)) return;
-+                  net.minecraftforge.client.ForgeHooksClient.onGuiMouseDragPost(this.field_198036_a.field_71462_r, d0, d1, this.field_198042_g, d2, d3);
-                }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
-             }
-          }
-@@ -267,6 +277,10 @@
+@@ -267,6 +272,10 @@
        return this.field_198039_d;
     }
  
@@ -75,19 +24,4 @@
 +
     public double func_198024_e() {
        return this.field_198040_e;
-    }
-@@ -275,6 +289,14 @@
-       return this.field_198041_f;
-    }
- 
-+   public double getXVelocity() {
-+      return this.field_198048_m;
-+   }
-+
-+   public double getYVelocity() {
-+      return this.field_198049_n;
-+   }
-+
-    public void func_198021_g() {
-       this.field_198043_h = true;
     }


### PR DESCRIPTION
This fix simply adds the never used GLFW xoffset from the scrollCallback to the yoffset, to include both in the scrolling functionality. As xoffset is used no where else in the code, it does not break anything else. Further, I have compiled and tested, and it works fine.