### PR TITLE
[1.16.x Hotfix] use '{assets_root}' rather than task output path for userdev config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -949,7 +949,7 @@ project(':forge') {
 
                 environment 'target', 'fmluserdevdata'
                 environment 'assetIndex', '{asset_index}'
-                environment 'assetDirectory', downloadAssets.output
+                environment 'assetDirectory', '{assets_root}'
 
                 environment 'MC_VERSION', "${MC_VERSION}"
                 environment 'FORGE_GROUP', "${project.group}"


### PR DESCRIPTION
This fixes the fix of #7871 by using the `{assets_root}` token for the userdev (which gets replaced in FG) instead of the `downloadAssets` task output path (which gets `baked` to `/home/gradle/.gradle/caches/forge_gradle/assets` during generation).

Signed-off-by: AterAnimAvis <AterAnimAvis@gmail.com>