### PR TITLE
Adds a damage float to LightningEntity to enable dynamic lightning damage

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -209,6 +209,15 @@
     public boolean func_205710_ba() {
        return true;
     }
+@@ -1948,7 +_,7 @@
+          this.func_70015_d(8);
+       }
+ 
+-      this.func_70097_a(DamageSource.field_180137_b, 5.0F);
++      this.func_70097_a(DamageSource.field_180137_b, p_241841_2_.getDamage());
+    }
+ 
+    public void func_203002_i(boolean p_203002_1_) {
 @@ -2032,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/entity/effect/LightningBoltEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/effect/LightningBoltEntity.java.patch
@@ -1,5 +1,28 @@
 --- a/net/minecraft/entity/effect/LightningBoltEntity.java
 +++ b/net/minecraft/entity/effect/LightningBoltEntity.java
+@@ -30,6 +_,7 @@
+    private boolean field_184529_d;
+    @Nullable
+    private ServerPlayerEntity field_204810_e;
++   private float damage = 5.0F;
+ 
+    public LightningBoltEntity(EntityType<? extends LightningBoltEntity> p_i231491_1_, World p_i231491_2_) {
+       super(p_i231491_1_, p_i231491_2_);
+@@ -51,6 +_,14 @@
+       this.field_204810_e = p_204809_1_;
+    }
+ 
++   public void setDamage(float damage){
++      this.damage = damage;
++   }
++
++   public float getDamage(){
++      return this.damage;
++   }
++
+    public void func_70071_h_() {
+       super.func_70071_h_();
+       if (this.field_70262_b == 2) {
 @@ -83,6 +_,7 @@
              List<Entity> list = this.field_70170_p.func_175674_a(this, new AxisAlignedBB(this.func_226277_ct_() - 3.0D, this.func_226278_cu_() - 3.0D, this.func_226281_cx_() - 3.0D, this.func_226277_ct_() + 3.0D, this.func_226278_cu_() + 6.0D + 3.0D, this.func_226281_cx_() + 3.0D), Entity::func_70089_S);
  


### PR DESCRIPTION
A small patch that moves the hardcoded 5.0f from Entity#thunderHit to a field in LightningBoltEntity, with appropriate setter and getter. 

This will allow modders to adjust lightning damage during the onEntityStruckByLightning event, as well as create lightning bolts that deal differing amounts of damage. 

**Why a new field?**
The damage source passed by the thunderHit method does not provide the damage source an instance of the lightning bolt entity, it is impossible to know if a mod using this damage source has actually spawned a bolt of lighting, or just wishes to use 'lightning damage' as a typing. 

Additionally, if a mod summons a bolt of lightning, but only wants that particular instance of lightning to deal additional damage, LivingHurtEvent does not provide the context necessary to increase that exclusive instance of damage without extra workarounds. 