### PR TITLE
Lazily initialize ItemStack capabilities

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -9,25 +9,23 @@
     public static final Codec<ItemStack> field_234691_a_ = RecordCodecBuilder.create((p_234698_0_) -> {
        return p_234698_0_.group(Registry.field_212630_s.fieldOf("id").forGetter((p_234706_0_) -> {
           return p_234706_0_.field_151002_e;
-@@ -82,6 +_,9 @@
+@@ -82,6 +_,8 @@
           return Optional.ofNullable(p_234704_0_.field_77990_d);
        })).apply(p_234698_0_, ItemStack::new);
     });
 +   private final net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
-+   private CompoundNBT capNBT;
 +
     private static final Logger field_199558_c = LogManager.getLogger();
     public static final ItemStack field_190927_a = new ItemStack((Item)null);
     public static final DecimalFormat field_111284_a = Util.func_200696_a(new DecimalFormat("#.##"), (p_234699_0_) -> {
-@@ -109,14 +_,19 @@
+@@ -109,10 +_,13 @@
        p_i231596_3_.ifPresent(this::func_77982_d);
     }
  
 -   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) {
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) { this(p_i48204_1_, p_i48204_2_, (CompoundNBT) null); }
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_, @Nullable CompoundNBT capNBT) {
-+      super(ItemStack.class);
-+      this.capNBT = capNBT;
++      super(ItemStack.class, capNBT);
        this.field_151002_e = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j();
 +      this.delegate = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j().delegate;
        this.field_77994_a = p_i48204_2_;
@@ -36,17 +34,11 @@
           this.func_196085_b(this.func_77952_i());
        }
  
-       this.func_190923_F();
-+      this.forgeInit();
-    }
- 
-    private void func_190923_F() {
-@@ -125,18 +_,23 @@
+@@ -125,14 +_,17 @@
     }
  
     private ItemStack(CompoundNBT p_i47263_1_) {
-+      super(ItemStack.class);
-+      this.capNBT = p_i47263_1_.func_74764_b("ForgeCaps") ? p_i47263_1_.func_74775_l("ForgeCaps") : null;
++      super(ItemStack.class, p_i47263_1_.func_74764_b("ForgeCaps") ? p_i47263_1_.func_74775_l("ForgeCaps") : null);
 +      Item rawItem =
        this.field_151002_e = Registry.field_212630_s.func_82594_a(new ResourceLocation(p_i47263_1_.func_74779_i("id")));
 +      this.delegate = rawItem.delegate;
@@ -61,11 +53,6 @@
           this.func_196085_b(this.func_77952_i());
        }
  
-       this.func_190923_F();
-+      this.forgeInit();
-    }
- 
-    public static ItemStack func_199557_a(CompoundNBT p_199557_0_) {
 @@ -167,10 +_,19 @@
     }
  
@@ -220,7 +207,7 @@
        return multimap;
     }
  
