### PR TITLE
Add generic EntityTeleportEvent

### DIFF
--- a/patches/minecraft/net/minecraft/command/impl/SpreadPlayersCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/SpreadPlayersCommand.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/command/impl/SpreadPlayersCommand.java
++++ b/net/minecraft/command/impl/SpreadPlayersCommand.java
+@@ -162,7 +_,8 @@
+             spreadplayerscommand$position = p_241072_2_[i++];
+          }
+ 
+-         entity.func_223102_j((double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198713_a) + 0.5D, (double)spreadplayerscommand$position.func_198710_a(p_241072_1_, p_241072_3_), (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198714_b) + 0.5D);
++         net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportSpreadPlayersCommand(entity, (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198713_a) + 0.5D, (double)spreadplayerscommand$position.func_198710_a(p_241072_1_, p_241072_3_), (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198714_b) + 0.5D);
++         if (target != null) entity.func_223102_j(target.field_72450_a, target.field_72448_b, target.field_72449_c);
+          double d2 = Double.MAX_VALUE;
+ 
+          for(SpreadPlayersCommand.Position spreadplayerscommand$position1 : p_241072_2_) {

--- a/patches/minecraft/net/minecraft/command/impl/SpreadPlayersCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/SpreadPlayersCommand.java.patch
@@ -5,8 +5,8 @@
           }
  
 -         entity.func_223102_j((double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198713_a) + 0.5D, (double)spreadplayerscommand$position.func_198710_a(p_241072_1_, p_241072_3_), (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198714_b) + 0.5D);
