### PR TITLE
Pass the world to ChunkDataEvent.Load

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
@@ -30,7 +30,7 @@
        }
  
        if (chunkstatus$type == ChunkStatus.Type.LEVELCHUNK) {
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_0_, p_222656_4_, chunkstatus$type));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_4_, chunkstatus$type));
           return new ChunkPrimerWrapper((Chunk)ichunk);
        } else {
           ChunkPrimer chunkprimer1 = (ChunkPrimer)ichunk;

--- a/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/ChunkSerializer.java.patch
@@ -30,7 +30,7 @@
        }
  
        if (chunkstatus$type == ChunkStatus.Type.LEVELCHUNK) {
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_4_, chunkstatus$type));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_0_, p_222656_4_, chunkstatus$type));
           return new ChunkPrimerWrapper((Chunk)ichunk);
        } else {
           ChunkPrimer chunkprimer1 = (ChunkPrimer)ichunk;
@@ -38,7 +38,7 @@
              chunkprimer1.func_205767_a(generationstage$carving, BitSet.valueOf(compoundnbt5.func_74770_j(s1)));
           }
  
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_4_, chunkstatus$type));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkDataEvent.Load(ichunk, p_222656_0_, p_222656_4_, chunkstatus$type));
 +
           return chunkprimer1;
        }

--- a/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
@@ -80,6 +80,12 @@ public class ChunkDataEvent extends ChunkEvent
             this.status = status;
         }
 
+        public Load(IChunk chunk, IWorld world, CompoundNBT data, ChunkStatus.Type status)
+        {
+            super(chunk, world, data);
+            this.status = status;
+        }
+
         public ChunkStatus.Type getStatus()
         {
             return this.status;


### PR DESCRIPTION
Currently `ChunkDataEvent.Load` sometimes does not provide the `ServerWorld`.

The chunk passed in the second `new ChunkDataEvent.Load(...)` is a `ChunkPrimer`, which does not return a world in `getWorldForge()` when passed onto `ChunkEvent#<init>`, making chunks with a status other than `ChunkStatus.Type.LEVELCHUNK` pass a null world to the event.