### PR TITLE
Only fire LootingLevelEvent if there is a killer entity

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -390,7 +390,7 @@ public class ForgeHooks
         int looting = 0;
         if (killer instanceof LivingEntity)
             looting = EnchantmentHelper.getMobLooting((LivingEntity)killer);
-        if (target instanceof LivingEntity)
+        if (target instanceof LivingEntity && killer != null)
             looting = getLootingLevel((LivingEntity)target, cause, looting);
         return looting;
     }

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.event.entity.living;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.DamageSource;
 
@@ -34,6 +36,7 @@ public class LootingLevelEvent extends LivingEvent {
         this.lootingLevel = lootingLevel;
     }
 
+    @Nullable
     public DamageSource getDamageSource() {
         return damageSource;
     }


### PR DESCRIPTION
This fix makes it so that the LootingLevelEvent only fires if there is a
killer entity, since looting without a killer makes little sense. Also
adds the Nullable annotation to LootingLevelEvent.getDamageSource() to
more clearly communicate to modders that the DamageSource can be null in
LootingLevelEvent.

See issue #7714 for a more in depth discussion about the origin of this
pull request.