### PR TITLE
Add Opacity to ForgeHooksClient#renderMainMenu

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screen/MainMenuScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/MainMenuScreen.java.patch
@@ -38,7 +38,7 @@
  
           this.field_230706_i_.func_110434_K().func_110577_a(field_194400_H);
           func_238463_a_(p_230430_1_, j + 88, 67, 0.0F, 0.0F, 98, 14, 128, 16);
-+         net.minecraftforge.client.ForgeHooksClient.renderMainMenu(this, p_230430_1_, this.field_230712_o_, this.field_230708_k_, this.field_230709_l_);
++         net.minecraftforge.client.ForgeHooksClient.renderMainMenu(this, p_230430_1_, this.field_230712_o_, this.field_230708_k_, this.field_230709_l_, l);
           if (this.field_73975_c != null) {
              RenderSystem.pushMatrix();
              RenderSystem.translatef((float)(this.field_230708_k_ / 2 + 90), 70.0F, 0.0F);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -242,6 +242,12 @@ public class ForgeHooksClient
         //RenderingRegistry.registerBlockHandler(RenderBlockFluid.instance);
     }
 
+    @Deprecated // TODO: Remove in 1.17
+    public static void renderMainMenu(MainMenuScreen gui, MatrixStack mStack, FontRenderer font, int width, int height)
+    {
+        renderMainMenu(gui, mStack, font, width, height, -1);
+    }
+
     public static void renderMainMenu(MainMenuScreen gui, MatrixStack mStack, FontRenderer font, int width, int height, int alpha)
     {
         VersionChecker.Status status = ForgeVersion.getStatus();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -242,16 +242,16 @@ public class ForgeHooksClient
         //RenderingRegistry.registerBlockHandler(RenderBlockFluid.instance);
     }
 
-    public static void renderMainMenu(MainMenuScreen gui, MatrixStack mStack, FontRenderer font, int width, int height)
+    public static void renderMainMenu(MainMenuScreen gui, MatrixStack mStack, FontRenderer font, int width, int height, int alpha)
     {
         VersionChecker.Status status = ForgeVersion.getStatus();
         if (status == BETA || status == BETA_OUTDATED)
         {
             // render a warning at the top of the screen,
             ITextComponent line = new TranslationTextComponent("forge.update.beta.1", TextFormatting.RED, TextFormatting.RESET).mergeStyle(TextFormatting.RED);
-            AbstractGui.drawCenteredString(mStack, font, line, width / 2, 4 + (0 * (font.FONT_HEIGHT + 1)), -1);
+            AbstractGui.drawCenteredString(mStack, font, line, width / 2, 4 + (0 * (font.FONT_HEIGHT + 1)), 0xFFFFFF | alpha);
             line = new TranslationTextComponent("forge.update.beta.2");
-            AbstractGui.drawCenteredString(mStack, font, line, width / 2, 4 + (1 * (font.FONT_HEIGHT + 1)), -1);
+            AbstractGui.drawCenteredString(mStack, font, line, width / 2, 4 + (1 * (font.FONT_HEIGHT + 1)), 0xFFFFFF | alpha);
         }
 
         String line = null;


### PR DESCRIPTION
It's minor, but I was working on a title screen modification mod and found that this wasn't passing the alpha to this (though all of the other text was fading), so I figured "eh, what the heck, I'll make a PR" and now here we are.

This does not break the color formatting, the 0xFFFFFF does _not_ override the TextFormatting style and is required for it to work correctly.