### PR TITLE
[1.16] Allow ITeleporter to override the vanilla teleport sound

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -56,7 +56,12 @@
              this.field_71134_c.func_73080_a(p_241206_1_);
              this.field_71135_a.func_147359_a(new SPlayerAbilitiesPacket(this.field_71075_bZ));
              playerlist.func_72354_b(this, p_241206_1_);
-@@ -670,6 +_,7 @@
+@@ -666,10 +_,12 @@
+                this.field_71135_a.func_147359_a(new SPlayEntityEffectPacket(this.func_145782_y(), effectinstance));
+             }
+ 
++            if (!teleporter.playTeleportSound(this, serverworld, p_241206_1_))
+             this.field_71135_a.func_147359_a(new SPlaySoundEventPacket(1032, BlockPos.field_177992_a, 0, false));
              this.field_71144_ck = -1;
              this.field_71149_ch = -1.0F;
              this.field_71146_ci = -1;

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -60,7 +60,7 @@
                 this.field_71135_a.func_147359_a(new SPlayEntityEffectPacket(this.func_145782_y(), effectinstance));
              }
  
-+            if (!teleporter.playTeleportSound(this, serverworld, p_241206_1_))
++            if (teleporter.playTeleportSound(this, serverworld, p_241206_1_))
              this.field_71135_a.func_147359_a(new SPlaySoundEventPacket(1032, BlockPos.field_177992_a, 0, false));
              this.field_71144_ck = -1;
              this.field_71149_ch = -1.0F;

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -91,4 +91,17 @@ public interface ITeleporter
     {
         return this.getClass() == Teleporter.class;
     }
+
+    /**
+     * Called when vanilla wants to play the portal sound after teleporting. Return true to "handle this" and not play the vanilla sound.
+     * @param player the player
+     * @param sourceWorld the source world
+     * @param destWorld the target world
+     * @return true to not play the vanilla sound
+     */
+    default boolean playTeleportSound(ServerPlayerEntity player, ServerWorld sourceWorld, ServerWorld destWorld)
+    {
+        return false;
+    }
+
 }

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -93,15 +93,15 @@ public interface ITeleporter
     }
 
     /**
-     * Called when vanilla wants to play the portal sound after teleporting. Return true to "handle this" and not play the vanilla sound.
+     * Called when vanilla wants to play the portal sound after teleporting. Return true to play the vanilla sound.
      * @param player the player
      * @param sourceWorld the source world
      * @param destWorld the target world
-     * @return true to not play the vanilla sound
+     * @return true to play the vanilla sound
      */
     default boolean playTeleportSound(ServerPlayerEntity player, ServerWorld sourceWorld, ServerWorld destWorld)
     {
-        return false;
+        return true;
     }
 
 }


### PR DESCRIPTION
Vanilla unconditionally plays the level event 1032 (portal sound) when a player changes dimension. This adds a method in `ITeleporter` to disable this (and potentially play your own sound).