### PR TITLE
Chunk tick event

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -96,7 +96,24 @@
           if (biome.func_201848_a(this, blockpos3)) {
              this.func_175656_a(blockpos3, Blocks.field_150432_aD.func_176223_P());
           }
-@@ -598,9 +604,10 @@
+@@ -489,7 +495,7 @@
+       }
+ 
+       iprofiler.func_219895_b("tickBlocks");
+-      if (p_217441_2_ > 0) {
++      if (net.minecraftforge.common.ForgeHooks.onChunkTickPre(p_217441_1_, p_217441_2_) > 0) {
+          for(ChunkSection chunksection : p_217441_1_.func_76587_i()) {
+             if (chunksection != Chunk.field_186036_a && chunksection.func_206915_b()) {
+                int k = chunksection.func_222632_g();
+@@ -512,6 +518,7 @@
+             }
+          }
+       }
++      net.minecraftforge.common.ForgeHooks.onChunkTickPost(p_217441_1_);
+ 
+       iprofiler.func_76319_b();
+    }
+@@ -598,9 +605,10 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
@@ -108,7 +125,7 @@
              p_217479_1_.func_70071_h_();
              iprofiler.func_76319_b();
           }
-@@ -687,6 +694,7 @@
+@@ -687,6 +695,7 @@
              p_217445_1_.func_200209_c(new TranslationTextComponent("menu.savingChunks"));
           }
  
@@ -116,7 +133,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -777,6 +785,7 @@
+@@ -777,6 +786,7 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -124,7 +141,7 @@
        Entity entity = this.field_175741_N.get(p_217448_1_.func_110124_au());
        if (entity != null) {
           field_147491_a.warn("Force-added player with duplicate UUID {}", (Object)p_217448_1_.func_110124_au().toString());
-@@ -801,6 +810,7 @@
+@@ -801,6 +811,7 @@
        } else if (this.func_217478_l(p_72838_1_)) {
           return false;
        } else {
@@ -132,7 +149,7 @@
           IChunk ichunk = this.func_217353_a(MathHelper.func_76128_c(p_72838_1_.func_226277_ct_() / 16.0D), MathHelper.func_76128_c(p_72838_1_.func_226281_cx_() / 16.0D), ChunkStatus.field_222617_m, p_72838_1_.field_98038_p);
           if (!(ichunk instanceof Chunk)) {
              return false;
-@@ -816,6 +826,7 @@
+@@ -816,6 +827,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -140,7 +157,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -879,12 +890,17 @@
+@@ -879,12 +891,17 @@
  
     }
  
@@ -161,7 +178,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -898,6 +914,8 @@
+@@ -898,6 +915,8 @@
           this.field_217495_I.remove(((MobEntity)p_217484_1_).func_70661_as());
        }
  
@@ -170,7 +187,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -905,8 +923,8 @@
+@@ -905,8 +924,8 @@
           this.field_217499_z.add(p_217465_1_);
        } else {
           this.field_217498_x.put(p_217465_1_.func_145782_y(), p_217465_1_);
@@ -181,7 +198,7 @@
                 this.field_217498_x.put(enderdragonpartentity.func_145782_y(), enderdragonpartentity);
              }
           }
-@@ -918,15 +936,19 @@
+@@ -918,15 +937,19 @@
           }
        }
  
@@ -202,7 +219,7 @@
        }
     }
  
-@@ -939,8 +961,11 @@
+@@ -939,8 +962,11 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -216,7 +233,7 @@
        this.func_72854_c();
     }
  
-@@ -959,10 +984,20 @@
+@@ -959,10 +985,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -237,7 +254,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -998,6 +1033,7 @@
+@@ -998,6 +1034,7 @@
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
        Explosion explosion = new Explosion(this, p_230546_1_, p_230546_2_, p_230546_3_, p_230546_4_, p_230546_6_, p_230546_8_, p_230546_10_, p_230546_11_, p_230546_12_);
