### PR TITLE
Add an event when a shootable item tries to find a projectile item.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -329,7 +329,7 @@
        return this.func_208016_c(iformattabletextcomponent);
     }
  
-@@ -1901,18 +_,19 @@
+@@ -1901,18 +_,18 @@
           Predicate<ItemStack> predicate = ((ShootableItem)p_213356_1_.func_77973_b()).func_220006_d();
           ItemStack itemstack = ShootableItem.func_220005_a(this, predicate);
           if (!itemstack.func_190926_b()) {
@@ -347,8 +347,7 @@
              }
  
 -            return this.field_71075_bZ.field_75098_d ? new ItemStack(Items.field_151032_g) : ItemStack.field_190927_a;
-+            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_213356_1_,
-+                    this.field_71075_bZ.field_75098_d ? new ItemStack(Items.field_151032_g) : ItemStack.field_190927_a);
++            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_213356_1_, this.field_71075_bZ.field_75098_d ? new ItemStack(Items.field_151032_g) : ItemStack.field_190927_a);
           }
        }
     }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -329,6 +329,29 @@
        return this.func_208016_c(iformattabletextcomponent);
     }
  
+@@ -1901,18 +_,19 @@
+          Predicate<ItemStack> predicate = ((ShootableItem)p_213356_1_.func_77973_b()).func_220006_d();
+          ItemStack itemstack = ShootableItem.func_220005_a(this, predicate);
+          if (!itemstack.func_190926_b()) {
+-            return itemstack;
++            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_213356_1_, itemstack);
+          } else {
+             predicate = ((ShootableItem)p_213356_1_.func_77973_b()).func_220004_b();
+ 
+             for(int i = 0; i < this.field_71071_by.func_70302_i_(); ++i) {
+                ItemStack itemstack1 = this.field_71071_by.func_70301_a(i);
+                if (predicate.test(itemstack1)) {
+-                  return itemstack1;
++                  return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_213356_1_, itemstack1);
+                }
+             }
+ 
+-            return this.field_71075_bZ.field_75098_d ? new ItemStack(Items.field_151032_g) : ItemStack.field_190927_a;
++            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_213356_1_,
++                    this.field_71075_bZ.field_75098_d ? new ItemStack(Items.field_151032_g) : ItemStack.field_190927_a);
+          }
+       }
+    }
 @@ -1986,5 +_,63 @@
        public ITextComponent func_221259_a() {
           return this.field_221260_g;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -90,6 +90,7 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.BucketItem;
 import net.minecraft.item.EnchantedBookItem;
 import net.minecraft.item.HoeItem;
+import net.minecraft.item.Items;
 import net.minecraft.item.PickaxeItem;
 import net.minecraft.item.PotionItem;
 import net.minecraft.item.ShovelItem;
@@ -166,6 +167,7 @@ import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.entity.player.PlayerFindProjectileEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -1067,6 +1069,19 @@ public class ForgeHooks
         ItemAttributeModifierEvent event = new ItemAttributeModifierEvent(stack, equipmentSlot, attributes);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getModifiers();
+    }
+    
+    /**
+     * Hook to fire {@link PlayerFindProjectileEvent}. Returns the ammo to be used.
+     */
+    public static ItemStack findProjectile(PlayerEntity player, ItemStack shootable, ItemStack ammo)
+    {
+        PlayerFindProjectileEvent event = new PlayerFindProjectileEvent(player, shootable, ammo);
+        if (MinecraftForge.EVENT_BUS.post(event)) {
+            return player.isCreative() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
+        } else {
+            return event.getProjectile();
+        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1077,9 +1077,12 @@ public class ForgeHooks
     public static ItemStack findProjectile(PlayerEntity player, ItemStack shootable, ItemStack ammo)
     {
         PlayerFindProjectileEvent event = new PlayerFindProjectileEvent(player, shootable, ammo);
-        if (MinecraftForge.EVENT_BUS.post(event)) {
+        if (MinecraftForge.EVENT_BUS.post(event))
+        {
             return player.isCreative() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
-        } else {
+        }
+        else
+        {
             return event.getProjectile();
         }
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
@@ -1,0 +1,87 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * This event is fired when a player attempts to use an item that is an {@link net.minecraft.item.ShootableItem}
+ * that requires some ammo. (For example a bow which will search for arrows in the players inventory)
+ * <br>
+ * This event is {@link net.minecraftforge.eventbus.api.Cancelable}. If the event is canceled, in survival mode
+ * no projectile will be found and in creative mode a plain arrow will be returned. This equals vanilla behaviour
+ * when no arrow is in the players inventory.
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class PlayerFindProjectileEvent extends Event
+{
+    private final PlayerEntity player;
+    private final ItemStack shootable;
+    private ItemStack projectile;
+
+    public PlayerFindProjectileEvent(PlayerEntity player, ItemStack shootable, ItemStack ammo)
+    {
+        this.player = player;
+        this.shootable = shootable;
+        this.projectile = ammo;
+    }
+
+    /**
+     * Gets the player that is using the shootable item.
+     */
+    public PlayerEntity getPlayer()
+    {
+        return this.player;
+    }
+
+    /**
+     * Gets the shootable item that is looking for a projectile.
+     */
+    public ItemStack getShootable()
+    {
+        return this.shootable;
+    }
+
+    /**
+     * Gets the projectile found. Initially this is set to the projectile found by vanilla behaviour.
+     */
+    public ItemStack getProjectile()
+    {
+        return this.projectile;
+    }
+
+    /**
+     * Sets the projectile to be used. Whenever the projectile is fired/consumed the stack will be
+     * shrunk by one. To disable this behaviour you can copy the stack before giving it to the event.
+     * For bows you can use {@link ArrowLooseEvent} to remove the arrow yourself.
+     */
+    public void setProjectile(ItemStack projectile)
+    {
+        this.projectile = projectile;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
@@ -23,7 +23,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * This event is fired when a player attempts to use an item that is an {@link net.minecraft.item.ShootableItem}
@@ -38,25 +37,16 @@ import net.minecraftforge.eventbus.api.Event;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @Cancelable
-public class PlayerFindProjectileEvent extends Event
+public class PlayerFindProjectileEvent extends PlayerEvent
 {
-    private final PlayerEntity player;
     private final ItemStack shootable;
     private ItemStack projectile;
 
     public PlayerFindProjectileEvent(PlayerEntity player, ItemStack shootable, ItemStack ammo)
     {
-        this.player = player;
+        super(player);
         this.shootable = shootable;
         this.projectile = ammo;
-    }
-
-    /**
-     * Gets the player that is using the shootable item.
-     */
-    public PlayerEntity getPlayer()
-    {
-        return this.player;
     }
 
     /**


### PR DESCRIPTION
This allows for example for bows to find arrows from quivers.