### PR TITLE
[1.16.x] Use wither as griefing entity for roses

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -160,7 +160,7 @@
           boolean flag = false;
           if (p_226298_1_ instanceof WitherEntity) {
 -            if (this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223599_b)) {
-+            if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this)) {
++            if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, p_226298_1_)) {
                 BlockPos blockpos = this.func_233580_cy_();
                 BlockState blockstate = Blocks.field_222388_bz.func_176223_P();
 -               if (this.field_70170_p.func_180495_p(blockpos).func_196958_f() && blockstate.func_196955_c(this.field_70170_p, blockpos)) {


### PR DESCRIPTION
A MobGriefingEvent is fired when a LivingEntity is killed by a WitherEntity, the outcome of the event is used to determine whether to create a WitherRoseBlock or WitherRose item.

The entity passed to the MobGriefingEvent is currently the LivingEntity being killed, but I feel that it would be more intuitive if it was the WitherEntity itself.
All other mobGriefing events are based on the entity taking an action (movement, attacking etc.) so it feels like the attacking Wither should be the owner of this particular behaviour, rather than the entity who is passively dying.

I realise this deviates slightly from how the other MobGriefingEvents are done, so I'll accept this being rejected if its not something that warrants consideration/discussion.