### PR TITLE
Add option for linear filtering of text texture

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/client/renderer/RenderType.java
++++ b/net/minecraft/client/renderer/RenderType.java
+@@ -215,11 +_,11 @@
+    }
+ 
+    public static RenderType func_228658_l_(ResourceLocation p_228658_0_) {
+-      return func_228633_a_("text", DefaultVertexFormats.field_227852_q_, 7, 256, false, true, RenderType.State.func_228694_a_().func_228724_a_(new RenderState.TextureState(p_228658_0_, false, false)).func_228713_a_(field_228517_i_).func_228726_a_(field_228515_g_).func_228719_a_(field_228528_t_).func_228728_a_(false));
++      return net.minecraftforge.client.ForgeRenderTypes.getText(p_228658_0_);
+    }
+ 
+    public static RenderType func_228660_m_(ResourceLocation p_228660_0_) {
+-      return func_228633_a_("text_see_through", DefaultVertexFormats.field_227852_q_, 7, 256, false, true, RenderType.State.func_228694_a_().func_228724_a_(new RenderState.TextureState(p_228660_0_, false, false)).func_228713_a_(field_228517_i_).func_228726_a_(field_228515_g_).func_228719_a_(field_228528_t_).func_228715_a_(field_228492_B_).func_228727_a_(field_228496_F_).func_228728_a_(false));
++      return net.minecraftforge.client.ForgeRenderTypes.getTextSeeThrough(p_228660_0_);
+    }
+ 
+    public static RenderType func_228657_l_() {

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -19,18 +19,21 @@
 
 package net.minecraftforge.client;
 
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderState;
+import net.minecraft.client.renderer.RenderState.TextureState;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderType.State;
 import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.NonNullLazy;
 import net.minecraftforge.common.util.NonNullSupplier;
 import org.lwjgl.opengl.GL11;
-
-import net.minecraft.client.renderer.RenderState.TextureState;
-import net.minecraft.client.renderer.RenderType.State;
+import java.util.function.Supplier;
 
 @SuppressWarnings("deprecation")
 public enum ForgeRenderTypes
@@ -42,6 +45,8 @@ public enum ForgeRenderTypes
     ITEM_UNSORTED_TRANSLUCENT(()-> getUnsortedTranslucent(AtlasTexture.LOCATION_BLOCKS)),
     ITEM_UNLIT_TRANSLUCENT(()-> getUnlitTranslucent(AtlasTexture.LOCATION_BLOCKS)),
     ITEM_UNSORTED_UNLIT_TRANSLUCENT(()-> getUnlitTranslucent(AtlasTexture.LOCATION_BLOCKS, false));
+
+    public static boolean enableTextTextureLinearFiltering = false;
 
     /**
      * @return A RenderType fit for multi-layer solid item rendering.
@@ -108,6 +113,22 @@ public enum ForgeRenderTypes
     public static RenderType getEntityCutoutMipped(ResourceLocation textureLocation)
     {
         return Internal.layeredItemCutoutMipped(textureLocation);
+    }
+
+    /**
+     * @return Replacement of {@link RenderType#getText(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getText(ResourceLocation locationIn)
+    {
+        return Internal.getText(locationIn);
+    }
+
+    /**
+     * @return Replacement of {@link RenderType#getTextSeeThrough(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getTextSeeThrough(ResourceLocation locationIn)
+    {
+        return Internal.getTextSeeThrough(locationIn);
     }
 
     // ----------------------------------------
@@ -208,6 +229,44 @@ public enum ForgeRenderTypes
                     .setOverlayState(OVERLAY)
                     .createCompositeState(true);
             return create("forge_item_entity_translucent_cull", DefaultVertexFormats.NEW_ENTITY, 7, 256, true, true, rendertype$state);
+        }
+
+        public static RenderType getText(ResourceLocation locationIn) {
+            RenderType.State rendertype$state = RenderType.State.builder()
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setAlphaState(DEFAULT_ALPHA)
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .createCompositeState(false);
+            return create("forge_text", DefaultVertexFormats.POSITION_COLOR_TEX_LIGHTMAP, 7, 256, false, true, rendertype$state);
+        }
+
+        public static RenderType getTextSeeThrough(ResourceLocation locationIn) {
+            RenderType.State rendertype$state = RenderType.State.builder()
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setAlphaState(DEFAULT_ALPHA)
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .setDepthTestState(NO_DEPTH_TEST)
+                    .setWriteMaskState(COLOR_WRITE)
+                    .createCompositeState(false);
+            return create("forge_text_see_through", DefaultVertexFormats.POSITION_COLOR_TEX_LIGHTMAP, 7, 256, false, true, rendertype$state);
+        }
+    }
+
+    private static class CustomizableTextureState extends TextureState
+    {
+        private CustomizableTextureState(ResourceLocation resLoc, Supplier<Boolean> blur, Supplier<Boolean> mipmap)
+        {
+            super(resLoc, blur.get(), mipmap.get());
+            this.setupState = () -> {
+                this.blur = blur.get();
+                this.mipmap = mipmap.get();
+                RenderSystem.enableTexture();
+                TextureManager texturemanager = Minecraft.getInstance().getTextureManager();
+                texturemanager.bind(resLoc);
+                texturemanager.getTexture(resLoc).setFilter(this.blur, this.mipmap);
+            };
         }
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -154,6 +154,9 @@ public net.minecraft.client.renderer.GameRenderer func_175069_a(Lnet/minecraft/u
 private net.minecraft.client.renderer.ItemModelMesher field_199313_a #force public -> private
 public net.minecraft.client.renderer.ItemRenderer func_229112_a_(Lcom/mojang/blaze3d/matrix/MatrixStack;Lcom/mojang/blaze3d/vertex/IVertexBuilder;Ljava/util/List;Lnet/minecraft/item/ItemStack;II)V # renderQuads
 public net.minecraft.client.renderer.ItemRenderer func_229114_a_(Lnet/minecraft/client/renderer/model/IBakedModel;Lnet/minecraft/item/ItemStack;IILcom/mojang/blaze3d/matrix/MatrixStack;Lcom/mojang/blaze3d/vertex/IVertexBuilder;)V # renderModel
+protected-f net.minecraft.client.renderer.RenderState field_228507_Q_ # setupState
+protected-f net.minecraft.client.renderer.RenderState$TextureState field_228603_R_ # blur
+protected-f net.minecraft.client.renderer.RenderState$TextureState field_228604_S_ # mipmap
 public net.minecraft.client.renderer.entity.EntityRendererManager field_78729_o #renderers
 public net.minecraft.client.renderer.entity.EntityRendererManager func_229087_a_(Lnet/minecraft/entity/EntityType;Lnet/minecraft/client/renderer/entity/EntityRenderer;)V # addRenderer
 protected net.minecraft.client.renderer.entity.ItemRenderer func_177078_a(Lnet/minecraft/item/ItemStack;)I # getMiniItemCount

--- a/src/test/java/net/minecraftforge/debug/client/rendering/LinearTextTextureFilteringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/LinearTextTextureFilteringTest.java
@@ -1,0 +1,53 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraft.client.gui.screen.MainMenuScreen;
+import net.minecraftforge.client.ForgeRenderTypes;
+import net.minecraftforge.client.event.GuiScreenEvent.DrawScreenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.api.distmarker.Dist;
+
+@Mod(LinearTextTextureFilteringTest.MODID)
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class LinearTextTextureFilteringTest
+{
+    public static final String MODID = "text_linear_filtering_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onGuiRenderPre(DrawScreenEvent.Pre event)
+    {
+        if (ENABLED && event.getGui() instanceof MainMenuScreen)
+        {
+            ForgeRenderTypes.enableTextTextureLinearFiltering = true;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onGuiRenderPost(DrawScreenEvent.Post event)
+    {
+        if (ENABLED && event.getGui() instanceof MainMenuScreen)
+        {
+            ForgeRenderTypes.enableTextTextureLinearFiltering = false;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -122,3 +122,5 @@ license="LGPL v2.1"
     modId="enum_argument_test"
 [[mods]]
     modId="entity_teleport_event_test"
+[[mods]]
+    modId="text_linear_filtering_test"


### PR DESCRIPTION
When scaling text in unrounded scales (eg. 1.5x) the nn (nearest neighbor) filtering makes the text look weird and in small scales unreadable. This PR adds the ability to turn on linear filtering for text texture making a bit more readable but might seem a bit more transparent.
note: I don't know enough about mipmaps and if they would bring improvement so they are kept disabled

Before:
![image](https://user-images.githubusercontent.com/17338378/107121980-896d7580-6895-11eb-96fa-0b2f6e063831.png)

After:
![image](https://user-images.githubusercontent.com/17338378/107122162-48299580-6896-11eb-8197-db6f5c45635b.png)