### PR TITLE
Add RenderItemEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -9,7 +9,14 @@
  
        for(Item item : Registry.field_212630_s) {
           if (!field_195411_c.contains(item)) {
-@@ -95,7 +_,7 @@
+@@ -89,13 +_,14 @@
+ 
+    public void func_229111_a_(ItemStack p_229111_1_, ItemCameraTransforms.TransformType p_229111_2_, boolean p_229111_3_, MatrixStack p_229111_4_, IRenderTypeBuffer p_229111_5_, int p_229111_6_, int p_229111_7_, IBakedModel p_229111_8_) {
+       if (!p_229111_1_.func_190926_b()) {
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Model(p_229111_4_, p_229111_1_, p_229111_5_, p_229111_6_, p_229111_7_, p_229111_8_));
+          p_229111_4_.func_227860_a_();
+          boolean flag = p_229111_2_ == ItemCameraTransforms.TransformType.GUI || p_229111_2_ == ItemCameraTransforms.TransformType.GROUND || p_229111_2_ == ItemCameraTransforms.TransformType.FIXED;
+          if (p_229111_1_.func_77973_b() == Items.field_203184_eO && flag) {
              p_229111_8_ = this.field_175059_m.func_178083_a().func_174953_a(new ModelResourceLocation("minecraft:trident#inventory"));
           }
  
@@ -56,12 +63,21 @@
              crashreportcategory.func_189529_a("Item Damage", () -> {
                 return String.valueOf(p_239387_2_.func_77952_i());
              });
+@@ -290,7 +_,7 @@
+    public void func_180453_a(FontRenderer p_180453_1_, ItemStack p_180453_2_, int p_180453_3_, int p_180453_4_, @Nullable String p_180453_5_) {
+       if (!p_180453_2_.func_190926_b()) {
+          MatrixStack matrixstack = new MatrixStack();
+-         if (p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null) {
++         if ((p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null) && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Overlay(p_180453_1_, matrixstack, p_180453_2_, p_180453_3_, p_180453_4_, net.minecraftforge.client.event.RenderItemEvent.Overlay.OverlayPart.COUNT))) {
+             String s = p_180453_5_ == null ? String.valueOf(p_180453_2_.func_190916_E()) : p_180453_5_;
+             matrixstack.func_227861_a_(0.0D, 0.0D, (double)(this.field_77023_b + 200.0F));
+             IRenderTypeBuffer.Impl irendertypebuffer$impl = IRenderTypeBuffer.func_228455_a_(Tessellator.func_178181_a().func_178180_c());
 @@ -298,18 +_,16 @@
              irendertypebuffer$impl.func_228461_a_();
           }
  
 -         if (p_180453_2_.func_77951_h()) {
-+         if (p_180453_2_.func_77973_b().showDurabilityBar(p_180453_2_)) {
++         if (p_180453_2_.func_77973_b().showDurabilityBar(p_180453_2_) && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Overlay(p_180453_1_, matrixstack, p_180453_2_, p_180453_3_, p_180453_4_, net.minecraftforge.client.event.RenderItemEvent.Overlay.OverlayPart.DURABILITY))) {
              RenderSystem.disableDepthTest();
              RenderSystem.disableTexture();
              RenderSystem.disableAlphaTest();
@@ -79,6 +95,24 @@
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
              this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
              RenderSystem.enableBlend();
+@@ -320,7 +_,7 @@
+ 
+          ClientPlayerEntity clientplayerentity = Minecraft.func_71410_x().field_71439_g;
+          float f3 = clientplayerentity == null ? 0.0F : clientplayerentity.func_184811_cZ().func_185143_a(p_180453_2_.func_77973_b(), Minecraft.func_71410_x().func_184121_ak());
+-         if (f3 > 0.0F) {
++         if (f3 > 0.0F && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Overlay(p_180453_1_, matrixstack, p_180453_2_, p_180453_3_, p_180453_4_, net.minecraftforge.client.event.RenderItemEvent.Overlay.OverlayPart.COOLDOWN))) {
+             RenderSystem.disableDepthTest();
+             RenderSystem.disableTexture();
+             RenderSystem.enableBlend();
+@@ -331,7 +_,7 @@
+             RenderSystem.enableTexture();
+             RenderSystem.enableDepthTest();
+          }
+-
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Overlay(p_180453_1_, matrixstack, p_180453_2_, p_180453_3_, p_180453_4_, net.minecraftforge.client.event.RenderItemEvent.Overlay.OverlayPart.EXTRA));
+       }
+    }
+ 
 @@ -346,5 +_,10 @@
  
     public void func_195410_a(IResourceManager p_195410_1_) {

--- a/src/main/java/net/minecraftforge/client/event/RenderItemEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemEvent.java
@@ -1,0 +1,194 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Subsidiaries to this event are fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS} throughout
+ * the process of Item rendering, allowing adjustments to the default functionality.
+ * <br>
+ * In sequence, subsidiaries to this event are fired:
+ * <ol>
+ *     <li>Before an Item model is rendered.</li>
+ *     <li>Before an ItemStack count is rendered.</li>
+ *     <li>Before an ItemStack durability is rendered.</li>
+ *     <li>Before an Item cooldown is rendered.</li>
+ *     <li>After the entire Item overlay has been rendered.</li>
+ * </ol>
+ */
+public class RenderItemEvent extends Event
+{
+    public MatrixStack getMatrixStack()
+    {
+        return matrixStack;
+    }
+    public ItemStack getItemStack()
+    {
+        return itemStack;
+    }
+
+    private final MatrixStack matrixStack;
+    private final ItemStack itemStack;
+
+    private RenderItemEvent(MatrixStack matrixStack, ItemStack itemStack)
+    {
+        this.matrixStack = matrixStack;
+        this.itemStack = itemStack;
+    }
+
+    /**
+     * The RenderItemEvent.Model event is fired immediately before the model of an Item is rendered. This enables
+     * per-stack adjustment of what is displayed behind a rendered Item.
+     * <br>
+     * This event does not allow direct control over how Item models are rendered or whether they are rendered at all,
+     * though it does provide information that is used in the normal Item model rendering.
+     * <br>
+     * This event is not fired when empty Items are rendered.
+     */
+    public static class Model extends RenderItemEvent
+    {
+        public IRenderTypeBuffer getRenderTypeBuffer()
+        {
+            return renderTypeBuffer;
+        }
+
+        public int getCombinedLight()
+        {
+            return combinedLight;
+        }
+
+        public int getCombinedOverlay()
+        {
+            return combinedOverlay;
+        }
+
+        public IBakedModel getBakedModel()
+        {
+            return bakedModel;
+        }
+
+        private final IRenderTypeBuffer renderTypeBuffer;
+        private final int combinedLight;
+        private final int combinedOverlay;
+        private final IBakedModel bakedModel;
+
+        public Model(MatrixStack matrixStack, ItemStack itemStack, IRenderTypeBuffer renderTypeBuffer,
+                     int combinedLight, int combinedOverlay, IBakedModel bakedModel)
+        {
+            super(matrixStack, itemStack);
+
+            this.renderTypeBuffer = renderTypeBuffer;
+            this.combinedLight = combinedLight;
+            this.combinedOverlay = combinedOverlay;
+            this.bakedModel = bakedModel;
+        }
+    }
+
+    /**
+     * The RenderItemEvent.Overlay event is fired at three distinct points during the rendering of an Item overlay.
+     * <br>
+     * Accordingly, the event has three distinct types, as enumerated by {@link OverlayPart}. The specification of an
+     * {@link OverlayPart} is required for the firing of this event, and it may not be null.
+     * <ul>
+     *     <li>{@link OverlayPart#COUNT} Overlay events are fired immediately before the count of an ItemStack is
+     *     rendered. If canceled, the Item count will not be rendered.</li>
+     *     <li>{@link OverlayPart#DURABILITY} Overlay events are fired immediately before the durability of an ItemStack
+     *     is rendered, iff the durability bar of the Item should be rendered. If canceled, the durability bar of
+     *     applicable Items will not be rendered.</li>
+     *     <li>{@link OverlayPart#COOLDOWN} Overlay events are fired immediately before the cooldown of an Item is
+     *     rendered, iff the cooldown is nonzero. If canceled, the cooldown of applicable Items will not be rendered.
+     *     </li>
+     *     <li>{@link OverlayPart#EXTRA} Overlay events are fired after the overlay of an Item has been rendered,
+     *     regardless of the cancellation of its preceding Overlay events. These events cannot be canceled, as their
+     *     cancellation would have no effect.</li>
+     * </ul>
+     * This event is cancelable iff its {@link OverlayPart} is not {@link OverlayPart#EXTRA}.
+     */
+    @Cancelable
+    public static class Overlay extends RenderItemEvent
+    {
+        public FontRenderer font()
+        {
+            return fontRenderer;
+        }
+
+        public int getX()
+        {
+            return xPosition;
+        }
+
+        public int getY()
+        {
+            return yPosition;
+        }
+
+        public OverlayPart getOverlayPart()
+        {
+            return overlayPart;
+        }
+
+        private final FontRenderer fontRenderer;
+        private final int xPosition, yPosition;
+        private final OverlayPart overlayPart;
+
+        /**
+         * OverlayPart enumerates the distinct parts of an Item overlay that can be rendered.
+         * <ul>
+         *     <li>COUNT refers to the rendering of the count of an ItemStack.</li>
+         *     <li>DURABILITY refers to the rendering of the durability of an applicable ItemStack.</li>
+         *     <li>COOLDOWN refers to the rendering of the cooldown of applicable Items.</li>
+         *     <li>EXTRA refers to the rendering of anything above the previous three overlay parts.</li>
+         * </ul>
+         */
+        public static enum OverlayPart
+        {
+            COUNT,
+            DURABILITY,
+            COOLDOWN,
+            EXTRA
+        }
+
+        public Overlay(FontRenderer fontRenderer, MatrixStack matrixStack, ItemStack itemStack,
+                       int xPosition, int yPosition, @Nonnull OverlayPart overlayPart)
+        {
+            super(matrixStack, itemStack);
+
+            this.fontRenderer = fontRenderer;
+            this.xPosition = xPosition;
+            this.yPosition = yPosition;
+            this.overlayPart = overlayPart;
+        }
+
+        @Override
+        public boolean isCancelable()
+        {
+            return overlayPart != OverlayPart.EXTRA;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderItemEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderItemEventTest.java
@@ -1,0 +1,228 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.event.RenderItemEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Sample applications of {@link RenderItemEvent}.
+ */
+@Mod(RenderItemEventTest.MODID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = RenderItemEventTest.MODID)
+public class RenderItemEventTest
+{
+    public static final String MODID = "render_item_event_test";
+
+    /* Controls for the tests - USE_TEST will disable all other tests if false */
+    public static boolean USE_TEST = true;
+    public static boolean DISPLAY_CUSTOM_ITEMCOUNT = true;
+    public static boolean DISPLAY_CUSTOM_DURABILITY = true;
+    public static boolean DISPLAY_CUSTOM_COOLDOWN = true;
+    public static boolean DISPLAY_EXTRA_DETAILS = true;
+
+    /**
+     * Sample usage of the {@link RenderItemEvent.Model} event.
+     * <br>
+     * If DISPLAY_CUSTOM_DURABILITY is true, this event handler will display the durability of applicable ItemStacks as
+     * colored rectanges behind the rendered Items. The width of the rectangle represents is scaled according to the
+     * stack durability.
+     */
+    @SubscribeEvent
+    public static void onRenderItemModel(RenderItemEvent.Model event)
+    {
+        if (!USE_TEST) return;
+
+        if (DISPLAY_CUSTOM_DURABILITY)
+        {
+            ItemStack stack = event.getItemStack();
+
+            if (stack.isDamageableItem())
+            {
+                double durabilityScale = 1.0D - stack.getItem().getDurabilityForDisplay(stack);
+                int color = stack.getItem().getRGBDurabilityForDisplay(stack);
+
+                if (durabilityScale < 1.0D)
+                {
+                    MatrixStack matrixStack = event.getMatrixStack();
+
+                    int red = color >> 16 & 255, green = color >> 8 & 255, blue = color & 255;
+
+                    matrixStack.pushPose();
+                    drawVertexRect(event.getRenderTypeBuffer(), -0.5, -0.5, durabilityScale, 1.0, red, green, blue, 100);
+                    matrixStack.popPose();
+                }
+            }
+        }
+    }
+
+    /**
+     * Sample usage of the {@link RenderItemEvent.Overlay} event, and all of its different parts. See
+     * {@link RenderItemEvent.Overlay.OverlayPart} for the possible different Overlay events.
+     * <ul>
+     *     <li>If DISPLAY_CUSTOM_DURABILITY is true, this event handler will cancel the rendering of the default
+     *     durability bar in favor of the custom one drawn by
+     *     {@link RenderItemEventTest#onRenderItemModel(RenderItemEvent.Model)}.</li>
+     *     <li>If DISPLAY_CUSTOM_ITEMCOUNT is true, this event handler will cancel the rendering of the default item
+     *     count and display the count of a stack using a progress bar similar to the default durability bar for tools.
+     *     </li>
+     *     <li>If DISPLAY_CUSTOM_COOLDOWN is true, this event handler will cancel the rendering of the default item
+     *     cooldown and display the cooldown of applicable stacks using a progress bar similar to the default durability
+     *     bar for tools.</li>
+     *     <li>If DISPLAY_EXTRA_DETAILS is true, this event handler will draw a small gold square over the top left
+     *     corner of all edible items using the {@link RenderItemEvent.Overlay} event designated by the extra overlay
+     *     part, {@link RenderItemEvent.Overlay.OverlayPart#EXTRA}</li>
+     * </ul>
+     */
+    @SubscribeEvent
+    public static void onRenderItemOverlay(RenderItemEvent.Overlay event)
+    {
+        if (!USE_TEST) return;
+
+        RenderItemEvent.Overlay.OverlayPart part = event.getOverlayPart();
+        ItemStack stack = event.getItemStack();
+        int x = event.getX(), y = event.getY();
+
+        if (DISPLAY_CUSTOM_DURABILITY && part == RenderItemEvent.Overlay.OverlayPart.DURABILITY)
+        {
+            if (event.isCancelable()) event.setCanceled(true);
+        }
+
+        if (DISPLAY_CUSTOM_ITEMCOUNT && part == RenderItemEvent.Overlay.OverlayPart.COUNT)
+        {
+            if (event.isCancelable()) event.setCanceled(true);
+
+            if (stack.getCount() != 1)
+            {
+                double scale = (double) stack.getCount() / (double) stack.getMaxStackSize();
+
+                int width = (int) (scale * 13.0D);
+
+                if (!stack.isDamageableItem())
+                {
+                    y += 2;
+                }
+
+                drawRect(x + 2, y + 11, 13, 2, 0, 0, 0, 255);
+                drawRect(x + 2, y + 11, width, 1, 255, 255, 255, 255);
+            }
+        }
+
+        if (DISPLAY_CUSTOM_COOLDOWN && part == RenderItemEvent.Overlay.OverlayPart.COOLDOWN)
+        {
+            if (event.isCancelable()) event.setCanceled(true);
+
+            ClientPlayerEntity player = Minecraft.getInstance().player;
+
+            if (player != null)
+            {
+                float cooldownPercent = player.getCooldowns().getCooldownPercent(stack.getItem(), Minecraft.getInstance().getFrameTime());
+
+                if (cooldownPercent != 0.0F)
+                {
+                    int width = (int) (cooldownPercent * 13.0F);
+
+                    if (!stack.isDamageableItem())
+                    {
+                        y += 2;
+                    }
+
+                    drawRect(x + 2, y + 9, 13, 2, 0, 0, 0, 255);
+                    drawRect(x + 2, y + 9, width, 1, 255, 0, 0, 255);
+                }
+            }
+        }
+
+        if (DISPLAY_EXTRA_DETAILS && part == RenderItemEvent.Overlay.OverlayPart.EXTRA)
+        {
+            if (stack.getItem().isEdible())
+            {
+                int red = 255, green = 187, blue = 51, alpha = 255;
+
+                drawRect(x, y, 3, 3, red, green, blue, alpha);
+            }
+        }
+    }
+
+    /**
+     * Utility function for drawing rectangles onto the screen using the tessellator.
+     */
+    private static void drawRect(double x, double y, double width, double height, int red, int green, int blue, int alpha)
+    {
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder bufferBuilder = tessellator.getBuilder();
+
+        RenderSystem.disableDepthTest();
+        RenderSystem.disableTexture();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+
+        bufferBuilder.begin(7, DefaultVertexFormats.POSITION_COLOR);
+        bufferBuilder.vertex(x,         y,          0D).color(red, green, blue, alpha).endVertex();
+        bufferBuilder.vertex(x,         y + height, 0D).color(red, green, blue, alpha).endVertex();
+        bufferBuilder.vertex(x + width, y + height, 0D).color(red, green, blue, alpha).endVertex();
+        bufferBuilder.vertex(x + width, y,          0D).color(red, green, blue, alpha).endVertex();
+        tessellator.end();
+
+        RenderSystem.enableTexture();
+        RenderSystem.enableDepthTest();
+        RenderSystem.disableBlend();
+    }
+
+    /**
+     * Utility function for drawing rectangles onto the screen using a vertex builder.
+     */
+    private static void drawVertexRect(IRenderTypeBuffer renderTypeBuffer, double x, double y, double width, double height, int red, int green, int blue, int alpha)
+    {
+        IVertexBuilder vertexBuilder = renderTypeBuffer.getBuffer(RenderTypeHolder.RECTANGLES);
+        vertexBuilder.vertex(x,         y + height, 0).color(red, green, blue, alpha).endVertex();
+        vertexBuilder.vertex(x,         y,          0).color(red, green, blue, alpha).endVertex();
+        vertexBuilder.vertex(x + width, y,          0).color(red, green, blue, alpha).endVertex();
+        vertexBuilder.vertex(x + width, y + height, 0).color(red, green, blue, alpha).endVertex();
+    }
+
+    /**
+     * Utility class that holds the custom RenderType used by
+     * {@link RenderItemEventTest#drawVertexRect(IRenderTypeBuffer, double, double, double, double, int, int, int, int)}
+     */
+    private static class RenderTypeHolder extends RenderState
+    {
+        private static final RenderType RECTANGLES = RenderType.create(
+                "rectangles", DefaultVertexFormats.POSITION_COLOR, 7, 256, false, false,
+                RenderType.State.builder()
+                        .setWriteMaskState(COLOR_DEPTH_WRITE)
+                        .setTransparencyState(RenderState.TRANSLUCENT_TRANSPARENCY)
+                        .createCompositeState(false));
+
+        private RenderTypeHolder(String p_i225973_1_, Runnable p_i225973_2_, Runnable p_i225973_3_)
+        {
+            super(p_i225973_1_, p_i225973_2_, p_i225973_3_);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -120,3 +120,5 @@ license="LGPL v2.1"
     modId="add_entity_attribute_test"
 [[mods]]
     modId="enum_argument_test"
+[[mods]]
+    modId="render_item_event_test"


### PR DESCRIPTION
This pull request intends to afford mods greater control over how items are rendered by the ItemRenderer. This includes what is drawn beneath rendered items, as well as the item counts, durabilities, and cooldowns rendered above them. Some possible use cases are as follows:

- Any mod that renders additional durability bars over items, for example a mod with tools that have both energy and durability.
- A mod adjusting how the durability, item count, or item cooldown are rendered over items, including the colors used and the specific visual methods used to represent each property.
- Visual adjustments to certain itemstacks (e.g. overlaid markings or graphics used to further categorize items outside of the creative inventory) rendered above the default overlay or beneath the item rendering itself.

I have encountered at least the first listed use case in one of my own mods, and am reasonably certain that the events introduced by this pull request would simplify what would otherwise require a lot of awkward workarounds. While a custom durability bar would have previously required multiple event handlers for the display of items in different contexts (while being moved in the gui, when rendered in the hotbar, and when rendered in the gui) the RenderItemEvent added by this pull request combines the same adjustments into a single event. 

The event centralizes the possibility for item overlay customization about the item itself, rather than the context in which it is displayed.

---

This pull request includes a RenderItemEventTest class that makes use of each new event to achieve a certain result. An overview of the sample uses is as follows:

- A replacement of the default durability rendering that uses colored rectangles (behind damaged tools) that scale horizontally with the tool's durability (using RenderItemEvent.Model to render and the DURABILITY variant of RenderItemEvent.Overlay to cancel the default overlay).
- A replacement of the default item count rendering that turns the numerical display into a progress bar instead (using the COUNT variant of the RenderItemEvent.Overlay).
- A replacement of the default item cooldown rendering that turns the cooldown highlight into a red progress bar that ticks down as the cooldown time does (using the COOLDOWN variant of the RenderItemEvent.Overlay).
- A gold square rendered above all edible items (using the EXTRA variant of the RenderItemEvent.Overlay).

The documentation for RenderItemEvent contains specific instructions for how each event should be used, which can be canceled, and when they are fired on the forge event bus. 