### PR TITLE
RFC for 1.17: New API for HUD overlays

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.client.event;
 import java.util.ArrayList;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraftforge.client.gui.IIngameOverlay;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.client.MainWindow;
@@ -53,27 +54,12 @@ public class RenderGameOverlayEvent extends Event
     public static enum ElementType
     {
         ALL,
-        HELMET,
-        PORTAL,
-        CROSSHAIRS,
-        BOSSHEALTH, // All boss bars
+        LAYER,
         BOSSINFO,    // Individual boss bar
-        ARMOR,
-        HEALTH,
-        FOOD,
-        AIR,
-        HOTBAR,
-        EXPERIENCE,
         TEXT,
-        HEALTHMOUNT,
-        JUMPBAR,
         CHAT,
         PLAYER_LIST,
-        DEBUG,
-        POTION_ICONS,
-        SUBTITLES,
-        FPS_GRAPH,
-        VIGNETTE
+        DEBUG
     }
 
     private final MatrixStack mStack;
@@ -114,6 +100,38 @@ public class RenderGameOverlayEvent extends Event
         @Override public boolean isCancelable(){ return false; }
     }
 
+    public static class PreLayer extends Pre
+    {
+        private final IIngameOverlay overlay;
+
+        public PreLayer(MatrixStack mStack, RenderGameOverlayEvent parent, IIngameOverlay overlay)
+        {
+            super(mStack, parent, ElementType.LAYER);
+            this.overlay = overlay;
+        }
+
+        public IIngameOverlay getOverlay()
+        {
+            return overlay;
+        }
+    }
+
+    public static class PostLayer extends Post
+    {
+        private final IIngameOverlay overlay;
+
+        public PostLayer(MatrixStack mStack, RenderGameOverlayEvent parent, IIngameOverlay overlay)
+        {
+            super(mStack, parent, ElementType.LAYER);
+            this.overlay = overlay;
+        }
+
+        public IIngameOverlay getOverlay()
+        {
+            return overlay;
+        }
+    }
+
     public static class BossInfo extends Pre
     {
         private final ClientBossInfo bossInfo;
@@ -130,7 +148,7 @@ public class RenderGameOverlayEvent extends Event
         }
 
         /**
-         * @return The {@link BossInfoClient} currently being rendered
+         * @return The {@link ClientBossInfo} currently being rendered
          */
         public ClientBossInfo getBossInfo()
         {

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -59,6 +59,8 @@ import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
+import javax.annotation.Nullable;
+
 @SuppressWarnings("deprecation")
 public class ForgeIngameGui extends IngameGui
 {
@@ -99,6 +101,265 @@ public class ForgeIngameGui extends IngameGui
     //private static final String MC_VERSION = MinecraftForge.MC_VERSION;
     private GuiOverlayDebugForge debugOverlay;
 
+    public void setupOverlayRenderState(boolean blend, boolean alpha, boolean depthText)
+    {
+        setupOverlayRenderState(blend, alpha, depthText, AbstractGui.GUI_ICONS_LOCATION);
+    }
+    
+    public void setupOverlayRenderState(boolean blend, boolean alpha, boolean depthTest, @Nullable ResourceLocation texture)
+    {
+        if (blend)
+        {
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+        }
+        else
+        {
+            RenderSystem.disableBlend();
+        }
+
+        if (alpha)
+        {
+            RenderSystem.enableAlphaTest();
+        }
+        else
+        {
+            RenderSystem.disableAlphaTest();
+        }
+
+        if (depthTest)
+        {
+            RenderSystem.enableDepthTest();
+        }
+        else
+        {
+            RenderSystem.disableDepthTest();
+        }
+
+        if (texture != null)
+        {
+            RenderSystem.enableTexture();
+            bind(texture);
+        }
+        else
+        {
+            RenderSystem.disableTexture();
+        }
+        
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+    }
+
+    public static final IIngameOverlay VIGNETTE_ELEMENT = OverlayRegistry.registerOverlay(10, "Vignette", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderVignette && Minecraft.useFancyGraphics())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderVignette(gui.minecraft.getCameraEntity());
+        }
+    });
+
+    public static final IIngameOverlay HELMET_ELEMENT = OverlayRegistry.registerOverlay(20, "Helmet", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderHelmet)
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderHelmet(partialTicks, mStack);
+        }
+    });
+
+    public static final IIngameOverlay HOTBAR_ELEMENT = OverlayRegistry.registerOverlay(30, "Hotbar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (!gui.minecraft.options.hideGui)
+        {
+            if (gui.minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR)
+            {
+                if (renderSpectatorTooltip)
+                {
+                    gui.setupOverlayRenderState(true, false, false);
+                    gui.spectatorGui.renderHotbar(mStack, partialTicks);
+                }
+            }
+            else
+            {
+                if (renderHotbar)
+                {
+                    gui.setupOverlayRenderState(true, false, false);
+                    gui.renderHotbar(partialTicks, mStack);
+                }
+            }
+        }
+    });
+
+    public static final IIngameOverlay PORTAL_ELEMENT = OverlayRegistry.registerOverlay(40, "Portal", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+
+        if (renderPortal && !gui.minecraft.player.hasEffect(Effects.CONFUSION))
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderPortalOverlay(partialTicks);
+        }
+
+    });
+
+    public static final IIngameOverlay CROSSHAIR_ELEMENT = OverlayRegistry.registerOverlay(50, "Crosshair", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderCrosshairs && !gui.minecraft.options.hideGui)
+        {
+            gui.setupOverlayRenderState(true, true, false);
+            gui.setBlitOffset(-90);
+            gui.random.setSeed((long) (gui.tickCount * 312871));
+
+            gui.renderCrosshair(mStack);
+        }
+    });
+
+    public static final IIngameOverlay BOSS_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(60, "Boss Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderBossHealth && !gui.minecraft.options.hideGui)
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.setBlitOffset(-90);
+            gui.random.setSeed((long) (gui.tickCount * 312871));
+
+            gui.renderBossHealth(mStack);
+        }
+    });
+
+    public static final IIngameOverlay PLAYER_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(70, "Player Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderHealth && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderHealth(screenWidth, screenHeight, mStack);
+        }
+    });
+
+    public static final IIngameOverlay ARMOR_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(80, "Armor Level",(gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderArmor && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderArmor(mStack, screenWidth, screenHeight);
+        }
+    });
+
+    public static final IIngameOverlay FOOD_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(90, "Food Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderFood && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderFood(screenWidth, screenHeight, mStack);
+        }
+    });
+
+    public static final IIngameOverlay MOUNT_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(100, "Mount Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderHealthMount && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderHealthMount(screenWidth, screenHeight, mStack);
+        }
+    });
+
+    public static final IIngameOverlay AIR_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(110, "Air Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderAir && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderAir(screenWidth, screenHeight, mStack);
+        }
+    });
+
+    public static final IIngameOverlay JUMP_BAR_ELEMENT = OverlayRegistry.registerOverlay(120, "Jump Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderJumpBar && !gui.minecraft.options.hideGui)
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderJumpMeter(mStack, screenWidth / 2 - 91);
+        }
+    });
+
+    public static final IIngameOverlay EXPERIENCE_BAR_ELEMENT = OverlayRegistry.registerOverlay(130, "Experience Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (renderExperiance && !renderJumpBar && !gui.minecraft.options.hideGui)
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            gui.renderExperience(screenWidth / 2 - 91, mStack);
+        }
+    });
+
+    public static final IIngameOverlay ITEM_NAME_ELEMENT = OverlayRegistry.registerOverlay(140, "Item Name", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (!gui.minecraft.options.hideGui)
+        {
+            gui.setupOverlayRenderState(true, false, false);
+            if (gui.minecraft.options.heldItemTooltips && gui.minecraft.gameMode.getPlayerMode() != GameType.SPECTATOR) {
+                gui.renderSelectedItemName(mStack);
+            } else if (gui.minecraft.player.isSpectator()) {
+                gui.spectatorGui.renderTooltip(mStack);
+            }
+        }
+    });
+
+    public static final IIngameOverlay SLEEP_FADE_ELEMENT = OverlayRegistry.registerOverlay(150, "Sleep Fade", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        gui.renderSleepFade(screenWidth, screenHeight, mStack);
+    });
+
+    public static final IIngameOverlay HUD_TEXT_ELEMENT = OverlayRegistry.registerOverlay(160, "Text Columns", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        gui.renderHUDText(screenWidth, screenHeight, mStack);
+    });
+
+    public static final IIngameOverlay FPS_GRAPH_ELEMENT = OverlayRegistry.registerOverlay(170, "FPS Graph", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        gui.renderFPSGraph(mStack);
+    });
+
+    public static final IIngameOverlay POTION_ICONS_ELEMENT = OverlayRegistry.registerOverlay(180, "Potion Icons", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        gui.renderEffects(mStack);
+    });
+
+    public static final IIngameOverlay RECORD_OVERLAY_ELEMENT = OverlayRegistry.registerOverlay(190, "Record", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (!gui.minecraft.options.hideGui)
+        {
+            gui.renderRecordOverlay(screenWidth, screenHeight, partialTicks, mStack);
+        }
+    });
+
+    public static final IIngameOverlay SUBTITLES_ELEMENT = OverlayRegistry.registerOverlay(200, "Subtitles", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (!gui.minecraft.options.hideGui)
+        {
+            gui.renderSubtitles(mStack);
+        }
+    });
+
+    public static final IIngameOverlay TITLE_TEXT_ELEMENT = OverlayRegistry.registerOverlay(210, "Title Text", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+        if (!gui.minecraft.options.hideGui)
+        {
+            gui.renderTitle(screenWidth, screenHeight, partialTicks, mStack);
+        }
+    });
+
+    public static final IIngameOverlay SCOREBOARD_ELEMENT = OverlayRegistry.registerOverlay(220, "Scoreboard", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+
+        Scoreboard scoreboard = gui.minecraft.level.getScoreboard();
+        ScoreObjective objective = null;
+        ScorePlayerTeam scoreplayerteam = scoreboard.getPlayersTeam(gui.minecraft.player.getScoreboardName());
+        if (scoreplayerteam != null)
+        {
+            int slot = scoreplayerteam.getColor().getId();
+            if (slot >= 0) objective = scoreboard.getDisplayObjective(3 + slot);
+        }
+        ScoreObjective scoreobjective1 = objective != null ? objective : scoreboard.getDisplayObjective(1);
+        if (renderObjective && scoreobjective1 != null)
+        {
+            gui.displayScoreboardSidebar(mStack, scoreobjective1);
+        }
+
+    });
+
+    public static final IIngameOverlay CHAT_PANEL_ELEMENT = OverlayRegistry.registerOverlay(230, "Chat History", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+        RenderSystem.disableAlphaTest();
+
+        gui.renderChat(screenWidth, screenHeight, mStack);
+    });
+
+    public static final IIngameOverlay PLAYER_LIST_ELEMENT = OverlayRegistry.registerOverlay(240, "Player List", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+        RenderSystem.disableAlphaTest();
+
+        gui.renderPlayerList(screenWidth, screenHeight, mStack);
+    });
+
     public ForgeIngameGui(Minecraft mc)
     {
         super(mc);
@@ -121,100 +382,15 @@ public class ForgeIngameGui extends IngameGui
         if (pre(ALL, mStack)) return;
 
         fontrenderer = minecraft.font;
+
         //mc.entityRenderer.setupOverlayRendering();
-        RenderSystem.enableBlend();
-        if (renderVignette && Minecraft.useFancyGraphics())
-        {
-            renderVignette(minecraft.getCameraEntity());
-        }
-        else
-        {
-            RenderSystem.enableDepthTest();
-            RenderSystem.defaultBlendFunc();
-        }
 
-        if (renderHelmet) renderHelmet(partialTicks, mStack);
-
-        if (renderPortal && !minecraft.player.hasEffect(Effects.CONFUSION))
-        {
-            renderPortalOverlay(partialTicks);
-        }
-
-        if (this.minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR)
-        {
-            if (renderSpectatorTooltip) spectatorGui.renderHotbar(mStack, partialTicks);
-        }
-        else if (!this.minecraft.options.hideGui)
-        {
-            if (renderHotbar) renderHotbar(partialTicks, mStack);
-        }
-
-        if (!this.minecraft.options.hideGui) {
-            RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-            setBlitOffset(-90);
-            random.setSeed((long)(tickCount * 312871));
-
-            if (renderCrosshairs) renderCrosshair(mStack);
-            if (renderBossHealth) renderBossHealth(mStack);
-
-            RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-            if (this.minecraft.gameMode.canHurtPlayer() && this.minecraft.getCameraEntity() instanceof PlayerEntity)
-            {
-                if (renderHealth) renderHealth(this.screenWidth, this.screenHeight, mStack);
-                if (renderArmor)  renderArmor(mStack, this.screenWidth, this.screenHeight);
-                if (renderFood)   renderFood(this.screenWidth, this.screenHeight, mStack);
-                if (renderHealthMount) renderHealthMount(this.screenWidth, this.screenHeight, mStack);
-                if (renderAir)    renderAir(this.screenWidth, this.screenHeight, mStack);
-            }
-
-            if (renderJumpBar)
-            {
-                renderJumpMeter(mStack, this.screenWidth / 2 - 91);
-            }
-            else if (renderExperiance)
-            {
-                renderExperience(this.screenWidth / 2 - 91, mStack);
-            }
-            if (this.minecraft.options.heldItemTooltips && this.minecraft.gameMode.getPlayerMode() != GameType.SPECTATOR) {
-                this.renderSelectedItemName(mStack);
-             } else if (this.minecraft.player.isSpectator()) {
-                this.spectatorGui.renderTooltip(mStack);
-             }
-        }
-
-        renderSleepFade(this.screenWidth, this.screenHeight, mStack);
-
-        renderHUDText(this.screenWidth, this.screenHeight, mStack);
-        renderFPSGraph(mStack);
-        renderEffects(mStack);
-        if (!minecraft.options.hideGui) {
-            renderRecordOverlay(this.screenWidth, this.screenHeight, partialTicks, mStack);
-            renderSubtitles(mStack);
-            renderTitle(this.screenWidth, this.screenHeight, partialTicks, mStack);
-        }
-
-
-        Scoreboard scoreboard = this.minecraft.level.getScoreboard();
-        ScoreObjective objective = null;
-        ScorePlayerTeam scoreplayerteam = scoreboard.getPlayersTeam(minecraft.player.getScoreboardName());
-        if (scoreplayerteam != null)
-        {
-            int slot = scoreplayerteam.getColor().getId();
-            if (slot >= 0) objective = scoreboard.getDisplayObjective(3 + slot);
-        }
-        ScoreObjective scoreobjective1 = objective != null ? objective : scoreboard.getDisplayObjective(1);
-        if (renderObjective && scoreobjective1 != null)
-        {
-            this.displayScoreboardSidebar(mStack, scoreobjective1);
-        }
-
-        RenderSystem.enableBlend();
-        RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-        RenderSystem.disableAlphaTest();
-
-        renderChat(this.screenWidth, this.screenHeight, mStack);
-
-        renderPlayerList(this.screenWidth, this.screenHeight, mStack);
+        OverlayRegistry.getOrdered().forEach(overlay ->
+                {
+                    if (pre(overlay, mStack)) return;
+                    overlay.render(this, mStack, partialTicks, screenWidth, screenHeight);
+                    post(overlay, mStack);
+                });
 
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.enableAlphaTest();
@@ -222,35 +398,18 @@ public class ForgeIngameGui extends IngameGui
         post(ALL, mStack);
     }
 
