### PR TITLE
Comply with PlayerEvent.BreakSpeed's pos being nullable.

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -126,7 +126,7 @@ public class PlayerEvent extends LivingEvent
             this.state = state;
             this.originalSpeed = original;
             this.setNewSpeed(original);
-            this.pos = pos;
+            this.pos = pos != null ? pos : new BlockPos(0, -1, 0);
         }
 
         public BlockState getState() { return state; }


### PR DESCRIPTION
As @malte0811 noted in #7615, the BreakSpeed event is fired with Nullable position:
https://github.com/MinecraftForge/MinecraftForge/blob/19f8d2a7937dc7968ecbef2f9785687193fcd210/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch#L100-L108

but the event itself just passes it through with no double checking.
The javadoc mentions that a y position of -1 indicates unknown position, so I added a null check:
```
this.pos = pos != null ? pos : new BlockPos(0, -1, 0);
```

This retains compatibility with mods that were written according to the javadoc, and avoids an accidental breaking change.

Closes #7615.