### PR TITLE
delete Entity before calling changeDimensions()

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -218,7 +218,7 @@
     }
  
     public boolean func_70028_i(Entity p_70028_1_) {
-@@ -2087,14 +_,19 @@
+@@ -2087,14 +_,20 @@
  
     @Nullable
     public Entity func_241206_a_(ServerWorld p_241206_1_) {
@@ -235,6 +235,7 @@
           if (portalinfo == null) {
              return null;
           } else {
++            p_241206_1_.removeEntityComplete(this, true); //Forge: The entity is cloned so keep the data until after cloning calls copyFrom
 +            Entity transportedEntity = teleporter.placeEntity(this, (ServerWorld) this.field_70170_p, p_241206_1_, this.field_70177_z, spawnPortal -> { //Forge: Start vanilla logic
              this.field_70170_p.func_217381_Z().func_219895_b("reloading");
              Entity entity = this.func_200600_R().func_200721_a(p_241206_1_);


### PR DESCRIPTION
if `Entity.changeDimension()` is called with the other portal in the same dimension and the entity is not a player, a warning will be logged:
`Trying to add entity with duplicated UUID 6a4106d0-5834-4734-be6f-84155d7614b0. Existing minecraft:cow#22, new: minecraft:cow#204` and the entity will not be placed in the other portal

I'm new to modding/forge, so I might be wrong and the mod calling this code should call a different method than `changeDimension()`, but I think that this is caused by the entity not being deleted before `teleported.placeEntity()` is called

*To Reproduce*:
1) build/run [Portality](https://github.com/InnovativeOnlineIndustries/Portality) 
2) create 2 linked portals in the same dimension:  https://github.com/InnovativeOnlineIndustries/Portality#how-to-portality
3) spawn a cow and push it through the portal
4) the cow will disappear and will not reappear in the other portal, and a warning will be logged
5) if an item is thrown through the portal, the same thing will happen as the cow, the item disappears, does not reappear at the other portal, and a warning is logged 
6) if the player goes through the portal, they will spawn at the other portal and no warning will be logged


*How I tested the Fix*
1) built/published the patched version of forge to my local maven repo
2) added `mavenLocal()` to the repositories in `build.gradle`
3) changed [this line](https://github.com/InnovativeOnlineIndustries/Portality/blob/1.16/build.gradle#L94) to `minecraft 'net.minecraftforge:forge:1.16.5-36.1.2'`
4) built/ran Portality as described above and do the same tests - the cow should appear at the other portal and no warning should be logged
5) also tested that items/players work the same way

This came up from this issue: https://github.com/InnovativeOnlineIndustries/Portality/issues/102

As I said before, this could be an issue with the mod's implementation 
(https://github.com/InnovativeOnlineIndustries/Portality/blob/1.16/src/main/java/com/buuz135/portality/handler/TeleportHandler.java#L99 calls https://github.com/InnovativeOnlineIndustries/Portality/blob/1.16/src/main/java/com/buuz135/portality/handler/TeleportHandler.java#L99 which calls https://github.com/InnovativeOnlineIndustries/Titanium/blob/1.16/src/main/java/com/hrznstudio/titanium/util/TeleportationUtils.java#L30), but I'm not exactly sure who should handle deleting the non-player entity