### PR TITLE
Fix shears not properly breaking tripwire (MC-129055)

### DIFF
--- a/patches/minecraft/net/minecraft/block/TripWireHookBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TripWireHookBlock.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/block/TripWireHookBlock.java
++++ b/net/minecraft/block/TripWireHookBlock.java
+@@ -150,8 +150,8 @@
+             BlockPos blockpos2 = p_176260_2_.func_177967_a(direction, k);
+             BlockState blockstate2 = ablockstate[k];
+             if (blockstate2 != null) {
++               if (!p_176260_1_.func_180495_p(blockpos2).func_196958_f()) { // FORGE: fix MC-129055
+                p_176260_1_.func_180501_a(blockpos2, blockstate2.func_206870_a(field_176265_M, Boolean.valueOf(flag2)), 3);
+-               if (!p_176260_1_.func_180495_p(blockpos2).func_196958_f()) {
+                }
+             }
+          }


### PR DESCRIPTION
Shears when breaking tripwire are supposed to deactivate the tripwire to prevent tripwire hooks from triggering. However, they randomly do not properly breaking the tripwire, instead immediately replacing after breaking ([MC-129055](https://bugs.mojang.com/browse/MC-129055))

Apparently Mojang had the condition to fix this problem, but the problematic code was not inside the condition. Essentially part of the tripwire update logic iterates all relevant tripwire blocks in the area, and attaches them if relevant.

----

As far as replicating the bug, I typically place tripwire hooks at ground level and connect them with string. Then I just break and replace a piece of tripwire a few times until its triggered. I get the issue a bit less than 50% of the time. One you are confident that the issue is in fact happening, rebuild with this patch and you shouldn't see the bug happening.