### PR TITLE
Fix a couple places returning an invalid capability from getCapability

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
@@ -28,7 +28,7 @@
                 if (f1 > 0.0F) {
                    float f2 = MathHelper.func_76126_a(this.field_70177_z * ((float)Math.PI / 180F));
                    float f3 = MathHelper.func_76134_b(this.field_70177_z * ((float)Math.PI / 180F));
-@@ -1010,4 +1012,22 @@
+@@ -1010,4 +1012,23 @@
        this.func_230273_eI_();
        return super.func_213386_a(p_213386_1_, p_213386_2_, p_213386_3_, p_213386_4_, p_213386_5_);
     }
@@ -46,8 +46,9 @@
 +   protected void invalidateCaps() {
 +      super.invalidateCaps();
 +      if (itemHandler != null) {
-+         itemHandler.invalidate();
++         net.minecraftforge.common.util.LazyOptional<?> oldHandler = itemHandler;
 +         itemHandler = null;
++         oldHandler.invalidate();
 +      }
 +   }
  }

--- a/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/ChestTileEntity.java.patch
@@ -17,7 +17,7 @@
           TileEntity tileentity = p_195481_0_.func_175625_s(p_195481_1_);
           if (tileentity instanceof ChestTileEntity) {
              return ((ChestTileEntity)tileentity).field_145987_o;
-@@ -221,4 +222,39 @@
+@@ -221,4 +222,40 @@
     protected Container func_213906_a(int p_213906_1_, PlayerInventory p_213906_2_) {
        return ChestContainer.func_216992_a(p_213906_1_, p_213906_2_, this);
     }
@@ -26,8 +26,9 @@
 +   public void func_145836_u() {
 +      super.func_145836_u();
 +      if (this.chestHandler != null) {
-+         this.chestHandler.invalidate();
++         net.minecraftforge.common.util.LazyOptional<?> oldHandler = this.chestHandler;
 +         this.chestHandler = null;
++         oldHandler.invalidate();
 +      }
 +   }
 +


### PR DESCRIPTION
This PR fixes the fact that if an invalidation listener is registered, say to a chest's iitemhandler capability, then when it is fired if the listener tries to get the capability from the chest again to see if it still has one and the old one just is no longer valid, the old invalid capability is returned. It fixes this by grabbing the instance of the old handler, then setting the handler to null (so that the lazy assignment to it can be properly called), and then invalidate the old handler so that any calls to getCapability from within the invalidation listeners will be able to have the lazy assignment happen and properly return the new item handler capability for the chest.