-    @Override
-    protected void renderCrosshair(MatrixStack mStack)
+    public boolean shouldDrawSurvivalElements()
     {
-        if (pre(CROSSHAIRS, mStack)) return;
-        bind(AbstractGui.GUI_ICONS_LOCATION);
-        RenderSystem.enableBlend();
-        RenderSystem.enableAlphaTest();
-        super.renderCrosshair(mStack);
-        post(CROSSHAIRS, mStack);
-    }
-
-    @Override
-    protected void renderEffects(MatrixStack mStack)
-    {
-        if (pre(POTION_ICONS, mStack)) return;
-        super.renderEffects(mStack);
-        post(POTION_ICONS, mStack);
+        return minecraft.gameMode.canHurtPlayer() && minecraft.getCameraEntity() instanceof PlayerEntity;
     }
 
     protected void renderSubtitles(MatrixStack mStack)
     {
-        if (pre(SUBTITLES, mStack)) return;
         this.subtitleOverlay.render(mStack);
-        post(SUBTITLES, mStack);
     }
 
     protected void renderBossHealth(MatrixStack mStack)
     {
-        if (pre(BOSSHEALTH, mStack)) return;
         bind(AbstractGui.GUI_ICONS_LOCATION);
         RenderSystem.defaultBlendFunc();
         minecraft.getProfiler().push("bossHealth");
@@ -258,28 +417,12 @@ public class ForgeIngameGui extends IngameGui
         this.bossOverlay.render(mStack);
         RenderSystem.disableBlend();
         minecraft.getProfiler().pop();
-        post(BOSSHEALTH, mStack);
     }
