### PR TITLE
[1.16.x][LTS] Add a registry-friendly spawn egg constructor and an event for adding spawn eggs to the vanilla entitytype->egg map

### DIFF
--- a/patches/minecraft/net/minecraft/item/SpawnEggItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/SpawnEggItem.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/item/SpawnEggItem.java
++++ b/net/minecraft/item/SpawnEggItem.java
+@@ -39,11 +_,13 @@
+    private final int field_195989_d;
+    private final EntityType<?> field_200890_d;
+ 
++   /** @deprecated Mods should use {@link net.minecraftforge.common.ForgeSpawnEggItem} and {@link net.minecraftforge.event.RegisterSpawnEggsEvent} **/ @Deprecated
+    public SpawnEggItem(EntityType<?> p_i48465_1_, int p_i48465_2_, int p_i48465_3_, Item.Properties p_i48465_4_) {
+       super(p_i48465_4_);
+       this.field_200890_d = p_i48465_1_;
+       this.field_195988_c = p_i48465_2_;
+       this.field_195989_d = p_i48465_3_;
++      if (p_i48465_1_ != null) // mods' eggs shouldn't add {null->item} entries to map
+       field_195987_b.put(p_i48465_1_, this);
+    }
+ 

--- a/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
+++ b/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common;
 
 import java.util.function.Supplier;

