### PR TITLE
[1.16.x] Add method to get the number of elements in a model builder

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -200,6 +200,15 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     /**
+     * Gets the number of elements in this model builder
+     * @return the number of elements in this model builder
+     */
+    public int getElementCount()
+    {
+        return elements.size();
+    }
+
+    /**
      * Use a custom loader instead of the vanilla elements.
      * @param customLoaderFactory
      * @return the custom loader builder


### PR DESCRIPTION
Currently, model builders allow you to retrieve elements based on index, but do not provide a way to know how many elements there are. Because of this, iterating over all the elements in a builder requires using a try-catch block to increment the element index until a `IndexOutOfBoundsException` occurs. This PR fixes that by providing a method that simply returns the number of elements in the builder.