### PR TITLE
Fix jar file path detection if the path contains a "!"

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
@@ -54,8 +54,9 @@ public class LibraryFinder {
         try {
             Path path;
             final URI uri = resource.toURI();
-            if (uri.getRawSchemeSpecificPart().contains("!")) {
-                path = Paths.get(new URI(uri.getRawSchemeSpecificPart().split("!")[0]));
+            if (uri.getScheme().equals("jar") && uri.getRawSchemeSpecificPart().contains("!")) {
+                int lastExcl = uri.getRawSchemeSpecificPart().lastIndexOf('!');
+                path = Paths.get(new URI(uri.getRawSchemeSpecificPart().substring(0, lastExcl)));
             } else {
                 path = Paths.get(new URI("file://"+uri.getRawSchemeSpecificPart().substring(0, uri.getRawSchemeSpecificPart().length()-resourceName.length())));
             }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
@@ -54,8 +54,8 @@ public class LibraryFinder {
         try {
             Path path;
             final URI uri = resource.toURI();
-            if (uri.getScheme().equals("jar") && uri.getRawSchemeSpecificPart().contains("!")) {
-                int lastExcl = uri.getRawSchemeSpecificPart().lastIndexOf('!');
+            if (uri.getScheme().equals("jar") && uri.getRawSchemeSpecificPart().contains("!/")) {
+                int lastExcl = uri.getRawSchemeSpecificPart().lastIndexOf("!/");
                 path = Paths.get(new URI(uri.getRawSchemeSpecificPart().substring(0, lastExcl)));
             } else {
                 path = Paths.get(new URI("file://"+uri.getRawSchemeSpecificPart().substring(0, uri.getRawSchemeSpecificPart().length()-resourceName.length())));


### PR DESCRIPTION
`LibraryFinder` makes wrong assumptions about URIs, causing jar file detection to fail if the path to `.minecraft` contains a `!`.