### PR TITLE
[1.16.x] Add an API for dynamic dimensions

### DIFF
--- a/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.common;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -92,7 +91,7 @@ public class DynamicDimensionManager
      * Marks a world and its dimension for unregistration. Unregistered worlds will stop ticking,
      * unregistered dimensions will not be loaded on server startup unless and until they are reregistered again.
      * 
-     * Unregistration is delayed until the end of the server tick (just before the post-server-tick-event fires).
+     * Unregistration is delayed until the end of the server tick (just after the post-server-tick-event fires).
      * 
      * Players who are still in the given world at that time will be ejected to their respawn points.
      * Players who have respawn points in worlds being unloaded will have their spawn points reset to the overworld and respawned there.

--- a/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fml.network.NetworkHooks;
 @ParametersAreNonnullByDefault
 public class DynamicDimensionManager
 {
+    private static final Set<RegistryKey<World>> VANILLA_WORLDS = ImmutableSet.of(World.OVERWORLD, World.NETHER, World.END); 
     private static Set<RegistryKey<World>> pendingWorldsToUnregister = new HashSet<>();
     
     /**
@@ -99,16 +100,23 @@ public class DynamicDimensionManager
      * Unregistering a world does not delete the region files or other data associated with the world's world folder.
      * If a world is reregistered after unregistering it, the world will retain all prior data (unless manually deleted via server admin)
      * 
-     * @param worldToRemove The key for the world to schedule for unregistration.
+     * @param worldToRemove The key for the world to schedule for unregistration. Vanilla dimensions are not removable as they are
+     * generally assumed to exist (especially the overworld)
      * 
      * @apiNote Not intended for use with vanilla or json dimensions, doing so may cause strange problems.
+     * 
+     * However, if a vanilla or json dimension *is* removed, restarting the server will reconstitute it as
+     * vanilla automatically detects and registers these.
      * 
      * Mods whose dynamic dimensions require the ejection of players to somewhere other than their respawn point
      * should teleport these worlds' players to appropriate locations before unregistering their dimensions.
      */
     public static void markDimensionForUnregistration(final MinecraftServer server, final RegistryKey<World> worldToRemove)
     {
-        DynamicDimensionManager.pendingWorldsToUnregister.add(worldToRemove);
+        if (!VANILLA_WORLDS.contains(worldToRemove))
+        {
+            DynamicDimensionManager.pendingWorldsToUnregister.add(worldToRemove);
+        }
     }
     
     /**

--- a/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
@@ -1,0 +1,294 @@
+package net.minecraftforge.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.SimpleRegistry;
+import net.minecraft.world.Dimension;
+import net.minecraft.world.World;
+import net.minecraft.world.border.IBorderListener;
+import net.minecraft.world.border.WorldBorder;
+import net.minecraft.world.chunk.listener.IChunkStatusListener;
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.DerivedWorldInfo;
+import net.minecraft.world.storage.IServerConfiguration;
+import net.minecraft.world.storage.SaveFormat.LevelSave;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.network.NetworkHooks;
+
+/**
+ * API for creating and uncreating dynamic dimensions during game runtime. This
+ * should only be used for creating dynamic dimensions, whose quantity and
+ * properties aren't known until created by some game mechanic. Static
+ * dimensions (whose quantities and properties are fixed ahead of time) should
+ * be created using the vanilla json dimension system.
+ */
+@ParametersAreNonnullByDefault
+public class DynamicDimensionManager
+{
+    private static Set<RegistryKey<World>> pendingWorldsToUnregister = new HashSet<>();
+    
+    /**
+     * Retrieves the world for a given world key, registering and creating one if it doesn't already exist.
+     * 
+     * Worlds created this way will be saved to the world folder's dimension registry
+     * and will be automatically loaded the next time the server starts. All registered worlds will tick while they exist
+     * (though a world without any loaded chunks won't do much in the tick).
+     * 
+     * @param server a server
+     * @param worldKey The registry key for the world
+     * @param dimensionFactory The function to use to create the world's Dimension instance if it doesn't already exist;
+     * the given dimension key will have the same ID as the given world key
+     * @return A server world for the given key
+     * 
+     * @apiNote To retreive static dimensions that always exist, or to look up a (nullable) world without force-creating it,
+     * use {@link MinecraftServer#getLevel(RegistryKey)} instead.
+     * 
+     * To register a static dimension that always exists, make a json dimension instead; minecraft will load and register it automatically
+     * 
+     * To unregister a dynamic dimension world (preventing it from ticking, or from loading at server startup),
+     * use {@link DynamicDimensionManager#unregisterDimensions(MinecraftServer, Set)}.
+     */
+    public static ServerWorld getOrCreateWorld(final MinecraftServer server, final RegistryKey<World> worldKey, final BiFunction<MinecraftServer, RegistryKey<Dimension>, Dimension> dimensionFactory)
+    {
+        // (we're doing the lookup this way because we'll need the map if we need to add a new world)
+        @SuppressWarnings("deprecation") // forgeGetWorldMap is deprecated because it's a forge-internal-use-only method
+        final Map<RegistryKey<World>, ServerWorld> map = server.forgeGetWorldMap();
+        
+        // if the world already exists, return it
+        final @Nullable ServerWorld existingWorld = map.get(worldKey);
+        if (existingWorld != null)
+        {
+            return existingWorld;
+        }
+
+        final ServerWorld newWorld = createAndRegisterWorldAndDimension(server, map, worldKey, dimensionFactory);
+        return newWorld;
+    }
+    
+    /**
+     * Marks a world and its dimension for unregistration. Unregistered worlds will stop ticking,
+     * unregistered dimensions will not be loaded on server startup unless and until they are reregistered again.
+     * 
+     * Unregistration is delayed until the end of the server tick (just before the post-server-tick-event fires).
+     * 
+     * Players who are still in the given world at that time will be ejected to their respawn points.
+     * Players who have respawn points in worlds being unloaded will have their spawn points reset to the overworld and respawned there.
+     * 
+     * Unregistering a world does not delete the region files or other data associated with the world's world folder.
+     * If a world is reregistered after unregistering it, the world will retain all prior data (unless manually deleted via server admin)
+     * 
+     * @param worldToRemove The key for the world to schedule for unregistration.
+     * 
+     * @apiNote Not intended for use with vanilla or json dimensions, doing so may cause strange problems.
+     * 
+     * Mods whose dynamic dimensions require the ejection of players to somewhere other than their respawn point
+     * should teleport these worlds' players to appropriate locations before unregistering their dimensions.
+     */
+    public static void markDimensionForUnregistration(final MinecraftServer server, final RegistryKey<World> worldToRemove)
+    {
+        DynamicDimensionManager.pendingWorldsToUnregister.add(worldToRemove);
+    }
+    
+    /**
+     * @return an immutable view of the worlds pending to be unregistered and unloaded at the end of the current server tick
+     */
+    public static Set<RegistryKey<World>> getWorldsPendingUnregistration()
+    {
+        return Collections.unmodifiableSet(DynamicDimensionManager.pendingWorldsToUnregister);
+    }
+    
+    /**
+     * called at the end of the server tick just before the post-server-tick-event
+     * @deprecated Internal forge method 
+     */
+    @Deprecated
+    public static void unregisterScheduledDimensions(final MinecraftServer server)
+    {
+        // flush the buffer
+        final Set<RegistryKey<World>> keysToRemove = DynamicDimensionManager.pendingWorldsToUnregister;
+        DynamicDimensionManager.pendingWorldsToUnregister = new HashSet<>();
+        
+        // we need to remove the dimension/world form three places
+        // the server's dimension registry, the server's world registry, and the overworld's world border listener
+        // the world registry is just a simple map and the world border listener has a remove() method
+        // the dimension registry has five sub-collections that need to be cleaned up
+        // we should also eject players from the removed worlds or they could get stuck there
+        
+        final DimensionGeneratorSettings worldGenSettings = server.getWorldData().worldGenSettings();
+        final Set<RegistryKey<World>> removedWorldKeys = new HashSet<>();
+        final ServerWorld overworld = server.getLevel(World.OVERWORLD);
+        
+        for (final RegistryKey<World> worldKeyToRemove : keysToRemove)
+        {
+            @Nullable ServerWorld removedWorld = server.forgeGetWorldMap().remove(worldKeyToRemove); // null if the specified key was not present
+            if (removedWorld != null) // if we removed the key from the map
+            {
+                // eject players from dead world
+                // iterate over a copy as the world will remove players from the original list
+                for (final ServerPlayerEntity player : Lists.newArrayList(removedWorld.players()))
+                {
+                    // send players to their respawn point
+                    RegistryKey<World> respawnKey = player.getRespawnDimension();
+                    // if we're removing their respawn world then just send them to the overworld
+                    if (keysToRemove.contains(respawnKey))
+                    {
+                        respawnKey = World.OVERWORLD;
+                        player.setRespawnPosition(World.OVERWORLD, null, 0, false, false);
+                    }
+                    if (respawnKey == null)
+                        respawnKey = World.OVERWORLD;
+                    final ServerWorld destinationWorld = server.getLevel(respawnKey);
+                    BlockPos destinationPos = player.getRespawnPosition();
+                    if (destinationPos == null)
+                        destinationPos = destinationWorld.getSharedSpawnPos();
+                    final float respawnAngle = player.getRespawnAngle();
+                    // "respawning" the player via the player list schedules a task in the server to run after the post-server tick
+                    // that causes some minor logspam due to the player's world no longer being loaded
+                    // teleporting the player this way instead avoids this
+                    player.teleportTo(destinationWorld, destinationPos.getX(), destinationPos.getY(), destinationPos.getZ(), respawnAngle, 0F);
+                }
+                // save the world now or it won't be saved later and data that may be wanted to be kept may be lost
+                removedWorld.save(null, false, removedWorld.noSave());
+
+                // fire world unload event -- when the server stops, this would fire after worlds get saved, so we'll do that here too
+                MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(removedWorld));
+                
+                // remove the world border listener if possible
+                final WorldBorder overworldBorder = overworld.getWorldBorder();
+                final WorldBorder removedWorldBorder = removedWorld.getWorldBorder();
+                final List<IBorderListener> listeners = overworldBorder.listeners;
+                IBorderListener targetListener = null;
+                for (IBorderListener listener : listeners)
+                {
+                    if (listener instanceof IBorderListener.Impl && removedWorldBorder == ((IBorderListener.Impl)listener).worldBorder)
+                    {
+                        targetListener = listener;
+                        break;
+                    }
+                }
+                if (targetListener != null)
+                {
+                    overworldBorder.removeListener(targetListener);
+                }
+                
+                // track the removed world
+                removedWorldKeys.add(worldKeyToRemove);
+            }
+        }
+        
+        if (!removedWorldKeys.isEmpty())
+        {
+            // replace the old dimension registry with a new one containing the dimensions that weren't removed, in the same order
+            final SimpleRegistry<Dimension> oldRegistry = worldGenSettings.dimensions();
+            final SimpleRegistry<Dimension> newRegistry = new SimpleRegistry<>(Registry.LEVEL_STEM_REGISTRY, oldRegistry.elementsLifecycle());
+            
+            for (final Entry<RegistryKey<Dimension>, Dimension> entry : oldRegistry.entrySet())
+            {
+                final RegistryKey<Dimension> oldKey = entry.getKey();
+                final RegistryKey<World> oldWorldKey = RegistryKey.create(Registry.DIMENSION_REGISTRY, oldKey.location());
+                final Dimension dimension = entry.getValue();
+                if (oldKey != null && dimension != null && !removedWorldKeys.contains(oldWorldKey))
+                {
+                    newRegistry.register(oldKey, dimension, oldRegistry.lifecycle(dimension));
+                }
+            }
+            
+            // then replace the old registry with the new registry
+            worldGenSettings.dimensions = newRegistry;
+
+            // update the server's worlds so dead worlds don't get ticked
+            server.markWorldsDirty();
+            // client will need to be notified of the removed world for the dimension command suggester
+            NetworkHooks.updateClientDimensionLists(ImmutableSet.of(), removedWorldKeys);
+        }
+    }
+    
+    @SuppressWarnings("deprecation") // because we call the forge internal method server#markWorldsDirty
+    private static ServerWorld createAndRegisterWorldAndDimension(final MinecraftServer server, final Map<RegistryKey<World>, ServerWorld> map, final RegistryKey<World> worldKey, final BiFunction<MinecraftServer, RegistryKey<Dimension>, Dimension> dimensionFactory)
+    {
+        // get everything we need to create the dimension and the world
+        final ServerWorld overworld = server.getLevel(World.OVERWORLD);
+        
+        // dimension keys have a 1:1 relationship with world keys, they have the same IDs as well
+        final RegistryKey<Dimension> dimensionKey = RegistryKey.create(Registry.LEVEL_STEM_REGISTRY, worldKey.location());
+        final Dimension dimension = dimensionFactory.apply(server, dimensionKey);
+
+        // the int in create() here is radius of chunks to watch, 11 is what the server uses when it initializes worlds
+        final IChunkStatusListener chunkProgressListener = server.progressListenerFactory.create(11);
+        final Executor executor = server.executor;
+        final LevelSave anvilConverter = server.storageSource;
+        final IServerConfiguration worldData = server.getWorldData();
+        final DimensionGeneratorSettings worldGenSettings = worldData.worldGenSettings();
+        final DerivedWorldInfo derivedWorldInfo = new DerivedWorldInfo(worldData, worldData.overworldData());
+        
+        // now we have everything we need to create the dimension and the world
+        // this is the same order server init creates worlds:
+        // the dimensions are already registered when worlds are created, we'll do that first
+        // then instantiate world, add border listener, add to map, fire world load event
+        
+        // register the actual dimension
+        worldGenSettings.dimensions().register(dimensionKey, dimension, Lifecycle.experimental());
+
+        // create the world instance
+        final ServerWorld newWorld = new ServerWorld(
+            server,
+            executor,
+            anvilConverter,
+            derivedWorldInfo,
+            worldKey,
+            dimension.type(),
+            chunkProgressListener,
+            dimension.generator(),
+            worldGenSettings.isDebug(),
+            net.minecraft.world.biome.BiomeManager.obfuscateSeed(worldGenSettings.seed()),
+            ImmutableList.of(), // "special spawn list"
+                // phantoms, travelling traders, patrolling/sieging raiders, and cats are overworld special spawns
+                // this is always empty for non-overworld dimensions (including json dimensions)
+                // these spawners are ticked when the world ticks to do their spawning logic,
+                // mods that need "special spawns" for their own dimensions should implement them via tick events or other systems
+            false // "tick time", true for overworld, always false for nether, end, and json dimensions
+            );
+        
+        // add world border listener, for parity with json dimensions
+        // the vanilla behaviour is that world borders exist in every dimension simultaneously with the same size and position
+        // these border listeners are automatically added to the overworld as worlds are loaded, so we should do that here too
+        // TODO if world-specific world borders are ever added, change it here too
+        overworld.getWorldBorder().addListener(new IBorderListener.Impl(newWorld.getWorldBorder()));
+        
+        // register world
+        map.put(worldKey, newWorld);
+        
+        // update forge's world cache so the new world can be ticked
+        server.markWorldsDirty();
+        
+        // fire world load event
+        MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(newWorld));
+        
+        // update clients' world lists
+        NetworkHooks.updateClientDimensionLists(ImmutableSet.of(worldKey), ImmutableSet.of());
+        
+        return newWorld;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common;
 
 import java.util.Collections;

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -23,12 +23,15 @@ import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.animation.Animation;
+import net.minecraftforge.common.DynamicDimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraftforge.event.TickEvent;
 
 public class BasicEventHooks
@@ -117,6 +120,9 @@ public class BasicEventHooks
 
     public static void onPostServerTick()
     {
+        final MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+        if (server != null)
+            DynamicDimensionManager.unregisterScheduledDimensions(server);
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
     }
 }

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -120,9 +120,9 @@ public class BasicEventHooks
 
     public static void onPostServerTick()
     {
+        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
         final MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
         if (server != null)
             DynamicDimensionManager.unregisterScheduledDimensions(server);
-        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
     }
 }