-
-    @Override
-    protected void renderVignette(Entity entity)
-    {
-        MatrixStack mStack = new MatrixStack();
-        if (pre(VIGNETTE, mStack))
-        {
-            // Need to put this here, since Vanilla assumes this state after the vignette was rendered.
-            RenderSystem.enableDepthTest();
-            RenderSystem.defaultBlendFunc();
-            return;
-        }
-        super.renderVignette(entity);
-        post(VIGNETTE, mStack);
-    }
-
 
     private void renderHelmet(float partialTicks, MatrixStack mStack)
     {
-        if (pre(HELMET, mStack)) return;
+        RenderSystem.enableDepthTest();
+        RenderSystem.defaultBlendFunc();
 
         ItemStack itemstack = this.minecraft.player.inventory.getArmor(3);
 
@@ -295,13 +438,10 @@ public class ForgeIngameGui extends IngameGui
                 item.renderHelmetOverlay(itemstack, minecraft.player, this.screenWidth, this.screenHeight, partialTicks);
             }
         }
-
-        post(HELMET, mStack);
     }
 
     protected void renderArmor(MatrixStack mStack, int width, int height)
     {
-        if (pre(ARMOR, mStack)) return;
         minecraft.getProfiler().push("armor");
 
         RenderSystem.enableBlend();
@@ -329,45 +469,21 @@ public class ForgeIngameGui extends IngameGui
 
         RenderSystem.disableBlend();
         minecraft.getProfiler().pop();
-        post(ARMOR, mStack);
     }
 
     @Override
     protected void renderPortalOverlay(float partialTicks)
     {
-        MatrixStack mStack = new MatrixStack();
-        if (pre(PORTAL, mStack)) return;
-
         float f1 = minecraft.player.oPortalTime + (minecraft.player.portalTime - minecraft.player.oPortalTime) * partialTicks;
 
         if (f1 > 0.0F)
         {
             super.renderPortalOverlay(f1);
         }
-
-        post(PORTAL, mStack);
-    }
-
-    @Override
-    protected void renderHotbar(float partialTicks, MatrixStack mStack)
-    {
-        if (pre(HOTBAR, mStack)) return;
-
-        if (minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR)
-        {
-            this.spectatorGui.renderHotbar(mStack, partialTicks);
-        }
-        else
-        {
-            super.renderHotbar(partialTicks, mStack);
-        }
-
-        post(HOTBAR, mStack);
     }
 
     protected void renderAir(int width, int height, MatrixStack mStack)
     {
-        if (pre(AIR, mStack)) return;
         minecraft.getProfiler().push("air");
         PlayerEntity player = (PlayerEntity)this.minecraft.getCameraEntity();
         RenderSystem.enableBlend();
@@ -389,13 +505,12 @@ public class ForgeIngameGui extends IngameGui
 
         RenderSystem.disableBlend();
         minecraft.getProfiler().pop();
-        post(AIR, mStack);
     }
 
     public void renderHealth(int width, int height, MatrixStack mStack)
     {
         bind(GUI_ICONS_LOCATION);
-        if (pre(HEALTH, mStack)) return;
+
         minecraft.getProfiler().push("health");
         RenderSystem.enableBlend();
 
@@ -495,12 +610,10 @@ public class ForgeIngameGui extends IngameGui
 
         RenderSystem.disableBlend();
         minecraft.getProfiler().pop();
-        post(HEALTH, mStack);
     }
 
     public void renderFood(int width, int height, MatrixStack mStack)
     {
-        if (pre(FOOD, mStack)) return;
         minecraft.getProfiler().push("food");
 
         PlayerEntity player = (PlayerEntity)this.minecraft.getCameraEntity();
@@ -542,7 +655,6 @@ public class ForgeIngameGui extends IngameGui
         }
         RenderSystem.disableBlend();
         minecraft.getProfiler().pop();
