### PR TITLE
[1.15.x] Pass the 'includeName' flag to the ItemTossEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -88,7 +88,7 @@
     @Nullable
     public ItemEntity func_71019_a(ItemStack p_71019_1_, boolean p_71019_2_) {
 -      return this.func_146097_a(p_71019_1_, false, p_71019_2_);
-+      return net.minecraftforge.common.ForgeHooks.onPlayerTossEvent(this, p_71019_1_, false);
++      return net.minecraftforge.common.ForgeHooks.onPlayerTossEvent(this, p_71019_1_, p_71019_2_);
     }
  
     @Nullable


### PR DESCRIPTION
(Same as #7758 for 1.16)
The `PlayerEntity#dropItem(ItemStack, boolean)` method (`PlayerEntity#drop(ItemStack, boolean)` for mojmap), does not pass the second argument, the `includeName` flag, on to the `ItemTossEvent`.

This leads to situations where the player drops an item and the resulting `ItemEntity` does not have a thrower id.
For example, items thrown by a player from inside a `ContainerScreen` do not have a thrower id.

This pull request passes the `includeName` flag on to the `ItemTossEvent`, thus resolving the issue.