### PR TITLE
Synchronize `ResourcePackList#addPackFinder`

### DIFF
--- a/patches/minecraft/net/minecraft/resources/ResourcePackList.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackList.java.patch
@@ -15,7 +15,7 @@
        return this.field_198988_b.get(p_198981_1_);
 +   }
 +
-+   public void addPackFinder(IPackFinder packFinder) {
++   public synchronized void addPackFinder(IPackFinder packFinder) {
 +      this.field_198987_a.add(packFinder);
     }
  


### PR DESCRIPTION
Too few mods synchronize on this collection when adding to it. I have confirmed that multiple concurrent writes are happening into the resource finder set and suspect that it's corrupting resource data for some users. 

These changes circumvent requiring several other mods to synchronize their code while also providing a valid solution to the problem.