### PR TITLE
Fix MC-176559 Breaking animation and process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -560,7 +562,28 @@ public interface IForgeItem
     default boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
     {
         // Fix MC-176559 mending resets mining progress / breaking animation
-        return !ItemStack.isSameIgnoreDurability(oldStack, newStack);
+        if (!newStack.is(oldStack.getItem()))
+            return true;
+
+        if (!newStack.isDamageableItem() || !oldStack.isDamageableItem())
+            return !ItemStack.tagMatches(newStack, oldStack);
+
+        CompoundTag newTag = newStack.getTag();
+        CompoundTag oldTag = oldStack.getTag();
+
+        if (newTag == null || oldTag == null)
+            return !(newTag == null && oldTag == null);
+
+        Set<String> newKeys = new HashSet<>(newTag.getAllKeys());
+        Set<String> oldKeys = new HashSet<>(oldTag.getAllKeys());
+
+        newKeys.remove(ItemStack.TAG_DAMAGE);
+        oldKeys.remove(ItemStack.TAG_DAMAGE);
+
+        if (!newKeys.equals(oldKeys))
+            return true;
+
+        return !newKeys.stream().allMatch(key -> Objects.equals(newTag.get(key), oldTag.get(key)));
         // return !(newStack.is(oldStack.getItem()) && ItemStack.tagMatches(newStack, oldStack)
         //         && (newStack.isDamageableItem() || newStack.getDamageValue() == oldStack.getDamageValue()));
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -560,13 +560,9 @@ public interface IForgeItem
     default boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
     {
         // Fix MC-176559 mending resets mining progress / breaking animation
-        if (newStack.getItem() == oldStack.getItem() && newStack.isDamageableItem())
-        {
-            oldStack = oldStack.copy();
-            oldStack.setDamageValue(newStack.getDamageValue());
-        }
-        return !(newStack.getItem() == oldStack.getItem() && ItemStack.tagMatches(newStack, oldStack)
-                && (newStack.isDamageableItem() || newStack.getDamageValue() == oldStack.getDamageValue()));
+        return !ItemStack.isSameIgnoreDurability(oldStack, newStack);
+        // return !(newStack.is(oldStack.getItem()) && ItemStack.tagMatches(newStack, oldStack)
+        //         && (newStack.isDamageableItem() || newStack.getDamageValue() == oldStack.getDamageValue()));
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -559,6 +559,12 @@ public interface IForgeItem
      */
     default boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
     {
+        // Fix MC-176559 mending resets mining progress / breaking animation
+        if (newStack.getItem() == oldStack.getItem() && newStack.isDamageableItem())
+        {
+            oldStack = oldStack.copy();
+            oldStack.setDamageValue(newStack.getDamageValue());
+        }
         return !(newStack.getItem() == oldStack.getItem() && ItemStack.tagMatches(newStack, oldStack)
                 && (newStack.isDamageableItem() || newStack.getDamageValue() == oldStack.getDamageValue()));
     }


### PR DESCRIPTION
Potential fixes for [MC-176559](https://bugs.mojang.com/browse/MC-176559)

Just opening this PR for comments on the best way to fix this.
It seems to have been caused by the removal of metadata and then damage being stored in NBT instead.
~~Then again apparantly this bug was reintroduced in 1.15.2, so might take a look at how vanilla fixed it before that.~~
Turns out it's been an issue since as mentioned above, the issue tracker has only started tracking it since 1.15.2 though.

Currently, the check always fails at the term `ItemStack.areItemStackTagsEqual(newStack, oldStack)` if the damage is different so it never gets to `(newStack.isDamageable() || newStack.getDamage() == oldStack.getDamage())`.

As for a test mod for this PR (if it is needed) thinking of a command that drops experience orbs on the player and gives them a pickaxe with mending to mine stuff with. Either that or a pickaxe that is pre-damaged with mending that spawns experience orbs on the player while they are holding it.

### Methods considered:

**1) Use `ItemStack.areItemsEqualIgnoreDurability(oldStack, newStack)`**
Not sure if it is okay because that method actually ignores nbt completely rather than just damage/durability.
`IForgeItem#canContinueUsing` does use it though so maybe it's okay to also use it?

**2) Copy stack but change damage to match if the item is damagable (currently in this PR)**
Doesn't modify the existing vanilla code but `ItemStack.copy()` is probably bad to use here...

**3) Create a method to compare item stacks including NBT but ignoring the Damage tag.**
I think this is probably the best option but unsure where the code should go for this, maybe in `IForgeItemStack`?
Not quite sure what to name it because that's how I thought `areItemsEqualIgnoreDurability` should work but is already taken.