### PR TITLE
[1.16] Add missing Multipart Blockstate Builder feature: Nested condition groups

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -191,7 +191,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
              */
             public ConditionGroup nestedGroup()
             {
-                Preconditions.checkState(conditions.size() == 0, "Can't have nested condition groups if there are already normal conditions");
+                Preconditions.checkState(conditions.isEmpty(), "Can't have nested condition groups if there are already normal conditions");
                 ConditionGroup group = new ConditionGroup();
                 group.parent = this;
                 this.nestedConditionGroups.add(group);

--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -104,7 +104,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
          * @throws IllegalArgumentException if {@code prop} has already been configured
          * @throws IllegalArgumentException if {@code prop} is not applicable to the
          *                                  current block's state
-         * @throws IllegalStateException    if {@code nestedConditionGroups.size() != 0}
+         * @throws IllegalStateException    if {@code !nestedConditionGroups.isEmpty()}
          */
         @SafeVarargs
         public final <T extends Comparable<T>> PartBuilder condition(Property<T> prop, T... values) {
@@ -172,7 +172,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
              * @throws IllegalArgumentException if {@code prop} has already been configured
              * @throws IllegalArgumentException if {@code prop} is not applicable to the
              *                                  current block's state
-             * @throws IllegalStateException    if {@code nestedConditionGroups.size() != 0}
+             * @throws IllegalStateException    if {@code !nestedConditionGroups.isEmpty()}
              */
             @SafeVarargs
             public final <T extends Comparable<T>> ConditionGroup condition(Property<T> prop, T... values)
@@ -247,7 +247,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
             }
         }
     }
-    
+
     private static JsonObject toJson(List<PartBuilder.ConditionGroup> conditions, boolean useOr)
     {
         JsonObject groupJson = new JsonObject();
@@ -259,7 +259,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
         }
         return groupJson;
     }
-    
+
     private static JsonObject toJson(Multimap<Property<?>, Comparable<?>> conditions, boolean useOr)
     {
         JsonObject groupJson = new JsonObject();

--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import net.minecraft.block.Block;
@@ -71,10 +72,11 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
         return main;
     }
 
