### PR TITLE
Replace hardcoded check for dirt in AnimalEntity#checkAnimalSpawnRules.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/AnimalEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AnimalEntity.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/entity/passive/AnimalEntity.java
 +++ b/net/minecraft/entity/passive/AnimalEntity.java
+@@ -98,7 +_,7 @@
+    }
+ 
+    public static boolean func_223316_b(EntityType<? extends AnimalEntity> p_223316_0_, IWorld p_223316_1_, SpawnReason p_223316_2_, BlockPos p_223316_3_, Random p_223316_4_) {
+-      return p_223316_1_.func_180495_p(p_223316_3_.func_177977_b()).func_203425_a(Blocks.field_196658_i) && p_223316_1_.func_226659_b_(p_223316_3_, 0) > 8;
++      return p_223316_1_.func_180495_p(p_223316_3_.func_177977_b()).func_235714_a_(net.minecraftforge.common.Tags.Blocks.CREATURE_SPAWN) && p_223316_1_.func_226659_b_(p_223316_3_, 0) > 8;
+    }
+ 
+    public int func_70627_aG() {
 @@ -199,6 +_,17 @@
  
     public void func_234177_a_(ServerWorld p_234177_1_, AnimalEntity p_234177_2_) {

--- a/src/generated/resources/data/forge/tags/blocks/creatures_can_spawn.json
+++ b/src/generated/resources/data/forge/tags/blocks/creatures_can_spawn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:grass_block"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -57,6 +57,7 @@ public class Tags
         public static final IOptionalNamedTag<Block> FENCES = tag("fences");
         public static final IOptionalNamedTag<Block> FENCES_NETHER_BRICK = tag("fences/nether_brick");
         public static final IOptionalNamedTag<Block> FENCES_WOODEN = tag("fences/wooden");
+        public static final IOptionalNamedTag<Block> CREATURE_SPAWN = tag("creatures_can_spawn");
 
         public static final IOptionalNamedTag<Block> GLASS = tag("glass");
         public static final IOptionalNamedTag<Block> GLASS_BLACK = tag("glass/black");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -46,6 +46,7 @@ public class ForgeBlockTagsProvider extends BlockTagsProvider
     @Override
     public void addTags()
     {
+        tag(CREATURE_SPAWN).add(Blocks.GRASS_BLOCK);
         tag(BARRELS).addTag(BARRELS_WOODEN);
         tag(BARRELS_WOODEN).add(Blocks.BARREL);
         tag(CHESTS).addTags(CHESTS_ENDER, CHESTS_TRAPPED, CHESTS_WOODEN);


### PR DESCRIPTION
Changes the check for Blocks.GRASS_BLOCK to a new Forge tag, creatures_can_spawn, which contains grass block by default.
Mods can add to this tag to make creatures spawnable on their custom blocks.

Closes #7685 