### PR TITLE
Fix old assumption that ItemStacks may be null in FluidBucketWrapper

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -67,7 +67,7 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
         {
             return true;
         }
-        return fluid.getFluid().getAttributes().getBucket(fluid) != null;
+        return !fluid.getFluid().getAttributes().getBucket(fluid).isEmpty();
     }
 
     @Nonnull


### PR DESCRIPTION
Previously, `FluidBucketWrapper#canFillFluidType` checked for `getBucket(...)` returning null.
ItemStacks now use `ItemStack.EMPTY` rather than null.
Closes #7670.