### PR TITLE
Add RegisterCapabilitiesEvent

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -166,10 +166,10 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 
     public void registerCapabilities(RegisterCapabilitiesEvent evt)
     {
-        CapabilityItemHandler.register();
-        CapabilityFluidHandler.register();
-        CapabilityAnimation.register();
-        CapabilityEnergy.register();
+        CapabilityItemHandler.register(evt);
+        CapabilityFluidHandler.register(evt);
+        CapabilityAnimation.register(evt);
+        CapabilityEnergy.register(evt);
     }
 
     public void preInit(FMLCommonSetupEvent evt)

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -32,6 +32,7 @@ import net.minecraft.world.storage.IServerConfiguration;
 import net.minecraft.world.storage.SaveFormat;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.ForgeFluidTagsProvider;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
@@ -143,6 +144,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         modEventBus.addListener(this::preInit);
         modEventBus.addListener(this::gatherData);
         modEventBus.addListener(this::loadComplete);
+        modEventBus.addListener(this::registerCapabilities);
         modEventBus.addGenericListener(Fluid.class, this::registerFluids);
         modEventBus.register(this);
         ATTRIBUTES.register(modEventBus);
@@ -162,13 +164,16 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         BiomeDictionary.init();
     }
 
-    public void preInit(FMLCommonSetupEvent evt)
+    public void registerCapabilities(RegisterCapabilitiesEvent evt)
     {
         CapabilityItemHandler.register();
         CapabilityFluidHandler.register();
         CapabilityAnimation.register();
         CapabilityEnergy.register();
+    }
 
