### PR TITLE
Block pathnode entity parameter

### DIFF
--- a/patches/minecraft/net/minecraft/entity/ai/RandomPositionGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/RandomPositionGenerator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/ai/RandomPositionGenerator.java
++++ b/net/minecraft/entity/ai/RandomPositionGenerator.java
+@@ -120,7 +120,7 @@
+                }
+ 
+                if (p_226339_5_ || !p_226339_0_.field_70170_p.func_204610_c(blockpos3).func_206884_a(FluidTags.field_206959_a)) {
+-                  PathNodeType pathnodetype = WalkNodeProcessor.func_237231_a_(p_226339_0_.field_70170_p, blockpos3.func_239590_i_());
++                  PathNodeType pathnodetype = WalkNodeProcessor.func_237231_a_(p_226339_0_.field_70170_p, blockpos3.func_239590_i_(), p_226339_0_);
+                   if (p_226339_0_.func_184643_a(pathnodetype) == 0.0F) {
+                      double d1 = p_226339_8_.applyAsDouble(blockpos3);
+                      if (d1 > d0) {

--- a/patches/minecraft/net/minecraft/entity/ai/goal/FollowOwnerGoal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/goal/FollowOwnerGoal.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/ai/goal/FollowOwnerGoal.java
++++ b/net/minecraft/entity/ai/goal/FollowOwnerGoal.java
+@@ -120,7 +120,7 @@
+    }
+ 
+    private boolean func_226329_a_(BlockPos p_226329_1_) {
+-      PathNodeType pathnodetype = WalkNodeProcessor.func_237231_a_(this.field_75342_a, p_226329_1_.func_239590_i_());
++      PathNodeType pathnodetype = WalkNodeProcessor.func_237231_a_(this.field_75342_a, p_226329_1_.func_239590_i_(), field_75338_d);
+       if (pathnodetype != PathNodeType.WALKABLE) {
+          return false;
+       } else {

--- a/patches/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/pathfinding/FlyingNodeProcessor.java
++++ b/net/minecraft/pathfinding/FlyingNodeProcessor.java
+@@ -249,10 +249,10 @@
+ 
+    public PathNodeType func_186330_a(IBlockReader p_186330_1_, int p_186330_2_, int p_186330_3_, int p_186330_4_) {
+       BlockPos.Mutable blockpos$mutable = new BlockPos.Mutable();
+-      PathNodeType pathnodetype = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_));
++      PathNodeType pathnodetype = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_), this.field_186326_b);
+       if (pathnodetype == PathNodeType.OPEN && p_186330_3_ >= 1) {
+          BlockState blockstate = p_186330_1_.func_180495_p(blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_ - 1, p_186330_4_));
+-         PathNodeType pathnodetype1 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_ - 1, p_186330_4_));
++         PathNodeType pathnodetype1 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_ - 1, p_186330_4_), this.field_186326_b);
+          if (pathnodetype1 != PathNodeType.DAMAGE_FIRE && !blockstate.func_203425_a(Blocks.field_196814_hQ) && pathnodetype1 != PathNodeType.LAVA && !blockstate.func_235714_a_(BlockTags.field_232882_ax_)) {
+             if (pathnodetype1 == PathNodeType.DAMAGE_CACTUS) {
+                pathnodetype = PathNodeType.DAMAGE_CACTUS;

--- a/patches/minecraft/net/minecraft/pathfinding/WalkAndSwimNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkAndSwimNodeProcessor.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/pathfinding/WalkAndSwimNodeProcessor.java
++++ b/net/minecraft/pathfinding/WalkAndSwimNodeProcessor.java
+@@ -216,10 +216,10 @@
+ 
+    public PathNodeType func_186330_a(IBlockReader p_186330_1_, int p_186330_2_, int p_186330_3_, int p_186330_4_) {
+       BlockPos.Mutable blockpos$mutable = new BlockPos.Mutable();
+-      PathNodeType pathnodetype = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_));
++      PathNodeType pathnodetype = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_), this.field_186326_b);
+       if (pathnodetype == PathNodeType.WATER) {
+          for(Direction direction : Direction.values()) {
+-            PathNodeType pathnodetype2 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_).func_189536_c(direction));
++            PathNodeType pathnodetype2 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_, p_186330_4_).func_189536_c(direction), this.field_186326_b);
+             if (pathnodetype2 == PathNodeType.BLOCKED) {
+                return PathNodeType.WATER_BORDER;
+             }
+@@ -229,7 +229,7 @@
+       } else {
+          if (pathnodetype == PathNodeType.OPEN && p_186330_3_ >= 1) {
+             BlockState blockstate = p_186330_1_.func_180495_p(new BlockPos(p_186330_2_, p_186330_3_ - 1, p_186330_4_));
+-            PathNodeType pathnodetype1 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_ - 1, p_186330_4_));
++            PathNodeType pathnodetype1 = func_237238_b_(p_186330_1_, blockpos$mutable.func_181079_c(p_186330_2_, p_186330_3_ - 1, p_186330_4_), this.field_186326_b);
+             if (pathnodetype1 != PathNodeType.WALKABLE && pathnodetype1 != PathNodeType.OPEN && pathnodetype1 != PathNodeType.LAVA) {
+                pathnodetype = PathNodeType.WALKABLE;
+             } else {

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -1,10 +1,42 @@
 --- a/net/minecraft/pathfinding/WalkNodeProcessor.java
 +++ b/net/minecraft/pathfinding/WalkNodeProcessor.java
-@@ -463,9 +463,11 @@
+@@ -392,16 +392,21 @@
+    }
  
