### PR TITLE
Added a way for modders to modify the players turn speed

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -65,7 +65,15 @@
                 }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
              }
           }
-@@ -267,6 +277,10 @@
+@@ -226,6 +236,7 @@
+       this.field_198050_o = d0;
+       if (this.func_198035_h() && this.field_198036_a.func_195544_aj()) {
+          double d4 = this.field_198036_a.field_71474_y.field_74341_c * (double)0.6F + (double)0.2F;
++         d4 = net.minecraftforge.client.ForgeHooksClient.getTurnSpeed(field_198036_a.field_71439_g, d4);
+          double d5 = d4 * d4 * d4 * 8.0D;
+          double d2;
+          double d3;
+@@ -267,6 +278,10 @@
        return this.field_198039_d;
     }
  
@@ -76,7 +84,7 @@
     public double func_198024_e() {
        return this.field_198040_e;
     }
-@@ -275,6 +289,14 @@
+@@ -275,6 +290,14 @@
        return this.field_198041_f;
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -226,6 +226,13 @@ public class ForgeHooksClient
         MinecraftForge.EVENT_BUS.post(fovUpdateEvent);
         return fovUpdateEvent.getNewfov();
     }
+    
+    public static double getTurnSpeed(PlayerEntity player, double turnSpeed)
+    {
+        UpdatePlayerLookEvent event = new UpdatePlayerLookEvent(player, turnSpeed);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMouseTurnSpeed();
+    }
 
     public static double getFOVModifier(GameRenderer renderer, ActiveRenderInfo info, double renderPartialTicks, double fov) {
         EntityViewRenderEvent.FOVModifier event = new EntityViewRenderEvent.FOVModifier(renderer, info, renderPartialTicks, fov);

--- a/src/main/java/net/minecraftforge/client/event/UpdatePlayerLookEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/UpdatePlayerLookEvent.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class UpdatePlayerLookEvent extends PlayerEvent
+{
+    private double mouseTurnSpeed;
+
+    public UpdatePlayerLookEvent(PlayerEntity player, double speed)
+    {
+        super(player);
+        this.mouseTurnSpeed = speed;
+    }
+
+    public double getMouseTurnSpeed()
+    {
+        return mouseTurnSpeed;
+    }
+
+    public void setMouseTurnSpeed(double speed)
+    {
+        mouseTurnSpeed = speed;
+    }
+}


### PR DESCRIPTION
This PR adds a new event called `UpdatePlayerLookEvent` which allows modders to modify the player's turn speed via `UpdatePlayerLookEvent#setMouseTurnSpeed`. The event is fired in the `updatePlayerLook` method in the `MouseHelper` class.

This PR was made so modders could modify the players turn speed, for example if a modder wanted had an item that slowed the player's turn speed, they'd use this event.