### PR TITLE
Reinstate the MinecartCollisionHandler field to AbstractMinecartEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
@@ -25,22 +25,21 @@
  
     protected AbstractMinecartEntity(EntityType<?> p_i48538_1_, World p_i48538_2_) {
        super(p_i48538_1_, p_i48538_2_);
-@@ -104,6 +_,15 @@
+@@ -103,6 +_,14 @@
+       this.field_70167_r = p_i48539_5_;
        this.field_70166_s = p_i48539_7_;
     }
- 
++   
 +   public net.minecraftforge.common.IMinecartCollisionHandler getCollisionHandler() {
 +      return COLLISIONS;
 +   }
 +
-+   // IMinecartCollisionHandler redirects here via comment. We ensure it exists and it works.
 +   public static void registerCollisionHandler(@Nullable net.minecraftforge.common.IMinecartCollisionHandler handler) {
 +      COLLISIONS = handler;
 +   }
-+
+ 
     public static AbstractMinecartEntity func_184263_a(World p_184263_0_, double p_184263_1_, double p_184263_3_, double p_184263_5_, AbstractMinecartEntity.Type p_184263_7_) {
        if (p_184263_7_ == AbstractMinecartEntity.Type.CHEST) {
-          return new ChestMinecartEntity(p_184263_0_, p_184263_1_, p_184263_3_, p_184263_5_);
 @@ -138,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/minecart/AbstractMinecartEntity.java.patch
@@ -9,6 +9,14 @@
     private static final DataParameter<Integer> field_184265_a = EntityDataManager.func_187226_a(AbstractMinecartEntity.class, DataSerializers.field_187192_b);
     private static final DataParameter<Integer> field_184266_b = EntityDataManager.func_187226_a(AbstractMinecartEntity.class, DataSerializers.field_187192_b);
     private static final DataParameter<Float> field_184267_c = EntityDataManager.func_187226_a(AbstractMinecartEntity.class, DataSerializers.field_187193_c);
+@@ -77,6 +_,7 @@
+       p_226574_0_.put(RailShape.NORTH_WEST, Pair.of(vector3i2, vector3i));
+       p_226574_0_.put(RailShape.NORTH_EAST, Pair.of(vector3i2, vector3i1));
+    });
++   private static net.minecraftforge.common.IMinecartCollisionHandler COLLISIONS = null;
+    private int field_70510_h;
+    private double field_70511_i;
+    private double field_70509_j;
 @@ -89,6 +_,7 @@
     private double field_70507_ar;
     @OnlyIn(Dist.CLIENT)
@@ -17,6 +25,22 @@
  
     protected AbstractMinecartEntity(EntityType<?> p_i48538_1_, World p_i48538_2_) {
        super(p_i48538_1_, p_i48538_2_);
+@@ -104,6 +_,15 @@
+       this.field_70166_s = p_i48539_7_;
+    }
+ 
++   public net.minecraftforge.common.IMinecartCollisionHandler getCollisionHandler() {
++      return COLLISIONS;
++   }
++
++   // IMinecartCollisionHandler redirects here via comment. We ensure it exists and it works.
++   public static void registerCollisionHandler(@Nullable net.minecraftforge.common.IMinecartCollisionHandler handler) {
++      COLLISIONS = handler;
++   }
++
+    public static AbstractMinecartEntity func_184263_a(World p_184263_0_, double p_184263_1_, double p_184263_3_, double p_184263_5_, AbstractMinecartEntity.Type p_184263_7_) {
+       if (p_184263_7_ == AbstractMinecartEntity.Type.CHEST) {
+          return new ChestMinecartEntity(p_184263_0_, p_184263_1_, p_184263_3_, p_184263_5_);
 @@ -138,7 +_,7 @@
     }
  

--- a/src/main/java/net/minecraftforge/common/IMinecartCollisionHandler.java
+++ b/src/main/java/net/minecraftforge/common/IMinecartCollisionHandler.java
@@ -25,7 +25,7 @@ import net.minecraft.entity.item.minecart.AbstractMinecartEntity;
 
 /**
  * This class defines a replacement for the default minecart collision code.
- * Only one handler can be registered at a time. It it registered with EntityMinecart.registerCollisionHandler().
+ * Only one handler can be registered at a time. It it registered with AbstractMinecartEntity.registerCollisionHandler().
  * If you use this, make it a configuration option.
  * @author CovertJaguar
  */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
@@ -32,6 +32,7 @@ public interface IForgeEntityMinecart
     public static float DEFAULT_MAX_SPEED_AIR_LATERAL = 0.4f;
     public static float DEFAULT_MAX_SPEED_AIR_VERTICAL = -1.0f;
     public static double DEFAULT_AIR_DRAG = 0.95f;
+    /** TODO: Remove 1.17 */
     public static IMinecartCollisionHandler COLLISIONS = null;
 
     default AbstractMinecartEntity getMinecart() {
@@ -41,6 +42,7 @@ public interface IForgeEntityMinecart
     /**
      * Gets the current global Minecart Collision handler if none
      * is registered, returns null
+     * TODO: remove 1.17
      * @return The collision handler or null
      */
     default IMinecartCollisionHandler getCollisionHandler() {


### PR DESCRIPTION
Some time during the 1.12 update cycle, the `IMinecartCollisionHandler` functionality was moved out of EntityMinecart and into a new interface `IForgeEntityMinecart`.
Unfortunately the static field containing the current handler was moved with it, and due to interface fields being implicitly `public static final`, and initialized to `null`, it (and the getter) became totally unusable.

This PR moves the field and getter (plus the `registerCollisionHandler` function that was dropped in the move to the interface) back to `AbstractMinecartEntity`, making this field usable for vanilla minecarts again.

Since `AbstractMinecartEntity` is such a usable and prominent template used in almost every mod that uses Minecarts nowadays, I also added comments calling for the removal of the `IForgeEntityMinecart` field and getter, since it's (normally) impossible for them to return anything except null.