### PR TITLE
Add (cancelable) ToastAddEvent for use in ToastGui.add

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
@@ -1,13 +1,12 @@
 --- a/net/minecraft/client/gui/toasts/ToastGui.java
 +++ b/net/minecraft/client/gui/toasts/ToastGui.java
-@@ -62,7 +_,9 @@
+@@ -62,6 +_,9 @@
     }
  
     public void func_192988_a(IToast p_192988_1_) {
--      this.field_191792_h.add(p_192988_1_);
 +      net.minecraftforge.client.event.ToastAddEvent event = new net.minecraftforge.client.event.ToastAddEvent(p_192988_1_);
 +      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
-+      this.field_191792_h.add(event.getToast());
++      p_192988_1_ = event.getToast();
+       this.field_191792_h.add(p_192988_1_);
     }
  
-    public Minecraft func_192989_b() {

--- a/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/client/gui/toasts/ToastGui.java
++++ b/net/minecraft/client/gui/toasts/ToastGui.java
+@@ -62,7 +_,9 @@
+    }
+ 
+    public void func_192988_a(IToast p_192988_1_) {
+-      this.field_191792_h.add(p_192988_1_);
++      net.minecraftforge.client.event.ToastAddEvent event = new net.minecraftforge.client.event.ToastAddEvent(p_192988_1_);
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++      this.field_191792_h.add(event.getToast());
+    }
+ 
+    public Minecraft func_192989_b() {

--- a/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/toasts/ToastGui.java.patch
@@ -4,9 +4,9 @@
     }
  
     public void func_192988_a(IToast p_192988_1_) {
+-      this.field_191792_h.add(p_192988_1_);
 +      net.minecraftforge.client.event.ToastAddEvent event = new net.minecraftforge.client.event.ToastAddEvent(p_192988_1_);
 +      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
-+      p_192988_1_ = event.getToast();
-       this.field_191792_h.add(p_192988_1_);
++      this.field_191792_h.add(event.getToast());
     }
  

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.gui.toasts.IToast;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class ToastAddEvent extends Event {
+    private IToast toast;
+    public ToastAddEvent(IToast toast) {
+        setToast(toast);
+    }
+
+    public IToast getToast() {
+        return toast;
+    }
+
+    public void setToast(IToast toast) {
+        this.toast = toast;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -1,21 +1,55 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.toasts.IToast;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+/**
+ * Fired whenever the client is about to queue up a toast message to be rendered on-screen.
+ * Canceling the event will prevent the toast from being rendered.
+ */
 @Cancelable
-public class ToastAddEvent extends Event {
+public class ToastAddEvent extends Event
+{
     private IToast toast;
-    public ToastAddEvent(IToast toast) {
+
+    public ToastAddEvent(IToast toast)
+    {
         setToast(toast);
     }
 
-    public IToast getToast() {
+    /**
+     * @return the toast that will be rendered on-screen
+     */
+    public IToast getToast()
+    {
         return toast;
     }
 
-    public void setToast(IToast toast) {
+    /**
+     * @param toast the replacement toast to show instead of the original
+     */
+    public void setToast(IToast toast)
+    {
         this.toast = toast;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -30,11 +30,11 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class ToastAddEvent extends Event
 {
-    private IToast toast;
+    private final IToast toast;
 
     public ToastAddEvent(IToast toast)
     {
-        setToast(toast);
+        this.toast = toast;
     }
 
     /**
@@ -43,13 +43,5 @@ public class ToastAddEvent extends Event
     public IToast getToast()
     {
         return toast;
-    }
-
-    /**
-     * @param toast the replacement toast to show instead of the original
-     */
-    public void setToast(IToast toast)
-    {
-        this.toast = toast;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client;
 
 import com.mojang.blaze3d.matrix.MatrixStack;

--- a/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
@@ -23,7 +23,6 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.toasts.IToast;
 import net.minecraft.client.gui.toasts.RecipeToast;
-import net.minecraft.client.gui.toasts.SystemToast;
 import net.minecraft.client.gui.toasts.ToastGui;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -48,9 +47,13 @@ public class ToastAddTest
             return;
         }
 
-        if (toast instanceof SystemToast && ((SystemToast) toast).getToken().equals(SystemToast.Type.TUTORIAL_HINT))
+        if (toast instanceof CustomToast)
         {
-            event.setToast(new CustomToast("Tutorial hints have been disabled"));
+            CustomToast customToast = (CustomToast) toast;
+            if (!customToast.getText().startsWith("Notice: "))
+            {
+                customToast.setText("Notice: " + customToast.getText());
+            }
         }
     }
 
@@ -59,7 +62,7 @@ public class ToastAddTest
     @ParametersAreNonnullByDefault
     public static class CustomToast implements IToast
     {
-        private final String text;
+        private String text;
 
         public CustomToast(String text)
         {
@@ -71,6 +74,16 @@ public class ToastAddTest
         {
             toastGui.getMinecraft().font.draw(matrixStack, text, 0, 0, -1);
             return ticks >= 5000L ? IToast.Visibility.HIDE : IToast.Visibility.SHOW;
+        }
+
+        public String getText()
+        {
+            return this.text;
+        }
+
+        public void setText(String text)
+        {
+            this.text = text;
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ToastAddTest.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.debug.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.toasts.IToast;
+import net.minecraft.client.gui.toasts.RecipeToast;
+import net.minecraft.client.gui.toasts.SystemToast;
+import net.minecraft.client.gui.toasts.ToastGui;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ToastAddEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@Mod("toast_add_test")
+@Mod.EventBusSubscriber
+public class ToastAddTest
+{
+    @SubscribeEvent
+    public static void onToastAdd(ToastAddEvent event)
+    {
+        IToast toast = event.getToast();
+
+        if (toast instanceof RecipeToast)
+        {
+            event.setCanceled(true);
+            return;
+        }
+
+        if (toast instanceof SystemToast && ((SystemToast) toast).getToken().equals(SystemToast.Type.TUTORIAL_HINT))
+        {
+            event.setToast(new CustomToast("Tutorial hints have been disabled"));
+        }
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @MethodsReturnNonnullByDefault
+    @ParametersAreNonnullByDefault
+    public static class CustomToast implements IToast
+    {
+        private final String text;
+
+        public CustomToast(String text)
+        {
+            this.text = text;
+        }
+
+        @Override
+        public Visibility render(MatrixStack matrixStack, ToastGui toastGui, long ticks)
+        {
+            toastGui.getMinecraft().font.draw(matrixStack, text, 0, 0, -1);
+            return ticks >= 5000L ? IToast.Visibility.HIDE : IToast.Visibility.SHOW;
+        }
+    }
+}


### PR DESCRIPTION
Gives modders the ability to hook into the ToastGui's toast queue. To prevent the toast from being added, cancel the event. To change the toast, modify it directly or replace it with event.setToast(IToast).