### PR TITLE
[1.16 Hotfix] Fix missing userdev config for datagen runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -948,6 +948,8 @@ project(':forge') {
                 main 'net.minecraftforge.userdev.LaunchTesting'
 
                 environment 'target', 'fmluserdevdata'
+                environment 'assetIndex', '{asset_index}'
+                environment 'assetDirectory', downloadAssets.output
 
                 environment 'MC_VERSION', "${MC_VERSION}"
                 environment 'FORGE_GROUP', "${project.group}"


### PR DESCRIPTION
This PR fixes missing run configuration environment variables that cause data generation to break in a userdev environment after #6982.

