### PR TITLE
Check version ranges of optional dependencies when present

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -247,25 +247,27 @@ public class ModSorter
                 .flatMap(Collection::stream)
                 .collect(Collectors.groupingBy(Function.identity(), Java9BackportUtils.flatMapping(e -> e.getDependencies().stream(), Collectors.toList())));
 
-        final Set<IModInfo.ModVersion> mandatoryModVersions = modVersionDependencies
+        final Set<IModInfo.ModVersion> modRequirements = modVersionDependencies
                 .values()
                 .stream()
                 .flatMap(Collection::stream)
-                .filter(mv -> mv.isMandatory() && mv.getSide().isCorrectSide())
+                .filter(mv -> mv.getSide().isCorrectSide())
                 .collect(Collectors.toSet());
 
-        LOGGER.debug(LOADING, "Found {} mandatory requirements", mandatoryModVersions.size());
-        final Set<IModInfo.ModVersion> missingVersions = mandatoryModVersions
+        final long mandatoryRequired = modRequirements.stream().filter(IModInfo.ModVersion::isMandatory).count();
+        LOGGER.debug(LOADING, "Found {} mod requirements ({} mandatory, {} optional)", modRequirements.size(), mandatoryRequired, modRequirements.size() - mandatoryRequired);
+        final Set<IModInfo.ModVersion> missingVersions = modRequirements
                 .stream()
-                .filter(mv->this.modVersionNotContained(mv, modVersions))
+                .filter(mv -> (mv.isMandatory() || modVersions.containsKey(mv.getModId())) && this.modVersionNotContained(mv, modVersions))
                 .collect(Collectors.toSet());
-        LOGGER.debug(LOADING, "Found {} mandatory mod requirements missing", missingVersions.size());
+        final long mandatoryMissing = missingVersions.stream().filter(IModInfo.ModVersion::isMandatory).count();
+        LOGGER.debug(LOADING, "Found {} mod requirements missing ({} mandatory, {} optional)", missingVersions.size(), mandatoryMissing, missingVersions.size() - mandatoryMissing);
 
         if (!missingVersions.isEmpty()) {
             return missingVersions
                     .stream()
-                    .map(mv -> new ExceptionData("fml.modloading.missingdependency", mv.getOwner(),
-                            mv.getModId(), mv.getOwner().getModId(), mv.getVersionRange(),
+                    .map(mv -> new ExceptionData(mv.isMandatory() ? "fml.modloading.missingdependency" : "fml.modloading.missingdependency.optional",
+                            mv.getOwner(), mv.getModId(), mv.getOwner().getModId(), mv.getVersionRange(),
                             modVersions.getOrDefault(mv.getModId(), new DefaultArtifactVersion("null"))))
                     .collect(Collectors.toList());
         }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -54,6 +54,7 @@
   "fml.modloading.errorduringevent":"{0,modinfo,name} ({0,modinfo,id}) encountered an error during the {1,lower} event phase\n\u00a77{2,exc,msg}",
   "fml.modloading.failedtoloadforge": "Failed to load Forge",
   "fml.modloading.missingdependency": "Mod \u00a7e{4}\u00a7r requires \u00a76{3}\u00a7r \u00a7o{5,vr}\u00a7r\n\u00a77Currently, \u00a76{3}\u00a7r\u00a77 is \u00a7o{6,i18n,fml.messages.artifactversion.ornotinstalled}",
+  "fml.modloading.missingdependency.optional": "Mod \u00a7e{4}\u00a7r only supports \u00a73{3}\u00a7r \u00a7o{5,vr}\u00a7r\n\u00a77Currently, \u00a73{3}\u00a7r\u00a77 is \u00a7o{6}",
   "fml.modloading.cycle": "Detected a mod dependency cycle: {0}",
   "fml.modloading.failedtoprocesswork":"{0,modinfo,name} ({0,modinfo,id}) encountered an error processing deferred work\n\u00a77{2,exc,msg}",
   "fml.modloading.brokenfile": "File {2} is not a valid mod file",


### PR DESCRIPTION
This PR implements and closes #7696.

If an optional dependency is present, but it does not conform to the version range, it will now error out in the same fashion as missing required dependencies, instead of a more cryptic error down the line due to a missing method/class/field/etc.

Some [discussion in the Discord][discord-discussion] was made on whether to edit the messages to also include user-friendly suggestions on how to resolve the problem (such as to upgrade/downgrade), but it was decided that such edits would be better suited to another PR, for further discussion on the topic from more people.

The message (with I18n key `fml.modloading.missingdependency.optional`) is similar to the message for unsatisfied required dependencies, with two differences: the word "requires" is replaced with "only supports", and the gold color of the dependency name is replaced with dark aqua (as a more visual distinction).

I have tested the PR with the following configurations (through modification of the `mods.toml` of the test mods):
| Test case                                             | Result                                         |
|-------------------------------------------------------|------------------------------------------------|
| Missing required dependency                           | Errors out, _same as previous behavior_        |
| Unsatisfied required dependency; not in version range | Errors out, _same as previous behavior_        |
| Missing optional dependency                           | Continues loading, _same as previous behavior_ |
| Unsatisfied optional dependency; not in version range | Errors out, **new behavior from this PR**      |

**Message for unsatified required dependencies:**
![Message for unsatified required dependencies][old-message]

**Message for unsatified optional dependencies _(added by this PR)_:**
![Message for unsatified optional dependencies][new-message]

[discord-discussion]: https://discord.com/channels/313125603924639766/313125603924639766/829756672795869224
[old-message]: https://user-images.githubusercontent.com/21304337/114076194-fa9ec880-98d8-11eb-9458-31e7a23c34af.png
[new-message]: https://user-images.githubusercontent.com/21304337/114075936-aeec1f00-98d8-11eb-97e6-3df65b5ffb28.png