### PR TITLE
Fix OBJ Loader Generator's "materialLibraryOverride" string

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/OBJLoaderBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/OBJLoaderBuilder.java
@@ -110,7 +110,7 @@ public class OBJLoaderBuilder<T extends ModelBuilder<T>> extends CustomLoaderBui
             json.addProperty("ambientToFullbright", ambientToFullbright);
 
         if (materialLibraryOverrideLocation != null)
-            json.addProperty("materialLibraryOverrideLocation", materialLibraryOverrideLocation.toString());
+            json.addProperty("materialLibraryOverride", materialLibraryOverrideLocation.toString());
 
         return json;
     }


### PR DESCRIPTION
The OBJ Loader datagen provider previously added a key called `materialLibraryOverrideLocation`, but the OBJ Loader itself is looking for `materialLibraryOverride`:
https://github.com/MinecraftForge/MinecraftForge/blob/19f8d2a7937dc7968ecbef2f9785687193fcd210/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java#L67

Closes #7616