### PR TITLE
[1.16] Rework RenderWorldLastEvent (different approach)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 **/.classpath
 *.project
 
+#vscode
+/.vscode/
+
 #In case people make their workspace in the repo
 /eclipse/
 

--- a/patches/minecraft/net/minecraft/block/TripWireHookBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TripWireHookBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/block/TripWireHookBlock.java
 +++ b/net/minecraft/block/TripWireHookBlock.java
-@@ -150,8 +150,8 @@
+@@ -150,8 +_,8 @@
              BlockPos blockpos2 = p_176260_2_.func_177967_a(direction, k);
              BlockState blockstate2 = ablockstate[k];
              if (blockstate2 != null) {

--- a/patches/minecraft/net/minecraft/client/renderer/IRenderTypeBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/IRenderTypeBuffer.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/renderer/IRenderTypeBuffer.java
++++ b/net/minecraft/client/renderer/IRenderTypeBuffer.java
+@@ -79,6 +_,7 @@
+          boolean flag = Objects.equals(this.field_228459_c_, p_228462_1_.func_230169_u_());
+          if (flag || bufferbuilder != this.field_228457_a_) {
+             if (this.field_228460_d_.remove(bufferbuilder)) {
++               net.minecraftforge.client.event.RenderWorldEventHandler.fireRenderTypeFinish(p_228462_1_, bufferbuilder);
+                p_228462_1_.func_228631_a_(bufferbuilder, 0, 0, 0);
+                if (flag) {
+                   this.field_228459_c_ = Optional.empty();

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -33,6 +33,14 @@
                 this.field_175009_l.add(chunkrenderdispatcher$chunkrender4);
              } else {
                 this.field_72777_q.func_213239_aq().func_76320_a("build near");
+@@ -908,6 +_,7 @@
+          this.func_228419_a_(matrix4f, p_228426_9_, vector3d.field_72450_a, vector3d.field_72448_b, vector3d.field_72449_c, flag ? new ClippingHelper(matrix4f, p_228426_9_) : clippinghelper);
+          this.field_175002_T = false;
+       }
++      net.minecraftforge.client.event.RenderWorldEventHandler.startWorldRenderPhase(this, p_228426_1_, p_228426_2_, clippinghelper, p_228426_6_);
+ 
+       iprofiler.func_219895_b("clear");
+       FogRenderer.func_228371_a_(p_228426_6_, p_228426_2_, this.field_72777_q.field_71441_e, this.field_72777_q.field_71474_y.field_151451_c, p_228426_7_.func_205002_d(p_228426_2_));
 @@ -915,13 +_,13 @@
        float f = p_228426_7_.func_205001_m();
        boolean flag1 = this.field_72777_q.field_71441_e.func_239132_a_().func_230493_a_(MathHelper.func_76128_c(d0), MathHelper.func_76128_c(d1)) || this.field_72777_q.field_71456_v.func_184046_j().func_184056_f();
@@ -49,8 +57,11 @@
        iprofiler.func_219895_b("terrain_setup");
        this.func_228437_a_(p_228426_6_, clippinghelper, flag, this.field_228409_ai_++, this.field_72777_q.field_71439_g.func_175149_v());
        iprofiler.func_219895_b("updatechunks");
-@@ -942,7 +_,9 @@
+@@ -940,9 +_,12 @@
+       long k1 = j1 * 3L / 2L;
+       long l1 = MathHelper.func_226163_a_(k1, l, 33333333L);
        this.func_174967_a(p_228426_3_ + l1);
++      net.minecraftforge.client.event.RenderWorldEventHandler.fireTerrainUpdate(p_228426_3_ + l1);
        iprofiler.func_219895_b("terrain");
        this.func_228441_a_(RenderType.func_228639_c_(), p_228426_1_, d0, d1, d2);
 +      this.field_72777_q.func_209506_al().func_229356_a_(AtlasTexture.field_110575_b).setBlurMipmap(false, this.field_72777_q.field_71474_y.field_151442_I > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
@@ -108,15 +119,25 @@
           RenderState.field_239237_T_.func_228549_b_();
        } else {
           iprofiler.func_219895_b("translucent");
-@@ -1129,7 +_,7 @@
+@@ -1129,8 +_,9 @@
           iprofiler.func_219895_b("string");
           this.func_228441_a_(RenderType.func_241715_r_(), p_228426_1_, d0, d1, d2);
           iprofiler.func_219895_b("particles");
 -         this.field_72777_q.field_71452_i.func_228345_a_(p_228426_1_, irendertypebuffer$impl, p_228426_8_, p_228426_6_, p_228426_2_);
 +         this.field_72777_q.field_71452_i.renderParticles(p_228426_1_, irendertypebuffer$impl, p_228426_8_, p_228426_6_, p_228426_2_, clippinghelper);
        }
++      net.minecraftforge.client.event.RenderWorldEventHandler.endWorldRenderPhase();
  
        RenderSystem.pushMatrix();
+       RenderSystem.multMatrix(p_228426_1_.func_227866_c_().func_227870_a_());
+@@ -1239,6 +_,7 @@
+       }
+ 
+       VertexBuffer.func_177361_b();
++      net.minecraftforge.client.event.RenderWorldEventHandler.fireBlockLayer(p_228441_1_);
+       RenderSystem.clearCurrentColor();
+       this.field_228408_W_.func_227895_d_();
+       this.field_72777_q.func_213239_aq().func_76319_b();
 @@ -1481,6 +_,11 @@
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -149,6 +149,10 @@ public class ForgeHooksClient
         }
     }
 
