### PR TITLE
[1.16] Attempt to fix issues with configurations deemed invalid for no valid reason

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -537,7 +537,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         }
         public Builder comment(String... comment)
         {
-            if(comment == null || comment.length < 1 || comment[comment.length - 1].length() < 1)
+            if(comment == null || comment.length < 1 || (comment.length == 1 && comment[0].length() < 1))
             {
                 comment = new String[] {"No comment"};
             }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -194,7 +194,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
                 String newComment = levelComments.get(parentPath);
                 String oldComment = config.getComment(key);
-                if (!Objects.equals(oldComment, newComment))
+                if (!stringsMatchIgnoringNewlines(oldComment, newComment))
                 {
                     if (dryRun)
                         return 1;
@@ -217,7 +217,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                     count++;
                 }
                 String oldComment = config.getComment(key);
-                if (!Objects.equals(oldComment, valueSpec.getComment()))
+                if (!stringsMatchIgnoringNewlines(oldComment, valueSpec.getComment()))
                 {
                     if (dryRun)
                         return 1;
@@ -247,6 +247,23 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             }
         }
         return count;
+    }
+
+    private boolean stringsMatchIgnoringNewlines(Object obj1, Object obj2)
+    {
+        if(obj1 instanceof String && obj2 instanceof String)
+        {
+            String string1 = (String) obj1;
+            String string2 = (String) obj2;
+
+            if(string1.length() > 0 && string2.length() > 0)
+            {
+                return string1.replaceAll("\r\n", "\n")
+                        .equals(string2.replaceAll("\r\n", "\n"));
+
+            }
+        }
+        return false;
     }
 
     public static class Builder

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -264,7 +264,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         return count;
     }
 
-    private boolean stringsMatchIgnoringNewlines(Object obj1, Object obj2)
+    private boolean stringsMatchIgnoringNewlines(@Nullable Object obj1, @Nullable Object obj2)
     {
         if(obj1 instanceof String && obj2 instanceof String)
         {

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -605,7 +605,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         private boolean worldRestart = false;
         private Class<?> clazz;
 
-        public void setComment(String... value) { this.comment = value == null ? new String[] {" "} : value; } // TODO 1.17: this should throw an IllegalStateException in future
+        public void setComment(String... value) { this.comment = value == null ? new String[] {"No comment"} : value; } // TODO 1.17: this should throw an IllegalStateException in future
         public boolean hasComment() { return this.comment.length > 0; }
         public String[] getComment() { return this.comment; }
         public String buildComment() { return LINE_JOINER.join(comment); }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -548,7 +548,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 if(!FMLEnvironment.production)
                 {
                     LogManager.getLogger().error(CORE, "Null comment for config option {}, this is invalid and may be disallowed in the future.",
-                            this.currentPath);
+                            DOT_JOINER.join(this.currentPath));
                 }
             }
             context.setComment(comment);
@@ -562,7 +562,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 if(!FMLEnvironment.production)
                 {
                     LogManager.getLogger().error(CORE, "Null comment for config option {}, this is invalid and may be disallowed in the future.",
-                            this.currentPath);
+                            DOT_JOINER.join(this.currentPath));
                 }
             }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -223,7 +223,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                         return 1;
 
                     LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This might cause a backup to be created.", key);
-                    LogManager.getLogger().debug(CORE, "Current comment: {}\n, Spec: {}\n", oldComment, valueSpec.getComment());
+                    LogManager.getLogger().debug(CORE, "Current comment: {}, Spec: {}", oldComment, valueSpec.getComment());
                     config.setComment(key, valueSpec.getComment());
                 }
             }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -223,6 +223,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                         return 1;
 
                     LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This might cause a backup to be created.", key);
+                    LogManager.getLogger().debug(CORE, "Current comment: {}\n, Spec: {}\n", oldComment, valueSpec.getComment());
                     config.setComment(key, valueSpec.getComment());
                 }
             }
@@ -604,7 +605,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         private boolean worldRestart = false;
         private Class<?> clazz;
 
