### PR TITLE
Add 2 new events related to Villagers

### DIFF
--- a/patches/minecraft/net/minecraft/entity/AgeableEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/AgeableEntity.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/entity/AgeableEntity.java
++++ b/net/minecraft/entity/AgeableEntity.java
+@@ -135,6 +135,7 @@
+    }
+ 
+    protected void func_175500_n() {
++      net.minecraftforge.event.ForgeEventFactory.onAgeableEntityAgeChange(this);
+    }
+ 
+    public boolean func_70631_g_() {

--- a/patches/minecraft/net/minecraft/entity/merchant/villager/VillagerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/merchant/villager/VillagerEntity.java.patch
@@ -9,7 +9,16 @@
           if (this.func_70631_g_()) {
              this.func_213756_es();
              return ActionResultType.func_233537_a_(this.field_70170_p.field_72995_K);
-@@ -634,7 +634,8 @@
+@@ -489,6 +489,8 @@
+       }
+ 
+       this.field_70180_af.func_187227_b(field_213775_bC, p_213753_1_);
++      if (villagerdata.func_221130_b() != p_213753_1_.func_221130_b())
++         net.minecraftforge.event.ForgeEventFactory.onVillagerProfessionChange(this, villagerdata.func_221130_b());
+    }
+ 
+    public VillagerData func_213700_eh() {
+@@ -634,7 +636,8 @@
     }
  
     protected ITextComponent func_225513_by_() {
@@ -19,7 +28,7 @@
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -687,7 +688,7 @@
+@@ -687,7 +690,7 @@
     }
  
     public void func_241841_a(ServerWorld p_241841_1_, LightningBoltEntity p_241841_2_) {
@@ -28,7 +37,7 @@
           field_184243_a.info("Villager {} was struck by lightning {}.", this, p_241841_2_);
           WitchEntity witchentity = EntityType.field_200759_ay.func_200721_a(p_241841_1_);
           witchentity.func_70012_b(this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), this.field_70177_z, this.field_70125_A);
-@@ -699,6 +700,7 @@
+@@ -699,6 +702,7 @@
           }
  
           witchentity.func_110163_bv();

--- a/patches/minecraft/net/minecraft/entity/monster/HoglinEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/HoglinEntity.java.patch
@@ -9,7 +9,15 @@
              this.func_241412_a_(SoundEvents.field_232715_fE_);
              this.func_234360_a_((ServerWorld)this.field_70170_p);
           }