-        post(FOOD, mStack);
     }
 
     protected void renderSleepFade(int width, int height, MatrixStack mStack)
@@ -571,7 +683,6 @@ public class ForgeIngameGui extends IngameGui
     protected void renderExperience(int x, MatrixStack mStack)
     {
         bind(GUI_ICONS_LOCATION);
-        if (pre(EXPERIENCE, mStack)) return;
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.disableBlend();
 
@@ -581,15 +692,12 @@ public class ForgeIngameGui extends IngameGui
         }
         RenderSystem.enableBlend();
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-
-        post(EXPERIENCE, mStack);
     }
 
     @Override
     public void renderJumpMeter(MatrixStack mStack, int x)
     {
         bind(GUI_ICONS_LOCATION);
-        if (pre(JUMPBAR, mStack)) return;
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.disableBlend();
 
@@ -598,8 +706,6 @@ public class ForgeIngameGui extends IngameGui
         RenderSystem.enableBlend();
         minecraft.getProfiler().pop();
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-
-        post(JUMPBAR, mStack);
     }
 
     protected void renderHUDText(int width, int height, MatrixStack mStack)
@@ -660,10 +766,9 @@ public class ForgeIngameGui extends IngameGui
 
     protected void renderFPSGraph(MatrixStack mStack)
     {
-        if (this.minecraft.options.renderDebug && this.minecraft.options.renderFpsChart && !pre(FPS_GRAPH, mStack))
+        if (this.minecraft.options.renderDebug && this.minecraft.options.renderFpsChart)
         {
             this.debugOverlay.render(mStack);
-            post(FPS_GRAPH, mStack);
         }
     }
 
@@ -779,8 +884,6 @@ public class ForgeIngameGui extends IngameGui
 
         bind(GUI_ICONS_LOCATION);
 
-        if (pre(HEALTHMOUNT, mStack)) return;
-
         boolean unused = false;
         int left_align = width / 2 + 91;
 
@@ -819,7 +922,6 @@ public class ForgeIngameGui extends IngameGui
             right_height += 10;
         }
         RenderSystem.disableBlend();
-        post(HEALTHMOUNT, mStack);
     }
 
     //Helper macros
@@ -830,6 +932,14 @@ public class ForgeIngameGui extends IngameGui
     private void post(ElementType type, MatrixStack mStack)
     {
         MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.Post(mStack, eventParent, type));
+    }
+    private boolean pre(IIngameOverlay overlay, MatrixStack mStack)
+    {
+        return MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.PreLayer(mStack, eventParent, overlay));
+    }
+    private void post(IIngameOverlay overlay, MatrixStack mStack)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.PostLayer(mStack, eventParent, overlay));
     }
     private void bind(ResourceLocation res)
     {
@@ -862,4 +972,5 @@ public class ForgeIngameGui extends IngameGui
         }
         private List<String> getRight(){ return this.getSystemInformation(); }
     }
+
 }

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -55,6 +55,8 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.common.MinecraftForge;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -64,6 +66,8 @@ import javax.annotation.Nullable;
 @SuppressWarnings("deprecation")
 public class ForgeIngameGui extends IngameGui
 {
+    private static final Logger LOGGER = LogManager.getLogger();
+
     //private static final ResourceLocation VIGNETTE     = new ResourceLocation("textures/misc/vignette.png");
     //private static final ResourceLocation WIDGITS      = new ResourceLocation("textures/gui/widgets.png");
     //private static final ResourceLocation PUMPKIN_BLUR = new ResourceLocation("textures/misc/pumpkinblur.png");
@@ -149,7 +153,7 @@ public class ForgeIngameGui extends IngameGui
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
     }
 