@@ -245,7 +262,7 @@
        explosion.func_77278_a();
        explosion.func_77279_a(false);
        if (p_230546_12_ == Explosion.Mode.NONE) {
-@@ -1410,4 +1446,14 @@
+@@ -1410,4 +1447,14 @@
           p_241121_0_.func_175656_a(p_241122_1_, Blocks.field_150343_Z.func_176223_P());
        });
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -114,7 +114,6 @@ import net.minecraft.util.registry.WorldSettingsImport;
 import net.minecraft.util.registry.WorldGenSettingsExport;
 import net.minecraft.util.text.*;
 import net.minecraft.world.*;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunk;
 import net.minecraft.world.gen.DimensionSettings;
 import net.minecraft.world.gen.feature.structure.Structure;
@@ -1046,14 +1045,14 @@ public class ForgeHooks
 
     public static int onChunkTickPre(IChunk chunk, int randomTickSpeed)
     {
-        ChunkEvent.Tick.Pre event = new ChunkEvent.Tick.Pre(chunk, randomTickSpeed);
+        ChunkEvent.BlockTick.Pre event = new ChunkEvent.BlockTick.Pre(chunk, randomTickSpeed);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getRandomTickSpeed();
     }
 
     public static void onChunkTickPost(IChunk chunk)
     {
-        MinecraftForge.EVENT_BUS.post(new ChunkEvent.Tick.Post(chunk));
+        MinecraftForge.EVENT_BUS.post(new ChunkEvent.BlockTick.Post(chunk));
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -114,6 +114,7 @@ import net.minecraft.util.registry.WorldSettingsImport;
 import net.minecraft.util.registry.WorldGenSettingsExport;
 import net.minecraft.util.text.*;
 import net.minecraft.world.*;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunk;
 import net.minecraft.world.gen.DimensionSettings;
 import net.minecraft.world.gen.feature.structure.Structure;
@@ -169,6 +170,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.fluids.FluidAttributes;
@@ -1040,6 +1042,18 @@ public class ForgeHooks
     public static void onCropsGrowPost(World worldIn, BlockPos pos, BlockState state)
     {
         MinecraftForge.EVENT_BUS.post(new BlockEvent.CropGrowEvent.Post(worldIn, pos, state, worldIn.getBlockState(pos)));
+    }
+
+    public static int onChunkTickPre(IChunk chunk, int randomTickSpeed)
+    {
+        ChunkEvent.Tick.Pre event = new ChunkEvent.Tick.Pre(chunk, randomTickSpeed);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRandomTickSpeed();
+    }
+
+    public static void onChunkTickPost(IChunk chunk)
+    {
+        MinecraftForge.EVENT_BUS.post(new ChunkEvent.Tick.Post(chunk));
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -95,9 +95,9 @@ public class ChunkEvent extends WorldEvent
     /**
      * Fired when chunks are ticking. See sub-events.
      **/
-    public static abstract class Tick extends ChunkEvent
+    public static abstract class BlockTick extends ChunkEvent
     {
-        public Tick(IChunk chunk)
+        public BlockTick(IChunk chunk)
         {
             super(chunk);
         }
@@ -113,7 +113,7 @@ public class ChunkEvent extends WorldEvent
          * <br>
          * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
          */
-        public static class Pre extends Tick
+        public static class Pre extends BlockTick
         {
             private int randomTickSpeed;
             public Pre(IChunk chunk, int randomTickSpeedIn)
@@ -140,7 +140,7 @@ public class ChunkEvent extends WorldEvent
          * <br>
          * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
          */
-        public static class Post extends Tick
+        public static class Post extends BlockTick
         {
             public Post(IChunk chunk)
             {

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -91,4 +91,38 @@ public class ChunkEvent extends WorldEvent
             super(chunk);
         }
     }
+
+    public static abstract class Tick extends ChunkEvent
+    {
+        public Tick(IChunk chunk)
+        {
+            super(chunk);
+        }
+
+        public static class Pre extends Tick
+        {
+            private int randomTickSpeed;
+            public Pre(IChunk chunk, int randomTickSpeedIn)
+            {
+                super(chunk);
+                randomTickSpeed = randomTickSpeedIn;
+            }
+
+            public int getRandomTickSpeed() {
+                return randomTickSpeed;
+            }
+
+            public void setRandomTickSpeed(int randomTickSpeed) {
+                this.randomTickSpeed = randomTickSpeed;
+            }
+        }
+
+        public static class Post extends Tick
+        {
+            public Post(IChunk chunk)
+            {
+                super(chunk);
+            }
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -92,6 +92,9 @@ public class ChunkEvent extends WorldEvent
         }
     }
 
+    /**
+     * Fired when chunks are ticking. See sub-events.
+     **/
     public static abstract class Tick extends ChunkEvent
     {
         public Tick(IChunk chunk)
@@ -99,6 +102,17 @@ public class ChunkEvent extends WorldEvent
             super(chunk);
         }
 
+        /**
+         * ChunkEvent.Tick.Pre is fired when the server world begins ticking blocks for the chunk. The current
+         * randomTickSpeed for the chunk can be obtained with getRandomTickSpeed() and set with setRandomTickSpeed().<br>
+         * <br>
+         * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}, but it will skip ticking
+         * if randomTickSpeed is set to 0.<br>
+         * <br>
+         * This event does not have a result. {@link HasResult} <br>
+         * <br>
+         * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+         */
         public static class Pre extends Tick
         {
             private int randomTickSpeed;
@@ -117,6 +131,15 @@ public class ChunkEvent extends WorldEvent
             }
         }
 
+        /**
+         * ChunkEvent.Tick.Post is fired when the server world finishes ticking blocks for the chunk.<br>
+         * <br>
+         * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+         * <br>
+         * This event does not have a result. {@link HasResult} <br>
+         * <br>
+         * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+         */
         public static class Post extends Tick
         {
             public Post(IChunk chunk)

--- a/src/test/java/net/minecraftforge/debug/world/ChunkTickEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkTickEventTest.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraftforge.event.world.ChunkEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(ChunkTickEventTest.MODID)
+@Mod.EventBusSubscriber
+public class ChunkTickEventTest {
+    static final String MODID = "chunk_tick_event_test";
+    private static final Logger LOGGER = LogManager.getLogger(MODID);
+
+    @SubscribeEvent
+    public static void onChunkBlockTickPre(final ChunkEvent.BlockTick.Pre event)
+    {
+        if(event.getRandomTickSpeed() > 0)
+        {
+            LOGGER.info("Chunk at {} is ticking {} blocks per section.", event.getChunk().getPos(), event.getRandomTickSpeed());
+        }
+        else
+        {
+            LOGGER.info("Chunk at {} has no blocks to tick.", event.getChunk().getPos());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onChunkBlockTickPost(final ChunkEvent.BlockTick.Post event)
+    {
+        LOGGER.info("Chunk at {} finished ticking blocks.", event.getChunk().getPos());
+    }
+}


### PR DESCRIPTION
After seeing multiple people trying to update capabilities on world tick and running into possible concurrency problems with the threaded loading/unloading of chunks, I thought it might be nice to have an event that only fires when the chunk is actively loaded and ticking, instead of wasting cpu on chunks that are unloaded and awaiting garbage collection or something like that.

Inserting it at the randomTickSpeed check also allows mods to adjust the randomTickSpeed for individual chunks if they want, which could be useful for testing and server administration.

People besides me whom this would be useful for:
1) https://forums.minecraftforge.net/topic/94589-116-how-to-get-loaded-chunks/
2) https://discord.com/channels/313125603924639766/725850371834118214/812119574707306526
3) https://discord.com/channels/313125603924639766/313125603924639766/812840611551510528

Personally I'm saving metadata that relies on randomly ticking blocks I don't own, so that's why I need something like this. Gigaherz's solution is workable but will result in extra passes on chunks that are slated for GC and requires use of threadsafe collections which impact parallelization. Diesieben's solution requires reflection (or I guess an AT).