### PR TITLE
[1.16] Add truncation to FMLStatusPing to work around protocol limits

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -128,7 +128,7 @@ public class ClientHooks
             if (fmlver > FMLNetworkConstants.FMLNETVERSION) {
                 extraReason = "fml.menu.multiplayer.clientoutdated";
             }
-            target.forgeData = new ExtendedServerListData("FML", extraServerMods.isEmpty() && fmlNetMatches && channelsMatch && modsMatch, mods.size(), extraReason);
+            target.forgeData = new ExtendedServerListData("FML", extraServerMods.isEmpty() && fmlNetMatches && channelsMatch && modsMatch, mods.size(), extraReason, packet.getForgeData().isTruncated());
         } else {
             target.forgeData = new ExtendedServerListData("VANILLA", NetworkRegistry.canConnectToVanillaServer(),0, null);
         }
@@ -153,6 +153,10 @@ public class ClientHooks
                     } else {
                         tooltip = ForgeI18n.parseMessage("fml.menu.multiplayer.incompatible");
                     }
+                }
+                if (target.forgeData.truncated)
+                {
+                    tooltip += "\n" + ForgeI18n.parseMessage("fml.menu.multiplayer.truncated");
                 }
                 break;
             case "VANILLA":

--- a/src/main/java/net/minecraftforge/fml/client/ExtendedServerListData.java
+++ b/src/main/java/net/minecraftforge/fml/client/ExtendedServerListData.java
@@ -24,12 +24,19 @@ public class ExtendedServerListData {
     public final boolean isCompatible;
     public int numberOfMods;
     public String extraReason;
+    public final boolean truncated;
 
     public ExtendedServerListData(String type, boolean isCompatible, int num, String extraReason)
+    {
+        this(type, isCompatible, num, extraReason, false);
+    }
+
+    public ExtendedServerListData(String type, boolean isCompatible, int num, String extraReason, boolean truncated)
     {
         this.type = type;
         this.isCompatible = isCompatible;
         this.numberOfMods = num;
         this.extraReason = extraReason;
+        this.truncated = truncated;
     }
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -26,6 +26,7 @@
   "fml.menu.multiplayer.compatible":"Compatible FML modded server\n{0,choice,1#1 mod|1<{0} mods} present",
   "fml.menu.multiplayer.incompatible":"Incompatible FML modded server",
   "fml.menu.multiplayer.incompatible.extra":"Incompatible FML modded server\n{0}",
+  "fml.menu.multiplayer.truncated":"Data may be inaccurate due to protocol size limits.",
   "fml.menu.multiplayer.vanilla":"Vanilla server",
   "fml.menu.multiplayer.vanilla.incompatible":"Incompatible Vanilla server",
   "fml.menu.multiplayer.unknown":"Unknown server {0}",


### PR DESCRIPTION
If there are a lot of mods and/or network channels the JSON can get too large for `PacketBuffer#writeUtf`. This adds a truncation at 150 mods / channels respectively and shows a warning in clients that know about this.