### PR TITLE
Bypass chunk future chain when processing loads and getChunk called.

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkHolder.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkHolder.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/server/ChunkHolder.java
 +++ b/net/minecraft/world/server/ChunkHolder.java
+@@ -61,6 +_,7 @@
+    private final ChunkHolder.IPlayerProvider field_219328_w;
+    private boolean field_219329_x;
+    private boolean field_244384_x;
++   Chunk currentlyLoading; //Forge - Used to bypass future chain when loading chunks.
+ 
+    public ChunkHolder(ChunkPos p_i50716_1_, int p_i50716_2_, WorldLightManager p_i50716_3_, ChunkHolder.IListener p_i50716_4_, ChunkHolder.IPlayerProvider p_i50716_5_) {
+       this.field_219319_n = p_i50716_1_;
 @@ -204,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -8,11 +8,23 @@
                 }
  
                 this.func_219229_a(p_219185_5_);
-@@ -601,6 +_,7 @@
+@@ -581,6 +_,8 @@
+             chunk.func_217318_w();
+             if (this.field_219254_h.add(chunkpos.func_201841_a())) {
+                chunk.func_177417_c(true);
++               try {
++               p_219200_1_.currentlyLoading = chunk; //Forge - bypass the future chain when getChunk is called, this prevents deadlocks.
+                this.field_219255_i.func_147448_a(chunk.func_177434_r().values());
+                List<Entity> list = null;
+                ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = chunk.func_177429_s();
+@@ -601,6 +_,10 @@
                 if (list != null) {
                    list.forEach(chunk::func_76622_b);
                 }
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Load(chunk));
++               } finally {
++                   p_219200_1_.currentlyLoading = null;//Forge - Stop bypassing the future chain.
++               }
              }
  
              return chunk;

--- a/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerChunkProvider.java.patch
@@ -1,5 +1,17 @@
 --- a/net/minecraft/world/server/ServerChunkProvider.java
 +++ b/net/minecraft/world/server/ServerChunkProvider.java
+@@ -125,6 +_,11 @@
+             }
+          }
+ 
++         ChunkHolder chunkholder = this.func_217213_a(i);
++         if (chunkholder != null && chunkholder.currentlyLoading != null) {
++             return chunkholder.currentlyLoading; //Forge - If the requested chunk is loading, bypass the future chain to prevent a deadlock.
++         }
++
+          iprofiler.func_230035_c_("getChunkCacheMiss");
+          CompletableFuture<Either<IChunk, ChunkHolder.IChunkLoadingError>> completablefuture = this.func_217233_c(p_212849_1_, p_212849_2_, p_212849_3_, p_212849_4_);
+          this.field_217243_i.func_213161_c(completablefuture::isDone);
 @@ -353,7 +_,7 @@
                 if (optional1.isPresent()) {
                    Chunk chunk = optional1.get();


### PR DESCRIPTION
The Problem:
World interaction from places such as `TileEntity.onLoad()`, `ChunkEvent.Load`, and `EntityJoinWorldEvent` (possibly others), sometimes causes calls to `World.getChunk` and by extension `ServerChunkProvider.getChunk`. As these methods/events are called from within the Chunk CompletableFututre chain, it is incredibly easy to cause a loading deadlock, as the current thread starts blocking waiting for the CompletableFuture chain to exit, whilst it's already executing.

Current workarounds for this would be to delay any of your interaction with the world from any of the above, until the end of the tick or start of the next. However, this itself is still not a perfect solution either as some interactions might not be possible to delay, (replacing tiles without skipping ticks, setting up the internal state of things that are time-sensitive).

The solution:
There have been recent attempts at resolving this problem such as [this PR](https://github.com/MinecraftForge/MinecraftForge/pull/7532), ~~however, this doesn't really solve the root issue, instead opting for a delayed workaround as mentioned above for Item custom ItemEntities. With this PR. these changes become irrelevant and can likely be reverted, however, this is not verified.~~

This PR attempts to resolve the root issue outright by simply bypassing calls to the future chain in `ServerChunkProvider.getChunk` whilst the chunk is being post-processed (tiles/entities added and `ChunkEvent.Load`).

Is this safe?:
Yes, I believe so. From all the testing I have done with these patches, the bypass is not hit during normal gameplay, instead, _only_ when a deadlock would have occurred. Additionally, at the time the bypass is active, the chunk has already been marked as `FULL` and as loaded, the future chain just needs to exit out. Whilst this solution may not be perfect or the cleanest, there does not appear to be any cleaner way.

Other considerations:
At first, I considered moving the content post-processing blob to a separate detached future to be automatically executed once the future containing the initial post-processing had finished. However, it was impossible to assert that the post-process section of a given chunk was executed before any other events/tasks were processed by the executor.