### PR TITLE
[1.16.x] Adding TimeStamp to setCraftingPlayer

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.System;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -737,14 +738,21 @@ public class ForgeHooks
     }
 
     private static ThreadLocal<PlayerEntity> craftingPlayer = new ThreadLocal<PlayerEntity>();
+    private static ThreadLocal<Long> craftingPlayerTime = new ThreadLocal<Long>();
     public static void setCraftingPlayer(PlayerEntity player)
     {
         craftingPlayer.set(player);
+        craftingPlayerTime.set(System.currentTimeMillis());
     }
     public static PlayerEntity getCraftingPlayer()
     {
         return craftingPlayer.get();
     }
+    public static Long getCraftingPlayerUpdateTime()
+    {
+        return craftingPlayerTime.get();
+    }
+    
     @Nonnull
     public static ItemStack getContainerItem(@Nonnull ItemStack stack)
     {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common;
 
+import java.lang.System;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.System;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
Right now it is hard to check if a mod is not using setCraftingPlayer correctly, this PR adds a timestamp so a mod can easily check if the current player is up to date or made in the last tick (the time delta would be over 50ms so I would say it save to assume that the value is outdated)