### PR TITLE
Let Trapdoors be climbable for custom ladders

### DIFF
--- a/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
@@ -10,7 +10,7 @@
 +   public boolean isLadder(BlockState state, net.minecraft.world.IWorldReader world, BlockPos pos, net.minecraft.entity.LivingEntity entity) {
 +      if (state.func_177229_b(field_176283_b)) {
 +         BlockState down = world.func_180495_p(pos.func_177977_b());
-+         if (down.func_203425_a(net.minecraft.block.Blocks.field_150468_ap))
++         if (down.func_177230_c() instanceof LadderBlock)
 +            return down.func_177229_b(LadderBlock.field_176382_a) == state.func_177229_b(field_185512_D);
 +      }
 +      return false;

--- a/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TrapDoorBlock.java.patch
@@ -9,9 +9,9 @@
 +   @Override
 +   public boolean isLadder(BlockState state, net.minecraft.world.IWorldReader world, BlockPos pos, net.minecraft.entity.LivingEntity entity) {
 +      if (state.func_177229_b(field_176283_b)) {
-+         BlockState down = world.func_180495_p(pos.func_177977_b());
-+         if (down.func_177230_c() instanceof LadderBlock)
-+            return down.func_177229_b(LadderBlock.field_176382_a) == state.func_177229_b(field_185512_D);
++         BlockPos downPos = pos.func_177977_b();
++         BlockState down = world.func_180495_p(downPos);
++         return down.func_177230_c().makesOpenTrapdoorAboveClimbable(down, world, downPos, state);
 +      }
 +      return false;
 +   }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -117,6 +117,20 @@ public interface IForgeBlock
     }
 
     /**
+     * Checks if this block makes an open trapdoor above it climbable.
+     *
+     * @param state The current state
+     * @param world The current world
+     * @param pos Block position in world
+     * @param trapdoorState The current state of the open trapdoor above
+     * @return True if the block should act like a ladder
+     */
+    default boolean makesOpenTrapdoorAboveClimbable(BlockState state, IWorldReader world, BlockPos pos, BlockState trapdoorState)
+    {
+        return state.getBlock() instanceof LadderBlock && state.getValue(LadderBlock.FACING) == trapdoorState.getValue(TrapDoorBlock.FACING);
+    }
+
+    /**
      * Determines if this block should set fire and deal fire damage
      * to entities coming into contact with it.
      *


### PR DESCRIPTION
This PR fixes #7775 and changes the `isLadder` method of a Trapdoor to check, if the block below it is an instance of `LadderBlock` instead of being the vanilla Ladder block to support modded ladders.

Using the `climbable` tag is not useful here, because vines and other climbable blocks are also listed there.

Another possibility to fix the issue would be to invent a new tag called `makes_trapdoor_climbable` (or something similar), where blocks for this functionality are listed. But the additional check, that the facing of the ladder and the trapdoor must be equal, convinced me to do the `instanceof LadderBlock` check.