### PR TITLE
Exposes getExperienceReward and patches an experience dupe in ZombieEntity

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -195,14 +195,15 @@
     }
  
     protected void func_213337_cE() {
-@@ -1240,6 +_,7 @@
-       if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223602_e))) {
-          int i = this.func_70693_a(this.field_70717_bb);
+@@ -1238,7 +_,7 @@
  
-+         i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, i);
+    protected void func_226294_cV_() {
+       if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223602_e))) {
+-         int i = this.func_70693_a(this.field_70717_bb);
++         int i = this.getTotalExperienceValue(this.field_70717_bb);
+ 
           while(i > 0) {
              int j = ExperienceOrbEntity.func_70527_a(i);
-             i -= j;
 @@ -1260,7 +_,8 @@
        ResourceLocation resourcelocation = this.func_213346_cF();
        LootTable loottable = this.field_70170_p.func_73046_m().func_200249_aQ().func_186521_a(resourcelocation);
@@ -491,12 +492,10 @@
     }
  
     public boolean func_70094_T() {
-@@ -3080,6 +_,58 @@
- 
-    public void func_213334_d(Hand p_213334_1_) {
+@@ -3082,6 +_,58 @@
        this.func_213361_c(p_213334_1_ == Hand.MAIN_HAND ? EquipmentSlotType.MAINHAND : EquipmentSlotType.OFFHAND);
-+   }
-+
+    }
+ 
 +   /* ==== FORGE START ==== */
 +   /***
 +    * Removes all potion effects that have curativeItem as a curative item for its effect
@@ -547,6 +546,26 @@
 +      super.invalidateCaps();
 +      for (int x = 0; x < handlers.length; x++)
 +         handlers[x].invalidate();
-    }
- 
++   }
++
     @OnlyIn(Dist.CLIENT)
+    public AxisAlignedBB func_184177_bl() {
+       if (this.func_184582_a(EquipmentSlotType.HEAD).func_77973_b() == Items.field_196151_dA) {
+@@ -3090,5 +_,17 @@
+       } else {
+          return super.func_184177_bl();
+       }
++   }
++
++   /**
++    * Exposes the experience value of the entity after the getExperienceDrop event.
++    * @param playerEntity The player involved in obtaining this experience, typically lastHurtByPlayer. May be null.
++    * @return The amount of experience
++    */
++   public final int getTotalExperienceValue(PlayerEntity playerEntity){
++      if(!func_146066_aG())
++         return 0;
++      int i = this.func_70693_a(playerEntity);
++      return net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, playerEntity, i);
+    }
+ }

--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -195,15 +195,17 @@
     }
  
     protected void func_213337_cE() {
-@@ -1238,7 +_,7 @@
+@@ -1238,8 +_,9 @@
  
     protected void func_226294_cV_() {
        if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223602_e))) {
 -         int i = this.func_70693_a(this.field_70717_bb);
-+         int i = this.getTotalExperienceValue(this.field_70717_bb);
++         int i = func_70693_a(this.field_70717_bb);
  
++         i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, i);
           while(i > 0) {
              int j = ExperienceOrbEntity.func_70527_a(i);
+             i -= j;
 @@ -1260,7 +_,8 @@
        ResourceLocation resourcelocation = this.func_213346_cF();
        LootTable loottable = this.field_70170_p.func_73046_m().func_200249_aQ().func_186521_a(resourcelocation);

--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -195,12 +195,9 @@
     }
  
     protected void func_213337_cE() {
-@@ -1238,8 +_,9 @@
- 
-    protected void func_226294_cV_() {
+@@ -1240,6 +_,7 @@
        if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223602_e))) {
--         int i = this.func_70693_a(this.field_70717_bb);
-+         int i = func_70693_a(this.field_70717_bb);
+          int i = this.func_70693_a(this.field_70717_bb);
  
 +         i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, i);
           while(i > 0) {

--- a/patches/minecraft/net/minecraft/entity/monster/ZombieEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ZombieEntity.java.patch
@@ -1,5 +1,18 @@
 --- a/net/minecraft/entity/monster/ZombieEntity.java
 +++ b/net/minecraft/entity/monster/ZombieEntity.java
+@@ -151,11 +_,7 @@
+    }
+ 
+    protected int func_70693_a(PlayerEntity p_70693_1_) {
+-      if (this.func_70631_g_()) {
+-         this.field_70728_aV = (int)((float)this.field_70728_aV * 2.5F);
+-      }
+-
+-      return super.func_70693_a(p_70693_1_);
++      return this.func_70631_g_() ? (int) (super.func_70693_a(p_70693_1_) * 2.5F) : super.func_70693_a(p_70693_1_);
+    }
+ 
+    public void func_82227_f(boolean p_82227_1_) {
 @@ -186,7 +_,8 @@
        if (!this.field_70170_p.field_72995_K && this.func_70089_S() && !this.func_175446_cd()) {
           if (this.func_204706_dD()) {


### PR DESCRIPTION
This PR adds a new method to LivingEntity that calls the protected getExperienceRewards method and fires the forge getExperienceDrop event to return the 'true' exp value of a mob. The forge event in dropExperience has been replaced with this new method call that provides the same functionality. If shouldDropExperience returns false, this method returns 0.

One additional patch is made to ZombieEntity to remove the mutation of xpReward for babies, otherwise the experience value of the mob would increase each time getExperienceDrop is called. This change does not modify the experience value in any way in the super call, MobEntity#getExperienceReward where xpReward is simply checked for 0 and assigned to another int.

**Why a new method?**

Currently, there is no way to get the experience value of a mob until the forge event fires, when it has already died. getExpierenceDrop, shouldDropExperience, and xpReward are all set to protected in LivingEntity and MobEntity. Additionally, the xpReward  field is unreliable for getting the experience value of the mob, as it is not used at all for AnimalEntity and WaterMobEntity.

Changing getExperienceDrop and shouldDropExperience to public is a breaking change for 1.16, and should perhaps be considered for 1.17. Furthermore, even if these two methods were public, this method also combines the experience reward and the forge event for the modder without requiring them to manually fire the forge event each time. 