### PR TITLE
Rewrite the `TimeTracker` system and add support for tracking block & fluid ticks

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -96,6 +96,33 @@
           if (biome.func_201848_a(this, blockpos3)) {
              this.func_175656_a(blockpos3, Blocks.field_150432_aD.func_176223_P());
           }
+@@ -573,18 +_,24 @@
+ 
+    private void func_205339_a(NextTickListEntry<Fluid> p_205339_1_) {
+       FluidState fluidstate = this.func_204610_c(p_205339_1_.field_180282_a);
++      net.minecraftforge.server.timings.ForgeRegistryObjectHolder<?> obj
++              = new net.minecraftforge.server.timings.ForgeRegistryObjectHolder<>(fluidstate, p_205339_1_.field_180282_a, func_234923_W_());
++      net.minecraftforge.server.timings.TimeTracker.BLOCK_FLUID_UPDATE.trackStart(obj);
+       if (fluidstate.func_206886_c() == p_205339_1_.func_151351_a()) {
+          fluidstate.func_206880_a(this, p_205339_1_.field_180282_a);
+       }
+-
++      net.minecraftforge.server.timings.TimeTracker.BLOCK_FLUID_UPDATE.trackEnd(obj);
+    }
+ 
+    private void func_205338_b(NextTickListEntry<Block> p_205338_1_) {
+       BlockState blockstate = this.func_180495_p(p_205338_1_.field_180282_a);
++      net.minecraftforge.server.timings.ForgeRegistryObjectHolder<?> obj
++              = new net.minecraftforge.server.timings.ForgeRegistryObjectHolder<>(blockstate, p_205338_1_.field_180282_a, func_234923_W_());
++      net.minecraftforge.server.timings.TimeTracker.BLOCK_FLUID_UPDATE.trackStart(obj);
+       if (blockstate.func_203425_a(p_205338_1_.func_151351_a())) {
+          blockstate.func_227033_a_(this, p_205338_1_.field_180282_a, this.field_73012_v);
+       }
+-
++      net.minecraftforge.server.timings.TimeTracker.BLOCK_FLUID_UPDATE.trackEnd(obj);
+    }
+ 
+    public void func_217479_a(Entity p_217479_1_) {
 @@ -598,9 +_,10 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();

--- a/src/main/java/net/minecraftforge/server/timings/ForgeRegistryObjectHolder.java
+++ b/src/main/java/net/minecraftforge/server/timings/ForgeRegistryObjectHolder.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.server.timings;
+
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.Objects;
+
+public class ForgeRegistryObjectHolder<T> {
+    public final T object;
+    public final BlockPos pos;
+    public final RegistryKey<World> dimension;
+
+    public ForgeRegistryObjectHolder(T object, BlockPos pos, RegistryKey<World> dimension) {
+        this.object = object;
+        this.pos = pos;
+        this.dimension = dimension;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ForgeRegistryObjectHolder<?> that = (ForgeRegistryObjectHolder<?>) o;
+        return object.equals(that.object) && pos.equals(that.pos) && dimension.equals(that.dimension);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(object, pos, dimension);
+    }
+}

--- a/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
+++ b/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
@@ -32,13 +32,37 @@ public class ForgeTimings<T>
 {
 
     private WeakReference<T> object;
+    private long totalNanos;
+    private int totalTicks;
 
-    private int[] rawTimingData;
-
-    public ForgeTimings(T object, int[] rawTimingData)
+    public ForgeTimings(T object)
     {
         this.object = new WeakReference<T>(object);
-        this.rawTimingData = rawTimingData;
+    }
+
+    private ForgeTimings(WeakReference<T> ref, long nanos, int ticks) {
+        this.object = ref;
+        this.totalNanos = nanos;
+        this.totalTicks = ticks;
+    }
+
+    /**
+     * Makes a copy of this timing object
+     *
+     * @return A copy of this timing object
+     */
+    public ForgeTimings<T> copy() {
+        return new ForgeTimings<>(this.object, this.totalNanos, this.totalTicks);
+    }
+
+    /**
+     * Process a tick for the associated object
+     *
+     * @param nanos The duration of the tick (in nanoseconds)
+     */
+    public void processTick(long nanos) {
+        this.totalNanos += nanos;
+        this.totalTicks++;
     }
 
     /**
@@ -59,13 +83,6 @@ public class ForgeTimings<T>
      */
     public double getAverageTimings()
     {
-        double sum = 0.0;
-
-        for (int data : rawTimingData)
-        {
-            sum += data;
-        }
-
-        return sum / rawTimingData.length;
+        return ((double) this.totalNanos) / this.totalTicks;
     }
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -110,6 +110,8 @@
   "commands.forge.tracking.invalid": "Invalid tracking data.",
   "commands.forge.tracking.te.enabled": "Tile Entity tracking enabled for %d seconds.",
   "commands.forge.tracking.te.reset": "Tile entity timings data has been cleared!",
+  "commands.forge.tracking.block_fluid.enabled": "Block/fluid tracking enabled for %d seconds.",
+  "commands.forge.tracking.block_fluid.reset": "Block/fluid timings data has been cleared!",
   "commands.forge.tracking.timing_entry": "{0} - {1} [{2}, {3}, {4}]: {5}",
   "commands.forge.tracking.no_data": "No data has been recorded yet.",
 


### PR DESCRIPTION
There are still a few things left to be done (such as actually bugtesting and better documentation). This new version uses a simple rolling average, and should be easier to maintain in the long run. If desired, I can add more advanced tracking (e.g. storing multiple data points instead of one simple average), but for now I'll just upload as is to get feedback.