### PR TITLE
FIx race condition in LazyOptional

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -57,7 +57,8 @@ import net.minecraftforge.common.capabilities.Capability;
 public class LazyOptional<T>
 {
     private final NonNullSupplier<T> supplier;
-    private AtomicReference<T> resolved;
+    private final Object lock = new Object();
+    private T resolved;
     private Set<NonNullConsumer<LazyOptional<T>>> listeners = new HashSet<>();
     private boolean isValid = true;
 
@@ -108,23 +109,21 @@ public class LazyOptional<T>
         if (!isValid)
             return null;
         if (resolved != null)
-            return resolved.get();
+            return resolved;
 
-        if (supplier != null)
-        {
-            resolved = new AtomicReference<>(null);
-            T temp = supplier.get();
-            if (temp == null)
+        synchronized (lock) {
+            // resolved == null: Double checked locking to prevent two threads from resolving
+            if (resolved == null && supplier != null)
             {
-                LOGGER.catching(Level.WARN, new NullPointerException("Supplier should not return null value"));
-                return null;
+                T temp = supplier.get();
+                if (temp == null)
+                    LOGGER.catching(Level.WARN, new NullPointerException("Supplier should not return null value"));
+                resolved = temp;
             }
-            resolved.set(temp);
-            return resolved.get();
         }
-        return null;
+        return resolved;
     }
-    
+
     private T getValueUnsafe()
     {
         T ret = getValue();

--- a/src/test/java/net/minecraftforge/test/SlowLazyOptionalTest.java
+++ b/src/test/java/net/minecraftforge/test/SlowLazyOptionalTest.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.test;
+
+import com.mojang.datafixers.util.Unit;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.common.util.TextTable;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SlowLazyOptionalTest
+{
+    @Test
+    public void test() throws InterruptedException {
+        LazyOptional<Unit> slowLazy = LazyOptional.of(() -> {
+            try {
+                Thread.sleep(1000);
+            } catch(InterruptedException e) {
+                e.printStackTrace();
+            }
+            return Unit.INSTANCE;
+        });
+        List<Thread> threads = new ArrayList<>();
+        AtomicInteger successfulThreads = new AtomicInteger();
+        for (int i = 0; i < 2; ++i) {
+            threads.add(new Thread(() -> {
+                // Resolve uses getValueUnsafe, so it throws if the value is unexpectedly absent
+                if (slowLazy.resolve().isPresent()) {
+                    successfulThreads.incrementAndGet();
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertEquals(threads.size(), successfulThreads.get());
+    }
+}


### PR DESCRIPTION
See #7610 

Also adds a test for both corner cases discussed in the issue (parallel access and contract-violating suppliers).