-@@ -952,6 +_,24 @@
+@@ -952,6 +_,21 @@
  
     public boolean func_222117_E() {
        return this.func_77973_b().func_219971_r();
@@ -230,17 +217,14 @@
 +   public void deserializeNBT(CompoundNBT nbt) {
 +      final ItemStack itemStack = ItemStack.func_199557_a(nbt);
 +      getStack().func_77982_d(itemStack.func_77978_p());
-+      if (itemStack.capNBT != null) deserializeCaps(itemStack.capNBT);
 +   }
 +
-+   /**
-+    * Set up forge's ItemStack additions.
-+    */
-+   private void forgeInit() {
++   @Override
++   protected void initializeCaps(@Nullable CompoundNBT capNBT) {
 +      if (this.delegate != null) {
-+         net.minecraftforge.common.capabilities.ICapabilityProvider provider = field_151002_e.initCapabilities(this, this.capNBT);
++         net.minecraftforge.common.capabilities.ICapabilityProvider provider = field_151002_e.initCapabilities(this, capNBT);
 +         this.gatherCapabilities(provider);
-+         if (this.capNBT != null) deserializeCaps(this.capNBT);
++         if (capNBT != null) deserializeCaps(capNBT);
 +      }
     }
  

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -148,6 +148,13 @@ public final class CapabilityDispatcher implements INBTSerializable<CompoundNBT>
         return this.serializeNBT().equals(other.serializeNBT());
     }
 
+    public boolean areCompatibleNBT(@Nullable CompoundNBT otherNBT)
+    {
+        if (otherNBT == null) return this.writers.length == 0;
+        if (this.writers.length == 0) return otherNBT == null;
+        return this.serializeNBT().equals(otherNBT);
+    }
+
     public void invalidate()
     {
         this.listeners.forEach(Runnable::run);

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.capabilities;
 
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -36,10 +37,38 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
     private @Nullable CapabilityDispatcher capabilities;
     private boolean valid = true;
 
+    /**
+     * Some capability providers can be lazy (item stacks only in Forge).
+     * In that case, caps are only queried the first time getCapability() is called, and capNBT is used before that.
+     */
+    private final CompoundNBT capNBT; // only used before caps are initialized
+    private volatile boolean capsInitialized; // must be volatile for double-checked locking to be safe
+
+    /**
+     * Constructor for regular (non lazy) providers.
+     */
     protected CapabilityProvider(Class<B> baseClass)
     {
         this.baseClass = baseClass;
+        this.capNBT = null;
+        this.capsInitialized = true;
     }
+
+    /**
+     * Constructor for lazy providers. capNBT will be used before the first getCapability call.
+     */
+    protected CapabilityProvider(Class<B> baseClass, @Nullable CompoundNBT capNBT)
+    {
+        this.baseClass = baseClass;
+        this.capNBT = capNBT;
+        this.capsInitialized = false;
+    }
+
+    /**
+     * For lazy providers only: called right before getCapability when necessary, init your capabilities here.
+     * DO NOT CALL getCapabilities(), or anything using it. deserializeCaps() is safe to use.
+     */
+    protected void initializeCaps(@Nullable CompoundNBT capNBT) {}
 
     protected final void gatherCapabilities() { gatherCapabilities(null); }
 
@@ -50,16 +79,34 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final @Nullable CapabilityDispatcher getCapabilities()
     {
+        // Detect calls that don't check for capsInitialized, or calls from external code.
+        if (!this.capsInitialized)
+        {
+            throw new IllegalStateException("Lazy capabilities are not yet initialized. This is a bug!");
+        }
+
         return this.capabilities;
     }
 
     public final boolean areCapsCompatible(CapabilityProvider<B> other)
     {
-        return areCapsCompatible(other.getCapabilities());
+        if (this.capsInitialized) return other.areCapsCompatible(this.getCapabilities());
+        if (other.capsInitialized)
+        {
+            if (other.getCapabilities() == null) return this.capNBT == null;
+            else return other.getCapabilities().areCompatibleNBT(this.capNBT);
+        }
+        return Objects.equals(this.capNBT, other.capNBT);
     }
 
     public final boolean areCapsCompatible(@Nullable CapabilityDispatcher other)
     {
+        if (!this.capsInitialized)
+        {
+            if (other == null) return this.capNBT == null;
+            return other.areCompatibleNBT(this.capNBT);
+        }
+
         final CapabilityDispatcher disp = getCapabilities();
         if (disp == null)
         {
@@ -80,6 +127,11 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final @Nullable CompoundNBT serializeCaps()
     {
+        if (!this.capsInitialized)
+        {
+            return this.capNBT;
+        }
+
         final CapabilityDispatcher disp = getCapabilities();
         if (disp != null)
         {
@@ -90,7 +142,8 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final void deserializeCaps(CompoundNBT tag)
     {
-        final CapabilityDispatcher disp = getCapabilities();
+        // Don't call getCapabilities() to bypass the if (!this.caps.initialized) check.
+        final CapabilityDispatcher disp = this.capabilities;
         if (disp != null)
         {
             disp.deserializeNBT(tag);
@@ -110,10 +163,31 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
         this.valid = true; //Stupid players don't copy the entity when transporting across worlds.
     }
 
+    private void initializeCapsIfNeeded()
+    {
+        // A note on thread safety: capsInitialized == true guarantees that capabilities are safe to access.
+        // Because we are not using a lock for reads, it is possible that in some cases capsInitialized might be false,
+        // but capabilities have already been initialized due to another thread.
+        // When that happens, we assume that using the immutable capNBT instead of the capabilities themselves is fine.
+        // This is equivalent to assuming both threads only read at the same time.
+        if (!this.capsInitialized)
+        {
+            synchronized (this)
+            {
+                if (!this.capsInitialized)
+                {
+                    initializeCaps(capNBT);
+                    this.capsInitialized = true;
+                }
+            }
+        }
+    }
+
     @Override
     @Nonnull
     public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side)
     {
+        initializeCapsIfNeeded();
         final CapabilityDispatcher disp = getCapabilities();
         return !valid || disp == null ? LazyOptional.empty() : disp.getCapability(cap, side);
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -142,7 +142,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final void deserializeCaps(CompoundNBT tag)
     {
-        // Don't call getCapabilities() to bypass the if (!this.caps.initialized) check.
+        // Don't call getCapabilities() to bypass the if (!this.capsInitialized) check.
         final CapabilityDispatcher disp = this.capabilities;
         if (disp != null)
         {

--- a/src/test/java/net/minecraftforge/debug/capabilities/ItemStackCapabilitiesTest.java
+++ b/src/test/java/net/minecraftforge/debug/capabilities/ItemStackCapabilitiesTest.java
@@ -1,0 +1,159 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.capabilities;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.INBT;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod(ItemStackCapabilitiesTest.MODID)
+public class ItemStackCapabilitiesTest
+{
+    static final String MODID = "item_stack_capabilities_test";
+
+    @CapabilityInject(IItemHandler.class)
+    private static Capability<IItemHandler> CAP;
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final RegistryObject<Item> CAP_ITEM = ITEMS.register("cap_item", CapItem::new);
+    private static int attachCapabilitiesCount;
+
+    public ItemStackCapabilitiesTest()
+    {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ITEMS.register(modBus);
+        MinecraftForge.EVENT_BUS.addListener(ItemStackCapabilitiesTest::onServerStarted);
+        MinecraftForge.EVENT_BUS.addGenericListener(ItemStack.class, ItemStackCapabilitiesTest::onItemStackAttachCaps);
+    }
+
+    private static void onServerStarted(FMLServerStartedEvent event)
+    {
+        testItemStackCapabilities();
+    }
+
+    private static void onItemStackAttachCaps(AttachCapabilitiesEvent<ItemStack> event)
+    {
+        attachCapabilitiesCount++;
+    }
+
+    private static void testItemStackCapabilities()
+    {
+        attachCapabilitiesCount = 0;
+
+        ItemStack stackOne = new ItemStack(CAP_ITEM.get());
+        // get capability dispatches event
+        stackOne.getCapability(CAP).ifPresent(handler -> handler.insertItem(0, new ItemStack(Items.DIAMOND), false));
+        assertEquals(1, attachCapabilitiesCount);
+        // copy doesn't dispatch an event
+        ItemStack stackTwo = stackOne.copy();
+        // get capability does dispatch an event
+        stackTwo.getCapability(CAP).ifPresent(handler -> handler.insertItem(0, new ItemStack(Items.DIAMOND), false));
+        assertEquals(2, attachCapabilitiesCount);
+
+        // copies should handle comparisons just fine, without dispatching an attach capabilities event
+        ItemStack stackOneCopy = stackOne.copy();
+        ItemStack stackTwoCopy = stackTwo.copy();
+
+        // check that copies preserve equality
+        assertCompatible(stackOne, stackOneCopy);
+        assertCompatible(stackTwo, stackTwoCopy);
+        assertNotCompatible(stackOne, stackTwo);
+        assertNotCompatible(stackOne, stackTwoCopy);
+        assertNotCompatible(stackOneCopy, stackTwo);
+        assertNotCompatible(stackOneCopy, stackTwoCopy);
+
+        // only two dispatches should have happened (for the first two stacks)
+        assertEquals(2, attachCapabilitiesCount);
+    }
+
+    private static void assertEquals(int expected, int actual)
+    {
+        if (expected != actual) throw new AssertionError("Expected integer " + actual + " to be equal to " + expected + " , but it's not.");
+    }
+
+    private static void assertCompatible(ItemStack a, ItemStack b)
+    {
+        if (!a.areCapsCompatible(b)) throw new AssertionError("Expected capabilities to be compatible.");
+    }
+
+    private static void assertNotCompatible(ItemStack a, ItemStack b)
+    {
+        if (a.equals(b)) throw new AssertionError("Expected capabilities NOT to be compatible.");
+    }
+
+    private static class CapItem extends Item
+    {
+        private CapItem()
+        {
+            super(new Properties());
+        }
+
+        @Nullable
+        @Override
+        public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundNBT nbt)
+        {
+            return new TestCapProvider();
+        }
+    }
+
+    private static class TestCapProvider implements ICapabilityProvider, INBTSerializable<INBT>
+    {
+        private final IItemHandler handler = CAP.getDefaultInstance();
+
+        @Nonnull
+        @Override
+        public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, Direction side)
+        {
+            if (cap == CAP) return LazyOptional.of(() -> handler).cast();
+            else return LazyOptional.empty();
+        }
+
+        @Override
+        public INBT serializeNBT()
+        {
+            return CAP.getStorage().writeNBT(CAP, handler, null);
+        }
+
+        @Override
+        public void deserializeNBT(INBT nbt)
+        {
+            CAP.getStorage().readNBT(CAP, handler, null, nbt);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -136,3 +136,5 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="item_stack_capabilities_test"


### PR DESCRIPTION
This PR aims to fix the major bottleneck that item stack capabilities are - specifically, the attach capabilities event. I have seen countless profiles that indicate this is a major issue on worlds that make heavy use of item transfer. Lazily attaching capabilities means that the event will only be fired when accessing a capability. This should appropriately fix the performance issue.

~~I added a boolean field to `ItemStack` to track whether capabilities have already been initialized. The rest should be quite straightforward.~~ This PR allows `CapabilityProvider`s to be lazy. In that case, `capNBT` is used instead of the capabilities until the first `getCapability` call.

~~I will add a few unit tests to make sure this behaves as expected, but I'd like some feedback on the approach first.~~ Added a testmod that automatically runs a test on server start.