### PR TITLE
Prevent NullPointerException when adding new loot pool.

### DIFF
--- a/patches/minecraft/net/minecraft/loot/LootTable.java.patch
+++ b/patches/minecraft/net/minecraft/loot/LootTable.java.patch
@@ -76,7 +76,7 @@
 +
 +   public void addPool(LootPool pool) {
 +      checkFrozen();
-+      if (field_186466_c.stream().anyMatch(e -> e == pool || e != null && e.getName().equals(pool.getName())))
++      if (field_186466_c.stream().anyMatch(e -> e == pool || e.getName() != null && e.getName().equals(pool.getName())))
 +         throw new RuntimeException("Attempted to add a duplicate pool to loot table: " + pool.getName());
 +      this.field_186466_c.add(pool);
 +   }

--- a/patches/minecraft/net/minecraft/loot/LootTable.java.patch
+++ b/patches/minecraft/net/minecraft/loot/LootTable.java.patch
@@ -76,7 +76,7 @@
 +
 +   public void addPool(LootPool pool) {
 +      checkFrozen();
-+      if (field_186466_c.stream().anyMatch(e -> e == pool || e.getName().equals(pool.getName())))
++      if (field_186466_c.stream().anyMatch(e -> e == pool || e != null && e.getName().equals(pool.getName())))
 +         throw new RuntimeException("Attempted to add a duplicate pool to loot table: " + pool.getName());
 +      this.field_186466_c.add(pool);
 +   }


### PR DESCRIPTION
The `name` parameter of LootPool's init was added in a previous version and was required in order to create a new LootPool. With the switch to builders as of 1.14.4 (if not earlier), specifying a name became "optional" and is not enforced as part of the builder contruct.

Thus the `name` field became nullable and null by default. Any pool injected into a table using this method without specifically calling the `name` method of the builder returns null when `e.getName()` is called, but this is immediately dereferenced with an `equals` check.

This becomes extremely confusing to debug, however, as it is always a *previously added* pool without a name that causes a crash, rather than the pool being added by the mod. This makes it very difficult to track down.

Additionally, this causes the loot table being affected to not load and thus result in the table being considered empty.

This PR simply adds a null check before dereferencing `e.getName()`, preventing the NullPointerException.