### PR TITLE
Minor convenience/compat adjustment for PotionBrewing patch.

### DIFF
--- a/patches/minecraft/net/minecraft/potion/PotionBrewing.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionBrewing.java.patch
@@ -55,11 +55,11 @@
  
 -   static class MixPredicate<T> {
 -      private final T field_185198_a;
-+   static class MixPredicate<T extends net.minecraftforge.registries.ForgeRegistryEntry<T>> {
-+      private final net.minecraftforge.registries.IRegistryDelegate<T> field_185198_a;
++   public static class MixPredicate<T extends net.minecraftforge.registries.ForgeRegistryEntry<T>> {
++      public final net.minecraftforge.registries.IRegistryDelegate<T> field_185198_a;
        private final Ingredient field_185199_b;
 -      private final T field_185200_c;
-+      private final net.minecraftforge.registries.IRegistryDelegate<T> field_185200_c;
++      public final net.minecraftforge.registries.IRegistryDelegate<T> field_185200_c;
  
        public MixPredicate(T p_i47570_1_, Ingredient p_i47570_2_, T p_i47570_3_) {
 -         this.field_185198_a = p_i47570_1_;


### PR DESCRIPTION
Convenience change for potion enumeration - does not change patch size in any meaningful way!

Since Forge is patching this, modders can unfortunately not use ATs to access a couple of EXTREMELY useful fields. This changes that.

Fields are final, they just become accessible outside of package and readable without reflective hacks.

Signed-off-by: King Lemming <kinglemming@gmail.com>