-    public class PartBuilder {
+    public class PartBuilder implements IConditionGroup {
         public BlockStateProvider.ConfiguredModelList models;
         public boolean useOr;
         public final Multimap<Property<?>, Comparable<?>> conditions = MultimapBuilder.linkedHashKeys().arrayListValues().build();
+        public final List<ConditionGroup> nestedConditionGroups = new ArrayList<>();
 
         PartBuilder(BlockStateProvider.ConfiguredModelList models) {
             this.models = models;
@@ -99,6 +101,7 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
          * @throws IllegalArgumentException if {@code prop} has already been configured
          * @throws IllegalArgumentException if {@code prop} is not applicable to the
          *                                  current block's state
+         * @throws IllegalStateException    if {@code nestedConditionGroups.size() != 0}
          */
         @SafeVarargs
         public final <T extends Comparable<T>> PartBuilder condition(Property<T> prop, T... values) {
@@ -107,11 +110,26 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
             Preconditions.checkArgument(values.length > 0, "Value list must not be empty");
             Preconditions.checkArgument(!conditions.containsKey(prop), "Cannot set condition for property \"%s\" more than once", prop.getName());
             Preconditions.checkArgument(canApplyTo(owner), "IProperty %s is not valid for the block %s", prop, owner);
+            Preconditions.checkState(nestedConditionGroups.size() == 0, "Can't have normal conditions if there are already nested condition groups");
             this.conditions.putAll(prop, Arrays.asList(values));
             return this;
         }
 
+        /**
+         * Allows having nested groups of conditions if the current condition group is empty.
+         * @throws IllegalStateException if there are any normal conditions in the current condition group
+         */
+        public final ConditionGroup nestedGroup()
+        {
+            Preconditions.checkState(conditions.size() == 0, "Can't have nested condition groups if there are already normal conditions");
+            ConditionGroup group = new ConditionGroup();
+            this.nestedConditionGroups.add(group);
+            return group;
+        }
+
         public MultiPartBlockStateBuilder end() { return MultiPartBlockStateBuilder.this; }
+
+        public IConditionGroup endGroup() { return this; }
 
         JsonObject toJson() {
             JsonObject out = new JsonObject();
@@ -127,9 +145,26 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
                     when.addProperty(e.getKey().getName(), activeString.toString());
                 }
                 if (useOr) {
-                    JsonObject innerWhen = when;
+                    JsonArray innerWhen = new JsonArray();
+                    for (Entry<String, JsonElement> entry : when.entrySet())
+                    {
+                        JsonObject obj = new JsonObject();
+                        obj.add(entry.getKey(), entry.getValue());
+                        innerWhen.add(obj);
+                    }
                     when = new JsonObject();
                     when.add("OR", innerWhen);
+                }
+                out.add("when", when);
+            }
+            else if (!nestedConditionGroups.isEmpty())
+            {
+                JsonObject when = new JsonObject();
+                JsonArray innerWhen = new JsonArray();
+                when.add(useOr ? "OR" : "AND", innerWhen);
+                for (ConditionGroup group : nestedConditionGroups)
+                {
+                    innerWhen.add(group.toJson());
                 }
                 out.add("when", when);
             }
@@ -140,5 +175,137 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
         public boolean canApplyTo(Block b) {
             return b.getStateDefinition().getProperties().containsAll(conditions.keySet());
         }
+
+        public class ConditionGroup implements IConditionGroup
+        {
+            public boolean useOr;
+            private ConditionGroup parent = null;
+            public final Multimap<Property<?>, Comparable<?>> conditions = MultimapBuilder.linkedHashKeys().arrayListValues().build();
+            public final List<ConditionGroup> nestedConditionGroups = new ArrayList<>();
+
+            /**
+             * Set a condition for this part, which consists of a property and a set of
+             * valid values. Can be called multiple times for multiple different properties.
+             *
+             * @param <T>    the type of the property value
+             * @param prop   the property
+             * @param values a set of valid values
+             * @return this builder
+             * @throws NullPointerException     if {@code prop} is {@code null}
+             * @throws NullPointerException     if {@code values} is {@code null}
+             * @throws IllegalArgumentException if {@code values} is empty
+             * @throws IllegalArgumentException if {@code prop} has already been configured
+             * @throws IllegalArgumentException if {@code prop} is not applicable to the
+             *                                  current block's state
+             * @throws IllegalStateException    if {@code nestedConditionGroups.size() != 0}
+             */
+            @SafeVarargs
+            public final <T extends Comparable<T>> ConditionGroup condition(Property<T> prop, T... values)
+            {
+                Preconditions.checkNotNull(prop, "Property must not be null");
+                Preconditions.checkNotNull(values, "Value list must not be null");
+                Preconditions.checkArgument(values.length > 0, "Value list must not be empty");
+                Preconditions.checkArgument(!conditions.containsKey(prop), "Cannot set condition for property \"%s\" more than once", prop.getName());
+                Preconditions.checkArgument(canApplyTo(owner), "IProperty %s is not valid for the block %s", prop, owner);
+                Preconditions.checkState(nestedConditionGroups.size() == 0, "Can't have normal conditions if there are already nested condition groups");
+                this.conditions.putAll(prop, Arrays.asList(values));
+                return this;
+            }
+
+            /**
+             * Allows having nested groups of conditions if the current condition group is empty.
+             * @throws IllegalStateException if there are any normal conditions in the current condition group
+             */
+            public final ConditionGroup nestedGroup()
+            {
+                Preconditions.checkState(conditions.size() == 0, "Can't have nested condition groups if there are already normal conditions");
+                ConditionGroup group = new ConditionGroup();
+                group.parent = this;
+                this.nestedConditionGroups.add(group);
+                return group;
+            }
+
+            public IConditionGroup endGroup() 
+            {
+                if (parent == null)
+                {
+                    return MultiPartBlockStateBuilder.PartBuilder.this; 
+                }
+                else {
+                    return parent;
+                }
+            }
+
+            public MultiPartBlockStateBuilder end()
+            {
+                if (this.parent != null)
+                {
+                    return this.parent.end();
+                }
+                else
+                {
+                    return MultiPartBlockStateBuilder.PartBuilder.this.end();
+                }
+            }
+
+            public ConditionGroup useOr()
+            {
+                this.useOr = true;
+                return this;
+            }
+
+            JsonObject toJson()
+            {
+                if (!this.conditions.isEmpty()) {
+                    JsonObject groupJson = new JsonObject();
+                    for (Entry<Property<?>, Collection<Comparable<?>>> e : this.conditions.asMap().entrySet()) {
+                        StringBuilder activeString = new StringBuilder();
+                        for (Comparable<?> val : e.getValue()) {
+                            if (activeString.length() > 0)
+                                activeString.append("|");
+                            activeString.append(((Property) e.getKey()).getName(val));
+                        }
+                        groupJson.addProperty(e.getKey().getName(), activeString.toString());
+                    }
+                    if (useOr) {
+                        JsonArray innerWhen = new JsonArray();
+                        for (Entry<String, JsonElement> entry : groupJson.entrySet())
+                        {
+                            JsonObject obj = new JsonObject();
+                            obj.add(entry.getKey(), entry.getValue());
+                            innerWhen.add(obj);
+                        }
+                        groupJson = new JsonObject();
+                        groupJson.add("OR", innerWhen);
+                    }
+                    return groupJson;
+                } 
+                else if (!this.nestedConditionGroups.isEmpty())
+                {
+                    JsonObject groupJson = new JsonObject();
+                    JsonArray innerGroupJson = new JsonArray();
+                    groupJson.add(useOr ? "OR" : "AND", innerGroupJson);
+                    for (ConditionGroup group : this.nestedConditionGroups)
+                    {
+
+                        innerGroupJson.add(group.toJson());
+                    }
+                    return groupJson;
+                }
+                return new JsonObject();
+            }
+        }
+    }
+
+    public interface IConditionGroup
+    {
+        IConditionGroup nestedGroup();
+        /**
+         * If this is a {@link PartBuilder}, returns itself.
+         */
+        IConditionGroup endGroup();
+        IConditionGroup useOr();
+        <T extends Comparable<T>> IConditionGroup condition(Property<T> prop, T... values);
+        MultiPartBlockStateBuilder end();
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -119,8 +119,8 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
         }
 
         /**
-         * Allows having nested groups of conditions if the current condition group is empty.
-         * @throws IllegalStateException if there are any normal conditions in the current condition group
+         * Allows having nested groups of conditions if there are not any normal conditions.
+         * @throws IllegalStateException if {@code !conditions.isEmpty()}
          */
         public final ConditionGroup nestedGroup()
         {
@@ -186,8 +186,8 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
             }
 
             /**
-             * Allows having nested groups of conditions if the current condition group is empty.
-             * @throws IllegalStateException if there are any normal conditions in the current condition group
+             * Allows having nested groups of conditions if there are not any normal conditions.
+             * @throws IllegalStateException if {@code !conditions.isEmpty()}
              */
             public ConditionGroup nestedGroup()
             {

--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -135,13 +135,11 @@ public final class MultiPartBlockStateBuilder implements IGeneratedBlockstate {
         JsonObject toJson() {
             JsonObject out = new JsonObject();
             if (!conditions.isEmpty()) {
-                JsonObject when = MultiPartBlockStateBuilder.toJson(this.conditions, this.useOr);
-                out.add("when", when);
+                out.add("when", MultiPartBlockStateBuilder.toJson(this.conditions, this.useOr));
             }
             else if (!nestedConditionGroups.isEmpty())
             {
-                JsonObject when = MultiPartBlockStateBuilder.toJson(this.nestedConditionGroups, this.useOr);
-                out.add("when", when);
+                out.add("when", MultiPartBlockStateBuilder.toJson(this.nestedConditionGroups, this.useOr));
             }
             out.add("apply", models.toJSON());
             return out;


### PR DESCRIPTION
Multipart blockstate models support having nested condition groups in the 'when' section of each part. For an example of this, see the redstone dust blockstate file. Forge's multipart builder does not currently have a way to make nested condition groups, which is what this PR adds. I tested the changes by publishing to my local maven and trying them out with one of my mods that would benefit from this feature.

Feel free to critique my formatting and naming.