-    public static final IIngameOverlay VIGNETTE_ELEMENT = OverlayRegistry.registerOverlay(10, "Vignette", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay VIGNETTE_ELEMENT = OverlayRegistry.registerOverlayTop("Vignette", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderVignette && Minecraft.useFancyGraphics())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -157,7 +161,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay HELMET_ELEMENT = OverlayRegistry.registerOverlay(20, "Helmet", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay HELMET_ELEMENT = OverlayRegistry.registerOverlayTop("Helmet", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderHelmet)
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -165,7 +169,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay HOTBAR_ELEMENT = OverlayRegistry.registerOverlay(30, "Hotbar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay HOTBAR_ELEMENT = OverlayRegistry.registerOverlayTop("Hotbar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (!gui.minecraft.options.hideGui)
         {
             if (gui.minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR)
@@ -187,7 +191,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay PORTAL_ELEMENT = OverlayRegistry.registerOverlay(40, "Portal", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay PORTAL_ELEMENT = OverlayRegistry.registerOverlayTop("Portal", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
 
         if (renderPortal && !gui.minecraft.player.hasEffect(Effects.CONFUSION))
         {
@@ -197,7 +201,7 @@ public class ForgeIngameGui extends IngameGui
 
     });
 
-    public static final IIngameOverlay CROSSHAIR_ELEMENT = OverlayRegistry.registerOverlay(50, "Crosshair", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay CROSSHAIR_ELEMENT = OverlayRegistry.registerOverlayTop("Crosshair", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderCrosshairs && !gui.minecraft.options.hideGui)
         {
             gui.setupOverlayRenderState(true, true, false);
@@ -208,7 +212,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay BOSS_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(60, "Boss Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay BOSS_HEALTH_ELEMENT = OverlayRegistry.registerOverlayTop("Boss Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderBossHealth && !gui.minecraft.options.hideGui)
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -219,7 +223,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay PLAYER_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(70, "Player Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay PLAYER_HEALTH_ELEMENT = OverlayRegistry.registerOverlayTop("Player Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderHealth && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -227,7 +231,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay ARMOR_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(80, "Armor Level",(gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay ARMOR_LEVEL_ELEMENT = OverlayRegistry.registerOverlayTop("Armor Level",(gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderArmor && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -235,7 +239,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay FOOD_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(90, "Food Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay FOOD_LEVEL_ELEMENT = OverlayRegistry.registerOverlayTop("Food Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderFood && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -243,7 +247,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay MOUNT_HEALTH_ELEMENT = OverlayRegistry.registerOverlay(100, "Mount Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay MOUNT_HEALTH_ELEMENT = OverlayRegistry.registerOverlayTop("Mount Health", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderHealthMount && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -251,7 +255,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay AIR_LEVEL_ELEMENT = OverlayRegistry.registerOverlay(110, "Air Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay AIR_LEVEL_ELEMENT = OverlayRegistry.registerOverlayTop("Air Level", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderAir && !gui.minecraft.options.hideGui && gui.shouldDrawSurvivalElements())
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -259,7 +263,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay JUMP_BAR_ELEMENT = OverlayRegistry.registerOverlay(120, "Jump Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay JUMP_BAR_ELEMENT = OverlayRegistry.registerOverlayTop("Jump Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderJumpBar && !gui.minecraft.options.hideGui)
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -267,7 +271,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay EXPERIENCE_BAR_ELEMENT = OverlayRegistry.registerOverlay(130, "Experience Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay EXPERIENCE_BAR_ELEMENT = OverlayRegistry.registerOverlayTop("Experience Bar", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (renderExperiance && !renderJumpBar && !gui.minecraft.options.hideGui)
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -275,7 +279,7 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay ITEM_NAME_ELEMENT = OverlayRegistry.registerOverlay(140, "Item Name", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay ITEM_NAME_ELEMENT = OverlayRegistry.registerOverlayTop("Item Name", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (!gui.minecraft.options.hideGui)
         {
             gui.setupOverlayRenderState(true, false, false);
@@ -287,44 +291,44 @@ public class ForgeIngameGui extends IngameGui
         }
     });
 
-    public static final IIngameOverlay SLEEP_FADE_ELEMENT = OverlayRegistry.registerOverlay(150, "Sleep Fade", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay SLEEP_FADE_ELEMENT = OverlayRegistry.registerOverlayTop("Sleep Fade", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         gui.renderSleepFade(screenWidth, screenHeight, mStack);
     });
 
-    public static final IIngameOverlay HUD_TEXT_ELEMENT = OverlayRegistry.registerOverlay(160, "Text Columns", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay HUD_TEXT_ELEMENT = OverlayRegistry.registerOverlayTop("Text Columns", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         gui.renderHUDText(screenWidth, screenHeight, mStack);
     });
 
-    public static final IIngameOverlay FPS_GRAPH_ELEMENT = OverlayRegistry.registerOverlay(170, "FPS Graph", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay FPS_GRAPH_ELEMENT = OverlayRegistry.registerOverlayTop("FPS Graph", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         gui.renderFPSGraph(mStack);
     });
 
-    public static final IIngameOverlay POTION_ICONS_ELEMENT = OverlayRegistry.registerOverlay(180, "Potion Icons", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay POTION_ICONS_ELEMENT = OverlayRegistry.registerOverlayTop("Potion Icons", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         gui.renderEffects(mStack);
     });
 
-    public static final IIngameOverlay RECORD_OVERLAY_ELEMENT = OverlayRegistry.registerOverlay(190, "Record", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay RECORD_OVERLAY_ELEMENT = OverlayRegistry.registerOverlayTop("Record", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (!gui.minecraft.options.hideGui)
         {
             gui.renderRecordOverlay(screenWidth, screenHeight, partialTicks, mStack);
         }
     });
 
-    public static final IIngameOverlay SUBTITLES_ELEMENT = OverlayRegistry.registerOverlay(200, "Subtitles", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay SUBTITLES_ELEMENT = OverlayRegistry.registerOverlayTop("Subtitles", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (!gui.minecraft.options.hideGui)
         {
             gui.renderSubtitles(mStack);
         }
     });
 
-    public static final IIngameOverlay TITLE_TEXT_ELEMENT = OverlayRegistry.registerOverlay(210, "Title Text", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay TITLE_TEXT_ELEMENT = OverlayRegistry.registerOverlayTop("Title Text", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
         if (!gui.minecraft.options.hideGui)
         {
             gui.renderTitle(screenWidth, screenHeight, partialTicks, mStack);
         }
     });
 
-    public static final IIngameOverlay SCOREBOARD_ELEMENT = OverlayRegistry.registerOverlay(220, "Scoreboard", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay SCOREBOARD_ELEMENT = OverlayRegistry.registerOverlayTop("Scoreboard", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
 
         Scoreboard scoreboard = gui.minecraft.level.getScoreboard();
         ScoreObjective objective = null;
@@ -342,7 +346,7 @@ public class ForgeIngameGui extends IngameGui
 
     });
 
-    public static final IIngameOverlay CHAT_PANEL_ELEMENT = OverlayRegistry.registerOverlay(230, "Chat History", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay CHAT_PANEL_ELEMENT = OverlayRegistry.registerOverlayTop("Chat History", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
 
         RenderSystem.enableBlend();
         RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
@@ -351,7 +355,7 @@ public class ForgeIngameGui extends IngameGui
         gui.renderChat(screenWidth, screenHeight, mStack);
     });
 
-    public static final IIngameOverlay PLAYER_LIST_ELEMENT = OverlayRegistry.registerOverlay(240, "Player List", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
+    public static final IIngameOverlay PLAYER_LIST_ELEMENT = OverlayRegistry.registerOverlayTop("Player List", (gui, mStack, partialTicks, screenWidth, screenHeight) -> {
 
         RenderSystem.enableBlend();
         RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
@@ -385,12 +389,20 @@ public class ForgeIngameGui extends IngameGui
 
         //mc.entityRenderer.setupOverlayRendering();
 
-        OverlayRegistry.getOrdered().forEach(overlay ->
-                {
-                    if (pre(overlay, mStack)) return;
-                    overlay.render(this, mStack, partialTicks, screenWidth, screenHeight);
-                    post(overlay, mStack);
-                });
+        OverlayRegistry.orderedEntries().forEach(entry -> {
+            try
+            {
+                if (!entry.isEnabled()) return;
+                IIngameOverlay overlay = entry.getOverlay();
+                if (pre(overlay, mStack)) return;
+                overlay.render(this, mStack, partialTicks, screenWidth, screenHeight);
+                post(overlay, mStack);
+            }
+            catch(Exception e)
+            {
+                LOGGER.error("Error rendering overlay '{}'", entry.getDisplayName(), e);
+            }
+        });
 
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.enableAlphaTest();

--- a/src/main/java/net/minecraftforge/client/gui/IIngameOverlay.java
+++ b/src/main/java/net/minecraftforge/client/gui/IIngameOverlay.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.client.gui;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+public interface IIngameOverlay
+{
+    void render(ForgeIngameGui gui, MatrixStack mStack, float partialTicks, int width, int height);
+}

--- a/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
+++ b/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
@@ -1,0 +1,116 @@
+package net.minecraftforge.client.gui;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class OverlayRegistry
+{
+    public static synchronized IIngameOverlay registerOverlay(int priority, String displayName, IIngameOverlay overlay)
+    {
+        OverlayEntry entry = overlays.get(overlay);
+
+        if (entry != null)
+        {
+            if (entry.priority == priority)
+                return overlay;
+
+            overlaysOrdered.remove(entry);
+        }
+
+        int insertAt;
+        for(insertAt=0; insertAt< overlaysOrdered.size(); insertAt++)
+        {
+            OverlayEntry ov = overlaysOrdered.get(insertAt);
+            if (ov.getPriority() > priority)
+            {
+                break;
+            }
+        }
+
+        entry = new OverlayEntry(priority, overlay, displayName);
+
+        overlaysOrdered.add(insertAt, entry);
+        overlays.put(overlay, entry);
+
+        return overlay;
+    }
+
+    public static synchronized void enableOverlay(IIngameOverlay overlay, boolean enable)
+    {
+        OverlayEntry entry = overlays.get(overlay);
+        if (entry != null)
+        {
+            entry.setEnabled(enable);
+        }
+    }
+
+    public static synchronized void removeOverlay(IIngameOverlay overlay)
+    {
+        OverlayEntry entry = overlays.get(overlay);
+        if (entry != null)
+        {
+            overlays.remove(overlay);
+            overlaysOrdered.remove(entry);
+        }
+    }
+
+    private static final Map<IIngameOverlay, OverlayEntry> overlays = Maps.newHashMap();
+    private static final List<OverlayEntry> overlaysOrdered = Lists.newArrayList();
+
+    public static Stream<IIngameOverlay> getOrdered()
+    {
+        return overlaysOrdered.stream().map(o -> o.overlay);
+    }
+
+    public static List<OverlayEntry> orderedEntries()
+    {
+        return Collections.unmodifiableList(overlaysOrdered);
+    }
+
+    public static class OverlayEntry {
+
+        private final int priority;
+        private final IIngameOverlay overlay;
+        private final String displayName;
+        private boolean enabled = true;
+
+        public OverlayEntry(int priority, IIngameOverlay overlay, String displayName)
+        {
+            this.priority = priority;
+            this.overlay = overlay;
+            this.displayName = displayName;
+        }
+
+        public int getPriority()
+        {
+            return priority;
+        }
+
+        public IIngameOverlay getOverlay()
+        {
+            return overlay;
+        }
+
+        public String getDisplayName()
+        {
+            return displayName;
+        }
+
+        public boolean isEnabled()
+        {
+            return enabled;
+        }
+
+        // Call via OverlayRegistry.enableOverlay
+        private void setEnabled(boolean enabled)
+        {
+            this.enabled = enabled;
+        }
+    }
+
+}

--- a/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
+++ b/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
@@ -3,6 +3,7 @@ package net.minecraftforge.client.gui;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -11,40 +12,56 @@ import java.util.Map;
 public class OverlayRegistry
 {
     /**
-     * Adds a new overlay entry to the registry, placed at the end of the list.
-     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
-     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
-     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
-     * @return The same object passed into the {@param overlay} parameter.
-     */
-    public static synchronized IIngameOverlay registerOverlayTop(String displayName, IIngameOverlay overlay)
-    {
-        return registerOverlay(1, null, displayName, overlay);
-    }
-
-    /**
      * Adds a new overlay entry to the registry, placed at the beginning of the list.
      * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
      * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
      * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
      * @return The same object passed into the {@param overlay} parameter.
      */
-    public static synchronized IIngameOverlay registerOverlayBottom(String displayName, IIngameOverlay overlay)
+    public static synchronized IIngameOverlay registerOverlayBottom(@Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
         return registerOverlay(-1, null, displayName, overlay);
     }
 
-    public static synchronized IIngameOverlay registerOverlayAbove(IIngameOverlay other, String displayName, IIngameOverlay overlay)
-    {
-        return registerOverlay(1, other, displayName, overlay);
-    }
-
-    public static synchronized IIngameOverlay registerOverlayBelow(IIngameOverlay other, String displayName, IIngameOverlay overlay)
+    /**
+     * Adds a new overlay entry to the registry, placed at the beginning of the list.
+     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
+     * @param other The overlay to insert before. The overlay must be registered.
+     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
+     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
+     * @return The same object passed into the {@param overlay} parameter.
+     */
+    public static synchronized IIngameOverlay registerOverlayBelow(@Nonnull IIngameOverlay other, @Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
         return registerOverlay(-1, other, displayName, overlay);
     }
 
-    private static IIngameOverlay registerOverlay(int sort, @Nullable IIngameOverlay other, String displayName, IIngameOverlay overlay)
+    /**
+     * Adds a new overlay entry to the registry, placed at the beginning of the list.
+     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
+     * @param other The overlay to insert after. The overlay must be registered.
+     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
+     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
+     * @return The same object passed into the {@param overlay} parameter.
+     */
+    public static synchronized IIngameOverlay registerOverlayAbove(@Nonnull IIngameOverlay other, @Nonnull String displayName, @Nonnull IIngameOverlay overlay)
+    {
+        return registerOverlay(1, other, displayName, overlay);
+    }
+
+    /**
+     * Adds a new overlay entry to the registry, placed at the end of the list.
+     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
+     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
+     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
+     * @return The same object passed into the {@param overlay} parameter.
+     */
+    public static synchronized IIngameOverlay registerOverlayTop(@Nonnull String displayName, @Nonnull IIngameOverlay overlay)
+    {
+        return registerOverlay(1, null, displayName, overlay);
+    }
+
+    private static IIngameOverlay registerOverlay(int sort, @Nullable IIngameOverlay other, @Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
         OverlayEntry entry = overlays.get(overlay);
 
@@ -53,15 +70,14 @@ public class OverlayRegistry
             overlaysOrdered.remove(entry);
         }
 
-        int insertAt;
+        int insertAt = overlays.size();
         if (other == null)
         {
-            if (sort < 0) insertAt = 0;
-            else insertAt = overlays.size();
+            if (sort < 0)
+                insertAt = 0;
         }
         else
         {
-            insertAt = -1;
             for (int i = 0; i < overlaysOrdered.size(); i++)
             {
                 OverlayEntry ov = overlaysOrdered.get(i);
@@ -71,10 +87,6 @@ public class OverlayRegistry
                     else insertAt = i+1;
                     break;
                 }
-            }
-            if (insertAt < 0)
-            {
-                throw new RuntimeException("Error registering overlay " + displayName + ": dependency overlay not found in the list");
             }
         }
 
@@ -91,7 +103,7 @@ public class OverlayRegistry
      * @param overlay The overlay object to enable or disable
      * @param enable The new state
      */
-    public static synchronized void enableOverlay(IIngameOverlay overlay, boolean enable)
+    public static synchronized void enableOverlay(@Nonnull IIngameOverlay overlay, boolean enable)
     {
         OverlayEntry entry = overlays.get(overlay);
         if (entry != null)
@@ -105,7 +117,8 @@ public class OverlayRegistry
      * @param overlay The overlay to obtain the information for.
      * @return The registration entry for this overlay.
      */
-    public static synchronized OverlayEntry getEntry(IIngameOverlay overlay)
+    @Nullable
+    public static synchronized OverlayEntry getEntry(@Nonnull IIngameOverlay overlay)
     {
         return overlays.get(overlay);
     }

--- a/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
+++ b/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
@@ -16,7 +16,7 @@ public class OverlayRegistry
      * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
      * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
      * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
-     * @return The same object passed into the {@param overlay} parameter.
+     * @return The same object passed into the {@code overlay} parameter.
      */
     public static synchronized IIngameOverlay registerOverlayBottom(@Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
@@ -29,7 +29,7 @@ public class OverlayRegistry
      * @param other The overlay to insert before. The overlay must be registered.
      * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
      * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
-     * @return The same object passed into the {@param overlay} parameter.
+     * @return The same object passed into the {@code overlay} parameter.
      */
     public static synchronized IIngameOverlay registerOverlayBelow(@Nonnull IIngameOverlay other, @Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
@@ -42,7 +42,7 @@ public class OverlayRegistry
      * @param other The overlay to insert after. The overlay must be registered.
      * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
      * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
-     * @return The same object passed into the {@param overlay} parameter.
+     * @return The same object passed into the {@code overlay} parameter.
      */
     public static synchronized IIngameOverlay registerOverlayAbove(@Nonnull IIngameOverlay other, @Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {
@@ -54,7 +54,7 @@ public class OverlayRegistry
      * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
      * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
      * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
-     * @return The same object passed into the {@param overlay} parameter.
+     * @return The same object passed into the {@code overlay} parameter.
      */
     public static synchronized IIngameOverlay registerOverlayTop(@Nonnull String displayName, @Nonnull IIngameOverlay overlay)
     {

--- a/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
+++ b/src/main/java/net/minecraftforge/client/gui/OverlayRegistry.java
@@ -3,36 +3,82 @@ package net.minecraftforge.client.gui;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 public class OverlayRegistry
 {
-    public static synchronized IIngameOverlay registerOverlay(int priority, String displayName, IIngameOverlay overlay)
+    /**
+     * Adds a new overlay entry to the registry, placed at the end of the list.
+     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
+     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
+     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
+     * @return The same object passed into the {@param overlay} parameter.
+     */
+    public static synchronized IIngameOverlay registerOverlayTop(String displayName, IIngameOverlay overlay)
+    {
+        return registerOverlay(1, null, displayName, overlay);
+    }
+
+    /**
+     * Adds a new overlay entry to the registry, placed at the beginning of the list.
+     * Call from {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}. No need for enqueueWork.
+     * @param displayName A string for debug purposes, used primarily in exception traces coming from the overlays.
+     * @param overlay An instance, lambda or method reference for the logic used in rendering the overlay.
+     * @return The same object passed into the {@param overlay} parameter.
+     */
+    public static synchronized IIngameOverlay registerOverlayBottom(String displayName, IIngameOverlay overlay)
+    {
+        return registerOverlay(-1, null, displayName, overlay);
+    }
+
+    public static synchronized IIngameOverlay registerOverlayAbove(IIngameOverlay other, String displayName, IIngameOverlay overlay)
+    {
+        return registerOverlay(1, other, displayName, overlay);
+    }
+
+    public static synchronized IIngameOverlay registerOverlayBelow(IIngameOverlay other, String displayName, IIngameOverlay overlay)
+    {
+        return registerOverlay(-1, other, displayName, overlay);
+    }
+
+    private static IIngameOverlay registerOverlay(int sort, @Nullable IIngameOverlay other, String displayName, IIngameOverlay overlay)
     {
         OverlayEntry entry = overlays.get(overlay);
 
         if (entry != null)
         {
-            if (entry.priority == priority)
-                return overlay;
-
             overlaysOrdered.remove(entry);
         }
 
         int insertAt;
-        for(insertAt=0; insertAt< overlaysOrdered.size(); insertAt++)
+        if (other == null)
         {
-            OverlayEntry ov = overlaysOrdered.get(insertAt);
-            if (ov.getPriority() > priority)
+            if (sort < 0) insertAt = 0;
+            else insertAt = overlays.size();
+        }
+        else
+        {
+            insertAt = -1;
+            for (int i = 0; i < overlaysOrdered.size(); i++)
             {
-                break;
+                OverlayEntry ov = overlaysOrdered.get(i);
+                if (ov.getOverlay() == other)
+                {
+                    if (sort < 0) insertAt = i;
+                    else insertAt = i+1;
+                    break;
+                }
+            }
+            if (insertAt < 0)
+            {
+                throw new RuntimeException("Error registering overlay " + displayName + ": dependency overlay not found in the list");
             }
         }
 
-        entry = new OverlayEntry(priority, overlay, displayName);
+        entry = new OverlayEntry(overlay, displayName);
 
         overlaysOrdered.add(insertAt, entry);
         overlays.put(overlay, entry);
@@ -40,6 +86,11 @@ public class OverlayRegistry
         return overlay;
     }
 
+    /**
+     * Enables or disables an overlay. This is preferred over removing overlays.
+     * @param overlay The overlay object to enable or disable
+     * @param enable The new state
+     */
     public static synchronized void enableOverlay(IIngameOverlay overlay, boolean enable)
     {
         OverlayEntry entry = overlays.get(overlay);
@@ -49,64 +100,65 @@ public class OverlayRegistry
         }
     }
 
-    public static synchronized void removeOverlay(IIngameOverlay overlay)
+    /**
+     * Returns the information on a registered overlay.
+     * @param overlay The overlay to obtain the information for.
+     * @return The registration entry for this overlay.
+     */
+    public static synchronized OverlayEntry getEntry(IIngameOverlay overlay)
     {
-        OverlayEntry entry = overlays.get(overlay);
-        if (entry != null)
-        {
-            overlays.remove(overlay);
-            overlaysOrdered.remove(entry);
-        }
+        return overlays.get(overlay);
     }
 
-    private static final Map<IIngameOverlay, OverlayEntry> overlays = Maps.newHashMap();
-    private static final List<OverlayEntry> overlaysOrdered = Lists.newArrayList();
-
-    public static Stream<IIngameOverlay> getOrdered()
-    {
-        return overlaysOrdered.stream().map(o -> o.overlay);
-    }
-
+    /**
+     * @return Returns an unmodifiable view of the ordered list of entries.
+     */
     public static List<OverlayEntry> orderedEntries()
     {
         return Collections.unmodifiableList(overlaysOrdered);
     }
 
-    public static class OverlayEntry {
+    private static final Map<IIngameOverlay, OverlayEntry> overlays = Maps.newHashMap();
+    private static final List<OverlayEntry> overlaysOrdered = Lists.newArrayList();
 
-        private final int priority;
+    public static class OverlayEntry {
         private final IIngameOverlay overlay;
         private final String displayName;
         private boolean enabled = true;
 
-        public OverlayEntry(int priority, IIngameOverlay overlay, String displayName)
+        public OverlayEntry(IIngameOverlay overlay, String displayName)
         {
-            this.priority = priority;
             this.overlay = overlay;
             this.displayName = displayName;
         }
 
-        public int getPriority()
-        {
-            return priority;
-        }
-
+        /**
+         * @return Returns the overlay renderer.
+         */
         public IIngameOverlay getOverlay()
         {
             return overlay;
         }
 
+        /**
+         * @return Returns the debug name for this entry.
+         */
         public String getDisplayName()
         {
             return displayName;
         }
 
+        /**
+         * @return Returns true if the entry will be rendered.
+         */
         public boolean isEnabled()
         {
             return enabled;
         }
 
-        // Call via OverlayRegistry.enableOverlay
+        /**
+         * For internal use. Call via {@link #enableOverlay(IIngameOverlay, boolean)}.
+         */
         private void setEnabled(boolean enabled)
         {
             this.enabled = enabled;

--- a/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
@@ -28,7 +28,7 @@ public class OverlayLayersTest
         List<OverlayRegistry.OverlayEntry> overlays = OverlayRegistry.orderedEntries();
         for(int i=0;i<overlays.size();i++)
         {
-            OverlayRegistry.OverlayEntry entry = overlays.get(overlayIndex);
+            OverlayRegistry.OverlayEntry entry = overlays.get(i);
             event.getLeft().add(String.format(overlayIndex == i ? "> %s [%s] <" : "  %s [%s]  ", entry.getDisplayName(), entry.isEnabled()));
         }
     }

--- a/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
@@ -1,0 +1,69 @@
+package net.minecraftforge.debug.client;
+
+import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.client.gui.OverlayRegistry;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.List;
+
+@Mod("overlay_layers_test")
+public class OverlayLayersTest
+{
+    public OverlayLayersTest()
+    {
+        MinecraftForge.EVENT_BUS.addListener(this::renderTextEvent);
+        MinecraftForge.EVENT_BUS.addListener(this::keyInputEvent);
+    }
+
+    int overlayIndex = 0;
+
+    public void renderTextEvent(RenderGameOverlayEvent.Text event)
+    {
+        if (event.getType() != RenderGameOverlayEvent.ElementType.TEXT)
+            return;
+
+        List<OverlayRegistry.OverlayEntry> overlays = OverlayRegistry.orderedEntries();
+        for(int i=0;i<overlays.size();i++)
+        {
+            OverlayRegistry.OverlayEntry entry = overlays.get(overlayIndex);
+            event.getLeft().add(String.format(overlayIndex == i ? "> %s [%s] <" : "  %s [%s]  ", entry.getDisplayName(), entry.isEnabled()));
+        }
+    }
+
+    public void keyInputEvent(InputEvent.KeyInputEvent event)
+    {
+        if (event.getAction() != GLFW.GLFW_PRESS)
+            return;
+
+        if (event.getKey() == GLFW.GLFW_KEY_J)
+        {
+            List<OverlayRegistry.OverlayEntry> overlays = OverlayRegistry.orderedEntries();
+            if (overlayIndex >= overlays.size())
+                overlayIndex = 0;
+            else
+                overlayIndex = (overlayIndex + overlays.size() - 1) % overlays.size();
+        }
+        else if (event.getKey() == GLFW.GLFW_KEY_K)
+        {
+            List<OverlayRegistry.OverlayEntry> overlays = OverlayRegistry.orderedEntries();
+            if (overlayIndex >= overlays.size())
+                overlayIndex = 0;
+            else
+                overlayIndex = (overlayIndex + 1) % overlays.size();
+        }
+        else if (event.getKey() == GLFW.GLFW_KEY_I)
+        {
+            List<OverlayRegistry.OverlayEntry> overlays = OverlayRegistry.orderedEntries();
+            if (overlayIndex >= overlays.size())
+                overlayIndex = 0;
+            else
+            {
+                OverlayRegistry.OverlayEntry entry = overlays.get(overlayIndex);
+                OverlayRegistry.enableOverlay(entry.getOverlay(), !entry.isEnabled());
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -122,3 +122,5 @@ license="LGPL v2.1"
     modId="enum_argument_test"
 [[mods]]
     modId="entity_teleport_event_test"
+[[mods]]
+    modId="overlay_layers_test"


### PR DESCRIPTION
## What this does

1. Introduces a registry-based overlay list, with a basic dependency ordering option (**not** topological sorting).
2. Gives all current render elements their own overlay entry.
3. Reworks the RenderGameOverlayEvent to accomodate this new system: overlay layers become RenderGameOverlayEvent.PreLayer/PostLayer.

## What does doesn't do

1. It does not remove RenderGameOverlayEvent.
2. It does not change which layers exist in the rendering.
3. It does not change the order in which vanilla layers render.

## How it would be used

### To add a new layer

Call `OverlayRegistry.registerOverlayBottom`, `OverlayRegistry.registerOverlayBelow`, `OverlayRegistry.registerOverlayAbove`, or `OverlayRegistry.registerOverlayTop`, during FMLClientSetupEvent. This method is synchronized so there's no need for enqueueWork,

To know what priority value you want to use, look at `ForgeIngameGui` for which priorities are assigned to the vanilla layers.

### To hide or un-hide an existing layer

Call `OverlayRegistry.enableOverlay` with the appropriate enable value.
