### PR TITLE
Fix sign textures being stitched onto every texture atlas

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -164,7 +164,9 @@ public class ForgeHooksClient
         StartupMessageManager.mcLoaderConsumer().ifPresent(c->c.accept("Atlas Stitching : "+map.location().toString()));
         ModLoader.get().postEvent(new TextureStitchEvent.Pre(map, resourceLocations));
 //        ModelLoader.White.INSTANCE.register(map); // TODO Custom TAS
-        Atlases.SIGN_MATERIALS.values().forEach(material -> resourceLocations.add(material.texture()));
+        Atlases.SIGN_MATERIALS.values().stream()
+                .filter(rm -> rm.atlasLocation().equals(map.location()))
+                .forEach(rm -> resourceLocations.add(rm.texture()));
     }
 
     public static void onTextureStitchedPost(AtlasTexture map)


### PR DESCRIPTION
#7623 Caused sign textures to be added to every AtlasTexture, because the RenderMaterial's atlas location is not checked.
Example of the stitched particle texture before this fix:
![image](https://user-images.githubusercontent.com/1915984/111470616-58038780-8728-11eb-9061-d1c60a0c5474.png)