-        public void setComment(String... value) { this.comment = value == null ? new String[0] : value; } // TODO 1.17: this should throw an IllegalStateException in future
+        public void setComment(String... value) { this.comment = value == null ? new String[] {" "} : value; } // TODO 1.17: this should throw an IllegalStateException in future
         public boolean hasComment() { return this.comment.length > 0; }
         public String[] getComment() { return this.comment; }
         public String buildComment() { return LINE_JOINER.join(comment); }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -528,11 +528,20 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
         public Builder comment(String comment)
         {
+            if(comment == null || comment.length() < 1)
+            {
+                comment = "No comment";
+            }
             context.setComment(comment);
             return this;
         }
         public Builder comment(String... comment)
         {
+            if(comment == null || comment.length < 1 || comment[comment.length - 1].length() < 1)
+            {
+                comment = new String[] {"No comment"};
+            }
+
             context.setComment(comment);
             return this;
         }
@@ -605,7 +614,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         private boolean worldRestart = false;
         private Class<?> clazz;
 
-        public void setComment(String... value) { this.comment = value == null ? new String[] {"No comment"} : value; } // TODO 1.17: this should throw an IllegalStateException in future
+        public void setComment(String... value) { this.comment = value == null ? new String[] {""} : value; } // TODO 1.17: this should throw an IllegalStateException in future
         public boolean hasComment() { return this.comment.length > 0; }
         public String[] getComment() { return this.comment; }
         public String buildComment() { return LINE_JOINER.join(comment); }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -44,6 +44,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import net.minecraft.util.SharedConstants;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
@@ -90,7 +92,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                     (action, path, incorrectValue, correctedValue) ->
                             LogManager.getLogger().warn(CORE, "Incorrect key {} was corrected from {} to its default, {}. {}", DOT_JOINER.join( path ), incorrectValue, correctedValue, incorrectValue == correctedValue ? "This seems to be an error." : ""),
                     (action, path, incorrectValue, correctedValue) ->
-                            LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This may create a backup.", path));
+                            LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This may create a backup.", DOT_JOINER.join( path )));
 
             if (config instanceof FileConfig) {
                 ((FileConfig) config).save();
@@ -540,18 +542,28 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
         public Builder comment(String comment)
         {
-            if(comment == null || comment.length() < 1)
+            if(comment == null || comment.isEmpty())
             {
                 comment = "No comment";
+                if(!FMLEnvironment.production)
+                {
+                    LogManager.getLogger().error(CORE, "Null passed to comment for config option " + this.currentPath +
+                            ", this is invalid and may be disallowed in the future.");
+                }
             }
             context.setComment(comment);
             return this;
         }
         public Builder comment(String... comment)
         {
-            if(comment == null || comment.length < 1 || (comment.length == 1 && comment[0].length() < 1))
+            if(comment == null || comment.length < 1 || (comment.length == 1 && comment[0].isEmpty()))
             {
                 comment = new String[] {"No comment"};
+                if(!FMLEnvironment.production)
+                {
+                    LogManager.getLogger().error(CORE, "Null comment for config option " + this.currentPath +
+                            ", this is invalid and may be disallowed in the future.");
+                }
             }
 
             context.setComment(comment);

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -86,7 +86,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             String configName = config instanceof FileConfig ? ((FileConfig) config).getNioPath().toString() : config.toString();
             LogManager.getLogger().warn(CORE, "Configuration file {} is not correct. Correcting", configName);
             correct(config, (action, path, incorrectValue, correctedValue) ->
-                    LogManager.getLogger().warn(CORE, "Incorrect key {} was corrected from {} to its default, {}", DOT_JOINER.join( path ), incorrectValue, correctedValue));
+                    LogManager.getLogger().warn(CORE, "Incorrect key {} was corrected from {} to its default, {}. {}", DOT_JOINER.join( path ), incorrectValue, correctedValue, incorrectValue == correctedValue ? "This seems to be an error." : ""));
             if (config instanceof FileConfig) {
                 ((FileConfig) config).save();
             }
@@ -199,7 +199,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                     if (dryRun)
                         return 1;
 
-                    //TODO: Comment correction listener?
+                    LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This might cause a backup to be created.", key);
                     config.setComment(key, newComment);
                 }
             }
