### PR TITLE
Fix updateItemStackNBT not properly being called using a field transformer

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -13,13 +13,13 @@
           return Optional.ofNullable(p_234704_0_.field_77990_d);
        })).apply(p_234698_0_, ItemStack::new);
     });
-+   private net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
++   private final net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
 +   private CompoundNBT capNBT;
 +
     private static final Logger field_199558_c = LogManager.getLogger();
     public static final ItemStack field_190927_a = new ItemStack((Item)null);
     public static final DecimalFormat field_111284_a = Util.func_200696_a(new DecimalFormat("#.##"), (p_234699_0_) -> {
-@@ -109,14 +112,18 @@
+@@ -109,14 +112,19 @@
        p_i231596_3_.ifPresent(this::func_77982_d);
     }
  
@@ -29,6 +29,7 @@
 +      super(ItemStack.class);
 +      this.capNBT = capNBT;
        this.field_151002_e = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j();
++      this.delegate = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j().delegate;
        this.field_77994_a = p_i48204_2_;
 -      if (this.field_151002_e != null && this.field_151002_e.func_77645_m()) {
 +      if (this.field_151002_e != null && this.field_151002_e.isDamageable(this)) {
@@ -40,16 +41,18 @@
     }
  
     private void func_190923_F() {
-@@ -125,6 +132,8 @@
+@@ -125,18 +133,23 @@
     }
  
     private ItemStack(CompoundNBT p_i47263_1_) {
 +      super(ItemStack.class);
 +      this.capNBT = p_i47263_1_.func_74764_b("ForgeCaps") ? p_i47263_1_.func_74775_l("ForgeCaps") : null;
++      Item rawItem =
        this.field_151002_e = Registry.field_212630_s.func_82594_a(new ResourceLocation(p_i47263_1_.func_74779_i("id")));
++      this.delegate = rawItem.delegate;
        this.field_77994_a = p_i47263_1_.func_74771_c("Count");
        if (p_i47263_1_.func_150297_b("tag", 10)) {
-@@ -132,11 +141,12 @@
+          this.field_77990_d = p_i47263_1_.func_74775_l("tag");
           this.func_77973_b().func_179215_a(p_i47263_1_);
        }
  
@@ -63,16 +66,7 @@
     }
  
     public static ItemStack func_199557_a(CompoundNBT p_199557_0_) {
-@@ -151,7 +161,7 @@
-    public boolean func_190926_b() {
-       if (this == field_190927_a) {
-          return true;
--      } else if (this.func_77973_b() != null && this.func_77973_b() != Items.field_190931_a) {
-+      } else if (this.getItemRaw() != null && this.getItemRaw() != Items.field_190931_a) {
-          return this.field_77994_a <= 0;
-       } else {
-          return true;
-@@ -167,10 +177,19 @@
+@@ -167,10 +180,19 @@
     }
  
     public Item func_77973_b() {
@@ -93,7 +87,7 @@
        PlayerEntity playerentity = p_196084_1_.func_195999_j();
        BlockPos blockpos = p_196084_1_.func_195995_a();
        CachedBlockInfo cachedblockinfo = new CachedBlockInfo(p_196084_1_.func_195991_k(), blockpos, false);
-@@ -178,7 +197,7 @@
+@@ -178,7 +200,7 @@
           return ActionResultType.PASS;
        } else {
           Item item = this.func_77973_b();
@@ -102,7 +96,7 @@
           if (playerentity != null && actionresulttype.func_226246_a_()) {
              playerentity.func_71029_a(Stats.field_75929_E.func_199076_b(item));
           }
-@@ -206,12 +225,15 @@
+@@ -206,12 +228,15 @@
        if (this.field_77990_d != null) {
           p_77955_1_.func_218657_a("tag", this.field_77990_d.func_74737_b());
        }
@@ -120,7 +114,7 @@
     }
  
     public boolean func_77985_e() {
-@@ -219,7 +241,7 @@
+@@ -219,7 +244,7 @@
     }
  
     public boolean func_77984_f() {
@@ -129,7 +123,7 @@
           CompoundNBT compoundnbt = this.func_77978_p();
           return compoundnbt == null || !compoundnbt.func_74767_n("Unbreakable");
        } else {
-@@ -228,19 +250,19 @@
+@@ -228,19 +253,19 @@
     }
  
     public boolean func_77951_h() {
@@ -153,7 +147,7 @@
     }
  
     public boolean func_96631_a(int p_96631_1_, Random p_96631_2_, @Nullable ServerPlayerEntity p_96631_3_) {
-@@ -276,6 +298,7 @@
+@@ -276,6 +301,7 @@
     public <T extends LivingEntity> void func_222118_a(int p_222118_1_, T p_222118_2_, Consumer<T> p_222118_3_) {
        if (!p_222118_2_.field_70170_p.field_72995_K && (!(p_222118_2_ instanceof PlayerEntity) || !((PlayerEntity)p_222118_2_).field_71075_bZ.field_75098_d)) {
           if (this.func_77984_f()) {
@@ -161,7 +155,7 @@
              if (this.func_96631_a(p_222118_1_, p_222118_2_.func_70681_au(), p_222118_2_ instanceof ServerPlayerEntity ? (ServerPlayerEntity)p_222118_2_ : null)) {
                 p_222118_3_.accept(p_222118_2_);
                 Item item = this.func_77973_b();
-@@ -308,7 +331,7 @@
+@@ -308,7 +334,7 @@
     }
  
     public boolean func_150998_b(BlockState p_150998_1_) {
@@ -170,7 +164,7 @@
     }
  
     public ActionResultType func_111282_a_(PlayerEntity p_111282_1_, LivingEntity p_111282_2_, Hand p_111282_3_) {
-@@ -319,7 +342,7 @@
+@@ -319,7 +345,7 @@
        if (this.func_190926_b()) {
           return field_190927_a;
        } else {
@@ -179,7 +173,7 @@
           itemstack.func_190915_d(this.func_190921_D());
           if (this.field_77990_d != null) {
              itemstack.field_77990_d = this.field_77990_d.func_74737_b();
-@@ -336,7 +359,7 @@
+@@ -336,7 +362,7 @@
           if (p_77970_0_.field_77990_d == null && p_77970_1_.field_77990_d != null) {
              return false;
           } else {
@@ -188,7 +182,7 @@
           }
        } else {
           return false;
-@@ -359,7 +382,7 @@
+@@ -359,7 +385,7 @@
        } else if (this.field_77990_d == null && p_77959_1_.field_77990_d != null) {
           return false;
        } else {
@@ -197,7 +191,7 @@
        }
     }
  
-@@ -479,7 +502,7 @@
+@@ -479,7 +505,7 @@
  
     public void func_77982_d(@Nullable CompoundNBT p_77982_1_) {
        this.field_77990_d = p_77982_1_;
@@ -206,7 +200,7 @@
           this.func_196085_b(this.func_77952_i());
        }
  
-@@ -673,6 +696,7 @@
+@@ -673,6 +699,7 @@
           }
        }
  
@@ -214,7 +208,7 @@
        return list;
     }
  
-@@ -817,9 +841,10 @@
+@@ -817,9 +844,10 @@
              }
           }
        } else {
@@ -226,7 +220,7 @@
        return multimap;
     }
  
-@@ -954,6 +979,35 @@
+@@ -954,6 +982,24 @@
        return this.func_77973_b().func_219971_r();
     }
  
@@ -241,22 +235,11 @@
 +    * Set up forge's ItemStack additions.
 +    */
 +   private void forgeInit() {
-+      Item item = getItemRaw();
-+      if (item != null) {
-+         this.delegate = item.delegate;
-+         net.minecraftforge.common.capabilities.ICapabilityProvider provider = item.initCapabilities(this, this.capNBT);
++      if (this.delegate != null) {
++         net.minecraftforge.common.capabilities.ICapabilityProvider provider = field_151002_e.initCapabilities(this, this.capNBT);
 +         this.gatherCapabilities(provider);
 +         if (this.capNBT != null) deserializeCaps(this.capNBT);
 +      }
-+   }
-+
-+   /**
-+    * Internal call to get the actual item, not the delegate.
-+    * In all other methods, FML replaces calls to this.item with the item delegate.
-+    */
-+   @Nullable
-+   private Item getItemRaw() {
-+       return this.field_151002_e;
 +   }
 +
     public SoundEvent func_226629_F_() {

--- a/src/main/resources/META-INF/fieldtomethodtransformers.js
+++ b/src/main/resources/META-INF/fieldtomethodtransformers.js
@@ -73,6 +73,18 @@ function initializeCoreMod() {
                 asmapi.redirectFieldToMethod(classNode, fn, asmapi.mapMethod('getFishType'))
                 return classNode;
             }
+        },
+        'itemstack': {
+            'target': {
+                'type': 'CLASS',
+                'name': 'net.minecraft.item.ItemStack'
+            },
+            'transformer': function(classNode) {
+                var asmapi=Java.type('net.minecraftforge.coremod.api.ASMAPI')
+                var fn = asmapi.mapField('field_151002_e') // item - remap to mcp if necessary
+                asmapi.redirectFieldToMethod(classNode, fn, asmapi.mapMethod('func_77973_b'))
+                return classNode;
+            }
         }
     }
 }


### PR DESCRIPTION
When an item is read from NBT and it contains a NBT tag, it calls `getItem().updateItemStackNBT()` within the NBT constructor. However, Forge does not initialize the item delegate until the end of the consructor, meaning at that time `getItem()` always returns `Items.AIR`.

This fixes the issue by setting the delegate earlier. Since it was just pulled out of the registry, the field will never returns null so its null safe. In addition, since only one other constructor needed the delegate set, it now directly sets it as well.

A few implementation notes:
* As per request on Discord, this PR includes a field transformer to replace all references to `this.item` with `this.getItem()`
* Since only the two constructors need to directly access `this.item` now, `getRawItem()` was removed.
     * In the NBT constructor, a local variable `rawItem` was created instead to set the delegate without it getting transformed to `this.getItem().delegate`.
     * In the `IItemProvider` constructor, it uses the `IItemProvider` parameter directly meaning its an extra call to `IItemProvider#asItem`. That method is trivial or cached in its implementations so I figured it won't be a hit, though I could swap it for a similar local variable using a slightly larger patch
* `forgeInit` no longer sets the delegate. The null check on `this.item` was replaced with a null check to `this.delegate`, which will only be null when creating `ItemStack#EMPTY` using a null item provider (meaning the empty item stack will not get capabilities). Item stacks that are empty via stack size will receive capabilities as before.
* Removed the patch on `ItemStack#isEmpty` as `getItem()` can be accurately checked against air. The `this.getItem() != null` check is redundant as its never null, but shouldn't impact performance

----

To test that this PR does not break item stack delegates, simply load a world that contains item stacks in some inventory. They should be non-empty.

To test this PR fixes`updateItemStackNBT`, place a breakpoint in `SkullItem::updateItemStackNBT`, then cheat in a player head containing NBT. Grabbing the item in creative and renaming it in an anvil is a sufficient method. After adding the NBT, exit and rejoin the world and the breakpoint should be hit.