### PR TITLE
Fix onBlockAdded being called twice for ItemEntity placing non-TE blocks

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -26,7 +26,7 @@
     }
  
     public Chunk(World p_i49947_1_, ChunkPrimer p_i49947_2_) {
-@@ -264,14 +265,14 @@
+@@ -264,28 +265,28 @@
  
           if (!this.field_76637_e.field_72995_K) {
              blockstate.func_196947_b(this.field_76637_e, p_177436_1_, p_177436_2_, p_177436_3_);
@@ -43,7 +43,11 @@
                 TileEntity tileentity = this.func_177424_a(p_177436_1_, Chunk.CreateEntityType.CHECK);
                 if (tileentity != null) {
                    tileentity.func_145836_u();
-@@ -282,10 +283,10 @@
+                }
+             }
+ 
+-            if (!this.field_76637_e.field_72995_K) {
++            if (!this.field_76637_e.field_72995_K && !this.field_76637_e.captureBlockSnapshots) {
                 p_177436_2_.func_215705_a(this.field_76637_e, p_177436_1_, blockstate, p_177436_3_);
              }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -667,10 +667,7 @@ public class ForgeHooks
                     int updateFlag = snap.getFlag();
                     BlockState oldBlock = snap.getReplacedBlock();
                     BlockState newBlock = world.getBlockState(snap.getPos());
-                    if (!newBlock.hasTileEntity()) // Containers get placed automatically
-                    {
-                        newBlock.onBlockAdded(world, snap.getPos(), oldBlock, false);
-                    }
+                    newBlock.onBlockAdded(world, snap.getPos(), oldBlock, false);
 
                     world.markAndNotifyBlock(snap.getPos(), world.getChunkAt(snap.getPos()), oldBlock, newBlock, updateFlag, 512);
                 }


### PR DESCRIPTION
While capturing block snapshots, Forge used to delay `onBlockAdded` until after the block change event:
https://github.com/MinecraftForge/MinecraftForge/blob/c2630d2a79d291f0ff364c02f74f8dee3e8aa77a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch#L90-L91

This patch got lost in the 1.13 update, however the delayed `onBlockAdded` was not removed, causing it to fire twice for blocks that don't have tile entities.

The special handling for tile entities is no longer needed, as `onBlockAdded` is no longer involved with adding / handling fo TEs.