--- a/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
+++ b/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.common;
+
+import java.util.function.Supplier;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.Item;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.nbt.CompoundNBT;
+
+public class ForgeSpawnEggItem extends SpawnEggItem
+{    
+    private final Supplier<? extends EntityType<?>> typeSupplier;
+
+    /**
+     * Registry-friendly spawn egg constructor.
+     * @param typeSupplier A RegistryObject or other entity type supplier to retrieve the spawn egg's associated entity type later
+     * @param foregroundColor The foreground color for the egg texture
+     * @param backgroundColor The background (spots) color for the egg texture
+     * @param properties The item properties for the egg item
+     * **/ 
+    public ForgeSpawnEggItem(final Supplier<? extends EntityType<?>> typeSupplier, final int backgroundColor, final int foregroundColor, final Item.Properties properties)
+    {
+       super(null, backgroundColor, foregroundColor, properties);
+       this.typeSupplier = java.util.Objects.requireNonNull(typeSupplier);
+    }
+
+    @Override
+    public EntityType<?> getType(CompoundNBT nbt)
+    {
+        // run the vanilla logic to allow type overrides via itemstack NBT
+        EntityType<?> type = super.getType(nbt);
+        // otherwise return our supplied type
+        return type != null ? type : this.typeSupplier.get();
+    }
+    
+    public Supplier<? extends EntityType<?>> getTypeSupplier()
+    {
+        return this.typeSupplier;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/RegisterSpawnEggsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterSpawnEggsEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import java.util.Map;

--- a/src/main/java/net/minecraftforge/event/RegisterSpawnEggsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterSpawnEggsEvent.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.event;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.lifecycle.IModBusEvent;
+
+/**
+ * Mod bus event that allows mods to mark their spawn eggs as behaving like vanilla spawn eggs.
+ * Marking an egg as a "standard mod egg" by adding it to this event's map will cause these things to happen:<br>
+ * 
+ * -- The egg item will be added to vanilla's entitytype->eggitem lookup map.<br>
+ * -- Creative players will be able to obtain the egg item by middle-click-picking associated entities<br>
+ * -- On client distributions, a standard color tinter will be assigned to the egg item. This will occur before the
+ *  {@link ColorHandlerEvent.Item} for item colors, allowing mods to override the tinting function for their egg if they desire.<br>
+ *  
+ * Using this event will not automatically register dispenser-spawning behavior to the spawn egg.
+ * 
+ * A mutable map of IDs-to-egg-suppliers is provided, allowing addon mods to remove egg suppliers if they intend to
+ * associate nonstandard behavior with the egg item.<br>
+ * 
+ * Because this event must fire before color handlers are registered, it also must necessarily fire before
+ * common configs load and before common setup.
+ */
+public class RegisterSpawnEggsEvent extends Event implements IModBusEvent
+{
+    private final Map<ResourceLocation, Supplier<? extends ForgeSpawnEggItem>> eggMap;
+    
+    public RegisterSpawnEggsEvent(Map<ResourceLocation, Supplier<? extends ForgeSpawnEggItem>> eggMap)
+    {
+        this.eggMap = eggMap;
+    }
+    
+    /**
+     * Gets the (mutable) map of standard mod spawn egg suppliers.
+     * Egg suppliers added to this map will be considered "standard mod spawn eggs" -- they will be added to the vanilla
+     * EntityType->SpawnEggItem lookup map, will be obtainable in creative mode by middle-click-picking their associated entities,
+     * and will automatically have a color tinter assigned.
+     * 
+     * This does *not* automatically register the egg item to the dispenser behavior registry.
+     * @return map
+     */
+    public Map<ResourceLocation, Supplier<? extends ForgeSpawnEggItem>> getStandardModEggs()
+    {
+        return this.eggMap;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import cpw.mods.modlauncher.TransformingClassLoader;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.event.RegisterSpawnEggsEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
@@ -48,6 +49,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -200,6 +202,8 @@ public class ModLoader
         GameData.setCustomTagTypesFromRegistries();
         statusConsumer.ifPresent(c->c.accept("Populating registries"));
         dispatchAndHandleError(ModLoadingStage.LOAD_REGISTRIES, syncExecutor, parallelExecutor, periodicTask);
+        statusConsumer.ifPresent(c->c.accept("Registering mods' standard spawn eggs"));
+        GameData.registerStandardModSpawnEggs();
         statusConsumer.ifPresent(c->c.accept("Early mod loading complete"));
     }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -255,6 +255,7 @@ public net.minecraft.item.ToolItem <init>(FFLnet/minecraft/item/IItemTier;Ljava/
 public-f net.minecraft.item.ItemGroup field_78032_a # TABS - group array
 public net.minecraft.item.ItemModelsProperties func_239418_a_(Lnet/minecraft/item/Item;Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/IItemPropertyGetter;)V # register
 public net.minecraft.item.ItemUseContext <init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockRayTraceResult;)V # constructor
+public net.minecraft.item.SpawnEggItem field_195987_b # BY_ID
 public-f net.minecraft.item.crafting.Ingredient
 protected net.minecraft.item.crafting.Ingredient <init>(Ljava/util/stream/Stream;)V # constructor
 public+f net.minecraft.item.crafting.Ingredient func_199564_a(Lnet/minecraft/network/PacketBuffer;)V # toNetwork

--- a/src/test/java/net/minecraftforge/debug/item/SuppliableSpawnEggsTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/SuppliableSpawnEggsTest.java
@@ -1,0 +1,136 @@
+package net.minecraftforge.debug.item;
+
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.client.renderer.entity.ChickenRenderer;
+import net.minecraft.client.renderer.entity.CowRenderer;
+import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.ChickenEntity;
+import net.minecraft.entity.passive.CowEntity;
+import net.minecraft.entity.passive.PigEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterSpawnEggsEvent;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod(SuppliableSpawnEggsTest.MODID)
+public class SuppliableSpawnEggsTest
+{
+    public static final String MODID = "suppliable_spawn_eggs_test";
+    public static final String TEST_PIG_NAME = "test_pig";
+    public static final String TEST_CHICKEN_NAME = "test_chicken";
+    public static final String TEST_COW_NAME = "test_cow";
+    
+    // there are three existing standards for making spawn eggs that we should test for backwards compatibility with the new spawn egg logic
+    // A) Extend SpawnEggItem to use a supplier and pass a null entity type to the base class's constructor. We will test this with a pig-type entity
+    // B) preinit the entity type and just use SpawnEggItem as-is. We will test this with a chicken-like entity.
+    // C) Reimplement spawn egg behavior using a new class that does not extend SpawnEggItem, ignoring the entitytype->SpawnEggItem map.
+        // We won't test against this as we're only concerned with SpawnEggItem and its type map.
+    // We'll also test a spawn egg that intentionally takes advantage of our new spawn egg patches with a cow-like entity. 
+    public static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(ForgeRegistries.ENTITIES, MODID);
+    public static final RegistryObject<EntityType<PigEntity>> TEST_PIG = ENTITIES.register(TEST_PIG_NAME, () -> EntityType.Builder.of(PigEntity::new, EntityClassification.CREATURE).sized(0.9F, 0.9F).clientTrackingRange(10).build(new ResourceLocation(MODID, TEST_PIG_NAME).toString()));
+    private static final EntityType<ChickenEntity> PRE_TEST_CHICKEN = EntityType.Builder.of(ChickenEntity::new, EntityClassification.CREATURE).sized(0.9F, 0.9F).clientTrackingRange(10).build(new ResourceLocation(MODID, TEST_CHICKEN_NAME).toString());
+    public static final RegistryObject<EntityType<ChickenEntity>> TEST_CHICKEN = ENTITIES.register(TEST_CHICKEN_NAME, () -> PRE_TEST_CHICKEN);
+    public static final RegistryObject<EntityType<CowEntity>> TEST_COW = ENTITIES.register(TEST_COW_NAME, () -> EntityType.Builder.of(CowEntity::new, EntityClassification.CREATURE).sized(0.9F, 0.9F).clientTrackingRange(10).build(new ResourceLocation(MODID, TEST_COW_NAME).toString()));
+    
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    public static final RegistryObject<SpawnEggItem> TEST_PIG_EGG = ITEMS.register(TEST_PIG_NAME + "_spawn_egg", () -> new PostHocSpawnEggItem(TEST_PIG, 0, 0xFFDDDD, new Item.Properties().tab(ItemGroup.TAB_MISC)));
+    public static final RegistryObject<SpawnEggItem> TEST_CHICKEN_EGG = ITEMS.register(TEST_CHICKEN_NAME + "_spawn_egg", () -> new SpawnEggItem(PRE_TEST_CHICKEN, 0, 0xFF0000, new Item.Properties().tab(ItemGroup.TAB_MISC)));
+    public static final RegistryObject<ForgeSpawnEggItem> TEST_COW_EGG = ITEMS.register(TEST_COW_NAME + "_spawn_egg", () -> new ForgeSpawnEggItem(TEST_COW, 0, 0xDDCC55, new Item.Properties().tab(ItemGroup.TAB_MISC)));
+    
+    public SuppliableSpawnEggsTest()
+    {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        IEventBus forgeBus = MinecraftForge.EVENT_BUS;
+        
+        // subscribe deferred registers
+        ITEMS.register(modBus);
+        ENTITIES.register(modBus);
+        
+        // subscribe events
+        modBus.addListener(this::onRegisterEntityAttributes);
+        modBus.addListener(this::onRegisterSpawnEggs);
+        
+        // classload-safely subscribe client events
+        if (FMLEnvironment.dist == Dist.CLIENT)
+        {
+            SuppliableSpawnEggsTestClientEvents.subscribeEvents(modBus, forgeBus);
+        }
+    }
+    
+    private void onRegisterEntityAttributes(EntityAttributeCreationEvent event)
+    {
+        event.put(TEST_PIG.get(), PigEntity.createAttributes().build());
+        event.put(TEST_CHICKEN.get(), ChickenEntity.createAttributes().build());
+        event.put(TEST_COW.get(), CowEntity.createAttributes().build());
+    }
+    
+    private void onRegisterSpawnEggs(RegisterSpawnEggsEvent event)
+    {
+        event.getStandardModEggs().put(TEST_COW_EGG.getId(), TEST_COW_EGG);
+    }
+    
+    public static class SuppliableSpawnEggsTestClientEvents
+    {
+        private static void subscribeEvents(IEventBus modBus, IEventBus forgeBus)
+        {
+            modBus.addListener(SuppliableSpawnEggsTestClientEvents::onClientSetup);
+            modBus.addListener(SuppliableSpawnEggsTestClientEvents::onRegisterItemColors);
+        }
+        
+        private static void onClientSetup(FMLClientSetupEvent event)
+        {
+            RenderingRegistry.registerEntityRenderingHandler(TEST_PIG.get(), PigRenderer::new);
+            RenderingRegistry.registerEntityRenderingHandler(TEST_CHICKEN.get(), ChickenRenderer::new);
+            RenderingRegistry.registerEntityRenderingHandler(TEST_COW.get(), CowRenderer::new);
+        }
+        
+        private static void onRegisterItemColors(ColorHandlerEvent.Item event)
+        {
+            // null-type pigs must have color tinter manually registered
+            event.getItemColors().register((stack,index) -> TEST_PIG_EGG.get().getColor(index), TEST_PIG_EGG.get());
+            // preinit-type chickens' color tinter is automatically registered
+        }
+    }
+    
+    // One of the existing standards for registering spawn eggs: pass in a null type to the base class, but use a type supplier when queried
+    // we use this here to test backwards-compatibility of the new spawn egg logic
+    public static class PostHocSpawnEggItem extends SpawnEggItem
+    {
+        private final Supplier<? extends EntityType<?>> typeSupplier;
+        public PostHocSpawnEggItem(Supplier<? extends EntityType<?>> typeSupplier, int bgcolor, int fgcolor, Properties properties)
+        {
+            super(null, bgcolor, fgcolor, properties);
+            this.typeSupplier = typeSupplier;
+        }
+        @Override
+        public EntityType<?> getType(CompoundNBT nbt)
+        {
+            // run base logic in case we have NBT to override the type
+            @Nullable EntityType<?> baseType = super.getType(nbt);
+            // otherwise get the type from our supplier
+            return baseType != null ? baseType : typeSupplier.get();
+        }
+        
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/item/SuppliableSpawnEggsTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/SuppliableSpawnEggsTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import java.util.function.Supplier;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -138,3 +138,5 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="suppliable_spawn_eggs_test"

--- a/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_chicken_spawn_egg.json
+++ b/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_chicken_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+	"parent": "minecraft:item/template_spawn_egg"
+}

--- a/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_cow_spawn_egg.json
+++ b/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_cow_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+	"parent": "minecraft:item/template_spawn_egg"
+}

--- a/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_pig_spawn_egg.json
+++ b/src/test/resources/assets/suppliable_spawn_eggs_test/models/item/test_pig_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+	"parent": "minecraft:item/template_spawn_egg"
+}


### PR DESCRIPTION
## Background Information
While vanilla minecraft static-inits everything at once, forge registers things in a specific order. This occasionally requires improvements to vanilla types by adding supplier-based constructors to them.

While this generally works, spawn egg items are particularly problematic due to the eggs' constructor adding the egg's entity type to an entitytype->eggitem lookup map, which is used for the following things:

* When a creative-mode player middle-click-picks an entity, if that entity's entitytype is present in the egg lookup map, the associated spawn egg is added to the player's inventory.
* When vanilla item colors init (just before the item color registration event that mods use), every egg *value* in the lookup map has a color tinter assigned to it.
* When vanilla dispenser behaviors are created during vanilla registry bootstrap (before mods load), a vanilla dispenser behavior is added for each entry in the lookup map.
* Vanilla datagen uses the lookup map as well, but this is mostly ignorable.

This causes problems for mods that add spawn eggs, as the vanilla spawn egg map is difficult to reconcile with the supplier-in-constructor patterns. Generally, mods follow one of three patterns when creating spawn eggs:

* Extend SpawnEggItem to use a supplier, pass in a null entitytype to the base class, and override the type getter to use the supplier.
  * Entity picking will not work unless the mod manually adds their egg item to the lookup map in common setup.
  * A color tinter *must* be manually added during the color handler event.
    * The last mod to fail to do this will have an automatic color tinter registered by vanilla due to the item being assigned to the null key; this is considered inconsistent behavior.
  * Dispenser spawning behaviors must be manually registered, otherwise dispensers will dispense the egg like a normal item.
* Preinit the entity type before registration and construct a spawn egg in the vanilla manner. This pattern tends to be tolerated more then pre-registration-init of other things because it results in a relatively clean way to achieve consistency with vanilla spawn eggs (though it makes registry-replacement of the entity type more difficult).
  * Entity picking will automatically work
  * A color tinter will be automatically registered
  * Dispenser spawning behaviors must be manually registered, otherwise dispensers will dispense the egg like a normal item.
* Reimplement spawning-of-entity behavior in a separate item that does not extend SpawnEggItem.
  * The mod must use the middle-click event to manually implement entitytype picking.

All three of these patterns have flaws; this PR aims to provide an alternative method.

## Goals of This PR
* Patch sizes should be minimal.
* Binary compatibility with existing mods must be retained.
* Mods that add spawn eggs via existing standard patterns should continue to work; this PR should not cause unwanted changes to users of existing mods.
  * It is not a goal of this PR that existing mods whose spawn eggs have inconsistent or unstable behavior remains inconsistent or unstable.
* With the new APIs made available in this PR, mods should be able to add spawn eggs without preinitializing entitytypes before registration and without causing inconsistent behavior.
* It is not a goal of this PR to add additional APIs for registering dispenser-spawning behavior for spawn eggs, as dispenser behavior of mod's spawn eggs is already consistent (either they add a dispenser behavior for their spawn eggs and dispensers spawn mobs, or they don't add a behavior and dispensers eject eggs like a standard item (or they add a custom behavior)).
  * i.e. consider the potential existence of a server where a player's dispenser contraption is relying on the fact that a mod's spawn egg ejects like a regular item and doesn't spawn their mob

## What This PR Adds
* A very small patch to SpawnEggItem, which prevents spawn eggs from registering null entity types to the lookup map. This also deprecates the vanilla SpawnEggItem constructor.
* A supplier-based constructor for a new class that extends SpawnEggItem, which mods can use to construct spawn egg instances in a registry-friendly way.
* An event for adding mods' spawn egg items to the vanilla lookup map. If a mod specifies that their egg should be added to the lookup map via this event, that egg's associated entities will have the standard middle-click-pick behavior; on the client distribution, the standard item color tinting function will also become assigned to the egg. This provides a standard timing for adding spawn egg items to this map.

## Alternative PRs that add this feature
#7621 provides similar features; it patches SpawnEggItem more substantially, and adds automatic registration of dispenser spawning behavior.