+    public PathNodeType func_186330_a(IBlockReader p_186330_1_, int p_186330_2_, int p_186330_3_, int p_186330_4_) {
+-      return func_237231_a_(p_186330_1_, new BlockPos.Mutable(p_186330_2_, p_186330_3_, p_186330_4_));
++      return func_237231_a_(p_186330_1_, new BlockPos.Mutable(p_186330_2_, p_186330_3_, p_186330_4_), this.field_186326_b);
+    }
+ 
++   @Deprecated
+    public static PathNodeType func_237231_a_(IBlockReader p_237231_0_, BlockPos.Mutable p_237231_1_) {
++      return func_237231_a_(p_237231_0_, p_237231_1_, null);
++   }
++
++   public static PathNodeType func_237231_a_(IBlockReader p_237231_0_, BlockPos.Mutable p_237231_1_, @Nullable MobEntity mobEntity) {
+       int i = p_237231_1_.func_177958_n();
+       int j = p_237231_1_.func_177956_o();
+       int k = p_237231_1_.func_177952_p();
+-      PathNodeType pathnodetype = func_237238_b_(p_237231_0_, p_237231_1_);
++      PathNodeType pathnodetype = func_237238_b_(p_237231_0_, p_237231_1_, mobEntity);
+       if (pathnodetype == PathNodeType.OPEN && j >= 1) {
+-         PathNodeType pathnodetype1 = func_237238_b_(p_237231_0_, p_237231_1_.func_181079_c(i, j - 1, k));
++         PathNodeType pathnodetype1 = func_237238_b_(p_237231_0_, p_237231_1_.func_181079_c(i, j - 1, k), mobEntity);
+          pathnodetype = pathnodetype1 != PathNodeType.WALKABLE && pathnodetype1 != PathNodeType.OPEN && pathnodetype1 != PathNodeType.WATER && pathnodetype1 != PathNodeType.LAVA ? PathNodeType.WALKABLE : PathNodeType.OPEN;
+          if (pathnodetype1 == PathNodeType.DAMAGE_FIRE) {
+             pathnodetype = PathNodeType.DAMAGE_FIRE;
+@@ -461,11 +466,18 @@
+       return p_237232_2_;
+    }
+ 
++   @Deprecated
     protected static PathNodeType func_237238_b_(IBlockReader p_237238_0_, BlockPos p_237238_1_) {
++      return func_237238_b_(p_237238_0_, p_237238_1_, null);
++   }
++
++   protected static PathNodeType func_237238_b_(IBlockReader p_237238_0_, BlockPos p_237238_1_, @Nullable MobEntity mobEntity) {
        BlockState blockstate = p_237238_0_.func_180495_p(p_237238_1_);
-+      PathNodeType type = blockstate.getAiPathNodeType(p_237238_0_, p_237238_1_);
++      PathNodeType type = blockstate.getAiPathNodeType(p_237238_0_, p_237238_1_, mobEntity);
 +      if (type != null) return type;
        Block block = blockstate.func_177230_c();
        Material material = blockstate.func_185904_a();

--- a/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2020.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.event;
 
 import com.google.common.collect.HashMultimap;

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -48,6 +48,8 @@ net/minecraft/item/ItemStack.<init>(Lnet/minecraft/util/IItemProvider;ILnet/mine
 net/minecraft/item/ItemStack.onItemUse(Lnet/minecraft/item/ItemUseContext;)Lnet/minecraft/util/ActionResultType;=|p_196084_1_
 net/minecraft/item/ItemStack.onItemUse(Lnet/minecraft/item/ItemUseContext;Ljava/util/function/Function;)Lnet/minecraft/util/ActionResultType;=|p_196084_1_,callback
 net/minecraft/network/PacketBuffer.writeItemStack(Lnet/minecraft/item/ItemStack;Z)Lnet/minecraft/network/PacketBuffer;=|p_150788_1_,limitedTag
+net/minecraft/pathfinding/WalkNodeProcessor.func_237231_a_(Lnet/minecraft/world/IBlockReader;Lnet/minecraft/util/math/BlockPos$Mutable;Lnet/minecraft/entity/MobEntity;)Lnet/minecraft/pathfinding/PathNodeType;=|p_237231_0_,p_237231_1_,mobEntity
+net/minecraft/pathfinding/WalkNodeProcessor.func_237238_b_(Lnet/minecraft/world/IBlockReader;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/MobEntity;)Lnet/minecraft/pathfinding/PathNodeType;=|p_237238_0_,p_237238_1_,mobEntity
 net/minecraft/potion/PotionBrewing$MixPredicate.<init>(Lnet/minecraftforge/registries/ForgeRegistryEntry;Lnet/minecraft/item/crafting/Ingredient;Lnet/minecraftforge/registries/ForgeRegistryEntry;)V=|p_i47570_1_,p_i47570_2_,p_i47570_3_
 net/minecraft/server/dedicated/DedicatedServer.sendMessage(Lnet/minecraft/util/text/ITextComponent;Ljava/util/UUID;)V=|message,p_145747_2_
 net/minecraft/server/management/PlayerInteractionManager.removeBlock(Lnet/minecraft/util/math/BlockPos;Z)Z=|p_180235_1_,canHarvest

--- a/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.entity.ai.attributes.AttributeModifier;

--- a/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeChunkManagerTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2020.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
I saw there is a method `getAiPathNodeType` in `IForgeBlockState` with a `MobEntity` parameter but it is only ever called with `null` because it is accessed from a static context, even though there is always a relevant `MobEntity` 1-2 invocations away. So I threaded it through. This way blocks can have entity-sensitive pathing to go with their entity-sensitive collision boxes. I also created deprecated mirror methods in case any mods are still using the unaltered methods.

I will use this in my mod to create a block which undead cannot path through.

Also attached: 1 commit with updated licenses (required to build & test this change).