### PR TITLE
WIP Fix client GameData not reverting to frozen in all necessary places

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -304,7 +304,7 @@
        SaveFormat.LevelSave saveformat$levelsave;
        try {
           saveformat$levelsave = this.field_71469_aa.func_237274_c_(p_238195_1_);
-@@ -1667,12 +_,17 @@
+@@ -1667,12 +_,19 @@
        }
  
        Minecraft.PackManager minecraft$packmanager;
@@ -314,7 +314,9 @@
 +         Minecraft.PackManager mgr = this.func_238189_a_(p_238195_2_, p_238195_3_, p_238195_4_, p_238195_5_, saveformat$levelsave);
 +         // We need to rebuild this if we're loading world, so that it gets all the information from AFTER we inject our mappings from the save.
 +         dyn_f = creating ? p_238195_2_ : DynamicRegistries.func_239770_b_();
-+         minecraft$packmanager = creating ? mgr : this.func_238189_a_(dyn_f, p_238195_3_, p_238195_4_, p_238195_5_, saveformat$levelsave); //Note this runs the injection again... which isn't good.. but hey.. we need a better spot to hook in.
++         // revert to frozen so that 2nd injection works properly, do it _after_ grabbing the DynamicRegistries snapshot...
++         if (!creating) net.minecraftforge.registries.GameData.revertToFrozen();
++         minecraft$packmanager = creating ? mgr : this.func_238189_a_(dyn_f, p_238195_3_, p_238195_4_, p_238195_5_, saveformat$levelsave);
 +
        } catch (Exception exception) {
           field_147123_G.warn("Failed to load datapacks, can't proceed with server load", (Throwable)exception);

--- a/patches/minecraft/net/minecraft/client/gui/screen/EditWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/EditWorldScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screen/EditWorldScreen.java
++++ b/net/minecraft/client/gui/screen/EditWorldScreen.java
+@@ -113,7 +_,7 @@
+             });
+          } catch (ExecutionException | InterruptedException interruptedexception) {
+             dataresult = DataResult.error("Could not parse level data!");
+-         }
++         } finally { net.minecraftforge.registries.GameData.revertToFrozen(); }
+ 
+          ITextComponent itextcomponent = new StringTextComponent(dataresult.get().map(Function.identity(), PartialResult::message));
+          ITextComponent itextcomponent1 = new TranslationTextComponent(dataresult.result().isPresent() ? "selectWorld.edit.export_worldgen_settings.success" : "selectWorld.edit.export_worldgen_settings.failure");

--- a/patches/minecraft/net/minecraft/client/gui/screen/OptimizeWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/OptimizeWorldScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screen/OptimizeWorldScreen.java
++++ b/net/minecraft/client/gui/screen/OptimizeWorldScreen.java
+@@ -49,7 +_,7 @@
+       } catch (Exception exception) {
+          field_239024_a_.warn("Failed to load datapacks, can't optimize world", (Throwable)exception);
+          return null;
+-      }
++      } finally { net.minecraftforge.registries.GameData.revertToFrozen(); }
+    }
+ 
+    private OptimizeWorldScreen(BooleanConsumer p_i232319_1_, DataFixer p_i232319_2_, SaveFormat.LevelSave p_i232319_3_, WorldSettings p_i232319_4_, boolean p_i232319_5_, ImmutableSet<RegistryKey<World>> p_i232319_6_) {

--- a/patches/minecraft/net/minecraft/client/gui/screen/WorldSelectionList.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/WorldSelectionList.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screen/WorldSelectionList.java
++++ b/net/minecraft/client/gui/screen/WorldSelectionList.java
+@@ -353,7 +_,7 @@
+             this.field_214449_b.func_147108_a(new AlertScreen(() -> {
+                this.field_214449_b.func_147108_a(this.field_214450_c);
+             }, new TranslationTextComponent("selectWorld.recreate.error.title"), new TranslationTextComponent("selectWorld.recreate.error.text")));
+-         }
++         } finally { net.minecraftforge.registries.GameData.revertToFrozen(); }
+ 
+       }
+ 


### PR DESCRIPTION
In certain circumstances the client injects the game data twice, without reverting to frozen in between. This causes the 2nd injection to not work properly, because for example missing blocks get substituted for air, making the 2nd injection think they are not missing. An effect of this is that "Open to LAN" no longer works at all once registry entries are removed from the world.

This "fix" is absolutely horrid, please someone suggest something better? Thank you.