### PR TITLE
Prevents Tile Entity data leak by copying CompoundNBT before writing

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -153,7 +153,7 @@
  
 +         CompoundNBT caps = serializeCaps();
 +         if (caps != null) p_189511_1_.func_218657_a("ForgeCaps", caps);
-+         if (persistentData != null) p_189511_1_.func_218657_a("ForgeData", persistentData);
++         if (persistentData != null) p_189511_1_.func_218657_a("ForgeData", persistentData.func_74737_b());
 +
           this.func_213281_b(p_189511_1_);
           if (this.func_184207_aI()) {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -31,15 +31,30 @@
     }
  
     public CompoundNBT func_189515_b(CompoundNBT p_189515_1_) {
-@@ -62,6 +_,8 @@
-          p_189516_1_.func_74768_a("x", this.field_174879_c.func_177958_n());
-          p_189516_1_.func_74768_a("y", this.field_174879_c.func_177956_o());
-          p_189516_1_.func_74768_a("z", this.field_174879_c.func_177952_p());
-+         if (this.customTileData != null) p_189516_1_.func_218657_a("ForgeData", this.customTileData);
-+         if (getCapabilities() != null) p_189516_1_.func_218657_a("ForgeCaps", serializeCaps());
-          return p_189516_1_;
+@@ -54,15 +_,18 @@
+    }
+ 
+    private CompoundNBT func_189516_d(CompoundNBT p_189516_1_) {
++      CompoundNBT compoundNBT = p_189516_1_.func_74737_b();
+       ResourceLocation resourcelocation = TileEntityType.func_200969_a(this.func_200662_C());
+       if (resourcelocation == null) {
+          throw new RuntimeException(this.getClass() + " is missing a mapping! This is a bug!");
+       } else {
+-         p_189516_1_.func_74778_a("id", resourcelocation.toString());
+-         p_189516_1_.func_74768_a("x", this.field_174879_c.func_177958_n());
+-         p_189516_1_.func_74768_a("y", this.field_174879_c.func_177956_o());
+-         p_189516_1_.func_74768_a("z", this.field_174879_c.func_177952_p());
+-         return p_189516_1_;
++         compoundNBT.func_74778_a("id", resourcelocation.toString());
++         compoundNBT.func_74768_a("x", this.field_174879_c.func_177958_n());
++         compoundNBT.func_74768_a("y", this.field_174879_c.func_177956_o());
++         compoundNBT.func_74768_a("z", this.field_174879_c.func_177952_p());
++         if (this.customTileData != null) compoundNBT.func_218657_a("ForgeData", this.customTileData);
++         if (getCapabilities() != null) compoundNBT.func_218657_a("ForgeCaps", serializeCaps());
++         return compoundNBT;
        }
     }
+ 
 @@ -94,7 +_,7 @@
        if (this.field_145850_b != null) {
           this.field_195045_e = this.field_145850_b.func_180495_p(this.field_174879_c);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -31,30 +31,15 @@
     }
  
     public CompoundNBT func_189515_b(CompoundNBT p_189515_1_) {
-@@ -54,15 +_,18 @@
-    }
- 
-    private CompoundNBT func_189516_d(CompoundNBT p_189516_1_) {
-+      CompoundNBT compoundNBT = p_189516_1_.func_74737_b();
-       ResourceLocation resourcelocation = TileEntityType.func_200969_a(this.func_200662_C());
-       if (resourcelocation == null) {
-          throw new RuntimeException(this.getClass() + " is missing a mapping! This is a bug!");
-       } else {
--         p_189516_1_.func_74778_a("id", resourcelocation.toString());
--         p_189516_1_.func_74768_a("x", this.field_174879_c.func_177958_n());
--         p_189516_1_.func_74768_a("y", this.field_174879_c.func_177956_o());
--         p_189516_1_.func_74768_a("z", this.field_174879_c.func_177952_p());
--         return p_189516_1_;
-+         compoundNBT.func_74778_a("id", resourcelocation.toString());
-+         compoundNBT.func_74768_a("x", this.field_174879_c.func_177958_n());
-+         compoundNBT.func_74768_a("y", this.field_174879_c.func_177956_o());
-+         compoundNBT.func_74768_a("z", this.field_174879_c.func_177952_p());
-+         if (this.customTileData != null) compoundNBT.func_218657_a("ForgeData", this.customTileData);
-+         if (getCapabilities() != null) compoundNBT.func_218657_a("ForgeCaps", serializeCaps());
-+         return compoundNBT;
+@@ -62,6 +_,8 @@
+          p_189516_1_.func_74768_a("x", this.field_174879_c.func_177958_n());
+          p_189516_1_.func_74768_a("y", this.field_174879_c.func_177956_o());
+          p_189516_1_.func_74768_a("z", this.field_174879_c.func_177952_p());
++         if (this.customTileData != null) p_189516_1_.func_218657_a("ForgeData", this.customTileData.func_74737_b());
++         if (getCapabilities() != null) p_189516_1_.func_218657_a("ForgeCaps", serializeCaps());
+          return p_189516_1_;
        }
     }
- 
 @@ -94,7 +_,7 @@
        if (this.field_145850_b != null) {
           this.field_195045_e = this.field_145850_b.func_180495_p(this.field_174879_c);


### PR DESCRIPTION
Prevents Tile Entity data leak by copying CompoundNBT before writing and closes #7760.