-+         net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportSpreadPlayersCommand(entity, (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198713_a) + 0.5D, (double)spreadplayerscommand$position.func_198710_a(p_241072_1_, p_241072_3_), (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198714_b) + 0.5D);
-+         if (target != null) entity.func_223102_j(target.field_72450_a, target.field_72448_b, target.field_72449_c);
++         net.minecraftforge.event.entity.living.EntityTeleportEvent.SpreadPlayersCommand event = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportSpreadPlayersCommand(entity, (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198713_a) + 0.5D, (double)spreadplayerscommand$position.func_198710_a(p_241072_1_, p_241072_3_), (double)MathHelper.func_76128_c(spreadplayerscommand$position.field_198714_b) + 0.5D);
++         if (!event.isCanceled()) entity.func_223102_j(event.getTargetX(), event.getTargetY(), event.getTargetZ());
           double d2 = Double.MAX_VALUE;
  
           for(SpreadPlayersCommand.Position spreadplayerscommand$position1 : p_241072_2_) {

--- a/patches/minecraft/net/minecraft/command/impl/TeleportCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/TeleportCommand.java.patch
@@ -1,14 +1,12 @@
 --- a/net/minecraft/command/impl/TeleportCommand.java
 +++ b/net/minecraft/command/impl/TeleportCommand.java
-@@ -121,6 +_,11 @@
+@@ -121,6 +_,9 @@
     }
  
     private static void func_201127_a(CommandSource p_201127_0_, Entity p_201127_1_, ServerWorld p_201127_2_, double p_201127_3_, double p_201127_5_, double p_201127_7_, Set<SPlayerPositionLookPacket.Flags> p_201127_9_, float p_201127_10_, float p_201127_11_, @Nullable TeleportCommand.Facing p_201127_12_) throws CommandSyntaxException {
-+      net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportCommand(p_201127_1_, p_201127_3_, p_201127_5_, p_201127_7_);
-+      if (target == null) return;
-+      p_201127_3_ = target.field_72450_a;
-+      p_201127_5_ = target.field_72448_b;
-+      p_201127_7_ = target.field_72449_c;
++      net.minecraftforge.event.entity.living.EntityTeleportEvent.TeleportCommand event = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportCommand(p_201127_1_, p_201127_3_, p_201127_5_, p_201127_7_);
++      if (event.isCanceled()) return;
++      p_201127_3_ = event.getTargetX(); p_201127_5_ = event.getTargetY(); p_201127_7_ = event.getTargetZ();
        BlockPos blockpos = new BlockPos(p_201127_3_, p_201127_5_, p_201127_7_);
        if (!World.func_234935_k_(blockpos)) {
           throw field_241077_a_.create();

--- a/patches/minecraft/net/minecraft/command/impl/TeleportCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/TeleportCommand.java.patch
@@ -1,5 +1,17 @@
 --- a/net/minecraft/command/impl/TeleportCommand.java
 +++ b/net/minecraft/command/impl/TeleportCommand.java
+@@ -121,6 +_,11 @@
+    }
+ 
+    private static void func_201127_a(CommandSource p_201127_0_, Entity p_201127_1_, ServerWorld p_201127_2_, double p_201127_3_, double p_201127_5_, double p_201127_7_, Set<SPlayerPositionLookPacket.Flags> p_201127_9_, float p_201127_10_, float p_201127_11_, @Nullable TeleportCommand.Facing p_201127_12_) throws CommandSyntaxException {
++      net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportCommand(p_201127_1_, p_201127_3_, p_201127_5_, p_201127_7_);
++      if (target == null) return;
++      p_201127_3_ = target.field_72450_a;
++      p_201127_5_ = target.field_72448_b;
++      p_201127_7_ = target.field_72449_c;
+       BlockPos blockpos = new BlockPos(p_201127_3_, p_201127_5_, p_201127_7_);
+       if (!World.func_234935_k_(blockpos)) {
+          throw field_241077_a_.create();
 @@ -159,7 +_,6 @@
                 p_201127_1_.func_70012_b(p_201127_3_, p_201127_5_, p_201127_7_, f1, f);
                 p_201127_1_.func_70034_d(f1);

--- a/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
@@ -1,26 +1,23 @@
 --- a/net/minecraft/entity/item/EnderPearlEntity.java
 +++ b/net/minecraft/entity/item/EnderPearlEntity.java
-@@ -55,6 +_,10 @@
+@@ -55,6 +_,8 @@
           if (entity instanceof ServerPlayerEntity) {
              ServerPlayerEntity serverplayerentity = (ServerPlayerEntity)entity;
              if (serverplayerentity.field_71135_a.func_147298_b().func_150724_d() && serverplayerentity.field_70170_p == this.field_70170_p && !serverplayerentity.func_70608_bn()) {
-+               net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(serverplayerentity, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), 5.0F);
-+               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { // Don't indent to lower patch size //TODO Forge: Scrap this event in 1.17
-+               net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl evt = net.minecraftforge.event.ForgeEventFactory.onEnderPearlLand(this, serverplayerentity, event.getTargetX(), event.getTargetY(), event.getTargetZ(), event.getAttackDamage());
-+               if (!evt.isCanceled()) { // Don't indent to lower patch size
++               net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl event = net.minecraftforge.event.ForgeEventFactory.onEnderPearlLand(serverplayerentity, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), this, 5.0F);
++               if (!event.isCanceled()) { // Don't indent to lower patch size
                 if (this.field_70146_Z.nextFloat() < 0.05F && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223601_d)) {
                    EndermiteEntity endermiteentity = EntityType.field_200804_r.func_200721_a(this.field_70170_p);
                    endermiteentity.func_175496_a(true);
-@@ -66,9 +_,11 @@
+@@ -66,9 +_,10 @@
                    entity.func_184210_p();
                 }
  
 -               entity.func_70634_a(this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_());
-+               entity.func_70634_a(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ());
++               entity.func_70634_a(event.getTargetX(), event.getTargetY(), event.getTargetZ());
                 entity.field_70143_R = 0.0F;
 -               entity.func_70097_a(DamageSource.field_76379_h, 5.0F);
-+               entity.func_70097_a(DamageSource.field_76379_h, evt.getAttackDamage());
-+               } //Forge: End
++               entity.func_70097_a(DamageSource.field_76379_h, event.getAttackDamage());
 +               } //Forge: End
              }
           } else if (entity != null) {

--- a/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
@@ -5,9 +5,9 @@
              ServerPlayerEntity serverplayerentity = (ServerPlayerEntity)entity;
              if (serverplayerentity.field_71135_a.func_147298_b().func_150724_d() && serverplayerentity.field_70170_p == this.field_70170_p && !serverplayerentity.func_70608_bn()) {
 +               net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(serverplayerentity, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), 5.0F);
-+               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { // Don't indent to lower patch size // Forge: Scrap this event in 1.17
-+               net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl evt = new net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl(this, serverplayerentity, event.getTargetX(), event.getTargetY(), event.getTargetZ(), event.getAttackDamage());
-+               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt)) { // Don't indent to lower patch size
++               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { // Don't indent to lower patch size //TODO Forge: Scrap this event in 1.17
++               net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl evt = net.minecraftforge.event.ForgeEventFactory.onEnderPearlLand(this, serverplayerentity, event.getTargetX(), event.getTargetY(), event.getTargetZ(), event.getAttackDamage());
++               if (!evt.isCanceled()) { // Don't indent to lower patch size
                 if (this.field_70146_Z.nextFloat() < 0.05F && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223601_d)) {
                    EndermiteEntity endermiteentity = EntityType.field_200804_r.func_200721_a(this.field_70170_p);
                    endermiteentity.func_175496_a(true);

--- a/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EnderPearlEntity.java.patch
@@ -1,23 +1,26 @@
 --- a/net/minecraft/entity/item/EnderPearlEntity.java
 +++ b/net/minecraft/entity/item/EnderPearlEntity.java
-@@ -55,6 +_,8 @@
+@@ -55,6 +_,10 @@
           if (entity instanceof ServerPlayerEntity) {
              ServerPlayerEntity serverplayerentity = (ServerPlayerEntity)entity;
              if (serverplayerentity.field_71135_a.func_147298_b().func_150724_d() && serverplayerentity.field_70170_p == this.field_70170_p && !serverplayerentity.func_70608_bn()) {
 +               net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(serverplayerentity, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_(), 5.0F);
-+               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { // Don't indent to lower patch size
++               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { // Don't indent to lower patch size // Forge: Scrap this event in 1.17
++               net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl evt = new net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderPearl(this, serverplayerentity, event.getTargetX(), event.getTargetY(), event.getTargetZ(), event.getAttackDamage());
++               if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt)) { // Don't indent to lower patch size
                 if (this.field_70146_Z.nextFloat() < 0.05F && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223601_d)) {
                    EndermiteEntity endermiteentity = EntityType.field_200804_r.func_200721_a(this.field_70170_p);
                    endermiteentity.func_175496_a(true);
-@@ -66,9 +_,10 @@
+@@ -66,9 +_,11 @@
                    entity.func_184210_p();
                 }
  
 -               entity.func_70634_a(this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_());
-+               entity.func_70634_a(event.getTargetX(), event.getTargetY(), event.getTargetZ());
++               entity.func_70634_a(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ());
                 entity.field_70143_R = 0.0F;
 -               entity.func_70097_a(DamageSource.field_76379_h, 5.0F);
-+               entity.func_70097_a(DamageSource.field_76379_h, event.getAttackDamage());
++               entity.func_70097_a(DamageSource.field_76379_h, evt.getAttackDamage());
++               } //Forge: End
 +               } //Forge: End
              }
           } else if (entity != null) {

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -31,16 +31,14 @@
           return false;
        } else {
           Vector3d vector3d = p_70821_1_.func_70676_i(1.0F).func_72432_b();
-@@ -265,7 +_,11 @@
+@@ -265,7 +_,9 @@
        boolean flag = blockstate.func_185904_a().func_76230_c();
        boolean flag1 = blockstate.func_204520_s().func_206884_a(FluidTags.field_206959_a);
        if (flag && !flag1) {
 -         boolean flag2 = this.func_213373_a(p_70825_1_, p_70825_3_, p_70825_5_, true);
-+         net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, p_70825_1_, p_70825_3_, p_70825_5_, 0);
-+         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return false; //TODO Forge: Scrap this event in 1.17
-+         net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity evt = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
-+         if (evt.isCanceled()) return false;
-+         boolean flag2 = this.func_213373_a(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ(), true);
++         net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity event = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, p_70825_1_, p_70825_3_, p_70825_5_);
++         if (event.isCanceled()) return false;
++         boolean flag2 = this.func_213373_a(event.getTargetX(), event.getTargetY(), event.getTargetZ(), true);
           if (flag2 && !this.func_174814_R()) {
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70169_q, this.field_70167_r, this.field_70166_s, SoundEvents.field_187534_aX, this.func_184176_by(), 1.0F, 1.0F);
              this.func_184185_a(SoundEvents.field_187534_aX, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -31,14 +31,16 @@
           return false;
        } else {
           Vector3d vector3d = p_70821_1_.func_70676_i(1.0F).func_72432_b();
-@@ -265,7 +_,9 @@
+@@ -265,7 +_,11 @@
        boolean flag = blockstate.func_185904_a().func_76230_c();
        boolean flag1 = blockstate.func_204520_s().func_206884_a(FluidTags.field_206959_a);
        if (flag && !flag1) {
 -         boolean flag2 = this.func_213373_a(p_70825_1_, p_70825_3_, p_70825_5_, true);
 +         net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, p_70825_1_, p_70825_3_, p_70825_5_, 0);
-+         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return false;
-+         boolean flag2 = this.func_213373_a(event.getTargetX(), event.getTargetY(), event.getTargetZ(), true);
++         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return false; // Forge: Scrap this event in 1.17
++         net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
++         if (target == null) return false;
++         boolean flag2 = this.func_213373_a(target.field_72450_a, target.field_72448_b, target.field_72449_c, true);
           if (flag2 && !this.func_174814_R()) {
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70169_q, this.field_70167_r, this.field_70166_s, SoundEvents.field_187534_aX, this.func_184176_by(), 1.0F, 1.0F);
              this.func_184185_a(SoundEvents.field_187534_aX, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -37,10 +37,10 @@
        if (flag && !flag1) {
 -         boolean flag2 = this.func_213373_a(p_70825_1_, p_70825_3_, p_70825_5_, true);
 +         net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, p_70825_1_, p_70825_3_, p_70825_5_, 0);
-+         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return false; // Forge: Scrap this event in 1.17
-+         net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
-+         if (target == null) return false;
-+         boolean flag2 = this.func_213373_a(target.field_72450_a, target.field_72448_b, target.field_72449_c, true);
++         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return false; //TODO Forge: Scrap this event in 1.17
++         net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity evt = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
++         if (evt.isCanceled()) return false;
++         boolean flag2 = this.func_213373_a(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ(), true);
           if (flag2 && !this.func_174814_R()) {
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70169_q, this.field_70167_r, this.field_70166_s, SoundEvents.field_187534_aX, this.func_184176_by(), 1.0F, 1.0F);
              this.func_184185_a(SoundEvents.field_187534_aX, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
@@ -25,16 +25,14 @@
           Optional<BlockPos> optional1 = Optional.of(new BlockPos(p_70107_1_, p_70107_3_, p_70107_5_));
           if (!optional1.equals(optional)) {
              this.field_70180_af.func_187227_b(field_184701_b, optional1);
-@@ -282,6 +_,14 @@
+@@ -282,6 +_,12 @@
              BlockPos blockpos1 = blockpos.func_177982_a(8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17));
              if (blockpos1.func_177956_o() > 0 && this.field_70170_p.func_175623_d(blockpos1) && this.field_70170_p.func_175723_af().func_177746_a(blockpos1) && this.field_70170_p.func_226665_a__(this, new AxisAlignedBB(blockpos1))) {
                 Direction direction = this.func_234299_g_(blockpos1);
 +               if (direction != null) {
-+                  net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), 0);
-+                  if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) direction = null; //TODO Forge: Scrap this event in 1.17
-+                  net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity evt = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
-+                  if (evt.isCanceled()) direction = null;
-+                  blockpos1 = new BlockPos(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ());
++                  net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity event = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p());
++                  if (event.isCanceled()) direction = null;
++                  blockpos1 = new BlockPos(event.getTargetX(), event.getTargetY(), event.getTargetZ());
 +               }
 +
                 if (direction != null) {

--- a/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
@@ -25,14 +25,17 @@
           Optional<BlockPos> optional1 = Optional.of(new BlockPos(p_70107_1_, p_70107_3_, p_70107_5_));
           if (!optional1.equals(optional)) {
              this.field_70180_af.func_187227_b(field_184701_b, optional1);
-@@ -282,6 +_,12 @@
+@@ -282,6 +_,15 @@
              BlockPos blockpos1 = blockpos.func_177982_a(8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17));
              if (blockpos1.func_177956_o() > 0 && this.field_70170_p.func_175623_d(blockpos1) && this.field_70170_p.func_175723_af().func_177746_a(blockpos1) && this.field_70170_p.func_226665_a__(this, new AxisAlignedBB(blockpos1))) {
                 Direction direction = this.func_234299_g_(blockpos1);
 +               if (direction != null) {
 +                   net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), 0);
-+                   if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) direction = null;
-+                   blockpos1 = new BlockPos(event.getTargetX(), event.getTargetY(), event.getTargetZ());
++                   if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) direction = null; // Forge: Scrap this event in 1.17
++                   net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
++                   if (target == null) direction = null;
++                   else
++                   blockpos1 = new BlockPos(target.field_72450_a, target.field_72448_b, target.field_72449_c);
 +               }
 +
                 if (direction != null) {

--- a/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ShulkerEntity.java.patch
@@ -25,17 +25,16 @@
           Optional<BlockPos> optional1 = Optional.of(new BlockPos(p_70107_1_, p_70107_3_, p_70107_5_));
           if (!optional1.equals(optional)) {
              this.field_70180_af.func_187227_b(field_184701_b, optional1);
-@@ -282,6 +_,15 @@
+@@ -282,6 +_,14 @@
              BlockPos blockpos1 = blockpos.func_177982_a(8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17), 8 - this.field_70146_Z.nextInt(17));
              if (blockpos1.func_177956_o() > 0 && this.field_70170_p.func_175623_d(blockpos1) && this.field_70170_p.func_175723_af().func_177746_a(blockpos1) && this.field_70170_p.func_226665_a__(this, new AxisAlignedBB(blockpos1))) {
                 Direction direction = this.func_234299_g_(blockpos1);
 +               if (direction != null) {
-+                   net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), 0);
-+                   if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) direction = null; // Forge: Scrap this event in 1.17
-+                   net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
-+                   if (target == null) direction = null;
-+                   else
-+                   blockpos1 = new BlockPos(target.field_72450_a, target.field_72448_b, target.field_72449_c);
++                  net.minecraftforge.event.entity.living.EnderTeleportEvent event = new net.minecraftforge.event.entity.living.EnderTeleportEvent(this, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), 0);
++                  if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) direction = null; //TODO Forge: Scrap this event in 1.17
++                  net.minecraftforge.event.entity.living.EntityTeleportEvent.EnderEntity evt = net.minecraftforge.event.ForgeEventFactory.onEnderTeleport(this, event.getTargetX(), event.getTargetY(), event.getTargetZ());
++                  if (evt.isCanceled()) direction = null;
++                  blockpos1 = new BlockPos(evt.getTargetX(), evt.getTargetY(), evt.getTargetZ());
 +               }
 +
                 if (direction != null) {

--- a/patches/minecraft/net/minecraft/item/ChorusFruitItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/ChorusFruitItem.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/item/ChorusFruitItem.java
++++ b/net/minecraft/item/ChorusFruitItem.java
+@@ -29,7 +_,9 @@
+                p_77654_3_.func_184210_p();
+             }
+ 
+-            if (p_77654_3_.func_213373_a(d3, d4, d5, true)) {
++            net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onChorusFruitTeleport(p_77654_3_, d3, d4, d5);
++            if (target == null) return itemstack;
++            if (p_77654_3_.func_213373_a(target.field_72450_a, target.field_72448_b, target.field_72449_c, true)) {
+                SoundEvent soundevent = p_77654_3_ instanceof FoxEntity ? SoundEvents.field_232710_ez_ : SoundEvents.field_187544_ad;
+                p_77654_2_.func_184148_a((PlayerEntity)null, d0, d1, d2, soundevent, SoundCategory.PLAYERS, 1.0F, 1.0F);
+                p_77654_3_.func_184185_a(soundevent, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/item/ChorusFruitItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/ChorusFruitItem.java.patch
@@ -5,9 +5,9 @@
              }
  
 -            if (p_77654_3_.func_213373_a(d3, d4, d5, true)) {
-+            net.minecraft.util.math.vector.Vector3d target = net.minecraftforge.event.ForgeEventFactory.onChorusFruitTeleport(p_77654_3_, d3, d4, d5);
-+            if (target == null) return itemstack;
-+            if (p_77654_3_.func_213373_a(target.field_72450_a, target.field_72448_b, target.field_72449_c, true)) {
++            net.minecraftforge.event.entity.living.EntityTeleportEvent.ChorusFruit event = net.minecraftforge.event.ForgeEventFactory.onChorusFruitTeleport(p_77654_3_, d3, d4, d5);
++            if (event.isCanceled()) return itemstack;
++            if (p_77654_3_.func_213373_a(event.getTargetX(), event.getTargetY(), event.getTargetZ(), true)) {
                 SoundEvent soundevent = p_77654_3_ instanceof FoxEntity ? SoundEvents.field_232710_ez_ : SoundEvents.field_187544_ad;
                 p_77654_2_.func_184148_a((PlayerEntity)null, d0, d1, d2, soundevent, SoundCategory.PLAYERS, 1.0F, 1.0F);
                 p_77654_3_.func_184185_a(soundevent, 1.0F, 1.0F);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -43,6 +43,7 @@ import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.effect.LightningBoltEntity;
+import net.minecraft.entity.item.EnderPearlEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.monster.ZombieEntity;
 import net.minecraft.entity.passive.AnimalEntity;
@@ -60,7 +61,6 @@ import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
 import net.minecraft.resources.IFutureReloadListener;
 import net.minecraft.resources.DataPackRegistries;
-import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.spawner.AbstractSpawner;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.ActionResultType;
@@ -771,28 +771,38 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new LivingConversionEvent.Post(entity, outcome));
     }
 
-    public static Vector3d onEntityTeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
+    public static EntityTeleportEvent.TeleportCommand onEntityTeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
     {
-        return genericEntityTeleport(new EntityTeleportEvent.TeleportCommand(entity, targetX, targetY, targetZ));
+        EntityTeleportEvent.TeleportCommand event = new EntityTeleportEvent.TeleportCommand(entity, targetX, targetY, targetZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
-    public static Vector3d onEntityTeleportSpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
+    public static EntityTeleportEvent.SpreadPlayersCommand onEntityTeleportSpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
     {
-        return genericEntityTeleport(new EntityTeleportEvent.SpreadPlayersCommand(entity, targetX, targetY, targetZ));
+        EntityTeleportEvent.SpreadPlayersCommand event = new EntityTeleportEvent.SpreadPlayersCommand(entity, targetX, targetY, targetZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
-    public static Vector3d onEnderTeleport(Entity entity, double targetX, double targetY, double targetZ)
+    public static EntityTeleportEvent.EnderEntity onEnderTeleport(Entity entity, double targetX, double targetY, double targetZ)
     {
-        return genericEntityTeleport(new EntityTeleportEvent.EnderEntity(entity, targetX, targetY, targetZ));
+        EntityTeleportEvent.EnderEntity event = new EntityTeleportEvent.EnderEntity(entity, targetX, targetY, targetZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
-    public static Vector3d onChorusFruitTeleport(LivingEntity entity, double targetX, double targetY, double targetZ)
+    public static EntityTeleportEvent.EnderPearl onEnderPearlLand(EnderPearlEntity pearlEntity, ServerPlayerEntity entity, double targetX, double targetY, double targetZ, float attackDamage)
     {
-        return genericEntityTeleport(new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ));
+        EntityTeleportEvent.EnderPearl event = new EntityTeleportEvent.EnderPearl(pearlEntity, entity, targetX, targetY, targetZ, attackDamage);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
-    private static Vector3d genericEntityTeleport(EntityTeleportEvent event)
+    public static EntityTeleportEvent.ChorusFruit onChorusFruitTeleport(LivingEntity entity, double targetX, double targetY, double targetZ)
     {
-        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getTarget();
+        EntityTeleportEvent.ChorusFruit event = new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -60,6 +60,7 @@ import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
 import net.minecraft.resources.IFutureReloadListener;
 import net.minecraft.resources.DataPackRegistries;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.spawner.AbstractSpawner;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.ActionResultType;
@@ -113,6 +114,7 @@ import net.minecraftforge.event.entity.living.LivingHealEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
+import net.minecraftforge.event.entity.living.EntityTeleportEvent;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
 import net.minecraftforge.event.entity.player.ArrowNockEvent;
@@ -767,5 +769,30 @@ public class ForgeEventFactory
     public static void onLivingConvert(LivingEntity entity, LivingEntity outcome)
     {
         MinecraftForge.EVENT_BUS.post(new LivingConversionEvent.Post(entity, outcome));
+    }
+
+    public static Vector3d onEntityTeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
+    {
+        return genericEntityTeleport(new EntityTeleportEvent.TeleportCommand(entity, targetX, targetY, targetZ));
+    }
+
+    public static Vector3d onEntityTeleportSpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
+    {
+        return genericEntityTeleport(new EntityTeleportEvent.SpreadPlayersCommand(entity, targetX, targetY, targetZ));
+    }
+
+    public static Vector3d onEnderTeleport(Entity entity, double targetX, double targetY, double targetZ)
+    {
+        return genericEntityTeleport(new EntityTeleportEvent.EnderEntity(entity, targetX, targetY, targetZ));
+    }
+
+    public static Vector3d onChorusFruitTeleport(LivingEntity entity, double targetX, double targetY, double targetZ)
+    {
+        return genericEntityTeleport(new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ));
+    }
+
+    private static Vector3d genericEntityTeleport(EntityTeleportEvent event)
+    {
+        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getTarget();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
@@ -27,7 +27,7 @@ import net.minecraft.entity.LivingEntity;
  * @author Mithion
  * @deprecated Use {@link EntityTeleportEvent.EnderEntity} or {@link EntityTeleportEvent.EnderPearl}.
  */
-@Deprecated // Forge: Remove in 1.17
+@Deprecated //TODO Forge: Remove in 1.17
 @Cancelable
 public class EnderTeleportEvent extends LivingEvent
 {

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
@@ -25,8 +25,9 @@ import net.minecraft.entity.LivingEntity;
 /**
  * Event for when an Enderman/Shulker teleports or an ender pearl is used.  Can be used to either modify the target position, or cancel the teleport outright.
  * @author Mithion
- *
+ * @deprecated Use {@link EntityTeleportEvent.EnderEntity} or {@link EntityTeleportEvent.EnderPearl}.
  */
+@Deprecated // Forge: Remove in 1.17
 @Cancelable
 public class EnderTeleportEvent extends LivingEvent
 {

--- a/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
@@ -109,9 +109,17 @@ public class EntityTeleportEvent extends EntityEvent
     @Cancelable
     public static class EnderEntity extends EntityTeleportEvent
     {
-        public EnderEntity(Entity entity, double targetX, double targetY, double targetZ)
+        private final LivingEntity entityLiving;
+
+        public EnderEntity(LivingEntity entity, double targetX, double targetY, double targetZ)
         {
             super(entity, targetX, targetY, targetZ);
+            this.entityLiving = entity;
+        }
+
+        public LivingEntity getEntityLiving()
+        {
+            return entityLiving;
         }
     }
 
@@ -136,7 +144,7 @@ public class EntityTeleportEvent extends EntityEvent
         private final EnderPearlEntity pearlEntity;
         private float attackDamage;
 
-        public EnderPearl(EnderPearlEntity pearlEntity, ServerPlayerEntity entity, double targetX, double targetY, double targetZ, float attackDamage)
+        public EnderPearl(ServerPlayerEntity entity, double targetX, double targetY, double targetZ, EnderPearlEntity pearlEntity, float attackDamage)
         {
             super(entity, targetX, targetY, targetZ);
             this.pearlEntity = pearlEntity;

--- a/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
@@ -55,6 +55,8 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
+     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * <br>
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
@@ -77,6 +79,8 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
+     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * <br>
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
@@ -98,6 +102,8 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
+     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * <br>
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
@@ -118,6 +124,8 @@ public class EntityTeleportEvent extends EntityEvent
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
@@ -166,6 +174,8 @@ public class EntityTeleportEvent extends EntityEvent
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */

--- a/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
@@ -1,0 +1,188 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.item.EnderPearlEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+/**
+ * EntityTeleportEvent is fired when an event involving any teleportation of an Entity occurs.<br>
+ * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
+ * receive every child event of this class.<br>
+ * <br>
+ * {@link #getTarget()} contains the target destination.<br>
+ * {@link #getPrev()} contains the entity's current position.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+public class EntityTeleportEvent extends EntityEvent
+{
+    protected double targetX;
+    protected double targetY;
+    protected double targetZ;
+
+    public EntityTeleportEvent(Entity entity, double targetX, double targetY, double targetZ) {
+        super(entity);
+        this.targetX = targetX;
+        this.targetY = targetY;
+        this.targetZ = targetZ;
+    }
+
+    public double getTargetX() { return targetX; }
+    public void setTargetX(double targetX) { this.targetX = targetX; }
+    public double getTargetY() { return targetY; }
+    public void setTargetY(double targetY) { this.targetY = targetY; }
+    public double getTargetZ() { return targetZ; }
+    public void setTargetZ(double targetZ) { this.targetZ = targetZ; }
+    public Vector3d getTarget() { return new Vector3d(this.targetX, this.targetY, this.targetZ); }
+    public double getPrevX() { return getEntity().getX(); }
+    public double getPrevY() { return getEntity().getY(); }
+    public double getPrevZ() { return getEntity().getZ(); }
+    public Vector3d getPrev() { return getEntity().position(); }
+
+    /**
+     * EntityTeleportEvent.TeleportCommand is fired before a living entity is teleported
+     * from use of {@link net.minecraft.command.impl.TeleportCommand}.
+     * <br>
+     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * If the event is not canceled, the entity will be teleported.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * If this event is canceled, the entity will not be teleported.
+     */
+    @Cancelable
+    public static class TeleportCommand extends EntityTeleportEvent
+    {
+        public TeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
+        {
+            super(entity, targetX, targetY, targetZ);
+        }
+    }
+
+    /**
+     * EntityTeleportEvent.SpreadPlayersCommand is fired before a living entity is teleported
+     * from use of {@link net.minecraft.command.impl.SpreadPlayersCommand}.
+     * <br>
+     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * If the event is not canceled, the entity will be teleported.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * If this event is canceled, the entity will not be teleported.
+     */
+    @Cancelable
+    public static class SpreadPlayersCommand extends EntityTeleportEvent
+    {
+        public SpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
+        {
+            super(entity, targetX, targetY, targetZ);
+        }
+    }
+
+    /**
+     * EntityTeleportEvent.EnderEntity is fired before an Enderman or Shulker randomly teleports.
+     * <br>
+     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * If the event is not canceled, the entity will be teleported.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * If this event is canceled, the entity will not be teleported.
+     */
+    @Cancelable
+    public static class EnderEntity extends EntityTeleportEvent
+    {
+        public EnderEntity(Entity entity, double targetX, double targetY, double targetZ)
+        {
+            super(entity, targetX, targetY, targetZ);
+        }
+    }
+
+    /**
+     * EntityTeleportEvent.EnderPearl is fired before an Entity is teleported from an EnderPearlEntity.
+     * <br>
+     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * If the event is not canceled, the entity will be teleported.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * If this event is canceled, the entity will not be teleported.
+     */
+    @Cancelable
+    public static class EnderPearl extends EntityTeleportEvent
+    {
+        private final ServerPlayerEntity player;
+        private final EnderPearlEntity pearlEntity;
+        private float attackDamage;
+
+        public EnderPearl(EnderPearlEntity pearlEntity, ServerPlayerEntity entity, double targetX, double targetY, double targetZ, float attackDamage)
+        {
+            super(entity, targetX, targetY, targetZ);
+            this.pearlEntity = pearlEntity;
+            this.player = entity;
+            this.attackDamage = attackDamage;
+        }
+
+        public EnderPearlEntity getPearlEntity()
+        {
+            return pearlEntity;
+        }
+
+        public ServerPlayerEntity getPlayer()
+        {
+            return player;
+        }
+
+        public float getAttackDamage()
+        {
+            return attackDamage;
+        }
+
+        public void setAttackDamage(float attackDamage)
+        {
+            this.attackDamage = attackDamage;
+        }
+    }
+
+    /**
+     * EntityTeleportEvent.ChorusFruit is fired before a LivingEntity is teleported due to consuming Chorus Fruit.
+     * <br>
+     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * If the event is not canceled, the entity will be teleported.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * <br>
+     * If this event is canceled, the entity will not be teleported.
+     */
+    @Cancelable
+    public static class ChorusFruit extends EntityTeleportEvent
+    {
+        private final LivingEntity entityLiving;
+
+        public ChorusFruit(LivingEntity entity, double targetX, double targetY, double targetZ)
+        {
+            super(entity, targetX, targetY, targetZ);
+            this.entityLiving = entity;
+        }
+
+        public LivingEntity getEntityLiving()
+        {
+            return entityLiving;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/EntityTeleportEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/EntityTeleportEventTest.java
@@ -21,7 +21,7 @@ public class EntityTeleportEventTest
     }
 
     @SubscribeEvent
-    public void registerCommands(EntityTeleportEvent event)
+    public void entityTeleport(EntityTeleportEvent event)
     {
         LOGGER.info("{} teleporting from {} to {}", event.getEntity(), event.getPrev(), event.getTarget());
     }

--- a/src/test/java/net/minecraftforge/debug/entity/EntityTeleportEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/EntityTeleportEventTest.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.debug.entity;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.EntityTeleportEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("entity_teleport_event_test")
+public class EntityTeleportEventTest
+{
+    public static final boolean ENABLE = true;
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    public EntityTeleportEventTest()
+    {
+        if (ENABLE)
+            MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void registerCommands(EntityTeleportEvent event)
+    {
+        LOGGER.info("{} teleporting from {} to {}", event.getEntity(), event.getPrev(), event.getTarget());
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -120,3 +120,5 @@ license="LGPL v2.1"
     modId="add_entity_attribute_test"
 [[mods]]
     modId="enum_argument_test"
+[[mods]]
+    modId="entity_teleport_event_test"


### PR DESCRIPTION
Forge currently does not have a generic `EntityTeleportEvent` that can be used for catching any and all teleportation related to an `Entity`. This PR adds the functionality along with hooks into vanilla, enabling the events.

Currently, `TeleportCommand`, `SpreadPlayersCommand`, `EnderEntity`, `EnderPearl`, and `ChorusFruit` are all supported subclasses. Documentation has also been added to the generic event and all subclasses. `EnderTeleportEvent` has been deprecated for removal in 1.17 in favor of `EntityTeleportEvent.EnderEntity` and `EntityTeleportEvent.EnderPearl`.

A test mod is also provided that logs whenever an entity teleport event takes place. I also did local testing and confirmed that cancelling the event works in all supported subclasses.

I tried to keep my patch changes minimal, but please let me know if there is anything else I can do to minimize them further.