### PR TITLE
[1.16.x] Fix two existing test mods so running forge_test_server doesn't crash immediately

### DIFF
--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerGameModeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerGameModeEventTest.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.debug.entity.player;
 
 import net.minecraft.world.GameType;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientPlayerChangeGameModeEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -43,11 +44,15 @@ public class PlayerGameModeEventTest
         if (event.getNewGameMode() == GameType.SURVIVAL)
             event.setCanceled(true);
     }
-
-    @SubscribeEvent
-    public static void onClientPlayerChangeGameModeEvent(ClientPlayerChangeGameModeEvent event)
+    
+    @Mod.EventBusSubscriber(modid="player_game_mode_event_test", value=Dist.CLIENT, bus=Mod.EventBusSubscriber.Bus.FORGE)
+    public static class PlayerGameModeEventTestClientForgeEvents
     {
-        if (!ENABLE) return;
-        LOGGER.info("Client notified of changed game mode from '{}'. Current GameType: {}. New Game Type: {}", event.getInfo().getProfile(), event.getCurrentGameMode(), event.getNewGameMode());
+        @SubscribeEvent
+        public static void onClientPlayerChangeGameModeEvent(ClientPlayerChangeGameModeEvent event)
+        {
+            if (!ENABLE) return;
+            LOGGER.info("Client notified of changed game mode from '{}'. Current GameType: {}. New Game Type: {}", event.getInfo().getProfile(), event.getCurrentGameMode(), event.getNewGameMode());
+        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/world/ForgeWorldTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeWorldTypeTest.java
@@ -28,12 +28,14 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.DimensionSettings;
 import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ForgeWorldTypeScreens;
 import net.minecraftforge.common.world.ForgeWorldType;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.ObjectHolder;
 
@@ -46,7 +48,6 @@ public class ForgeWorldTypeTest
     public ForgeWorldTypeTest()
     {
         FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(ForgeWorldType.class, this::registerWorldTypes);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::registerWorldTypeScreenFactories);
     }
 
     private void registerWorldTypes(RegistryEvent.Register<ForgeWorldType> event)
@@ -64,19 +65,24 @@ public class ForgeWorldTypeTest
         return DimensionGeneratorSettings.makeDefaultOverworld(biomes, dimensionSettings, seed);
     }
 
-    private void registerWorldTypeScreenFactories(FMLClientSetupEvent event)
+    @Mod.EventBusSubscriber(modid="forge_world_type_test", value=Dist.CLIENT, bus=Bus.MOD)
+    public static class ForgeWorldTypeTestClientModEvents
     {
-        ForgeWorldTypeScreens.registerFactory(testWorldType, (returnTo, dimensionGeneratorSettings) -> new Screen(testWorldType.getDisplayName())
+        @SubscribeEvent
+        public static void registerWorldTypeScreenFactories(FMLClientSetupEvent event)
         {
-            @Override
-            protected void init()
+            ForgeWorldTypeScreens.registerFactory(testWorldType, (returnTo, dimensionGeneratorSettings) -> new Screen(testWorldType.getDisplayName())
             {
-                super.init();
+                @Override
+                protected void init()
+                {
+                    super.init();
 
-                addButton(new Button(0, 0, 120, 20, new StringTextComponent("close"), btn -> {
-                    Minecraft.getInstance().setScreen(returnTo);
-                }));
-            }
-        });
+                    addButton(new Button(0, 0, 120, 20, new StringTextComponent("close"), btn -> {
+                        Minecraft.getInstance().setScreen(returnTo);
+                    }));
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Two existing test mods (PlayerGameModeEventTest and ForgeWorldTypeTest) classload client-only classes from their main mod classes, crashing the dedicated server, preventing potential PR branches from being able to run their own test mods on forge_test_server unless they manually fix them, which can cause git headaches for forge contributors.

This PR fixes these test mods by moving their client event subscribers into static inner EventBusSubscriber classes, which is classload-safe; running forge_test_server no longer crashes.