### PR TITLE
Make DoorBlock.isWoodenDoor use the wooden doors tag

### DIFF
--- a/patches/minecraft/net/minecraft/block/DoorBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/DoorBlock.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/block/DoorBlock.java
++++ b/net/minecraft/block/DoorBlock.java
+@@ -224,6 +_,6 @@
+    }
+ 
+    public static boolean func_235492_h_(BlockState p_235492_0_) {
+-      return p_235492_0_.func_177230_c() instanceof DoorBlock && (p_235492_0_.func_185904_a() == Material.field_151575_d || p_235492_0_.func_185904_a() == Material.field_237214_y_);
++      return p_235492_0_.func_177230_c() instanceof DoorBlock && p_235492_0_.func_177230_c().func_203417_a(net.minecraft.tags.BlockTags.field_200152_g);
+    }
+ }


### PR DESCRIPTION
Previously, villagers closing doors required the tag, but opening the door was based on a material check, meaning that doors that do not have `Materials.WOOD` will be unable to be opened by villagers. In addition, some mob path finding is based on this method, to determine if a door block is openable without redstone. As a result of this patch, mods can add doors which can be controlled by hand but are not wood to the tag `minecraft:wooden_doors` and villagers will be able to fully control the door. Since this is all serverside only logic, it seems safe to use a tag in patches.

To test this patch, use [this attached datapack](https://github.com/MinecraftForge/MinecraftForge/files/6476415/DoorMadness.zip). It will tag iron doors as `minecraft:wooden_doors`, allowing villagers to open iron doors. You can use a bell to force a villager to run inside.

Actual use cases:
* I have a "slimewood" door which is effectively wood, but not broken by an axe (so it uses a different material). This would allow treating that door as wooden doors for villagers
* I have a glass door that similarly has the wrong material for villagers to use it

----

It is worth noting to get the desired behavior, doors that are not logically wooden will be added to the wooden doors tag by mods. Semantically this is a little odd if mods are expecting that tag to contain only doors that are logically wood. However, recipes would be unaffected as only the block tag needs wooden doors for this functionality, and not the item tag.

If this is still considered a problem, there are a few potential changes:
* Forge could add separate wooden tags for mods that want to check if something is logically wood
* Forge could add a new tag (e.g. `forge:interactable_doors`) for the desired functionality for this pull request. I did not do that innitially as it would increase the patch number quite a bit, especially as I did not feel it was right to replace the logic inside `DoorBlock.isWoodenDoor` to use a tag that is not labeled wooden, so I would have to instead update places that call that method (essentially the same problem before adding the new tag)

If either of those solutions is preferred I can change my patch to match.
