### PR TITLE
Reinstate's Forge's Chunk Manager

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -33,7 +33,15 @@
        ServerWorld serverworld = this.func_241755_D_();
        field_147145_h.info("Preparing start region for dimension {}", (Object)serverworld.func_234923_W_().func_240901_a_());
        BlockPos blockpos = serverworld.func_241135_u_();
-@@ -566,6 +569,7 @@
+@@ -479,6 +482,7 @@
+                ChunkPos chunkpos = new ChunkPos(i);
+                serverworld1.func_72863_F().func_217206_a(chunkpos, true);
+             }
++            net.minecraftforge.common.world.ForgeChunkManager.reinstatePersistentChunks(serverworld1, forcedchunkssavedata);
+          }
+       }
+ 
+@@ -566,6 +570,7 @@
        for(ServerWorld serverworld1 : this.func_212370_w()) {
           if (serverworld1 != null) {
              try {
@@ -41,7 +49,7 @@
                 serverworld1.close();
              } catch (IOException ioexception1) {
                 field_147145_h.error("Exception closing the level", (Throwable)ioexception1);
-@@ -614,6 +618,7 @@
+@@ -614,6 +619,7 @@
     protected void func_240802_v_() {
        try {
           if (this.func_71197_b()) {
@@ -49,7 +57,7 @@
              this.field_211151_aa = Util.func_211177_b();
              this.field_147147_p.func_151315_a(new StringTextComponent(this.field_71286_C));
              this.field_147147_p.func_151321_a(new ServerStatusResponse.Version(SharedConstants.func_215069_a().getName(), SharedConstants.func_215069_a().getProtocolVersion()));
-@@ -643,7 +648,10 @@
+@@ -643,7 +649,10 @@
                 this.func_240795_b_(longtickdetector);
                 this.field_71296_Q = true;
              }
@@ -60,7 +68,7 @@
              this.func_71228_a((CrashReport)null);
           }
        } catch (Throwable throwable1) {
-@@ -662,6 +670,7 @@
+@@ -662,6 +671,7 @@
              field_147145_h.error("We were unable to save this crash report to disk.");
           }
  
@@ -68,7 +76,7 @@
           this.func_71228_a(crashreport);
        } finally {
           try {
-@@ -670,6 +679,7 @@
+@@ -670,6 +680,7 @@
           } catch (Throwable throwable) {
              field_147145_h.error("Exception stopping the server", throwable);
           } finally {
@@ -76,7 +84,7 @@
              this.func_71240_o();
           }
  
-@@ -771,6 +781,7 @@
+@@ -771,6 +782,7 @@
  
     protected void func_71217_p(BooleanSupplier p_71217_1_) {
        long i = Util.func_211178_c();
@@ -84,7 +92,7 @@
        ++this.field_71315_w;
        this.func_71190_q(p_71217_1_);
        if (i - this.field_147142_T >= 5000000000L) {
-@@ -785,6 +796,7 @@
+@@ -785,6 +797,7 @@
  
           Collections.shuffle(Arrays.asList(agameprofile));
           this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -92,7 +100,7 @@
        }
  
        if (this.field_71315_w % 6000 == 0) {
-@@ -812,6 +824,7 @@
+@@ -812,6 +825,7 @@
        long i1 = Util.func_211178_c();
        this.field_213215_ap.func_181747_a(i1 - i);
        this.field_71304_b.func_76319_b();
@@ -100,7 +108,7 @@
     }
  
     protected void func_71190_q(BooleanSupplier p_71190_1_) {
-@@ -819,7 +832,8 @@
+@@ -819,7 +833,8 @@
        this.func_193030_aL().func_73660_a();
        this.field_71304_b.func_219895_b("levels");
  
@@ -110,7 +118,7 @@
           this.field_71304_b.func_194340_a(() -> {
              return serverworld + " " + serverworld.func_234923_W_().func_240901_a_();
           });
-@@ -830,6 +844,7 @@
+@@ -830,6 +845,7 @@
           }
  
           this.field_71304_b.func_76320_a("tick");
@@ -118,7 +126,7 @@
  
           try {
              serverworld.func_72835_b(p_71190_1_);
-@@ -838,9 +853,11 @@
+@@ -838,9 +854,11 @@
              serverworld.func_72914_a(crashreport);
              throw new ReportedException(crashreport);
           }
@@ -130,7 +138,7 @@
        }
  
        this.field_71304_b.func_219895_b("connection");
-@@ -915,7 +932,7 @@
+@@ -915,7 +933,7 @@
     }
  
     public String getServerModName() {
@@ -139,7 +147,7 @@
     }
  
     public CrashReport func_71230_b(CrashReport p_71230_1_) {
-@@ -928,6 +945,7 @@
+@@ -928,6 +946,7 @@
        p_71230_1_.func_85056_g().func_189529_a("Data Packs", () -> {
           StringBuilder stringbuilder = new StringBuilder();
  
@@ -147,7 +155,7 @@
           for(ResourcePackInfo resourcepackinfo : this.field_195577_ad.func_198980_d()) {
              if (stringbuilder.length() > 0) {
                 stringbuilder.append(", ");
-@@ -1280,6 +1298,7 @@
+@@ -1280,6 +1299,7 @@
           this.func_184103_al().func_193244_w();
           this.field_200258_al.func_240946_a_(this.field_195576_ac.func_240960_a_());
           this.field_240765_ak_.func_195410_a(this.field_195576_ac.func_240970_h_());
@@ -155,7 +163,7 @@
        }, this);
        if (this.func_213162_bc()) {
           this.func_213161_c(completablefuture::isDone);
-@@ -1289,10 +1308,13 @@
+@@ -1289,10 +1309,13 @@
     }
  
     public static DatapackCodec func_240772_a_(ResourcePackList p_240772_0_, DatapackCodec p_240772_1_, boolean p_240772_2_) {
@@ -171,7 +179,7 @@
        } else {
           Set<String> set = Sets.newLinkedHashSet();
  
-@@ -1442,6 +1464,31 @@
+@@ -1442,6 +1465,31 @@
  
     public abstract boolean func_213199_b(GameProfile p_213199_1_);
  
@@ -203,7 +211,7 @@
     public void func_223711_a(Path p_223711_1_) throws IOException {
        Path path = p_223711_1_.resolve("levels");
  
-@@ -1570,6 +1617,10 @@
+@@ -1570,6 +1618,10 @@
        return this.field_240768_i_;
     }
  

--- a/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
+++ b/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/world/ForcedChunksSaveData.java
++++ b/net/minecraft/world/ForcedChunksSaveData.java
+@@ -14,14 +14,30 @@
+ 
+    public void func_76184_a(CompoundNBT p_76184_1_) {
+       this.field_212439_a = new LongOpenHashSet(p_76184_1_.func_197645_o("Forced"));
++      this.blockForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++      this.entityForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++      net.minecraftforge.common.world.ForgeChunkManager.readForgeForcedChunks(p_76184_1_, this.blockForcedChunks, this.entityForcedChunks);
+    }
+ 
+    public CompoundNBT func_189551_b(CompoundNBT p_189551_1_) {
+       p_189551_1_.func_197644_a("Forced", this.field_212439_a.toLongArray());
++      net.minecraftforge.common.world.ForgeChunkManager.writeForgeForcedChunks(p_189551_1_, this.blockForcedChunks, this.entityForcedChunks);
+       return p_189551_1_;
+    }
+ 
+    public LongSet func_212438_a() {
+       return this.field_212439_a;
+    }
++
++   /* ======================================== FORGE START =====================================*/
++   private it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>> blockForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++   private it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>> entityForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++
++   public it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>> getBlockForcedChunks() {
++      return this.blockForcedChunks;
++   }
++
++   public it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>> getEntityForcedChunks() {
++      return this.entityForcedChunks;
++   }
+ }

--- a/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
+++ b/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
@@ -4,8 +4,8 @@
  
     public void func_76184_a(CompoundNBT p_76184_1_) {
        this.field_212439_a = new LongOpenHashSet(p_76184_1_.func_197645_o("Forced"));
-+      this.blockForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
-+      this.entityForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++      this.blockForcedChunks = new java.util.HashMap<>();
++      this.entityForcedChunks = new java.util.HashMap<>();
 +      net.minecraftforge.common.world.ForgeChunkManager.readForgeForcedChunks(p_76184_1_, this.blockForcedChunks, this.entityForcedChunks);
     }
  
@@ -20,14 +20,14 @@
     }
 +
 +   /* ======================================== FORGE START =====================================*/
-+   private it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>> blockForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
-+   private it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>> entityForcedChunks = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
++   private java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>, LongSet> blockForcedChunks = new java.util.HashMap<>();
++   private java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>, LongSet> entityForcedChunks = new java.util.HashMap<>();
 +
-+   public it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>> getBlockForcedChunks() {
++   public java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>, LongSet> getBlockForcedChunks() {
 +      return this.blockForcedChunks;
 +   }
 +
-+   public it.unimi.dsi.fastutil.objects.Object2LongMap<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>> getEntityForcedChunks() {
++   public java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>, LongSet> getEntityForcedChunks() {
 +      return this.entityForcedChunks;
 +   }
  }

--- a/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
+++ b/patches/minecraft/net/minecraft/world/ForcedChunksSaveData.java.patch
@@ -4,8 +4,8 @@
  
     public void func_76184_a(CompoundNBT p_76184_1_) {
        this.field_212439_a = new LongOpenHashSet(p_76184_1_.func_197645_o("Forced"));
-+      this.blockForcedChunks = new java.util.HashMap<>();
-+      this.entityForcedChunks = new java.util.HashMap<>();
++      this.blockForcedChunks = new net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<>();
++      this.entityForcedChunks = new net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<>();
 +      net.minecraftforge.common.world.ForgeChunkManager.readForgeForcedChunks(p_76184_1_, this.blockForcedChunks, this.entityForcedChunks);
     }
  
@@ -20,14 +20,14 @@
     }
 +
 +   /* ======================================== FORGE START =====================================*/
-+   private java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>, LongSet> blockForcedChunks = new java.util.HashMap<>();
-+   private java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>, LongSet> entityForcedChunks = new java.util.HashMap<>();
++   private net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<net.minecraft.util.math.BlockPos> blockForcedChunks = new net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<>();
++   private net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<java.util.UUID> entityForcedChunks = new net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<>();
 +
-+   public java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<net.minecraft.util.math.BlockPos>, LongSet> getBlockForcedChunks() {
++   public net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<net.minecraft.util.math.BlockPos> getBlockForcedChunks() {
 +      return this.blockForcedChunks;
 +   }
 +
-+   public java.util.Map<net.minecraftforge.common.world.ForgeChunkManager.TicketOwner<java.util.UUID>, LongSet> getEntityForcedChunks() {
++   public net.minecraftforge.common.world.ForgeChunkManager.TicketTracker<java.util.UUID> getEntityForcedChunks() {
 +      return this.entityForcedChunks;
 +   }
  }

--- a/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
@@ -9,3 +9,18 @@
                       chunk.func_177415_c(chunk.func_177416_w() + j);
                       if (flag1 && (this.field_217246_l || this.field_217247_m) && this.field_73251_h.func_175723_af().func_177730_a(chunk.func_76632_l())) {
                          WorldEntitySpawner.func_234979_a_(this.field_73251_h, chunk, worldentityspawner$entitydensitymanager, this.field_217247_m, this.field_217246_l, flag2);
+@@ -429,6 +429,14 @@
+       this.field_217240_d.func_219362_d(p_217222_1_, p_217222_2_, p_217222_3_, p_217222_4_);
+    }
+ 
++   public <T> void registerTickingTicket(TicketType<T> type, ChunkPos pos, int distance, T value) {
++      this.field_217240_d.registerTicking(type, pos, distance, value);
++   }
++
++   public <T> void releaseTickingTicket(TicketType<T> type, ChunkPos pos, int distance, T value) {
++      this.field_217240_d.releaseTicking(type, pos, distance, value);
++   }
++
+    public void func_217206_a(ChunkPos p_217206_1_, boolean p_217206_2_) {
+       this.field_217240_d.func_219364_a(p_217206_1_, p_217206_2_);
+    }

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -61,6 +61,15 @@
           }
  
           this.func_229856_ab_();
+@@ -338,7 +343,7 @@
+       this.func_147488_Z();
+       this.field_211159_Q = false;
+       iprofiler.func_219895_b("entities");
+-      boolean flag3 = !this.field_217491_A.isEmpty() || !this.func_217469_z().isEmpty();
++      boolean flag3 = !this.field_217491_A.isEmpty() || net.minecraftforge.common.world.ForgeChunkManager.hasForcedChunks(this); //Forge: Replace vanilla's has forced chunk check with forge's that checks both the vanilla and forge added ones
+       if (flag3) {
+          this.func_82742_i();
+       }
 @@ -395,7 +400,7 @@
              }
  

--- a/patches/minecraft/net/minecraft/world/server/TicketManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/TicketManager.java.patch
@@ -34,7 +34,22 @@
     }
  
     public <T> void func_219356_a(TicketType<T> p_219356_1_, ChunkPos p_219356_2_, int p_219356_3_, T p_219356_4_) {
-@@ -242,6 +255,11 @@
+@@ -175,6 +188,14 @@
+       this.func_219349_b(p_219362_2_.func_201841_a(), ticket);
+    }
+ 
++   public <T> void registerTicking(TicketType<T> type, ChunkPos pos, int distance, T value) {
++      this.func_219347_a(pos.func_201841_a(), new Ticket<>(type, 33 - distance, value, true));
++   }
++
++   public <T> void releaseTicking(TicketType<T> type, ChunkPos pos, int distance, T value) {
++      this.func_219349_b(pos.func_201841_a(), new Ticket<>(type, 33 - distance, value, true));
++   }
++
+    private SortedArraySet<Ticket<?>> func_229848_e_(long p_229848_1_) {
+       return this.field_219377_e.computeIfAbsent(p_229848_1_, (p_229851_0_) -> {
+          return SortedArraySet.func_226172_a_(4);
+@@ -242,6 +263,11 @@
        return this.field_219384_l.func_225396_a();
     }
  

--- a/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
@@ -51,6 +51,15 @@ public class ForgeChunkManager
     }
 
     /**
+     * Checks if a world has any forced chunks. Mainly used for seeing if a world should continue ticking with no players in it.
+     */
+    public static boolean hasForcedChunks(ServerWorld world)
+    {
+        ForcedChunksSaveData data = world.getSavedData().get(ForcedChunksSaveData::new, "chunks");
+        return data != null && (!data.getChunks().isEmpty() || !data.getBlockForcedChunks().isEmpty() || !data.getEntityForcedChunks().isEmpty());
+    }
+
+    /**
      * Forces a chunk to be loaded for the given mod with the "owner" of the ticket being a given block position.
      *
      * @param add {@code true} to force the chunk, {@code false} to unforce the chunk.

--- a/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.world;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;

--- a/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
@@ -1,0 +1,262 @@
+package net.minecraftforge.common.world;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.util.UUIDCodec;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.ForcedChunksSaveData;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.server.TicketType;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fml.ModList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@ParametersAreNonnullByDefault
+public class ForgeChunkManager
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final TicketType<OwnedTicketInfo<BlockPos>> BLOCK = TicketType.create("forge:block", Comparator.comparing(info -> info));
+    private static final TicketType<OwnedTicketInfo<UUID>> ENTITY = TicketType.create("forge:entity", Comparator.comparing(info -> info));
+
+    public static boolean forceChunk(ServerWorld world, String modId, BlockPos owner, int chunkX, int chunkZ, boolean add)
+    {
+        return forceChunk(world, modId, owner, chunkX, chunkZ, add, BLOCK, ForcedChunksSaveData::getBlockForcedChunks);
+    }
+
+    public static boolean forceChunk(ServerWorld world, String modId, Entity owner, int chunkX, int chunkZ, boolean add)
+    {
+        return forceChunk(world, modId, owner.getUniqueID(), chunkX, chunkZ, add);
+    }
+
+    public static boolean forceChunk(ServerWorld world, String modId, UUID owner, int chunkX, int chunkZ, boolean add)
+    {
+        return forceChunk(world, modId, owner, chunkX, chunkZ, add, ENTITY, ForcedChunksSaveData::getEntityForcedChunks);
+    }
+
+    //Based on ServerWorld#forceChunk
+    private static <T extends Comparable<? super T>> boolean forceChunk(ServerWorld world, String modId, T owner, int chunkX, int chunkZ, boolean add,
+          TicketType<OwnedTicketInfo<T>> type, Function<ForcedChunksSaveData, Object2LongMap<TicketOwner<T>>> ticketGetter)
+    {
+        if (!ModList.get().isLoaded(modId))
+        {
+            LOGGER.warn("A mod attempted to force a chunk for an unloaded mod of id: {}", modId);
+            return false;
+        }
+        ForcedChunksSaveData data = world.getSavedData().getOrCreate(ForcedChunksSaveData::new, "chunks");
+        Object2LongMap<TicketOwner<T>> tickets = ticketGetter.apply(data);
+        TicketOwner<T> ticketOwner = new TicketOwner<>(modId, owner);
+        boolean contains = tickets.containsKey(ticketOwner);
+        if (add != contains)
+        {
+            //If we are adding it doesn't already exist, if we are removing it already exists
+            ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+            if (add)
+            {
+                tickets.put(ticketOwner, pos.asLong());
+                world.getChunk(chunkX, chunkZ);
+            }
+            else
+            {
+                tickets.removeLong(ticketOwner);
+            }
+            data.setDirty(true);
+            forceChunk(world, pos, type, ticketOwner, add);
+            return true;
+        }
+        return false;
+    }
+
+    private static <T extends Comparable<? super T>> void forceChunk(ServerWorld world, ChunkPos pos, TicketType<OwnedTicketInfo<T>> type, TicketOwner<T> value, boolean add)
+    {
+        //We use distance 2, as when using register/releaseTicket the ticket's level is set to 33 - distance
+        // and the level that forced chunks use is 31
+        OwnedTicketInfo<T> ticketInfo = new OwnedTicketInfo<>(value, pos);
+        if (add)
+            world.getChunkProvider().registerTicket(type, pos, 2, ticketInfo);
+        else
+            world.getChunkProvider().releaseTicket(type, pos, 2, ticketInfo);
+    }
+
+    public static void reinstatePersistentChunks(ServerWorld world, ForcedChunksSaveData saveData)
+    {
+        reinstatePersistentChunks(world, BLOCK, saveData.getBlockForcedChunks());
+        reinstatePersistentChunks(world, ENTITY, saveData.getEntityForcedChunks());
+    }
+
+    private static <T extends Comparable<? super T>> void reinstatePersistentChunks(ServerWorld world, TicketType<OwnedTicketInfo<T>> type, Object2LongMap<TicketOwner<T>> tickets)
+    {
+        for (Object2LongMap.Entry<TicketOwner<T>> entry : tickets.object2LongEntrySet())
+        {
+            forceChunk(world, new ChunkPos(entry.getLongValue()), type, entry.getKey(), true);
+        }
+    }
+
+    public static void writeForgeForcedChunks(CompoundNBT nbt, Object2LongMap<TicketOwner<BlockPos>> blockForcedChunks, Object2LongMap<TicketOwner<UUID>> entityForcedChunks)
+    {
+        if (!blockForcedChunks.isEmpty() || !entityForcedChunks.isEmpty())
+        {
+            //TODO: Some sort of docs that the second part being a map is mainly for purpose of looking up same chunk entries
+            // but different other data but the data also contains the long
+            Map<String, Long2ObjectMap<CompoundNBT>> forcedEntries = new HashMap<>();
+            writeForcedChunkOwners(forcedEntries, blockForcedChunks, "Blocks", Constants.NBT.TAG_COMPOUND, (pos, forcedBlocks) -> forcedBlocks.add(NBTUtil.writeBlockPos(pos)));
+            writeForcedChunkOwners(forcedEntries, entityForcedChunks, "Entities", Constants.NBT.TAG_INT_ARRAY, (uuid, forcedEntities) -> forcedEntities.add(NBTUtil.func_240626_a_(uuid)));
+            ListNBT forcedChunks = new ListNBT();
+            for (Map.Entry<String, Long2ObjectMap<CompoundNBT>> entry : forcedEntries.entrySet())
+            {
+                CompoundNBT forcedEntry = new CompoundNBT();
+                forcedEntry.putString("Mod", entry.getKey());
+                ListNBT modForced = new ListNBT();
+                modForced.addAll(entry.getValue().values());
+                forcedEntry.put("ModForced", modForced);
+                forcedChunks.add(forcedEntry);
+            }
+            nbt.put("ForgeForced", forcedChunks);
+        }
+    }
+
+    private static <T extends Comparable<? super T>> void writeForcedChunkOwners(Map<String, Long2ObjectMap<CompoundNBT>> forcedEntries,
+          Object2LongMap<TicketOwner<T>> forcedChunks, String listKey, int listType, BiConsumer<T, ListNBT> ownerWriter)
+    {
+        for (Object2LongMap.Entry<TicketOwner<T>> entry : forcedChunks.object2LongEntrySet())
+        {
+            Long2ObjectMap<CompoundNBT> modForced = forcedEntries.computeIfAbsent(entry.getKey().modId, modId -> new Long2ObjectOpenHashMap<>());
+            CompoundNBT modEntry = modForced.computeIfAbsent(entry.getLongValue(), chunkPos -> {
+                CompoundNBT baseEntry = new CompoundNBT();
+                baseEntry.putLong("Chunk", chunkPos);
+                return baseEntry;
+            });
+            ListNBT ownerList = modEntry.getList(listKey, listType);
+            ownerWriter.accept(entry.getKey().owner, ownerList);
+            //TODO: Some sort of note that we can't just check if our entry already contains a list of listKey because
+            // if the type is mismatched somehow then it just returns a new list and to make sure we properly persist
+            // we are going to have to set it anyways
+            modEntry.put(listKey, ownerList);
+        }
+    }
+
+    //List{modid, List{ChunkPos, List{BlockPos}, List{UUID}}}
+    public static void readForgeForcedChunks(CompoundNBT nbt, Object2LongMap<TicketOwner<BlockPos>> blockForcedChunks, Object2LongMap<TicketOwner<UUID>> entityForcedChunks)
+    {
+        ListNBT forcedChunks = nbt.getList("ForgeForced", Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < forcedChunks.size(); i++)
+        {
+            CompoundNBT forcedEntry = forcedChunks.getCompound(i);
+            String modId = forcedEntry.getString("Mod");
+            if (ModList.get().isLoaded(modId))
+            {
+                ListNBT modForced = forcedEntry.getList("ModForced", Constants.NBT.TAG_COMPOUND);
+                for (int j = 0; j < modForced.size(); j++)
+                {
+                    CompoundNBT modEntry = modForced.getCompound(j);
+                    long chunkPos = modEntry.getLong("Chunk");
+                    ListNBT forcedBlocks = modEntry.getList("Blocks", Constants.NBT.TAG_COMPOUND);
+                    for (int k = 0; k < forcedBlocks.size(); k++)
+                    {
+                        blockForcedChunks.put(new TicketOwner<>(modId, NBTUtil.readBlockPos(forcedBlocks.getCompound(k))), chunkPos);
+                    }
+                    ListNBT forcedEntities = modEntry.getList("Entities", Constants.NBT.TAG_INT_ARRAY);
+                    for (int k = 0; k < forcedEntities.size(); k++)
+                    {
+                        //Based on how vanilla's NBTUtil handles UUIDs
+                        int[] rawUUID = forcedEntities.getIntArray(k);
+                        if (rawUUID.length == 4)
+                        {
+                            entityForcedChunks.put(new TicketOwner<>(modId, UUIDCodec.decodeUUID(rawUUID)), chunkPos);
+                        }
+                        else
+                        {
+                            //Something went wrong, this should never happen unless the data gets corrupted, but validate it just in case
+                            LOGGER.warn("Found chunk loading data for mod {} with invalid UUID-Array of length {}, but expected length 4 - it will be removed from the world save.", modId, rawUUID.length);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                LOGGER.warn("Found chunk loading data for mod {} which is currently not available or active - it will be removed from the world save.", modId);
+            }
+        }
+    }
+
+    public static class TicketOwner<T extends Comparable<? super T>> implements Comparable<TicketOwner<T>>
+    {
+        private final String modId;
+        private final T owner;
+
+        private TicketOwner(String modId, T owner)
+        {
+            this.modId = modId;
+            this.owner = owner;
+        }
+
+        @Override
+        public int compareTo(TicketOwner<T> other)
+        {
+            int res = modId.compareTo(other.modId);
+            return res == 0 ? owner.compareTo(other.owner) : res;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TicketOwner<?> that = (TicketOwner<?>) o;
+            return Objects.equals(modId, that.modId) && Objects.equals(owner, that.owner);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(modId, owner);
+        }
+    }
+
+    private static class OwnedTicketInfo<T extends Comparable<? super T>> implements Comparable<OwnedTicketInfo<T>>
+    {
+        private final ChunkPos chunkPos;
+        private final TicketOwner<T> owner;
+
+        public OwnedTicketInfo(TicketOwner<T> owner, ChunkPos chunkPos)
+        {
+            this.chunkPos = chunkPos;
+            this.owner = owner;
+        }
+
+        @Override
+        public int compareTo(OwnedTicketInfo<T> other)
+        {
+            int res = Long.compare(chunkPos.asLong(), other.chunkPos.asLong());
+            return res == 0 ? owner.compareTo(other.owner) : res;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            OwnedTicketInfo<?> other = (OwnedTicketInfo<?>) o;
+            return chunkPos.equals(other.chunkPos) && owner.equals(other.owner);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(chunkPos, owner);
+        }
+    }
+}

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -58,5 +58,6 @@ net/minecraft/world/gen/feature/template/Template.processEntityInfos(Lnet/minecr
 net/minecraft/world/server/ServerWorld.removeEntity(Lnet/minecraft/entity/Entity;Z)V=|p_217467_1_,keepData
 net/minecraft/world/server/ServerWorld.removeEntityComplete(Lnet/minecraft/entity/Entity;Z)V=|p_217484_1_,keepData
 net/minecraft/world/server/ServerWorld.removePlayer(Lnet/minecraft/entity/player/ServerPlayerEntity;Z)V=|p_217434_1_,keepData
+net/minecraft/world/server/Ticket.<init>(Lnet/minecraft/world/server/TicketType;ILjava/lang/Object;Z)V=|p_i226095_1_,p_i226095_2_,p_i226095_3_,forceTicks
 net/minecraft/world/spawner/WorldEntitySpawner.canSpawnAtBody(Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/IWorldReader;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/EntityType;)Z=|p_209382_0_,p_209382_1_,p_209382_2_,p_209382_3_
 net/minecraft/world/storage/SaveFormat.getReader(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/util/datafix/codec/DatapackCodec;Lnet/minecraft/world/storage/SaveFormat$LevelSave;)Ljava/util/function/BiFunction;=|p_237270_0_,p_237270_1_,levelSave

--- a/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.debug.world;
 
+import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Map;
 import net.minecraft.block.AbstractBlock;
@@ -64,15 +65,16 @@ public class ForgeChunkManagerTest
     private void commonSetup(FMLCommonSetupEvent event)
     {
         event.enqueueWork(() -> ForgeChunkManager.setForcedChunkLoadingCallback(MODID, (world, ticketHelper) -> {
-            for (Map.Entry<BlockPos, LongSet> entry : ticketHelper.getBlockTickets().entrySet())
+            for (Map.Entry<BlockPos, Pair<LongSet, LongSet>> entry : ticketHelper.getBlockTickets().entrySet())
             {
                 BlockPos key = entry.getKey();
+                int ticketCount = entry.getValue().getFirst().size() + entry.getValue().getSecond().size();
                 if (world.getBlockState(key).isIn(CHUNK_LOADER_BLOCK.get()))
-                    LOGGER.info("Allowing {} chunk tickets to be reinstated for position: {}.", entry.getValue().size(), key);
+                    LOGGER.info("Allowing {} chunk tickets to be reinstated for position: {}.", ticketCount, key);
                 else
                 {
                     ticketHelper.removeAllTickets(key);
-                    LOGGER.info("Removing {} chunk tickets for no longer valid position: {}.", entry.getValue().size(), key);
+                    LOGGER.info("Removing {} chunk tickets for no longer valid position: {}.", ticketCount, key);
                 }
             }
         }));
@@ -93,7 +95,7 @@ public class ForgeChunkManagerTest
             if (worldIn instanceof ServerWorld)
             {
                 ChunkPos chunkPos = new ChunkPos(pos);
-                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, true);
+                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, true, false);
             }
         }
 
@@ -104,7 +106,7 @@ public class ForgeChunkManagerTest
             if (worldIn instanceof ServerWorld && !state.isIn(newState.getBlock()))
             {
                 ChunkPos chunkPos = new ChunkPos(pos);
-                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, false);
+                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, false, false);
             }
         }
     }

--- a/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import it.unimi.dsi.fastutil.longs.LongSet;
+import java.util.Map;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.world.ForgeChunkManager;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(ForgeChunkManagerTest.MODID)
+public class ForgeChunkManagerTest
+{
+    public static final String MODID = "forge_chunk_manager_test";
+    private static final Logger LOGGER = LogManager.getLogger(MODID);
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final RegistryObject<Block> CHUNK_LOADER_BLOCK = BLOCKS.register("chunk_loader", () -> new ChunkLoaderBlock(AbstractBlock.Properties.create(Material.ROCK)));
+    private static final RegistryObject<Item> CHUNK_LOADER_ITEM = ITEMS.register("chunk_loader", () -> new BlockItem(CHUNK_LOADER_BLOCK.get(), new Item.Properties().group(ItemGroup.MISC)));
+
+    public ForgeChunkManagerTest()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        modEventBus.addListener(this::commonSetup);
+        BLOCKS.register(modEventBus);
+        ITEMS.register(modEventBus);
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event)
+    {
+        event.enqueueWork(() -> ForgeChunkManager.setForcedChunkLoadingCallback(MODID, (world, ticketHelper) -> {
+            for (Map.Entry<BlockPos, LongSet> entry : ticketHelper.getBlockTickets().entrySet())
+            {
+                BlockPos key = entry.getKey();
+                if (world.getBlockState(key).isIn(CHUNK_LOADER_BLOCK.get()))
+                    LOGGER.info("Allowing {} chunk tickets to be reinstated for position: {}.", entry.getValue().size(), key);
+                else
+                {
+                    ticketHelper.removeAllTickets(key);
+                    LOGGER.info("Removing {} chunk tickets for no longer valid position: {}.", entry.getValue().size(), key);
+                }
+            }
+        }));
+    }
+
+    private static class ChunkLoaderBlock extends Block
+    {
+
+        public ChunkLoaderBlock(Properties properties)
+        {
+            super(properties);
+        }
+
+        @Override
+        public void onBlockAdded(BlockState state, World worldIn, BlockPos pos, BlockState oldState, boolean isMoving)
+        {
+            super.onBlockAdded(state, worldIn, pos, oldState, isMoving);
+            if (worldIn instanceof ServerWorld)
+            {
+                ChunkPos chunkPos = new ChunkPos(pos);
+                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, true);
+            }
+        }
+
+        @Deprecated
+        public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving)
+        {
+            super.onReplaced(state, worldIn, pos, newState, isMoving);
+            if (worldIn instanceof ServerWorld && !state.isIn(newState.getBlock()))
+            {
+                ChunkPos chunkPos = new ChunkPos(pos);
+                ForgeChunkManager.forceChunk((ServerWorld) worldIn, MODID, pos, chunkPos.x, chunkPos.z, false);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
@@ -22,6 +22,7 @@ package net.minecraftforge.debug.world;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Map;
+import java.util.UUID;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -68,14 +69,22 @@ public class ForgeChunkManagerTest
             for (Map.Entry<BlockPos, Pair<LongSet, LongSet>> entry : ticketHelper.getBlockTickets().entrySet())
             {
                 BlockPos key = entry.getKey();
-                int ticketCount = entry.getValue().getFirst().size() + entry.getValue().getSecond().size();
+                int ticketCount = entry.getValue().getFirst().size();
+                int tickingTicketCount = entry.getValue().getSecond().size();
                 if (world.getBlockState(key).isIn(CHUNK_LOADER_BLOCK.get()))
-                    LOGGER.info("Allowing {} chunk tickets to be reinstated for position: {}.", ticketCount, key);
+                    LOGGER.info("Allowing {} chunk tickets and {} ticking chunk tickets to be reinstated for position: {}.", ticketCount, tickingTicketCount, key);
                 else
                 {
                     ticketHelper.removeAllTickets(key);
-                    LOGGER.info("Removing {} chunk tickets for no longer valid position: {}.", ticketCount, key);
+                    LOGGER.info("Removing {} chunk tickets and {} ticking chunk tickets for no longer valid position: {}.", ticketCount, tickingTicketCount, key);
                 }
+            }
+            for (Map.Entry<UUID, Pair<LongSet, LongSet>> entry : ticketHelper.getEntityTickets().entrySet())
+            {
+                UUID key = entry.getKey();
+                int ticketCount = entry.getValue().getFirst().size();
+                int tickingTicketCount = entry.getValue().getSecond().size();
+                LOGGER.info("Allowing {} chunk tickets and {} ticking chunk tickets to be reinstated for entity: {}.", ticketCount, tickingTicketCount, key);
             }
         }));
     }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -91,6 +91,8 @@ license="LGPL v2.1"
 [[mods]]
     modId="biome_loading_event_test"
 [[mods]]
+    modId="forge_chunk_manager_test"
+[[mods]]
     modId="living_conversion_event_test"
 [[mods]]
     modId="player_game_mode_event_test"

--- a/src/test/resources/assets/forge_chunk_manager_test/blockstates/chunk_loader.json
+++ b/src/test/resources/assets/forge_chunk_manager_test/blockstates/chunk_loader.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "forge_chunk_manager_test:block/chunk_loader"
+    }
+  }
+}

--- a/src/test/resources/assets/forge_chunk_manager_test/models/block/chunk_loader.json
+++ b/src/test/resources/assets/forge_chunk_manager_test/models/block/chunk_loader.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/cube_bottom_top",
+  "textures": {
+    "top": "minecraft:block/respawn_anchor_top",
+    "bottom": "minecraft:block/respawn_anchor_bottom",
+    "side": "minecraft:block/respawn_anchor_side4"
+  }
+}

--- a/src/test/resources/assets/forge_chunk_manager_test/models/item/chunk_loader.json
+++ b/src/test/resources/assets/forge_chunk_manager_test/models/item/chunk_loader.json
@@ -1,0 +1,3 @@
+{
+  "parent": "forge_chunk_manager_test:block/chunk_loader"
+}


### PR DESCRIPTION
This PR supersedes #7517, by reinstating forge's chunk manager to provide modders a way to keep track of chunks they want forced in a persistent way and in one that allows for multiple mods (or even the same mod) to register tickets for the same chunk unlike vanilla's forced chunk system which if two mods try to use (with default forced chunk tickets) and then one removes the ticket then the chunk will be unloaded even though the other mod may still want it loaded. This PR currently adds support for managing two types of ticket owners for modders: BLOCK (BlockPos) and ENTITY (UUID).

One thing to note about this PR is that it does not override `ServerWorld#getForcedChunks` as that method is primarily used for the `ForceLoadCommand` which Forge's Chunk Manager does not adjust. Instead we patch one of the calls to it to a method we add to check if any chunks are forced in the world (that is used to see if a world should keep ticking) for purposes of doing a quick lookup check without having to merge a potentially decent number of sets. We do not override the call in DebugOverlayGui that shows how many chunks are forced as in my opinion that is a more useful debug thing for purposes of the force load command and merging a bunch of sets to get the total count seems rather pointless to me.