### PR TITLE
Fix for ignored quotes in translation entries #7396

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ForgeI18n.java
+++ b/src/main/java/net/minecraftforge/fml/ForgeI18n.java
@@ -107,7 +107,12 @@ public class ForgeI18n {
     }
 
     public static String parseFormat(final String format, final Object... args) {
-        final ExtendedMessageFormat extendedMessageFormat = new ExtendedMessageFormat(format, customFactories);
+        String replacedFormat = format;
+        if (format.contains("'")) {
+            int count = org.apache.commons.lang3.StringUtils.countMatches(format, "'");
+            if (count % 2 == 0) replacedFormat = replacedFormat.replaceAll("'", "''");
+        }
+        final ExtendedMessageFormat extendedMessageFormat = new ExtendedMessageFormat(replacedFormat, customFactories);
         return extendedMessageFormat.format(args);
     }
 


### PR DESCRIPTION
This PR fixes issue #7396 by escaping single apostrophes if a format string contains an even number of them.

Here's an example of this fix for the problem detailed in the original issue:
![7396](https://user-images.githubusercontent.com/34078206/118370107-7a8a1380-b5a6-11eb-86e7-b207c2068cc9.png)