--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -32,6 +32,7 @@ import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.tags.ITagCollection;
 import net.minecraft.tags.ITagCollectionSupplier;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.common.thread.EffectiveSide;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,6 +48,7 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.handshake.client.CHandshakePacket;
 import net.minecraft.network.login.ServerLoginNetHandler;
+import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
@@ -264,5 +266,21 @@ public class NetworkHooks
     public static FMLConnectionData getConnectionData(NetworkManager mgr)
     {
         return mgr.channel().attr(FMLNetworkConstants.FML_CONNECTION_DATA).get();
+    }
+    
+    /**
+     * Notifies clients that their list of dimension IDs needs to be updated.
+     * This clientside list is normally only used for the command suggester.
+     * 
+     * @param newDimensions keys to add to clients' dimension lists
+     * @param removedDimensions keys to remove from clients' dimension lists
+     * 
+     * @apiNote Internal; this is invoked by {@link DynamicDimensionManager}
+     * when that's used to add or remove dynamic dimensions,
+     * so mods shouldn't need to call this themselves
+     */
+    public static void updateClientDimensionLists(Set<RegistryKey<World>> newDimensions, Set<RegistryKey<World>> removedDimensions)
+    {
+        FMLNetworkConstants.playChannel.send(PacketDistributor.ALL.noArg(), new FMLPlayMessages.SyncDimensionListChanges(newDimensions,removedDimensions));
     }
 }

