### PR TITLE
[1.16.x] Remove redundant mobgriefing check

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/SmallFireballEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/SmallFireballEntity.java.patch
@@ -5,7 +5,7 @@
        if (!this.field_70170_p.field_72995_K) {
           Entity entity = this.func_234616_v_();
 -         if (entity == null || !(entity instanceof MobEntity) || this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223599_b)) {
-+         if (entity == null || !(entity instanceof MobEntity) || this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223599_b) || net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this.getEntity())) {
++         if (entity == null || !(entity instanceof MobEntity) || net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this.getEntity())) {
              BlockPos blockpos = p_230299_1_.func_216350_a().func_177972_a(p_230299_1_.func_216354_b());
              if (this.field_70170_p.func_175623_d(blockpos)) {
                 this.field_70170_p.func_175656_a(blockpos, AbstractFireBlock.func_235326_a_(this.field_70170_p, blockpos));


### PR DESCRIPTION
The patch for SmallFireballEntity is applied incorrectly, the
MobGriefingEvent was added but the original GameRule check was not
removed.
As a result if the mobGriefing game rule is set to `true` then the event is never
fired and the default behaviour can not be overridden.