### PR TITLE
Fix global cache not being a block render type

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -782,9 +782,8 @@ public class ForgeHooksClient
                 .filter(t -> RenderTypeLookup.canRenderInLayer(state, t))
                 .forEach(rendertype ->
                 {
-                    rendertype = rendertype == RenderType.getTranslucent() ? RenderType.getTranslucentMovingBlock() : rendertype;
                     setRenderLayer(rendertype);
-                    IVertexBuilder ivertexbuilder = buffer.getBuffer(rendertype);
+                    IVertexBuilder ivertexbuilder = buffer.getBuffer(rendertype == RenderType.getTranslucent() ? RenderType.getTranslucentMovingBlock() : rendertype);
                     blockRenderer.getBlockModelRenderer().renderModel(world, blockRenderer.getModelForState(state), state, pos, stack, ivertexbuilder, checkSides, new Random(), state.getPositionRandom(pos), combinedOverlay);
                 });
         setRenderLayer(null);

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -156,9 +156,6 @@ public final class MultiLayerModel implements IModelGeometry<MultiLayerModel>
                 }
                 return builder.build();
             }
-            // fix translucent layer parts in piston-moving rendering as missing model
-            if (layer == RenderType.getTranslucentMovingBlock())
-                layer = RenderType.getTranslucent();
             // support for item layer rendering
             if (state == null && convertRenderTypes)
                 layer = ITEM_RENDER_TYPE_MAPPING.inverse().getOrDefault(layer, layer);


### PR DESCRIPTION
Fixes #7441 setting the global render type to a non block one. 
#7579 was fixing one of the effects of this issue, so it is reverted.