### PR TITLE
IFluidHandlerItem rework POC

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
@@ -19,23 +19,16 @@
 
 package net.minecraftforge.fluids.capability;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.context.IFluidActionContext;
 
 /**
- * ItemStacks handled by an {@link IFluidHandler} may change, so this class allows
- * users of the fluid handler to get the container after it has been used.
+ * TODO comment
  */
-public interface IFluidHandlerItem extends IFluidHandler
+public interface IFluidHandlerItem
 {
     /**
-     * Get the container currently acted on by this fluid handler.
-     * The ItemStack may be different from its initial state, in the case of fluid containers that have different items
-     * for their filled and empty states.
-     * May be an empty item if the container was drained and is consumable.
+     * May throw an exception if {@code context.getStack()} does not match the stack of this handler.
+     * Modders should prefer using {@link IFluidActionContext#getFluidHandler} over calling this directly.
      */
-    @Nonnull
-    ItemStack getContainer();
+    IFluidHandler getFluidHandler(IFluidActionContext context);
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/context/CursorFluidActionContext.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/context/CursorFluidActionContext.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.fluids.capability.context;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+public class CursorFluidActionContext implements IFluidActionContext {
+    private final PlayerInventory inventory;
+
+    public CursorFluidActionContext(PlayerEntity player) {
+        this(player.inventory);
+    }
+
+    public CursorFluidActionContext(PlayerInventory inventory) {
+        this.inventory = inventory;
+    }
+
+    @Override
+    public ItemStack getStack() {
+        return inventory.getCarried();
+    }
+
+    @Override
+    public boolean trySetStack(ItemStack newStack, IFluidHandler.FluidAction action) {
+        if (action.execute()) {
+            inventory.setCarried(newStack);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean tryInsertStack(ItemStack newStack, IFluidHandler.FluidAction action) {
+        if (action.execute()) {
+            inventory.placeItemBackInInventory(inventory.player.level, newStack);
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/minecraftforge/fluids/capability/context/IFluidActionContext.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/context/IFluidActionContext.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.fluids.capability.context;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+import java.util.Optional;
+
+public interface IFluidActionContext {
+    /**
+     * Current stack, NEVER MODIFY THIS.
+     */
+    ItemStack getStack();
+
+    /**
+     * Try to replace the current stack, return true if succeeded.
+     */
+    boolean trySetStack(ItemStack newStack, IFluidHandler.FluidAction action);
+
+    /**
+     * Try to insert the stack in the context (without overriding anything), return true if succeeded.
+     */
+    boolean tryInsertStack(ItemStack newStack, IFluidHandler.FluidAction action);
+
+    /**
+     * Get the {@link IFluidHandler} for this stack if it exists.
+     */
+    default Optional<IFluidHandler> getFluidHandler() {
+        return getStack().getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY)
+                .map(fluidHandlerItem -> fluidHandlerItem.getFluidHandler(this));
+    }
+
+    /**
+     * Try to replace one of the current stack by the passed stack.
+     * @throws IllegalArgumentException If {@code newStack.getCount()} is not 1.
+     */
+    default boolean tryReplaceOne(ItemStack newStack, IFluidHandler.FluidAction action) {
+        // TODO: allow passing EMPTY to delete one item? (single use fluid container)
+        if (newStack.getCount() != 1) {
+            throw new IllegalArgumentException();
+        }
+
+        // Try to replace empty
+        if (getStack().isEmpty() && trySetStack(newStack, action)) {
+            return true;
+        }
+        // Otherwise try to add to stack
+        if (ItemHandlerHelper.canItemStacksStack(getStack(), newStack) && getStack().getCount() < getStack().getMaxStackSize()) {
+            newStack.setCount(getStack().getCount()+1);
+            if (trySetStack(newStack, action)) {
+                return true;
+            }
+            // If it fails go back to a count of 1
+            newStack.setCount(1);
+        }
+        // Last resort: try to insert wherever
+        return tryInsertStack(newStack, action);
+    }
+}

--- a/src/main/java/net/minecraftforge/fluids/capability/context/ItemHandlerActionContext.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/context/ItemHandlerActionContext.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.fluids.capability.context;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+public class ItemHandlerActionContext implements IFluidActionContext {
+    private final IItemHandlerModifiable handler;
+    private final int slot;
+
+    public ItemHandlerActionContext(IItemHandlerModifiable handler, int slot) {
+        this.handler = handler;
+        this.slot = slot;
+    }
+
+    @Override
+    public ItemStack getStack() {
+        return handler.getStackInSlot(slot);
+    }
+
+    @Override
+    public boolean trySetStack(ItemStack newStack, IFluidHandler.FluidAction action) {
+        if (action.execute()) {
+            handler.setStackInSlot(slot, newStack);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean tryInsertStack(ItemStack newStack, IFluidHandler.FluidAction action) {
+        return ItemHandlerHelper.insertItemStacked(handler, newStack, action.simulate()).isEmpty();
+    }
+}

--- a/src/main/java/net/minecraftforge/fluids/capability/context/PlayerActionContext.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/context/PlayerActionContext.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.fluids.capability.context;
+
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.wrapper.InvWrapper;
+
+public class PlayerActionContext extends ItemHandlerActionContext {
+    private final PlayerInventory playerInventory;
+
+    public PlayerActionContext(PlayerInventory playerInventory, int slot) {
+        super(new InvWrapper(playerInventory), slot);
+        this.playerInventory = playerInventory;
+    }
+
+    // Override try insert to use placeItemBackInInventory() for players.
+    @Override
+    public boolean tryInsertStack(ItemStack newStack, IFluidHandler.FluidAction action) {
+        if (action.execute()) {
+            playerInventory.placeItemBackInInventory(playerInventory.player.level, newStack);
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Another option for a fluid handler item rework, very different from #7814. Very much a draft.

Example use to interact with a tank item in the inventory cursor slot:

```java
Optional<IFluidHandler> cursorHandler = new CursorFluidActionContext(player).getFluidHandler();
cursorHandler.ifPresent(handler -> {
    // normal IFluidHandler operations, will modify the cursor slot and player inventory according to IFluidActionContext.
});
```