### PR TITLE
Add support for caching of configuration values.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -90,6 +90,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 ((FileConfig) config).save();
             }
         }
+        this.afterReload();
     }
 
     public boolean isCorrecting() {

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
@@ -707,6 +708,9 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
     public static class ConfigValue<T>
     {
+        @VisibleForTesting
+        static boolean USE_CACHES = true;
+
         private final Builder parent;
         private final List<String> path;
         private final Supplier<T> defaultSupplier;
@@ -734,8 +738,10 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             if (spec.childConfig == null)
                 return defaultSupplier.get();
 
-            if (cachedValue == null)
+            if (USE_CACHES && cachedValue == null)
                 cachedValue = getRaw(spec.childConfig, path, defaultSupplier);
+            else if (!USE_CACHES)
+                return getRaw(spec.childConfig, path, defaultSupplier);
 
             return cachedValue;
         }

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -117,6 +117,7 @@ public class ConfigFileTypeHandler {
                 }
                 LOGGER.debug(CONFIG, "Config file {} changed, sending notifies", this.modConfig.getFileName());
                 this.modConfig.fireEvent(new ModConfig.Reloading(this.modConfig));
+                this.modConfig.getSpec().afterReload();
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -116,8 +116,8 @@ public class ConfigFileTypeHandler {
                     throw new ConfigLoadingException(modConfig, ex);
                 }
                 LOGGER.debug(CONFIG, "Config file {} changed, sending notifies", this.modConfig.getFileName());
-                this.modConfig.fireEvent(new ModConfig.Reloading(this.modConfig));
                 this.modConfig.getSpec().afterReload();
+                this.modConfig.fireEvent(new ModConfig.Reloading(this.modConfig));
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -121,6 +121,7 @@ public class ConfigTracker {
             Optional.ofNullable(fileMap.get(s2CConfigData.getFileName())).ifPresent(mc-> {
                 mc.setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(s2CConfigData.getBytes())));
                 mc.fireEvent(new ModConfig.Reloading(mc));
+                mc.getSpec().afterReload();
             });
         }
     }

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -121,7 +121,6 @@ public class ConfigTracker {
             Optional.ofNullable(fileMap.get(s2CConfigData.getFileName())).ifPresent(mc-> {
                 mc.setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(s2CConfigData.getBytes())));
                 mc.fireEvent(new ModConfig.Reloading(mc));
-                mc.getSpec().afterReload();
             });
         }
     }

