### PR TITLE
Fix #7738

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -172,10 +172,11 @@ public class ClientHooks
         Minecraft.getInstance().getTextureManager().bind(iconSheet);
         AbstractGui.blit(mStack, x + width - 18, y + 10, 16, 16, 0, idx, 16, 16, 256, 256);
 
-        if(relativeMouseX > width - 15 && relativeMouseX < width && relativeMouseY > 10 && relativeMouseY < 26)
-            //TODO using StringTextComponent here is a hack, we should be using TranslationTextComponents.
-            gui.setToolTip(Collections.singletonList(new StringTextComponent(tooltip)));
-
+        if(relativeMouseX > width - 15 && relativeMouseX < width && relativeMouseY > 10 && relativeMouseY < 26) {
+            //this is not the most proper way to do it,
+            //but works best here and has the least maintenance overhead
+            gui.setToolTip(Arrays.stream(tooltip.split("\n")).map(StringTextComponent::new).collect(Collectors.toList()));
+        }
     }
 
     public static String fixDescription(String description)


### PR DESCRIPTION
It's not really pretty, but trying to use `TranslationTextComponent` there seems to require more work, and this works for all use cases.