-@@ -212,6 +212,7 @@
+@@ -144,6 +144,7 @@
+          this.func_110148_a(Attributes.field_233823_f_).func_111128_a(6.0D);
+       }
+ 
++      super.func_175500_n();
+    }
+ 
+    public static boolean func_234361_c_(EntityType<HoglinEntity> p_234361_0_, IWorld p_234361_1_, SpawnReason p_234361_2_, BlockPos p_234361_3_, Random p_234361_4_) {
+@@ -212,6 +213,7 @@
        ZoglinEntity zoglinentity = this.func_233656_b_(EntityType.field_233590_aW_, true);
        if (zoglinentity != null) {
           zoglinentity.func_195064_c(new EffectInstance(Effects.field_76431_k, 200, 0));

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -44,6 +44,8 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.item.ItemEntity;
+import net.minecraft.entity.merchant.villager.VillagerEntity;
+import net.minecraft.entity.merchant.villager.VillagerProfession;
 import net.minecraft.entity.monster.ZombieEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -113,6 +115,7 @@ import net.minecraftforge.event.entity.living.LivingHealEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
+import net.minecraftforge.event.entity.living.VillagerProfessionChangeEvent;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
 import net.minecraftforge.event.entity.player.ArrowNockEvent;
@@ -761,4 +764,10 @@ public class ForgeEventFactory
     {
         MinecraftForge.EVENT_BUS.post(new LivingConversionEvent.Post(entity, outcome));
     }
+
+    public static void onVillagerProfessionChange(VillagerEntity entity, VillagerProfession oldProfession)
+    {
+        MinecraftForge.EVENT_BUS.post(new VillagerProfessionChangeEvent(entity, oldProfession));
+    }
+
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -42,6 +42,7 @@ import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.AgeableEntity;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.merchant.villager.VillagerEntity;
@@ -106,6 +107,7 @@ import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
+import net.minecraftforge.event.entity.living.AgeableEntityAgeChangeEvent;
 import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingConversionEvent;
 import net.minecraftforge.event.entity.living.LivingDestroyBlockEvent;
@@ -768,6 +770,11 @@ public class ForgeEventFactory
     public static void onVillagerProfessionChange(VillagerEntity entity, VillagerProfession oldProfession)
     {
         MinecraftForge.EVENT_BUS.post(new VillagerProfessionChangeEvent(entity, oldProfession));
+    }
+
+    public static void onAgeableEntityAgeChange(AgeableEntity entity)
+    {
+        MinecraftForge.EVENT_BUS.post(new AgeableEntityAgeChangeEvent(entity));
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/AgeableEntityAgeChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AgeableEntityAgeChangeEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.AgeableEntity;
+import net.minecraft.entity.merchant.villager.VillagerProfession;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+
+/**
+ * This event is fired when an {@link AgeableEntity} change from child to adult or vice-versa. <br>
+ * It is fired via {@link ForgeEventFactory#onAgeableEntityAgeChange(AgeableEntity)}.
+ * <br>
+ * This event not is {@link net.minecraftforge.eventbus.api.Cancelable}.
+ * <br>
+ * This event does not have a result. {@link HasResult} <br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public class AgeableEntityAgeChangeEvent extends LivingEvent
+{
+    private final AgeableEntity ageableEntity;
+
+    public AgeableEntityAgeChangeEvent(AgeableEntity entity)
+    {
+        super(entity);
+        this.ageableEntity = entity;
+    }
+
+    public AgeableEntity getAgeableEntity() { return ageableEntity; }
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/VillagerProfessionChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/VillagerProfessionChangeEvent.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.merchant.villager.VillagerEntity;
+import net.minecraft.entity.merchant.villager.VillagerProfession;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+
+/**
+ * This event is fired when a {@link VillagerEntity} changes profession. <br>
+ * It is fired via {@link ForgeEventFactory#onVillagerProfessionChange(VillagerEntity, VillagerProfession)}.
+ * <br>
+ * {@link #oldProfession} contains the {@link VillagerProfession} the villager had before changing. <br>
+ * <br>
+ * This event not is {@link net.minecraftforge.eventbus.api.Cancelable}.
+ * <br>
+ * This event does not have a result. {@link HasResult} <br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public class VillagerProfessionChangeEvent extends LivingEvent
+{
+    private final VillagerEntity villager;
+    private final VillagerProfession oldProfession;
+
+    public VillagerProfessionChangeEvent(VillagerEntity entity, VillagerProfession oldProfession)
+    {
+        super(entity);
+        this.villager = entity;
+        this.oldProfession = oldProfession;
+    }
+
+    public VillagerEntity getVillager() { return villager; }
+
+    public VillagerProfession getOldProfession() { return oldProfession; }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/living/AgeableEntityAgeChangeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/AgeableEntityAgeChangeEventTest.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.debug.entity.living;
+
+import net.minecraft.entity.AgeableEntity;
+import net.minecraftforge.event.entity.living.AgeableEntityAgeChangeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("ageable_entity_age_change_event_test")
+@Mod.EventBusSubscriber
+public class AgeableEntityAgeChangeEventTest
+{
+    private static Logger LOGGER = LogManager.getLogger(AgeableEntityAgeChangeEventTest.class);
+
+    @SubscribeEvent
+    public static void onAgeableEntityGrowingAdult(AgeableEntityAgeChangeEvent event)
+    {
+        AgeableEntity entity = event.getAgeableEntity();
+        LOGGER.info("{} age change, it is now {}", entity, entity.isChild() ? "a child" : "an adult");
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/living/VillagerProfessionChangeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/VillagerProfessionChangeEventTest.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.debug.entity.living;
+
+import net.minecraftforge.event.entity.living.VillagerProfessionChangeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("villager_profession_change_event_test")
+@Mod.EventBusSubscriber
+public class VillagerProfessionChangeEventTest
+{
+    private static Logger LOGGER = LogManager.getLogger(VillagerProfessionChangeEventTest.class);
+
+    @SubscribeEvent
+    public static void onVillagerProfessionChanged(VillagerProfessionChangeEvent event)
+    {
+        LOGGER.info("{} changed profession. The old profession was {}", event.getVillager(), event.getOldProfession());
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -118,3 +118,5 @@ license="LGPL v2.1"
     modId="add_entity_attribute_test"
 [[mods]]
     modId="villager_profession_change_event_test"
+[[mods]]
+    modId="ageable_entity_age_change_event_test"

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -116,3 +116,5 @@ license="LGPL v2.1"
     modId="worldgen_registry_desync_test"
 [[mods]]
     modId="add_entity_attribute_test"
+[[mods]]
+    modId="villager_profession_change_event_test"


### PR DESCRIPTION
Adds 2 new events
- `VillagerProfessionChangeEvent` fired when a villager's profession changes
- `AgeableEntityGrowingAdultEvent` fired when an `AgeableEntity` grows from baby to adult.

Note: I combined these into a single pull request so the Forge maintainers only have 1 PR to review instead of 2, but they're in separate commits and I'd be happy to make 2 PRs instead if desired.

Reason for change:
Working on a mod where I am altering Villager behavior in order to have villagers interact with a custom block. I accomplish this by creating a new `Task` and adding it to the villager's brain during `EntityJoinWorld`. Sample code [here](https://github.com/sguest/village-life/blob/master/src/main/java/sguest/villagelife/entity/ai/VillagerBehavior.java). This is functional and seems to work well. However, when a villager changes profession or grows into an adult the villager's brain is re-initialized. This wipes out my added task and the villager no longer performs it until they trigger `EntityJoinWorld` again. These 2 new events would allow me to rerun the task init code in these cases.

Without these events I'm not sure how to accomplish persistence of this task beyond using a tick handler or similar construct to check periodically if things have changed, but that seems highly inefficient. Technically an event that simply fires on an entity's brain being reset would meet my personal needs even better, but these 2 events seem like they'd have much wider applicability.