### PR TITLE
Add the ability to pass along IRecipe hint in ItemCraftedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/CraftingResultSlot.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/CraftingResultSlot.java.patch
@@ -1,10 +1,14 @@
 --- a/net/minecraft/inventory/container/CraftingResultSlot.java
 +++ b/net/minecraft/inventory/container/CraftingResultSlot.java
-@@ -43,6 +_,7 @@
+@@ -43,6 +_,11 @@
     protected void func_75208_c(ItemStack p_75208_1_) {
        if (this.field_75237_g > 0) {
           p_75208_1_.func_77980_a(this.field_75238_b.field_70170_p, this.field_75238_b, this.field_75237_g);
-+         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerCraftingEvent(this.field_75238_b, p_75208_1_, this.field_75239_a);
++         net.minecraft.item.crafting.IRecipe<?> recipe = null;
++         if (this.field_75224_c instanceof IRecipeHolder) {
++            recipe = ((IRecipeHolder)this.field_75224_c).func_193055_i();
++         }
++         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerCraftingEvent(this.field_75238_b, p_75208_1_, this.field_75239_a, recipe);
        }
  
        if (this.field_75224_c instanceof IRecipeHolder) {

--- a/patches/minecraft/net/minecraft/inventory/container/CraftingResultSlot.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/CraftingResultSlot.java.patch
@@ -1,14 +1,10 @@
 --- a/net/minecraft/inventory/container/CraftingResultSlot.java
 +++ b/net/minecraft/inventory/container/CraftingResultSlot.java
-@@ -43,6 +_,11 @@
+@@ -43,6 +_,7 @@
     protected void func_75208_c(ItemStack p_75208_1_) {
        if (this.field_75237_g > 0) {
           p_75208_1_.func_77980_a(this.field_75238_b.field_70170_p, this.field_75238_b, this.field_75237_g);
-+         net.minecraft.item.crafting.IRecipe<?> recipe = null;
-+         if (this.field_75224_c instanceof IRecipeHolder) {
-+            recipe = ((IRecipeHolder)this.field_75224_c).func_193055_i();
-+         }
-+         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerCraftingEvent(this.field_75238_b, p_75208_1_, this.field_75239_a, recipe);
++         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerCraftingEvent(this.field_75238_b, p_75208_1_, this.field_75239_a, this.field_75224_c);
        }
  
        if (this.field_75224_c instanceof IRecipeHolder) {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -467,6 +467,10 @@ public class PlayerEvent extends LivingEvent
         private final IRecipe<?> recipe;
 
         // TODO 1.17 REMOVE
+        /**
+         * Use the constructor that takes an IRecipe, and pass null if it's unavailable for your use case.
+         */
+        @Deprecated
         public ItemCraftedEvent(PlayerEntity player, @Nonnull ItemStack crafting, IInventory craftMatrix)
         {
             this(player, crafting, craftMatrix, null);
@@ -499,11 +503,12 @@ public class PlayerEvent extends LivingEvent
         }
 
         /**
-         * @return Teturns the recipe that was used to craft the item. This can be null in case no
+         * @return Returns the recipe that was used to craft the item. This can be null in case no
          * particular recipe was used, or the recipe is unknown.
          */
         @Nullable
-        public IRecipe<?> getRecipe() {
+        public IRecipe<?> getRecipe()
+        {
             return recipe;
         }
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.world.GameType;
 import net.minecraft.world.World;
@@ -462,11 +463,28 @@ public class PlayerEvent extends LivingEvent
         @Nonnull
         private final ItemStack crafting;
         private final IInventory craftMatrix;
+        @Nullable
+        private final IRecipe<?> recipe;
+
+        // TODO 1.17 REMOVE
         public ItemCraftedEvent(PlayerEntity player, @Nonnull ItemStack crafting, IInventory craftMatrix)
+        {
+            this(player, crafting, craftMatrix, null);
+        }
+
+        /**
+         * Constructs an event to notify listeners about an item that was crafted by a player.
+         * @param player The player that crafted the item.
+         * @param crafting The item that was crafted.
+         * @param craftMatrix The crafting inventory that resulted in the item being crafted.
+         * @param recipe The registered recipe that was used to craft the given item (optional).
+         */
+        public ItemCraftedEvent(PlayerEntity player, @Nonnull ItemStack crafting, IInventory craftMatrix, @Nullable IRecipe<?> recipe)
         {
             super(player);
             this.crafting = crafting;
             this.craftMatrix = craftMatrix;
+            this.recipe = recipe;
         }
 
         @Nonnull
@@ -478,6 +496,15 @@ public class PlayerEvent extends LivingEvent
         public IInventory getInventory()
         {
             return this.craftMatrix;
+        }
+
+        /**
+         * @return Teturns the recipe that was used to craft the item. This can be null in case no
+         * particular recipe was used, or the recipe is unknown.
+         */
+        @Nullable
+        public IRecipe<?> getRecipe() {
+            return recipe;
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -23,6 +23,7 @@ import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.animation.Animation;
@@ -59,9 +60,15 @@ public class BasicEventHooks
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.ItemPickupEvent(player, item, clone));
     }
 
+    // TODO 1.17 REMOVE
     public static void firePlayerCraftingEvent(PlayerEntity player, ItemStack crafted, IInventory craftMatrix)
     {
-        MinecraftForge.EVENT_BUS.post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix));
+        firePlayerCraftingEvent(player, crafted, craftMatrix, null);
+    }
+
+    public static void firePlayerCraftingEvent(PlayerEntity player, ItemStack crafted, IInventory craftMatrix, IRecipe<?> recipe)
+    {
+        MinecraftForge.EVENT_BUS.post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix, recipe));
     }
 
     public static void firePlayerSmeltedEvent(PlayerEntity player, ItemStack smelted)

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.hooks;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.IRecipeHolder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.RegistryKey;
@@ -31,6 +32,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.event.TickEvent;
+
+import javax.annotation.Nullable;
 
 public class BasicEventHooks
 {
@@ -61,13 +64,22 @@ public class BasicEventHooks
     }
 
     // TODO 1.17 REMOVE
