### PR TITLE
AT DataGenerator in LootTableProvider to protected

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -181,6 +181,7 @@ default net.minecraft.client.settings.KeyBinding field_74513_e # pressed
 public net.minecraft.command.arguments.EntityOptions func_202024_a(Ljava/lang/String;Lnet/minecraft/command/arguments/EntityOptions$IFilter;Ljava/util/function/Predicate;Lnet/minecraft/util/text/ITextComponent;)V # register
 public net.minecraft.command.arguments.EntitySelectorParser func_197396_n()V # updateFilter
 public net.minecraft.command.arguments.EntitySelectorParser func_197404_d()V # parseArguments
+protected net.minecraft.data.LootTableProvider field_218443_d # dataGenerator
 protected net.minecraft.data.RecipeProvider field_200413_c # generator
 protected net.minecraft.data.RecipeProvider func_200403_a(Lnet/minecraft/util/IItemProvider;)Lnet/minecraft/advancements/criterion/InventoryChangeTrigger$Instance; # hasItem
 protected net.minecraft.data.RecipeProvider func_200404_a(Ljava/util/function/Consumer;)V # registerRecipes


### PR DESCRIPTION
Prevent the need for those who extend the LootTableProvider and want to access the DataGenerator from creating another variable within their subclass. I've seen quite a few do this and figured this should just be something that Forge could just take care of.