### PR TITLE
Inconsistent Attribute Modifier Order

### DIFF
--- a/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
@@ -19,7 +19,7 @@
 
 package net.minecraftforge.event;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimaps;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.entity.ai.attributes.Attribute;
@@ -82,7 +82,7 @@ public class ItemAttributeModifierEvent extends Event
     {
         if (this.modifiableModifiers == null)
         {
-            this.modifiableModifiers = HashMultimap.create(this.originalModifiers);
+            this.modifiableModifiers = LinkedHashMultimap.create(this.originalModifiers);
             this.unmodifiableModifiers = Multimaps.unmodifiableMultimap(this.modifiableModifiers);
         }
         return this.modifiableModifiers;


### PR DESCRIPTION
Currently, attribute modifiers added through the ItemAttributeModifierEvent are unreadable in the item tooltips because the order of the attribute modifiers is inconsistent in a HashMultimap and the attribute modifiers just keep on changing position on the tooltip. However, changing the attribute modifier HashMultimap to a LinkedHashMultimap causes the order of the attribute modifiers to be consistent and readable. 