+    /**
+     * @deprecated Use new {@link RenderWorldEvent events} - check which event suits the best your needs, TODO: remove in 1.17
+     */
+    @Deprecated
     public static void dispatchRenderLast(WorldRenderer context, MatrixStack mat, float partialTicks, Matrix4f projectionMatrix, long finishTimeNano)
     {
         MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, mat, partialTicks, projectionMatrix, finishTimeNano));

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldEvent.java
@@ -1,0 +1,162 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.culling.ClippingHelper;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Abstract class for all world rendering events.
+ * <br>
+ * These events are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class RenderWorldEvent extends Event
+{
+    protected final WorldRenderer worldRenderer;
+    protected final MatrixStack matrixStack;
+    protected final float partialTicks;
+    protected final ClippingHelper clippingHelper;
+    protected final ActiveRenderInfo activeRenderInfo;
+
+    protected RenderWorldEvent(final WorldRenderer worldRenderer,
+        final MatrixStack matrixStack,
+        final float partialTicks,
+        final ClippingHelper clippingHelper,
+        final ActiveRenderInfo activeRenderInfo)
+    {
+        this.worldRenderer = worldRenderer;
+        this.matrixStack = matrixStack;
+        this.partialTicks = partialTicks;
+        this.clippingHelper = clippingHelper;
+        this.activeRenderInfo = activeRenderInfo;
+    }
+
+    public WorldRenderer getWorldRenderer()
+    {
+        return worldRenderer;
+    }
+
+    public MatrixStack getMatrixStack()
+    {
+        return matrixStack;
+    }
+
+    public float getPartialTicks()
+    {
+        return partialTicks;
+    }
+
+    public ClippingHelper getClippingHelper()
+    {
+        return clippingHelper;
+    }
+
+    public ActiveRenderInfo getActiveRenderInfo()
+    {
+        return activeRenderInfo;
+    }
+
+    /**
+     * Fired after sky rendering, can be used to check which parts of terrain needs updating.
+     * <br>
+     * If {@link System#nanoTime} is greater than <code>finishTimeNano</code> then you should quit this event immediately.
+     */
+    public static class RenderWorldTerrainUpdateEvent extends RenderWorldEvent
+    {
+        protected final long finishTimeNano;
+
+        public RenderWorldTerrainUpdateEvent(final WorldRenderer worldRenderer,
+            final MatrixStack matrixStack,
+            final float partialTicks,
+            final ClippingHelper clippingHelper,
+            final ActiveRenderInfo activeRenderInfo,
+            final long finishTimeNano)
+        {
+            super(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo);
+            this.finishTimeNano = finishTimeNano;
+        }
+
+        public long getFinishTimeNano()
+        {
+            return finishTimeNano;
+        }
+    }
+
+    /**
+     * Fired for each block layer being rendered. After vanilla block layer rendering, render type already set up.
+     */
+    public static class RenderWorldBlockLayerEvent extends RenderWorldEvent
+    {
+        protected final RenderType renderType;
+
+        public RenderWorldBlockLayerEvent(final WorldRenderer worldRenderer,
+            final MatrixStack matrixStack,
+            final float partialTicks,
+            final ClippingHelper clippingHelper,
+            final ActiveRenderInfo activeRenderInfo,
+            final RenderType renderType)
+        {
+            super(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo);
+            this.renderType = renderType;
+        }
+
+        public RenderType getRenderType()
+        {
+            return renderType;
+        }
+    }
+
+    /**
+     * Fired right before finishing the buffer for given render type. Use the buffer builder.
+     */
+    public static class RenderWorldRenderTypeFinishEvent extends RenderWorldEvent
+    {
+        protected final RenderType renderType;
+        protected final BufferBuilder bufferBuilder;
+
+        public RenderWorldRenderTypeFinishEvent(final WorldRenderer worldRenderer,
+            final MatrixStack matrixStack,
+            final float partialTicks,
+            final ClippingHelper clippingHelper,
+            final ActiveRenderInfo activeRenderInfo,
+            final RenderType renderType,
+            final BufferBuilder bufferBuilder)
+        {
+            super(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo);
+            this.renderType = renderType;
+            this.bufferBuilder = bufferBuilder;
+        }
+
+        public RenderType getRenderType()
+        {
+            return renderType;
+        }
+
+        public BufferBuilder getBufferBuilder()
+        {
+            return bufferBuilder;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldEventHandler.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldEventHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.culling.ClippingHelper;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldTerrainUpdateEvent;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldBlockLayerEvent;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldRenderTypeFinishEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+public final class RenderWorldEventHandler
+{
+    private static boolean isRenderWorldPhase = false;
+
+    // context fields
+    private static WorldRenderer worldRenderer;
+    private static MatrixStack matrixStack;
+    private static float partialTicks;
+    private static ClippingHelper clippingHelper;
+    private static ActiveRenderInfo activeRenderInfo;
+
+    private RenderWorldEventHandler() {}
+
+    public static void startWorldRenderPhase(final WorldRenderer worldRendererIn,
+        final MatrixStack matrixStackIn,
+        final float partialTicksIn,
+        final ClippingHelper clippingHelperIn,
+        final ActiveRenderInfo activeRenderInfoIn)
+    {
+        isRenderWorldPhase = true;
+        worldRenderer = worldRendererIn;
+        matrixStack = matrixStackIn;
+        partialTicks = partialTicksIn;
+        clippingHelper = clippingHelperIn;
+        activeRenderInfo = activeRenderInfoIn;
+    }
+
+    public static void endWorldRenderPhase()
+    {
+        isRenderWorldPhase = false;
+    }
+
+    public static void fireTerrainUpdate(final long finishTimeNano)
+    {
+        if (!isRenderWorldPhase)
+            return;
+
+        isRenderWorldPhase = false;
+        MinecraftForge.EVENT_BUS.post(new RenderWorldTerrainUpdateEvent(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo, finishTimeNano));
+        isRenderWorldPhase = true;
+    }
+
+    public static void fireBlockLayer(final RenderType renderType)
+    {
+        if (!isRenderWorldPhase)
+            return;
+
+        isRenderWorldPhase = false;
+        MinecraftForge.EVENT_BUS.post(new RenderWorldBlockLayerEvent(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo, renderType));
+        isRenderWorldPhase = true;
+    }
+
+    public static void fireRenderTypeFinish(final RenderType renderType, final BufferBuilder bufferBuilder)
+    {
+        if (!isRenderWorldPhase)
+            return;
+
+        isRenderWorldPhase = false;
+        MinecraftForge.EVENT_BUS.post(new RenderWorldRenderTypeFinishEvent(worldRenderer, matrixStack, partialTicks, clippingHelper, activeRenderInfo, renderType, bufferBuilder));
+        isRenderWorldPhase = true;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -24,6 +24,10 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.util.math.vector.Matrix4f;
 
+/**
+ * @deprecated Use new {@link RenderWorldEvent events} - check which event suits the best your needs, TODO: remove in 1.17
+ */
+@Deprecated
 public class RenderWorldLastEvent extends net.minecraftforge.eventbus.api.Event
 {
     private final WorldRenderer context;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderWorldEventTest.java
@@ -1,0 +1,84 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldBlockLayerEvent;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldRenderTypeFinishEvent;
+import net.minecraftforge.client.event.RenderWorldEvent.RenderWorldTerrainUpdateEvent;
+import net.minecraftforge.event.TickEvent.Phase;
+import net.minecraftforge.event.TickEvent.RenderTickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(RenderWorldEventTest.MODID)
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class RenderWorldEventTest
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+    public static final String MODID = "render_world_event_test";
+    public static final boolean ENABLED = false;
+    private static int eventCount = 0;
+
+    @SubscribeEvent
+    public static void onTerrainUpdate(RenderWorldTerrainUpdateEvent event)
+    {
+        if (!ENABLED)
+            return;
+
+        eventCount++;
+        LOGGER.info("[RWE] terrain update");
+    }
+
+    @SubscribeEvent
+    public static void onBlockLayer(RenderWorldBlockLayerEvent event)
+    {
+        if (!ENABLED)
+            return;
+
+        eventCount++;
+        LOGGER.info("[RWE] block layer: " + event.getRenderType().toString());
+    }
+
+    @SubscribeEvent
+    public static void onRenderType(RenderWorldRenderTypeFinishEvent event)
+    {
+        if (!ENABLED)
+            return;
+
+        eventCount++;
+        LOGGER.info("[RWE] render type: " + event.getRenderType().toString());
+    }
+
+    @SubscribeEvent
+    public static void onRenderTickEnd(RenderTickEvent event)
+    {
+        if (!ENABLED)
+            return;
+
+        if (event.phase == Phase.END && eventCount != 0)
+        {
+            LOGGER.info("[RWE] event count: " + eventCount);
+            eventCount = 0;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -122,3 +122,5 @@ license="LGPL v2.1"
     modId="enum_argument_test"
 [[mods]]
     modId="entity_teleport_event_test"
+[[mods]]
+    modId="render_world_event_test"


### PR DESCRIPTION
_Based on [tterrag's comments](https://discord.com/channels/313125603924639766/725850371834118214/807735836749201438)_
Supersedes and closes #7225

Fires events per each renderType finish and per each blockLayer, also fires terrainUpdate event, doesn't fire another event when already firing (prevents loop-firing from mods)

[Sample](<https://gist.github.com/Nightenom/4ece03ee1907f86ceb54cb98dab92612>) from new world without TEs and small amount of entities
Event count per frame (roughly, vanilla): min 15 | average 25 | max 50
Time took by one empty event posting (based on #7225): +- 1000 ns, at worst case should far less than 100 μs (0.1 ms) per frame, as mentioned by tterrag timing might be an issue for this approach