### PR TITLE
[1.16.x] Fixed setting a BlockEntity with a BlockState overwriting pending BlockEntities

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -26,7 +26,7 @@
     }
  
     public Chunk(World p_i49947_1_, ChunkPrimer p_i49947_2_) {
-@@ -264,28 +_,28 @@
+@@ -264,30 +_,27 @@
  
           if (!this.field_76637_e.field_72995_K) {
              blockstate.func_196947_b(this.field_76637_e, p_177436_1_, p_177436_2_, p_177436_3_);
@@ -52,14 +52,17 @@
              }
  
 -            if (block instanceof ITileEntityProvider) {
-+            if (p_177436_2_.hasTileEntity()) {
-                TileEntity tileentity1 = this.func_177424_a(p_177436_1_, Chunk.CreateEntityType.CHECK);
-                if (tileentity1 == null) {
+-               TileEntity tileentity1 = this.func_177424_a(p_177436_1_, Chunk.CreateEntityType.CHECK);
+-               if (tileentity1 == null) {
 -                  tileentity1 = ((ITileEntityProvider)block).func_196283_a_(this.field_76637_e);
-+                  tileentity1 = p_177436_2_.createTileEntity(this.field_76637_e);
-                   this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
-                } else {
+-                  this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
+-               } else {
++            if (p_177436_2_.hasTileEntity()) {
++               TileEntity tileentity1 = this.field_76637_e.func_175625_s(p_177436_1_); // Forge - make sure to check for pending BlockEntities when placing a new BlockEntity into the world
++               if (tileentity1 != null) {
                    tileentity1.func_145836_u();
+                }
+             }
 @@ -321,11 +_,13 @@
           k = this.field_76645_j.length - 1;
        }


### PR DESCRIPTION
This Pull Request fixes that the code for BlockEntity placement in `Chunk.setBlockState()` doesn't respect the `pendingBlockEntities` field in `World`, the place where all BlockEntities placed during a tick are stored before they get placed into the world.

The prior behavior was to add the BlockEntity associated with the BlockState to `pendingBlockEntities`, no matter if a pending BlockEntity already exists at the position, and thus removing the old, correctly set-up BlockEntity from `pendingBlockEntities`. This can cause issues for BlockEntity-pushing Pistons (which usually work in a single tick) where the pushed BlockEntity gets added with their correct NBT to `pendingBlockEntities`, but (in some circumstances, for example if the pushed BE-Block immediately updates its state after getting pushed) then gets overridden by a new BlockEntity requested by `setBlockState()` which overwrites the correct BE in `pendingBlockEntities`, resulting in a BlockEntity without a NBT getting placed.

The attached fix changes `this.getBlockEntity(pos, Chunk.CreateEntityType.CHECK)` to `this.level.getBlockEntity(pos)` to make the BE check respect the `pendingBlockEntities`. However, `World.getBlockEntity()` does not take a `CreateEntityType` parameter and instead defaults to `Chunk.CreateEntityType.IMMEDIATE`. This is not a huge concern though because all `CreateEntityType.IMMEDIATE` does differently than `CreateEntityType.CHECK` is creating and placing the appropriate BE, which normally would already be done in `Chunk.setBlockState`. Thus, these two statements can be removed from the `Chunk` class, and the logic of the `tileentity.clearCache()` was also adjusted.