+    public void preInit(FMLCommonSetupEvent evt)
+    {
         VersionChecker.startVersionCheck();
 
         registerArgumentTypes();

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -52,7 +52,7 @@ public enum CapabilityManager
      * Registers a capability to be consumed by others.
      * APIs who define the capability should call this.
      * To retrieve the Capability instance, use the @CapabilityInject annotation.
-     * This method should be called during {@link RegisterCapabilitiesEvent}.
+     * This method is safe to call during parallel mod loading.
      *
      * @param type The Interface to be registered
      * @param storage A default implementation of the storage handler.

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -51,7 +51,7 @@ public enum CapabilityManager
      * Registers a capability to be consumed by others.
      * APIs who define the capability should call this.
      * To retrieve the Capability instance, use the @CapabilityInject annotation.
-     * This method is safe to call during parallel mod loading.
+     * This method should be called during {@link RegisterCapabilitiesEvent}.
      *
      * @param type The Interface to be registered
      * @param storage A default implementation of the storage handler.

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -59,6 +59,7 @@ public enum CapabilityManager
      */
     public <T> void register(Class<T> type, Capability.IStorage<T> storage, Callable<? extends T> factory)
     {
+        // TODO 1.17: verify that we are in RegisterCapabilitiesEvent and throw otherwise
         Objects.requireNonNull(type,"Attempted to register a capability with invalid type");
         Objects.requireNonNull(storage,"Attempted to register a capability with no storage implementation");
         Objects.requireNonNull(factory,"Attempted to register a capability with no default implementation factory");

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.capabilities;
 
 import java.util.concurrent.Callable;

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.common.capabilities;
+
+import java.util.concurrent.Callable;
+
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.lifecycle.IModBusEvent;
+
+/**
+ * This event fires when it is time to register an capabilities with the CapabilityManager
+ * using {@link CapabilityManager#register(Class, Capability.IStorage, Callable)}.
+ */
+public class RegisterCapabilitiesEvent extends Event implements IModBusEvent
+{
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.lifecycle.IModBusEvent;
 
 /**
- * This event fires when it is time to register an capabilities with the CapabilityManager
+ * This event fires when it is time to register any capabilities with the CapabilityManager
  * using {@link CapabilityManager#register(Class, Capability.IStorage, Callable)}.
  */
 public class RegisterCapabilitiesEvent extends Event implements IModBusEvent

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -23,8 +23,8 @@ import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
-import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nonnull;
@@ -35,9 +35,9 @@ public class CapabilityAnimation
     @CapabilityInject(IAnimationStateMachine.class)
     public static Capability<IAnimationStateMachine> ANIMATION_CAPABILITY = null;
 
-    public static void register()
+    public static void register(RegisterCapabilitiesEvent event)
     {
-        CapabilityManager.INSTANCE.register(IAnimationStateMachine.class, new Capability.IStorage<IAnimationStateMachine>()
+        event.register(IAnimationStateMachine.class, new Capability.IStorage<IAnimationStateMachine>()
         {
             @Override
             public INBT writeNBT(Capability<IAnimationStateMachine> capability, IAnimationStateMachine instance, Direction side)

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -30,9 +30,9 @@ public class CapabilityEnergy
     @CapabilityInject(IEnergyStorage.class)
     public static Capability<IEnergyStorage> ENERGY = null;
 
-    public static void register()
+    public static void register(RegisterCapabilitiesEvent event)
     {
-        CapabilityManager.INSTANCE.register(IEnergyStorage.class, new IStorage<IEnergyStorage>()
+        event.register(IEnergyStorage.class, new IStorage<IEnergyStorage>()
         {
             @Override
             public INBT writeNBT(Capability<IEnergyStorage> capability, IEnergyStorage instance, Direction side)

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -26,7 +26,7 @@ import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
-import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
@@ -39,11 +39,11 @@ public class CapabilityFluidHandler
     @CapabilityInject(IFluidHandlerItem.class)
     public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = null;
 
-    public static void register()
+    public static void register(RegisterCapabilitiesEvent event)
     {
-        CapabilityManager.INSTANCE.register(IFluidHandler.class, new DefaultFluidHandlerStorage<>(), () -> new FluidTank(FluidAttributes.BUCKET_VOLUME));
+        event.register(IFluidHandler.class, new DefaultFluidHandlerStorage<>(), () -> new FluidTank(FluidAttributes.BUCKET_VOLUME));
 
-        CapabilityManager.INSTANCE.register(IFluidHandlerItem.class, new DefaultFluidHandlerStorage<>(), () -> new FluidHandlerItemStack(new ItemStack(Items.BUCKET), FluidAttributes.BUCKET_VOLUME));
+        event.register(IFluidHandlerItem.class, new DefaultFluidHandlerStorage<>(), () -> new FluidHandlerItemStack(new ItemStack(Items.BUCKET), FluidAttributes.BUCKET_VOLUME));
     }
 
     private static class DefaultFluidHandlerStorage<T extends IFluidHandler> implements Capability.IStorage<T> {

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import cpw.mods.modlauncher.TransformingClassLoader;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.CapabilityManager;
-import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
@@ -191,7 +190,6 @@ public class ModLoader
         dispatchAndHandleError(ModLoadingStage.CREATE_REGISTRIES, syncExecutor, parallelExecutor, periodicTask);
         ObjectHolderRegistry.findObjectHolders();
         CapabilityManager.INSTANCE.injectCapabilities(modList.getAllScanData());
-        ModLoader.get().postEvent(new RegisterCapabilitiesEvent());
         statusConsumer.ifPresent(c->c.accept("Adding custom tag types"));
         GameData.setCustomTagTypesFromRegistries();
         statusConsumer.ifPresent(c->c.accept("Populating registries"));

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import cpw.mods.modlauncher.TransformingClassLoader;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
@@ -190,6 +191,7 @@ public class ModLoader
         dispatchAndHandleError(ModLoadingStage.CREATE_REGISTRIES, syncExecutor, parallelExecutor, periodicTask);
         ObjectHolderRegistry.findObjectHolders();
         CapabilityManager.INSTANCE.injectCapabilities(modList.getAllScanData());
+        ModLoader.get().postEvent(new RegisterCapabilitiesEvent());
         statusConsumer.ifPresent(c->c.accept("Adding custom tag types"));
         GameData.setCustomTagTypesFromRegistries();
         statusConsumer.ifPresent(c->c.accept("Populating registries"));

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -26,18 +26,16 @@ import net.minecraft.nbt.ListNBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
-import net.minecraftforge.common.capabilities.CapabilityManager;
-
-import java.util.concurrent.Callable;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityItemHandler
 {
     @CapabilityInject(IItemHandler.class)
     public static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = null;
 
-    public static void register()
+    public static void register(RegisterCapabilitiesEvent event)
     {
-        CapabilityManager.INSTANCE.register(IItemHandler.class, new Capability.IStorage<IItemHandler>()
+        event.register(IItemHandler.class, new Capability.IStorage<IItemHandler>()
         {
             @Override
             public INBT writeNBT(Capability<IItemHandler> capability, IItemHandler instance, Direction side)


### PR DESCRIPTION
Adds a new mod event bus event which is fired when it is time to register capabilities.
### Why is this necessary?
Currently the place to register capabilities is in `FMLCommonSetupEvent`. This event however is _too late_, because Minecraft will initialize its search tree earlier than that and items will have their `initCapabilities` method called. That means any `initCapabilities` method will need to have a null-check to see if the capabilities have been initialized yet. Capabilities cannot be registered in the mod class constructor, because the capability manager is not ready yet at that point. In tradition with other registrations, a dedicated event should be added for this.

### Future
In 1.17 we should make `CapabilityManager.register` error-out if it is called outside of `RegisterCapabilitiesEvent`.