### PR TITLE
[1.16.x] Use MobGriefingEvent for PiglinEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/PiglinEntity.java.patch
@@ -9,3 +9,12 @@
           this.func_184201_a(EquipmentSlotType.OFFHAND, p_234439_1_);
           this.func_233663_d_(EquipmentSlotType.OFFHAND);
        } else {
+@@ -317,7 +_,7 @@
+    }
+ 
+    public boolean func_230293_i_(ItemStack p_230293_1_) {
+-      return this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223599_b) && this.func_98052_bS() && PiglinTasks.func_234474_a_(this, p_230293_1_);
++      return net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this) && this.func_98052_bS() && PiglinTasks.func_234474_a_(this, p_230293_1_);
+    }
+ 
+    protected boolean func_234440_o_(ItemStack p_234440_1_) {


### PR DESCRIPTION
PiglinEntity has a mobGriefing check using the game rules directly,
instead of using the MobGriefingEvent.
Add a patch to use the Forge event when determining whether Piglins want
to pick up items.

From what I can tell this won't change any behaviour, because the code that calls this function does a separate check using the MobGriefingEvent. I wanted to raise this PR more for consistency reasons.