### PR TITLE
Fix IAngerable entities crashing when reading nbt on client

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -20,7 +20,7 @@
        }
  
        this.func_195406_b(blockstate);
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -16,7 +16,13 @@
     }
  
     protected void func_70088_a() {
-@@ -186,7 +186,7 @@
+@@ -181,12 +181,13 @@
+       }
+ 
+       this.func_195406_b(blockstate);
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
  
     private boolean func_70821_d(PlayerEntity p_70821_1_) {
        ItemStack itemstack = p_70821_1_.field_71071_by.field_70460_b.get(3);
@@ -25,7 +31,7 @@
           return false;
        } else {
           Vector3d vector3d = p_70821_1_.func_70676_i(1.0F).func_72432_b();
-@@ -265,7 +265,9 @@
+@@ -265,7 +266,9 @@
        boolean flag = blockstate.func_185904_a().func_76230_c();
        boolean flag1 = blockstate.func_204520_s().func_206884_a(FluidTags.field_206959_a);
        if (flag && !flag1) {
@@ -36,7 +42,7 @@
           if (flag2 && !this.func_174814_R()) {
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70169_q, this.field_70167_r, this.field_70166_s, SoundEvents.field_187534_aX, this.func_184176_by(), 1.0F, 1.0F);
              this.func_184185_a(SoundEvents.field_187534_aX, 1.0F, 1.0F);
-@@ -429,7 +431,7 @@
+@@ -429,7 +432,7 @@
        public boolean func_75250_a() {
           if (this.field_179475_a.func_195405_dq() == null) {
              return false;
@@ -45,7 +51,7 @@
              return false;
           } else {
              return this.field_179475_a.func_70681_au().nextInt(2000) == 0;
-@@ -449,7 +451,7 @@
+@@ -449,7 +452,7 @@
           BlockState blockstate2 = this.field_179475_a.func_195405_dq();
           if (blockstate2 != null) {
              blockstate2 = Block.func_199770_b(blockstate2, this.field_179475_a.field_70170_p, blockpos);
@@ -54,7 +60,7 @@
                 world.func_180501_a(blockpos, blockstate2, 3);
                 this.field_179475_a.func_195406_b((BlockState)null);
              }
-@@ -458,7 +460,7 @@
+@@ -458,7 +461,7 @@
        }
  
        private boolean func_220836_a(World p_220836_1_, BlockPos p_220836_2_, BlockState p_220836_3_, BlockState p_220836_4_, BlockState p_220836_5_, BlockPos p_220836_6_) {
@@ -63,7 +69,7 @@
        }
     }
  
-@@ -500,7 +502,7 @@
+@@ -500,7 +503,7 @@
        public boolean func_75250_a() {
           if (this.field_179473_a.func_195405_dq() != null) {
              return false;

--- a/patches/minecraft/net/minecraft/entity/monster/ZombifiedPiglinEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ZombifiedPiglinEntity.java.patch
@@ -4,7 +4,7 @@
  
     public void func_70037_a(CompoundNBT p_70037_1_) {
        super.func_70037_a(p_70037_1_);
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  

--- a/patches/minecraft/net/minecraft/entity/monster/ZombifiedPiglinEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ZombifiedPiglinEntity.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/entity/monster/ZombifiedPiglinEntity.java
++++ b/net/minecraft/entity/monster/ZombifiedPiglinEntity.java
+@@ -173,6 +173,7 @@
+ 
+    public void func_70037_a(CompoundNBT p_70037_1_) {
+       super.func_70037_a(p_70037_1_);
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/entity/passive/BeeEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/BeeEntity.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/entity/passive/BeeEntity.java
 +++ b/net/minecraft/entity/passive/BeeEntity.java
-@@ -425,7 +425,7 @@
+@@ -184,6 +184,7 @@
+       this.field_226363_bC_ = p_70037_1_.func_74762_e("TicksSincePollination");
+       this.field_226364_bD_ = p_70037_1_.func_74762_e("CannotEnterHiveTicks");
+       this.field_226365_bE_ = p_70037_1_.func_74762_e("CropsGrownSincePollination");
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
+ 
+@@ -425,7 +426,7 @@
           return false;
        } else {
           TileEntity tileentity = this.field_70170_p.func_175625_s(this.field_226369_bI_);

--- a/patches/minecraft/net/minecraft/entity/passive/BeeEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/BeeEntity.java.patch
@@ -4,7 +4,7 @@
        this.field_226363_bC_ = p_70037_1_.func_74762_e("TicksSincePollination");
        this.field_226364_bD_ = p_70037_1_.func_74762_e("CannotEnterHiveTicks");
        this.field_226365_bE_ = p_70037_1_.func_74762_e("CropsGrownSincePollination");
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  

--- a/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
@@ -18,7 +18,7 @@
     public void func_70037_a(CompoundNBT p_70037_1_) {
        super.func_70037_a(p_70037_1_);
        this.func_70849_f(p_70037_1_.func_74767_n("PlayerCreated"));
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  

--- a/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
@@ -14,3 +14,11 @@
           }
        }
  
+@@ -149,6 +150,7 @@
+    public void func_70037_a(CompoundNBT p_70037_1_) {
+       super.func_70037_a(p_70037_1_);
+       this.func_70849_f(p_70037_1_.func_74767_n("PlayerCreated"));
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/entity/passive/PolarBearEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/PolarBearEntity.java.patch
@@ -4,7 +4,7 @@
  
     public void func_70037_a(CompoundNBT p_70037_1_) {
        super.func_70037_a(p_70037_1_);
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  

--- a/patches/minecraft/net/minecraft/entity/passive/PolarBearEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/PolarBearEntity.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/entity/passive/PolarBearEntity.java
++++ b/net/minecraft/entity/passive/PolarBearEntity.java
+@@ -103,6 +103,7 @@
+ 
+    public void func_70037_a(CompoundNBT p_70037_1_) {
+       super.func_70037_a(p_70037_1_);
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/entity/passive/WolfEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/WolfEntity.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/entity/passive/WolfEntity.java
 +++ b/net/minecraft/entity/passive/WolfEntity.java
-@@ -347,7 +347,7 @@
+@@ -133,6 +133,7 @@
+          this.func_175547_a(DyeColor.func_196056_a(p_70037_1_.func_74762_e("CollarColor")));
+       }
+ 
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
+       this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
+    }
+ 
+@@ -347,7 +348,7 @@
                 itemstack.func_190918_g(1);
              }
  

--- a/patches/minecraft/net/minecraft/entity/passive/WolfEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/WolfEntity.java.patch
@@ -4,7 +4,7 @@
           this.func_175547_a(DyeColor.func_196056_a(p_70037_1_.func_74762_e("CollarColor")));
        }
  
-+      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client.
++      if(!field_70170_p.field_72995_K) //FORGE: allow this entity to be read from nbt on client. (Fixes MC-189565)
        this.func_241358_a_((ServerWorld)this.field_70170_p, p_70037_1_);
     }
  


### PR DESCRIPTION
Their readAdditional method has an unchecked cast to ServerWorld, even though vanilla itself uses this to render entities in the mob spawner (these entities all don't render in the mob spawner)

See #7619 