### PR TITLE
Fix vanilla packet splitter remote detection and add advancement packet splitting

### DIFF
--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -52,6 +52,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerContainerEvent;
 import net.minecraftforge.fml.config.ConfigTracker;
+import net.minecraftforge.network.NetworkFilters;
 
 import javax.annotation.Nullable;
 
@@ -117,6 +118,7 @@ public class NetworkHooks
     }
 
     public synchronized static void sendMCRegistryPackets(NetworkManager manager, String direction) {
+        NetworkFilters.injectIfNecessary(manager);
         final Set<ResourceLocation> resourceLocations = NetworkRegistry.buildChannelVersions().keySet().stream().
                 filter(rl -> !Objects.equals(rl.getNamespace(), "minecraft")).
                 collect(Collectors.toSet());

--- a/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -68,7 +68,6 @@ import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.packs.ModFileResourcePack;
 import net.minecraftforge.fml.packs.ResourcePackLoader;
 import net.minecraftforge.forgespi.language.IModInfo;
-import net.minecraftforge.network.NetworkFilters;
 import net.minecraftforge.registries.GameData;
 
 public class ServerLifecycleHooks
@@ -169,7 +168,6 @@ public class ServerLifecycleHooks
         if (packet.getIntention() == ProtocolType.STATUS) return true;
 
         NetworkHooks.registerServerLoginChannel(manager, packet);
-        NetworkFilters.injectIfNecessary(manager);
         return true;
 
     }

--- a/src/main/java/net/minecraftforge/network/ForgeConnectionNetworkFilter.java
+++ b/src/main/java/net/minecraftforge/network/ForgeConnectionNetworkFilter.java
@@ -77,7 +77,7 @@ public class ForgeConnectionNetworkFilter extends VanillaPacketFilter
     protected boolean isNecessary(NetworkManager manager)
     {
         // not needed on local connections, because packets are not encoded to bytes there
-        return !manager.isMemoryConnection() && !VanillaPacketSplitter.isRemoteCompatible(manager);
+        return !manager.isMemoryConnection() && VanillaPacketSplitter.isRemoteCompatible(manager);
     }
 
     private static void splitPacket(IPacket<?> packet, List<? super IPacket<?>> out)

--- a/src/main/java/net/minecraftforge/network/NetworkFilters.java
+++ b/src/main/java/net/minecraftforge/network/NetworkFilters.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.network;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import net.minecraft.network.NetworkManager;
 
@@ -33,14 +34,15 @@ public class NetworkFilters
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final Map<String, VanillaPacketFilter> instances = ImmutableMap.of(
-            "forge:vanilla_filter", new VanillaConnectionNetworkFilter(),
-            "forge:forge_fixes", new ForgeConnectionNetworkFilter()
+    private static final Map<String, Function<NetworkManager, VanillaPacketFilter>> instances = ImmutableMap.of(
+            "forge:vanilla_filter", manager -> new VanillaConnectionNetworkFilter(),
+            "forge:forge_fixes", ForgeConnectionNetworkFilter::new
     );
 
     public static void injectIfNecessary(NetworkManager manager)
     {
-        instances.forEach((key, filter) -> {
+        instances.forEach((key, filterFactory) -> {
+            VanillaPacketFilter filter = filterFactory.apply(manager);
             if (filter.isNecessary(manager))
             {
                 manager.channel().pipeline().addBefore("packet_handler", key, filter);

--- a/src/main/java/net/minecraftforge/network/VanillaPacketSplitter.java
+++ b/src/main/java/net/minecraftforge/network/VanillaPacketSplitter.java
@@ -59,7 +59,7 @@ public class VanillaPacketSplitter
     // Version 1.1 removed client-side whitelist
     // we don't bump actual channel version because that would prevent old clients from connecting
     // but we still need to detect new clients, so we add a dummy channel just for that.
-    public static final ResourceLocation V11_DUMMY_CHANNEL = new ResourceLocation("forge", "split_11");
+    private static final ResourceLocation V11_DUMMY_CHANNEL = new ResourceLocation("forge", "split_11");
     private static final String VERSION = "1.0";
     private static final String VERSION_11 = "1.1";
 
@@ -72,13 +72,12 @@ public class VanillaPacketSplitter
     private static final byte STATE_FIRST = 1;
     private static final byte STATE_LAST = 2;
 
-    private static EventNetworkChannel channel;
-
     public static void register()
     {
         Predicate<String> versionCheck = NetworkRegistry.acceptMissingOr(VERSION);
-        channel = NetworkRegistry.newEventChannel(CHANNEL, () -> VERSION, versionCheck, versionCheck);
+        EventNetworkChannel channel = NetworkRegistry.newEventChannel(CHANNEL, () -> VERSION, versionCheck, versionCheck);
         channel.addListener(VanillaPacketSplitter::onClientPacket);
+
         Predicate<String> version11Check = NetworkRegistry.acceptMissingOr(VERSION_11);
         NetworkRegistry.newEventChannel(V11_DUMMY_CHANNEL, () -> VERSION_11, version11Check, version11Check);
     }


### PR DESCRIPTION
The "does the remote know about packet splitting" check was broken, because it always ran before the client event sent its channel list. This was fixed by moving the injection and check to just after the switch to the PLAY protocol (after the handshake).

Additionally this removes the client-side whitelist from the packet splitting and adds splitting for the advancement packet (prompted by [this thread](https://forums.minecraftforge.net/topic/101170-player-cannot-join-serverbadly-compressed-package/), thanks @SizableShrimp for the idea of making it compatible with older clients).