### PR TITLE
Fix reflective access that was broken by Mojmap update

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1364,7 +1364,7 @@ public class ForgeHooks
             if (!currentDimNames.containsAll(VANILLA_DIMS))
             {
                 LOGGER.warn("Detected missing vanilla dimensions from the world!");
-                DynamicRegistries regs = ObfuscationReflectionHelper.getPrivateValue(WorldSettingsImport.class, ops, "registryHolder");
+                DynamicRegistries regs = ObfuscationReflectionHelper.getPrivateValue(WorldSettingsImport.class, ops, "field_240872_" + "d_");
                 if (regs == null) // should not happen, but it could after a MC version update.
                     throw new RuntimeException("Could not access dynamic registries using reflection. " +
                             "The world was detected to have missing vanilla dimensions and the attempted fix did not work.");

--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -73,11 +73,11 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootTableBuilder(LootTable.Builder builder, Item from, ITag.INamedTag<Item> to) {
-        List<LootPool> lootPools = ObfuscationReflectionHelper.getPrivateValue(LootTable.Builder.class, builder, "pools");
+        List<LootPool> lootPools = ObfuscationReflectionHelper.getPrivateValue(LootTable.Builder.class, builder, "field_216041" + "_a");
         boolean found = false;
 
         if (lootPools == null) {
-            throw new IllegalStateException(LootTable.Builder.class.getName() + " is missing field pools");
+            throw new IllegalStateException(LootTable.Builder.class.getName() + " is missing field field_216041" + "_a");
         }
 
         for (LootPool lootPool : lootPools) {
@@ -90,12 +90,12 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootPool(LootPool lootPool, Item from, ITag.INamedTag<Item> to) {
-        List<LootEntry> lootEntries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "entries");
-        List<ILootCondition> lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "conditions");
+        List<LootEntry> lootEntries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "field_186453" +"_a");
+        List<ILootCondition> lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "field_186454" + "_b");
         boolean found = false;
 
         if (lootEntries == null) {
-            throw new IllegalStateException(LootPool.class.getName() + " is missing field entries");
+            throw new IllegalStateException(LootPool.class.getName() + " is missing field field_186453" + "_a");
         }
 
         for (LootEntry lootEntry : lootEntries) {
@@ -107,7 +107,7 @@ public class ForgeLootTableProvider extends LootTableProvider {
         }
 
         if (lootConditions == null) {
-            throw new IllegalStateException(LootPool.class.getName() + " is missing field conditions");
+            throw new IllegalStateException(LootPool.class.getName() + " is missing field field_186454" + "_b");
         }
 
         for (int i = 0; i < lootConditions.size(); i++) {
@@ -116,7 +116,7 @@ public class ForgeLootTableProvider extends LootTableProvider {
                 lootConditions.set(i, MatchTool.toolMatches(ItemPredicate.Builder.item().of(to)).build());
                 found = true;
             } else if (lootCondition instanceof Inverted) {
-                ILootCondition invLootCondition = ObfuscationReflectionHelper.getPrivateValue(Inverted.class, (Inverted) lootCondition, "term");
+                ILootCondition invLootCondition = ObfuscationReflectionHelper.getPrivateValue(Inverted.class, (Inverted) lootCondition, "field_215981" + "_a");
 
                 if (invLootCondition instanceof MatchTool && checkMatchTool((MatchTool) invLootCondition, from)) {
                     lootConditions.set(i, Inverted.invert(MatchTool.toolMatches(ItemPredicate.Builder.item().of(to))).build());
@@ -131,11 +131,11 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInParentedLootEntry(ParentedLootEntry entry, Item from, ITag.INamedTag<Item> to) {
-        LootEntry[] lootEntries = ObfuscationReflectionHelper.getPrivateValue(ParentedLootEntry.class, entry, "children");
+        LootEntry[] lootEntries = ObfuscationReflectionHelper.getPrivateValue(ParentedLootEntry.class, entry, "field_216147" + "_c");
         boolean found = false;
 
         if (lootEntries == null) {
-            throw new IllegalStateException(ParentedLootEntry.class.getName() + " is missing field children");
+            throw new IllegalStateException(ParentedLootEntry.class.getName() + " is missing field field_216147" + "_c");
         }
 
         for (LootEntry lootEntry : lootEntries) {
@@ -148,11 +148,11 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootEntry(LootEntry entry, Item from, ITag.INamedTag<Item> to) {
-        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootEntry.class, entry, "conditions");
+        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootEntry.class, entry, "field_216144" + "_d");
         boolean found = false;
 
         if (lootConditions == null) {
-            throw new IllegalStateException(LootEntry.class.getName() + " is missing field conditions");
+            throw new IllegalStateException(LootEntry.class.getName() + " is missing field field_216144" + "_d");
         }
 
         for (int i = 0; i < lootConditions.length; i++) {
@@ -168,11 +168,11 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInAlternative(Alternative alternative, Item from, ITag.INamedTag<Item> to) {
-        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(Alternative.class, alternative, "terms");
+        ILootCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(Alternative.class, alternative, "field_215962" + "_a");
         boolean found = false;
 
         if (lootConditions == null) {
-            throw new IllegalStateException(Alternative.class.getName() + " is missing field terms");
+            throw new IllegalStateException(Alternative.class.getName() + " is missing field field_215962" + "_a");
         }
 
         for (int i = 0; i < lootConditions.length; i++) {
@@ -186,8 +186,8 @@ public class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean checkMatchTool(MatchTool lootCondition, Item expected) {
-        ItemPredicate predicate = ObfuscationReflectionHelper.getPrivateValue(MatchTool.class, lootCondition, "predicate");
-        Item item = ObfuscationReflectionHelper.getPrivateValue(ItemPredicate.class, predicate, "item");
+        ItemPredicate predicate = ObfuscationReflectionHelper.getPrivateValue(MatchTool.class, lootCondition, "field_216014" + "_a");
+        Item item = ObfuscationReflectionHelper.getPrivateValue(ItemPredicate.class, predicate, "field_192496" + "_b");
         return item != null && item.equals(expected);
     }
 }


### PR DESCRIPTION
The SRG name in this reflection code was not correctly split to prevent automatic replacement and thus was incorrectly replaced during the Mojmap update.