--- a/src/main/java/net/minecraftforge/fml/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkInitialization.java
@@ -110,6 +110,12 @@ class NetworkInitialization {
               encoder(FMLPlayMessages.SyncCustomTagTypes::encode).
               consumer(FMLPlayMessages.SyncCustomTagTypes::handle).
               add();
+        
+        playChannel.messageBuilder(FMLPlayMessages.SyncDimensionListChanges.class, 4).
+            decoder(FMLPlayMessages.SyncDimensionListChanges::decode).
+            encoder(FMLPlayMessages.SyncDimensionListChanges::encode).
+            consumer(FMLPlayMessages.SyncDimensionListChanges::handle).
+            add();
 
         return playChannel;
     }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -273,6 +273,9 @@ public net.minecraft.particles.ParticleType <init>(ZLnet/minecraft/particles/IPa
 public net.minecraft.resources.FallbackResourceManager field_199023_a # resourcePacks
 public net.minecraft.resources.ResourcePack field_195771_a # file
 protected net.minecraft.server.MinecraftServer field_211151_aa # serverTime
+public net.minecraft.server.MinecraftServer field_213217_au # executor
+public net.minecraft.server.MinecraftServer field_213220_d # progressListenerFactory
+public net.minecraft.server.MinecraftServer field_71310_m # storageSource
 public net.minecraft.server.dedicated.DedicatedServer field_71341_l # pendingCommandList
 public net.minecraft.tags.BlockTags func_199894_a(Ljava/lang/String;)Lnet/minecraft/tags/ITag$INamedTag; # makeWrapperTag
 public net.minecraft.tags.EntityTypeTags func_232896_a_(Ljava/lang/String;)Lnet/minecraft/tags/ITag$INamedTag; # makeWrapperTag
@@ -321,6 +324,8 @@ protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242567_a
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242568_b
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242569_c
 protected net.minecraft.world.biome.MobSpawnInfo$Builder field_242570_d
+public net.minecraft.world.border.IBorderListener$Impl field_219590_a # worldBorder
+public net.minecraft.world.border.WorldBorder field_177758_a # listeners
 public net.minecraft.world.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/chunk/ChunkStatus$Type;Lnet/minecraft/world/chunk/ChunkStatus$IGenerationWorker;Lnet/minecraft/world/chunk/ChunkStatus$ILoadingWorker;)V
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177462_b #GRID_WIDTH
 private-f net.minecraft.world.gen.DebugChunkGenerator field_177464_a #ALL_VALID_STATES
