### PR TITLE
[1.16.5] Shutup datafixer warning for modded entity types

### DIFF
--- a/patches/minecraft/net/minecraft/util/Util.java.patch
+++ b/patches/minecraft/net/minecraft/util/Util.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/Util.java
++++ b/net/minecraft/util/Util.java
+@@ -200,7 +200,7 @@
+       try {
+          type = DataFixesManager.func_210901_a().getSchema(DataFixUtils.makeKey(SharedConstants.func_215069_a().getWorldVersion())).getChoiceType(p_240990_0_, p_240990_1_);
+       } catch (IllegalArgumentException illegalargumentexception) {
+-         field_195650_a.error("No data fixer registered for {}", (Object)p_240990_1_);
++         field_195650_a.debug("No data fixer registered for {}", (Object)p_240990_1_);
+          if (SharedConstants.field_206244_b) {
+             throw illegalargumentexception;
+          }


### PR DESCRIPTION
This PR proposes a solution to make DFU shutup about modded entities not having a datafixer.
The only caveat is that in case a modder does register a datafixer, it will probably not work anymore with this fix.