@@ -222,8 +222,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                     if (dryRun)
                         return 1;
 
-                    LogManager.getLogger().warn(CORE, "The comment on key {} does not match the spec.", key);
-                    //TODO: Comment correction listener?
+                    LogManager.getLogger().debug(CORE, "The comment on key {} does not match the spec. This might cause a backup to be created.", key);
                     config.setComment(key, valueSpec.getComment());
                 }
             }
@@ -675,13 +674,19 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 boolean result = ((Number)min).doubleValue() <= n.doubleValue() && n.doubleValue() <= ((Number)max).doubleValue();
                 if(!result)
                 {
-                    LogManager.getLogger().debug(CORE, "Range value {} is deemed to need correction. Its bounds are {}-{}", n.doubleValue(), ((Number)min).doubleValue(), ((Number)max).doubleValue());
+                    LogManager.getLogger().debug(CORE, "Range value {} is not within its bounds {}-{}", n.doubleValue(), ((Number)min).doubleValue(), ((Number)max).doubleValue());
                 }
                 return result;
             }
             if (!clazz.isInstance(t)) return false;
             V c = clazz.cast(t);
-            return c.compareTo(min) >= 0 && c.compareTo(max) <= 0;
+
+            boolean result = c.compareTo(min) >= 0 && c.compareTo(max) <= 0;
+            if(!result)
+            {
+                LogManager.getLogger().debug(CORE, "Range value {} is not within its bounds {}-{}", c, min, max);
+            }
+            return result;
         }
 
         public Object correct(Object value, Object def)

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -263,7 +263,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
             }
         }
-        return false;
+        // Fallback for when we're not given Strings, or one of them is empty
+        return Objects.equals(obj1, obj2);
     }
 
     public static class Builder

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -547,8 +547,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 comment = "No comment";
                 if(!FMLEnvironment.production)
                 {
-                    LogManager.getLogger().error(CORE, "Null passed to comment for config option " + this.currentPath +
-                            ", this is invalid and may be disallowed in the future.");
+                    LogManager.getLogger().error(CORE, "Null comment for config option {}, this is invalid and may be disallowed in the future.",
+                            this.currentPath);
                 }
             }
             context.setComment(comment);
@@ -561,8 +561,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 comment = new String[] {"No comment"};
                 if(!FMLEnvironment.production)
                 {
-                    LogManager.getLogger().error(CORE, "Null comment for config option " + this.currentPath +
-                            ", this is invalid and may be disallowed in the future.");
+                    LogManager.getLogger().error(CORE, "Null comment for config option {}, this is invalid and may be disallowed in the future.",
+                            this.currentPath);
                 }
             }
 


### PR DESCRIPTION
Currently, there are a few oversights with regards to how config files are validated.  

Firstly, comments are checked bit-for-bit against the specification, which goes against platform standardization - that meaning, it could cause issues if the spec contains `\r\n` but the file is written with `\n`.  

Secondly, lists by default are deemed invalid if they are empty. This is a little silly, so i added an optional `defineListAllowEmpty` builder that skips that empty check. This is useful for eg. blacklists.  

Thirdly, strings are not checked for nullity when passed through the comment function. Since null strings is an invalid state, i added a wrapper to ensure this does not get saved to the file. Due to some limitations in NightConfig - mainly, writing an empty string ("") or a space (" ") will get parsed as null when the file is read. This means there has to be *some* text there as a default. I chose "No comment" as a safe default, but this can be changed on request.

Lastly, the log files do not say exactly why some things are deemed to need correction. To this end, i also added a bunch of logging to the preset configs, and to the validator (when it fails).

This solves all of the log spam (and as a bonus, the backup creation) with Repurposed Structures, Aquaculture and AE2, which are the only mods i'm aware of where this issue is easily reproducible.

This is not finalised, and there are more places where logging is needed.