--- a/src/test/java/net/minecraftforge/common/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/common/ForgeConfigSpecTest.java
@@ -1,0 +1,140 @@
+package net.minecraftforge.common;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToLongFunction;
+
+public class ForgeConfigSpecTest
+{
+    private final String TEST_CONFIG_PATH_TEMPLATE = "./tests/config/%s.toml";
+    private final int TEST_SIZE = 10000;
+
+    @Test
+    public void simpleSpeedTest() throws IOException
+    {
+        executeSpeedTest("test", "someDefaultValue", "simpleSpeedTest");
+    }
+
+    @Test
+    public void objectSpeedTest() throws IOException
+    {
+        executeSpeedTest("test", Lists.newArrayList(Lists.newArrayList("someValue")), "objectSpeedTest");
+    }
+
+    @Test
+    public void deepKeySpeedTest() throws IOException
+    {
+        executeSpeedTest("test.test.test.test.test.test.test.test.test.test", "deepKeyValue", "deepKeySpeedTest");
+    }
+
+    private <T> void executeSpeedTest(final String configKey, final T defaultKeyValue, final String testName) throws IOException
+    {
+        final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        final ForgeConfigSpec.ConfigValue<T> simpleValue = builder.define(configKey, defaultKeyValue);
+        final ForgeConfigSpec spec = builder.build();
+
+        final String configPath = String.format(TEST_CONFIG_PATH_TEMPLATE, testName);
+        final File configFile = new File(configPath);
+        configFile.getParentFile().mkdirs();
+        configFile.createNewFile();
+        final CommentedFileConfig configData = CommentedFileConfig.builder(configPath)
+                                                 .sync()
+                                                 .preserveInsertionOrder()
+                                                 .onFileNotFound((newfile, configFormat) -> {
+                                                     Files.createFile(newfile);
+                                                     return true;
+                                                 })
+                                                 .writingMode(WritingMode.REPLACE)
+                                                 .build();
+        spec.setConfig(configData);
+
+        final List<TestResult> results = runTestHarness(defaultKeyValue, testName, simpleValue, spec, 3, 20);
+        final double averageEnabled = results.stream().mapToLong(value -> value.enabledWatch.elapsed(TimeUnit.NANOSECONDS)).average().getAsDouble();
+        final double averageDisabled = results.stream().mapToLong(value -> value.disabledWatch.elapsed(TimeUnit.NANOSECONDS)).average().getAsDouble();
+        final double maxEnabledDeviation = results.stream().mapToLong(value -> value.enabledWatch.elapsed(TimeUnit.NANOSECONDS))
+          .mapToDouble(e -> e - averageEnabled)
+          .map(Math::abs)
+          .max()
+          .getAsDouble();
+        final double maxDisabledDeviation = results.stream().mapToLong(value -> value.disabledWatch.elapsed(TimeUnit.NANOSECONDS))
+                                             .mapToDouble(e -> e - averageDisabled)
+                                             .map(Math::abs)
+                                             .max()
+                                             .getAsDouble();
+
+        System.out.printf("Computed test results for: %s:%n", testName);
+        System.out.printf("  > Enabled:  ~%10.2f ns.   +- %10.2f ns.%n", averageEnabled, maxEnabledDeviation);
+        System.out.printf("  > Disabled: ~%10.2f ns.   +- %10.2f ns.%n", averageDisabled, maxDisabledDeviation);
+
+        configFile.delete();
+    }
+
+    private <T> List<TestResult> runTestHarness(final T defaultKeyValue, final String testName, final ForgeConfigSpec.ConfigValue<T> simpleValue, final ForgeConfigSpec spec, final int warmupRounds, final int testRounds)
+    {
+        final List<TestResult> results = new ArrayList<>();
+
+        for (int i = 0; i < warmupRounds; i++)
+        {
+            //Run a bunch of warm up rounds and ignore the results.
+            runTestOnce(defaultKeyValue, testName, simpleValue, spec);
+        }
+
+        for (int i = 0; i < testRounds; i++)
+        {
+            results.add(runTestOnce(defaultKeyValue, testName, simpleValue, spec));
+        }
+
+        return results;
+    }
+
+    private <T> TestResult runTestOnce(final T defaultKeyValue, final String testName, final ForgeConfigSpec.ConfigValue<T> simpleValue, final ForgeConfigSpec spec)
+    {
+        spec.afterReload();
+        ForgeConfigSpec.ConfigValue.USE_CACHES = false;
+        final Stopwatch watchDisabled = Stopwatch.createStarted();
+        for (int i = 0; i < TEST_SIZE; i++)
+        {
+            Assert.assertEquals(defaultKeyValue, simpleValue.get());
+        }
+        watchDisabled.stop();
+
+        spec.afterReload();
+        ForgeConfigSpec.ConfigValue.USE_CACHES = true;
+        final Stopwatch watchEnabled = Stopwatch.createStarted();
+        for (int i = 0; i < TEST_SIZE; i++)
+        {
+            Assert.assertEquals(defaultKeyValue, simpleValue.get());
+        }
+        watchEnabled.stop();
+
+        final TestResult result = new TestResult(watchEnabled, watchDisabled);
+
+        System.out.printf("Test result for: %s (Disabled: %s vs. Enabled: %s)%n", testName, watchDisabled.toString(), watchEnabled.toString());
+        return result;
+    }
+
+    private final static class TestResult {
+
+        private final Stopwatch enabledWatch;
+        private final Stopwatch disabledWatch;
+
+        public TestResult(final Stopwatch enabledWatch, final Stopwatch disabledWatch)
+        {
+            this.enabledWatch = enabledWatch;
+            this.disabledWatch = disabledWatch;
+        }
+    }
+}


### PR DESCRIPTION
After running into the case where I forgot to cache the forge configuration value myself and it being discussed many times in discord even some people creating coremods for something so trivial, I decided to look into this. 

Even though it is simple enough to store the configuration value in a static field and update it during the reloading event, many people do not do this, and call `get()` on the ConfigValue to get the value of the configuration entry when ever they need it. Sometimes even during performance critical pieces of code, like during rendering calls.

The lookups of the values in the config system can become a performance bottleneck here, and as such caching of that value is actually needed. This can be done (as described above) in a static field easily enough. But that would be something modders would need to take care of themselfs, and is not common knowledge. This little PR adds a caching value directly in the ConfigValue while also adding a callback to the reloading system to clear them when the value is loaded from disk.