@@ -331,6 +336,7 @@ public net.minecraft.world.gen.blockplacer.BlockPlacerType <init>(Lcom/mojang/se
 public net.minecraft.world.gen.blockstateprovider.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.gen.foliageplacer.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.gen.layer.LayerUtil func_202829_a(JLnet/minecraft/world/gen/layer/traits/IAreaTransformer1;Lnet/minecraft/world/gen/area/IAreaFactory;ILjava/util/function/LongFunction;)Lnet/minecraft/world/gen/area/IAreaFactory; # repeat
+public-f net.minecraft.world.gen.settings.DimensionGeneratorSettings field_236208_h_ # dimensions
 public net.minecraft.world.gen.treedecorator.TreeDecoratorType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 private-f net.minecraft.world.raid.Raid$WaveMember field_221284_f # VALUES
 public net.minecraft.world.server.ServerChunkProvider field_186029_c # chunkGenerator

--- a/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.world;
 
 import java.util.Objects;

--- a/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
@@ -90,18 +90,12 @@ public class DynamicDimensionManagerTest
         return 1;
     }
     
-    private static final Set<RegistryKey<World>> VANILLA_WORLDS = ImmutableSet.of(World.OVERWORLD, World.NETHER, World.END);
     private static int removeDimension(final CommandContext<CommandSource> context) throws CommandSyntaxException
     {
         final CommandSource source = context.getSource();
         final MinecraftServer server = source.getServer();
         final ServerWorld worldToRemove = DimensionArgument.getDimension(context, DIMENSION);
         final RegistryKey<World> key = worldToRemove.dimension();
-        if (VANILLA_WORLDS.contains(key))
-        {
-            source.sendFailure(new StringTextComponent(String.format("Removing vanilla dimension %s seems like a bad idea", key.location())));
-            return 0;
-        }
         source.sendSuccess(new StringTextComponent(String.format("Unregistering dimension %s", key.location())), true);
         DynamicDimensionManager.markDimensionForUnregistration(server, key);
         return 1;

--- a/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
@@ -1,0 +1,120 @@
+package net.minecraftforge.debug.world;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.command.ISuggestionProvider;
+import net.minecraft.command.arguments.DimensionArgument;
+import net.minecraft.command.arguments.ResourceLocationArgument;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.DynamicRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.Dimension;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.provider.BiomeProvider;
+import net.minecraft.world.biome.provider.OverworldBiomeProvider;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.DimensionSettings;
+import net.minecraft.world.gen.NoiseChunkGenerator;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.DynamicDimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+@Mod(DynamicDimensionManagerTest.MODID)
+public class DynamicDimensionManagerTest
+{
+    public static final String MODID = "dynamic_dimension_manager_test";
+    public static final String NEW_DIMENSION_NAME = "new_dimension_name";
+    public static final String DIMENSION = "dimension";
+    
+    public DynamicDimensionManagerTest()
+    {
+        final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        final IEventBus forgeBus = MinecraftForge.EVENT_BUS;
+        
+        forgeBus.addListener(this::onRegisterCommands);
+    }
+    
+    private void onRegisterCommands(final RegisterCommandsEvent event)
+    {
+        final CommandDispatcher<CommandSource> dispatcher = event.getDispatcher();
+        dispatcher.register(Commands.literal(MODID)
+            .requires(DynamicDimensionManagerTest::isCommandSourceServerAdmin)
+            .then(Commands.literal("add")
+                .then(Commands.argument(NEW_DIMENSION_NAME, ResourceLocationArgument.id())
+                    .suggests((context,builder) -> ISuggestionProvider.suggest(new String[]{"<new_dimension_name>"}, builder))
+                    .executes(DynamicDimensionManagerTest::addNewDimension)))
+            .then(Commands.literal("remove")
+                .then(Commands.argument(DIMENSION, DimensionArgument.dimension())
+                    .executes(DynamicDimensionManagerTest::removeDimension)))
+            );
+    }
+    
+    private static boolean isCommandSourceServerAdmin(final CommandSource source)
+    {
+        return source.hasPermission(4);
+    }
+    
+    private static int addNewDimension(final CommandContext<CommandSource> context)
+    {
+        final CommandSource source = context.getSource();
+        final ResourceLocation rawID = ResourceLocationArgument.getId(context, NEW_DIMENSION_NAME);
+        // convert minecraft namespace to modid
+        final ResourceLocation worldID = rawID.getNamespace() == "minecraft" ? new ResourceLocation(MODID, rawID.getPath()) : rawID;
+        final RegistryKey<World> worldKey = RegistryKey.create(Registry.DIMENSION_REGISTRY, worldID);
+        final MinecraftServer server = source.getServer();
+        final ServerWorld existingWorld = server.getLevel(worldKey);
+        if (existingWorld != null)
+        {
+            source.sendFailure(new StringTextComponent(String.format("World with id %s already exists", worldID)));
+            return 0;
+        }
+        DynamicDimensionManager.getOrCreateWorld(server, worldKey, DynamicDimensionManagerTest::makeDimension);
+        source.sendSuccess(new StringTextComponent(String.format("Created world with id %s", worldID)), true);
+        return 1;
+    }
+    
+    private static final Set<RegistryKey<World>> VANILLA_WORLDS = ImmutableSet.of(World.OVERWORLD, World.NETHER, World.END);
+    private static int removeDimension(final CommandContext<CommandSource> context) throws CommandSyntaxException
+    {
+        final CommandSource source = context.getSource();
+        final MinecraftServer server = source.getServer();
+        final ServerWorld worldToRemove = DimensionArgument.getDimension(context, DIMENSION);
+        final RegistryKey<World> key = worldToRemove.dimension();
+        if (VANILLA_WORLDS.contains(key))
+        {
+            source.sendFailure(new StringTextComponent(String.format("Removing vanilla dimension %s seems like a bad idea", key.location())));
+            return 0;
+        }
+        source.sendSuccess(new StringTextComponent(String.format("Unregistering dimension %s", key.location())), true);
+        DynamicDimensionManager.markDimensionForUnregistration(server, key);
+        return 1;
+    }
+    
+    private static Dimension makeDimension(final MinecraftServer server, final RegistryKey<Dimension> key)
+    {
+        final long seed = Objects.hash(server.getLevel(World.OVERWORLD).getSeed(), key.location());
+        final DynamicRegistries registries = server.registryAccess();
+        final DimensionType overworldDimensionType = registries.registryOrThrow(Registry.DIMENSION_TYPE_REGISTRY).get(DimensionType.OVERWORLD_LOCATION);
+        final BiomeProvider biomeProvider = new OverworldBiomeProvider(seed, false, false, registries.registryOrThrow(Registry.BIOME_REGISTRY));
+        final DimensionSettings noiseSettings = registries.registryOrThrow(Registry.NOISE_GENERATOR_SETTINGS_REGISTRY).get(DimensionSettings.OVERWORLD);
+        final ChunkGenerator chunkGenerator = new NoiseChunkGenerator(biomeProvider, seed, () -> noiseSettings);
+        return new Dimension(() -> overworldDimensionType, chunkGenerator);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -136,3 +136,5 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="dynamic_dimension_manager_test"


### PR DESCRIPTION
## What's this add?
* An API for adding and removing dimensions during server runtime

## Why's this add that?
* This API allows mods to generate indefinitely many concurrently-existing worlds whose properties and quantity are not necessarily known ahead of time
* Mods would be able to use this API to (for example) add random dungeon dimensions, per-player personal spaces, or dimensions whose properties are determined via player input.
* The ability to remove or unregister dimensions is needed by mods that add many dynamic dimensions, as registered worlds are kept in memory; this allows mods to completely unload worlds while they are not in use.

## Public APIs
* The new DynamicDimensionManager class contains all public APIs for this feature:
  * `getOrCreateWorld` returns a world for a specified world key, creating and registering the world and dimension if the world doesn't already exist.
    * This also fires a world load event once the world has been registered into the server.
  * `markDimensionForUnregistration` schedules a world and dimension to be unregistered and unloaded at the end of the current server tick, just after the post-server-tick-event fires.
    * World unload events are fired for each world in sequence, before any worlds and dimensions are removed from the registries.
    * If any players remain in a world when the world is unloaded, they will be ejected to their respawn point (or to the overworld if their respawn point was in a world-being-removed). Mods whose dynamic dimensions require players to be ejected elsewhere should manually teleport them before scheduling dimension removal.
  * `getWorldsPendingUnregistration` returns an immutable view of the world keys scheduled for unregistration.

## Other Features
* When dimensions are added or removed, a syncing packet is sent to clients to update their dimension ID list.
  * This list is normally only used for suggesting dimension IDs for commands; minecraft does not normally sync any information about dimensions other than their IDs.
  * This syncing feature is only available to clients if the client also has an up-to-date build of forge with the features added in this PR, as vanilla clients are only able to update their dimension ID lists on login. Vanilla clients and older forge clients (using forge builds without this PR's features) will be able to connect to forge servers, but are unable to handle the syncing packet when the servers' dimensions update during runtime, so these clients' dimension ID lists will remain outdated until they leave and rejoin the server.

## Effects on Existing Mods
* This PR adds no patches to vanilla sources, and does not directly cause any binary-breaking changes; if a server updates to a new build of forge with this PR without updating any existing mods installed on the server, then the server will experience no problems.
* However, the existence of a mod *using* the features added in this PR does change the assumptions that other mods are allowed to make (meaning that mods that start using the dynamic dimensions API may lose compatibility with other mods whose assumptions have been broken, until the other mods update to account for these changes):
  * This PR definalizes the dimension registry field of the server's DimensionGeneratorSettings, so that when dimensions are unregistered, the server's dimension registry can be replaced with a new registry containing only the keys and dimensions that were not removed (which is substantially simpler than removing dimensions from the existing registry). Any mod that is caching the server's dimension registry would need to update to not cache the server's dimension registry in order to be compatible with mods that use the dimension removal API. The probability of such a mod existing is not expected to be high.
  * This PR breaks the assumption that a world or dimension present in the server's world registry or dimension registry at any given point in time will continue to be present in the server's world or dimension registry at any point in the future (or that a world not being present will continue to not be present). Mods that assume this would need to update to be compatible with mods that use the dynamic dimension API. I have seen at least one existing mod that makes this assumption.

## Other Concerns
* While the dimension removal API does prevent the vanilla dimensions from being unregistered, currently there are no safeguards to prevent mods from using the dynamic dimension API to remove json dimensions. This is because A) this would be difficult to implement (json dimensions are loaded in the same manner as previously-registered dynamic dimensions), and B) unregistering a json dimension generally doesn't cause significant problems (the server will automatically reregister the dimension the next time the server starts).
* If a player leaves the server, then a dimension is removed from the server, then the player rejoins the server, they will be placed into the overworld instead (this is a vanilla failsafe).
* This PR also fixes the test mods for forge world types and player game mode change events so that this PR could be tested on a dedicated server.
* This API is not intended to replace the JSON dimension system; static dimensions should still be defined via JSONs.