+    // Use the version below, which takes the CraftingResultSlot's inventory
+    @Deprecated
     public static void firePlayerCraftingEvent(PlayerEntity player, ItemStack crafted, IInventory craftMatrix)
     {
         firePlayerCraftingEvent(player, crafted, craftMatrix, null);
     }
 
-    public static void firePlayerCraftingEvent(PlayerEntity player, ItemStack crafted, IInventory craftMatrix, IRecipe<?> recipe)
+    public static void firePlayerCraftingEvent(PlayerEntity player, ItemStack crafted, IInventory craftMatrix, @Nullable IInventory craftResultInventory)
     {
+        // Attempt to retrieve the recipe that was used to produce the crafted item
+        // This will generally be null client-side, which is fine since this is mostly a hint that is useful server-side
+        IRecipe<?> recipe = null;
+        if (craftResultInventory instanceof IRecipeHolder)
+        {
+            recipe = ((IRecipeHolder)craftResultInventory).getRecipeUsed();
+        }
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix, recipe));
     }
 


### PR DESCRIPTION
This allows listeners to avoid having to scan the recipe manager to find the recipe that was potentially used to craft the item.

This has been a major performance concern in mods such as CraftTweaker and previously ~~Witchery~~Wizardry, since they scanned the entire list of available recipes against the crafting inventory to figure out which recipe was being crafted. That resulted in performance degradation for fast autocrafting mods that still fire this event (i.e. AE2).

By passing along the recipe that was used - even if optional - such mods now have a fast-path available and only need to scan the registry as a fallback.

This is more useful for 1.17 since most mods are probably not going to consider this new hint for 1.16. I've commented on the existing ctor that now forwards with a null IRecipe that it should be removed in 1.17 since mod authors who fire this event should at least consider the problem.