### PR TITLE
[1.16.x] Add additional context to block side render check

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -19,6 +19,14 @@
     }
  
     @Deprecated
+@@ -112,6 +_,7 @@
+       return p_196271_1_;
+    }
+ 
++   /** Override {@link net.minecraftforge.common.extensions.IForgeBlock#skipRendering(IBlockReader, BlockPos, BlockState, BlockState, Direction)} instead */
+    @Deprecated
+    @OnlyIn(Dist.CLIENT)
+    public boolean func_200122_a(BlockState p_200122_1_, BlockState p_200122_2_, Direction p_200122_3_) {
 @@ -129,7 +_,7 @@
  
     @Deprecated

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -22,6 +22,15 @@
        this.field_176227_L = builder.func_235882_a_(Block::func_176223_P, BlockState::new);
        this.func_180632_j(this.field_176227_L.func_177621_b());
     }
+@@ -167,7 +_,7 @@
+    public static boolean func_176225_a(BlockState p_176225_0_, IBlockReader p_176225_1_, BlockPos p_176225_2_, Direction p_176225_3_) {
+       BlockPos blockpos = p_176225_2_.func_177972_a(p_176225_3_);
+       BlockState blockstate = p_176225_1_.func_180495_p(blockpos);
+-      if (p_176225_0_.func_200017_a(blockstate, p_176225_3_)) {
++      if (p_176225_0_.skipRendering(p_176225_1_, p_176225_2_, blockstate, p_176225_3_)) { //FORGE: add additional context
+          return false;
+       } else if (blockstate.func_200132_m()) {
+          Block.RenderSideCacheKey block$rendersidecachekey = new Block.RenderSideCacheKey(p_176225_0_, blockstate, p_176225_3_);
 @@ -261,7 +_,7 @@
     }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -923,4 +923,19 @@ public interface IForgeBlock
     {
         return state.is(Blocks.SCAFFOLDING);
     }
+
+    /**
+     * Checks if the side of this block should not be rendered
+     *
+     * @param world The world
+     * @param pos The block position in world
+     * @param state This blocks state
+     * @param neighborState This blocks neighbor on the given side
+     * @param side The side that is being checked
+     * @return True if the given side should not be rendered
+     */
+    default boolean skipRendering(IBlockReader world, BlockPos pos, BlockState state, BlockState neighborState, Direction side)
+    {
+        return getBlock().skipRendering(state, neighborState, side);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -808,4 +808,18 @@ public interface IForgeBlockState
     {
         return getBlockState().getBlock().isScaffolding(getBlockState(), entity.level, entity.blockPosition(), entity);
     }
+
+    /**
+     * Checks if the side of this block should not be rendered
+     *
+     * @param world The world
+     * @param pos The block position in world
+     * @param neighborState This blocks neighbor on the given side
+     * @param side The side that is being checked
+     * @return True if the given side should not be rendered
+     */
+    default boolean skipRendering(IBlockReader world, BlockPos pos, BlockState neighborState, Direction side)
+    {
+        return getBlockState().getBlock().skipRendering(world, pos, getBlockState(), neighborState, side);
+    }
 }


### PR DESCRIPTION
This PR adds additional context to the block side render check by introducing an alternate method to `AbstractBlock#skipRendering()` in `IForgeBlock`.
This is useful for mods adding blocks that can change their appearance and need data stored in the `TileEntity` to decide if a side should be hidden or not.