### PR TITLE
[1.16.x] Fix typo in FluidBlockWrapper

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBlockWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBlockWrapper.java
@@ -105,7 +105,7 @@ public class FluidBlockWrapper implements IFluidHandler
     @Override
     public FluidStack drain(int maxDrain, FluidAction action)
     {
-        if (maxDrain <= 0 && fluidBlock.canDrain(world, blockPos))
+        if (maxDrain > 0 && fluidBlock.canDrain(world, blockPos))
         {
             FluidStack simulatedDrained = fluidBlock.drain(world, blockPos, FluidAction.SIMULATE);
             if (simulatedDrained.getAmount() <= maxDrain)


### PR DESCRIPTION
A little oversight in the FluidBlockWrapper class that was never detected.