### PR TITLE
Fix cats, phantoms and pillagers saying they're at BlockPos.ZERO during LivingSpawnEvent.CheckSpawn

### DIFF
--- a/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
@@ -4,10 +4,10 @@
        if (catentity == null) {
           return 0;
        } else {
--         catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
-          catentity.func_174828_a(p_221122_1_, 0.0F, 0.0F);
++         catentity.func_174828_a(p_221122_1_, 0.0F, 0.0F); // Fix MC-147659: Some witch huts spawn the incorrect cat
 +         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(catentity, p_221122_2_, p_221122_1_.func_177958_n(), p_221122_1_.func_177956_o(), p_221122_1_.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
-+         catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
+          catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
+-         catentity.func_174828_a(p_221122_1_, 0.0F, 0.0F);
           p_221122_2_.func_242417_l(catentity);
           return 1;
        }

--- a/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/CatSpawner.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/world/spawner/CatSpawner.java
 +++ b/net/minecraft/world/spawner/CatSpawner.java
-@@ -80,6 +_,7 @@
+@@ -80,8 +_,9 @@
        if (catentity == null) {
           return 0;
        } else {
-+         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(catentity, p_221122_2_, p_221122_1_.func_177958_n(), p_221122_1_.func_177956_o(), p_221122_1_.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
-          catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
+-         catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
           catentity.func_174828_a(p_221122_1_, 0.0F, 0.0F);
++         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(catentity, p_221122_2_, p_221122_1_.func_177958_n(), p_221122_1_.func_177956_o(), p_221122_1_.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
++         catentity.func_213386_a(p_221122_2_, p_221122_2_.func_175649_E(p_221122_1_), SpawnReason.NATURAL, (ILivingEntityData)null, (CompoundNBT)null);
           p_221122_2_.func_242417_l(catentity);
+          return 1;
+       }

--- a/patches/minecraft/net/minecraft/world/spawner/PatrolSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/PatrolSpawner.java.patch
@@ -1,10 +1,10 @@
 --- a/net/minecraft/world/spawner/PatrolSpawner.java
 +++ b/net/minecraft/world/spawner/PatrolSpawner.java
-@@ -94,6 +_,7 @@
-          return false;
-       } else {
-          PatrollerEntity patrollerentity = EntityType.field_220350_aJ.func_200721_a(p_222695_1_);
-+         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollerentity, p_222695_1_, p_222695_2_.func_177958_n(), p_222695_2_.func_177956_o(), p_222695_2_.func_177952_p(), null, SpawnReason.PATROL) == -1) return false;
-          if (patrollerentity != null) {
-             if (p_222695_4_) {
-                patrollerentity.func_213635_r(true);
+@@ -101,6 +_,7 @@
+             }
+ 
+             patrollerentity.func_70107_b((double)p_222695_2_.func_177958_n(), (double)p_222695_2_.func_177956_o(), (double)p_222695_2_.func_177952_p());
++            if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollerentity, p_222695_1_, p_222695_2_.func_177958_n(), p_222695_2_.func_177956_o(), p_222695_2_.func_177952_p(), null, SpawnReason.PATROL) == -1) return false;
+             patrollerentity.func_213386_a(p_222695_1_, p_222695_1_.func_175649_E(p_222695_2_), SpawnReason.PATROL, (ILivingEntityData)null, (CompoundNBT)null);
+             p_222695_1_.func_242417_l(patrollerentity);
+             return true;

--- a/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/spawner/PhantomSpawner.java.patch
@@ -1,10 +1,10 @@
 --- a/net/minecraft/world/spawner/PhantomSpawner.java
 +++ b/net/minecraft/world/spawner/PhantomSpawner.java
-@@ -57,6 +_,7 @@
- 
+@@ -58,6 +_,7 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      PhantomEntity phantomentity = EntityType.field_203097_aH.func_200721_a(p_230253_1_);
-+                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
                                      phantomentity.func_174828_a(blockpos1, 0.0F, 0.0F);
++                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.func_177958_n(), blockpos1.func_177956_o(), blockpos1.func_177952_p(), null, SpawnReason.NATURAL) == -1) return 0;
                                      ilivingentitydata = phantomentity.func_213386_a(p_230253_1_, difficultyinstance, SpawnReason.NATURAL, ilivingentitydata, (CompoundNBT)null);
                                      p_230253_1_.func_242417_l(phantomentity);
+                                  }


### PR DESCRIPTION
# The Problem

Phantoms, Cats, and Pillagers from a Pillager Patrol do not set their positions until after `ForgeHooks.canEntitySpawn` is called.


# The Cause

Let's take a look at the phantom spawner.

As a result of my Forge PR, `net.minecraft.world.spawner.PhantomSpawner`,

the relevant method section look like this (lines 59 to 63 shown).

```java
PhantomEntity phantomentity = EntityType.PHANTOM.create(p_230253_1_);
if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.getX(), blockpos1.getY(), blockpos1.getZ(), null, SpawnReason.NATURAL) == -1) return 0;
phantomentity.moveTo(blockpos1, 0.0F, 0.0F);
ilivingentitydata = phantomentity.finalizeSpawn(p_230253_1_, difficultyinstance, SpawnReason.NATURAL, ilivingentitydata, (CompoundNBT)null);
p_230253_1_.addFreshEntityWithPassengers(phantomentity);
```

First, the phantom is created. This sets the default location to `BlockPos.ZERO`.

This happens in `net.minecraft.entity.Entity` on line 205.

Second, the ForgeHook to fire the `LivingSpawnEvent.CheckSpawn` event.

Third, the phantom is moved to the desired `blockpos1`.

The relevant method section looks like this (lines 199 to 207 shown).


```java
public Entity(EntityType<?> p_i48580_1_, World p_i48580_2_) {
  super(Entity.class);
  this.type = p_i48580_1_;
  this.level = p_i48580_2_;
  this.dimensions = p_i48580_1_.getDimensions();
  this.position = Vector3d.ZERO;
  this.blockPosition = BlockPos.ZERO;
  this.packetCoordinates = Vector3d.ZERO;
  this.setPos(0.0D, 0.0D, 0.0D);
```

`BlockPos.ZERO` is just `new BlockPos(0, 0, 0)`. 


Finally, the phantom's spawn is finalized.

Note that the event is fired before the phantom is moved to `blockpos`!

I should have correctly made sure that the event was fired after the entity's position was moved to the correct location.

However I failed to do so because I didn't think it would cause that big of a deal at the time. However, mods only really check the Entity's location, which is set to `BlockPos.ZERO`.

This value is technically correct at the time, as the entity hasn't been moved yet, but extremely unhelpful, since it doesn't show where the entity is going to be.

# The Solution

The solution is to just make sure that the event is always fired after the entity is moved to its correct location.

This is exactly what this patch does.

I do understand that this is an extremely minor patch, but I wanted to open it anyway to make awareness of the issue that I introduced.
