### PR TITLE
Fix mod menu URL click bounds

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
@@ -235,7 +235,7 @@ public class ModListScreen extends Screen
             IReorderingProcessor line = lines.get(lineIdx-1);
             if (line != null)
             {
-                return font.getSplitter().componentStyleAtWidth(line, mouseX);
+                return font.getSplitter().componentStyleAtWidth(line, mouseX - left - border);
             }
             return null;
         }


### PR DESCRIPTION
Not a big change. On the Mod Menu, the URL links do not pay attention to the X offset so often when clicking on the mod menu it will try to open links from the mod descriptions.

This just re-aligns the clicking bounds with where the lines actually are.