### PR TITLE
Fix "userProperties" errors for 1.12.x users. (Backport of #6740)

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
@@ -22,10 +22,14 @@ package net.minecraftforge.fml.common.launcher;
 import java.net.Proxy;
 import java.util.Map;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 import org.apache.logging.log4j.LogManager;
 
 import com.mojang.authlib.Agent;
 import com.mojang.authlib.exceptions.AuthenticationException;
+import com.mojang.authlib.properties.PropertyMap;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication;
 
@@ -52,9 +56,11 @@ public class Yggdrasil
             throw new RuntimeException(e); // don't set other variables
         }
 
+        Gson gson = (new GsonBuilder()).registerTypeAdapter(PropertyMap.class, new PropertyMap.Serializer()).create();
+
         args.put("--username",       auth.getSelectedProfile().getName());
         args.put("--uuid",           auth.getSelectedProfile().getId().toString().replace("-", ""));
         args.put("--accessToken",    auth.getAuthenticatedToken());
-        args.put("--userProperties", auth.getUserProperties().toString());
+        args.put("--userProperties", gson.toJson(auth.getUserProperties()));
     }
 }


### PR DESCRIPTION
Hi!

This is a fix for the problem where users with properties on their account cannot use the forge launcher. I have verified locally that it solves the problem for me. The fix is a straightforward backport of #6740; it's not a trivial cherry-pick since the code was in i different file, but the logic behind the fix is the same.

I understand if you guys just want to get rid of 1.12 already (trust me, I do too!) but due to Circumstances™️, it's not always that easy, and me (and certainly others!) are still stuck in the history. Please accept this PR, for our sake.