### PR TITLE
Fix config spec in cases of enum class discrepancies

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -374,7 +374,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                     return false;
                 }
                 try {
-                    return acceptableValues.contains(converter.get(obj, defaultValue.getClass()));
+                    return acceptableValues.contains(converter.get(obj, defaultValue.getDeclaringClass()));
                 } catch (IllegalArgumentException | ClassCastException e) {
                     return false;
                 }


### PR DESCRIPTION
If the enum has abstract methods `#getClass#getEnumConstants()` will return null, as it is not the "generic" enum class. 
This causes an issue here https://github.com/TheElectronWill/night-config/blob/stable-3.x/core/src/main/java/com/electronwill/nightconfig/core/EnumGetMethod.java#L68 as it NPEs. 
The fix is simply passing `#getDeclaredClass` which will get the proper enum class and actually have the enum constants

The workaround is to just pass in your own predicate.