### PR TITLE
[1.17] Add stack_sensitive transformer 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1024,6 +1024,19 @@ project(':forge') {
             */
         }
     }
+    
+    task findStackSensitiveChecks(type: StackSensitiveFinder, dependsOn: ['reobfJar']) {
+        jar = tasks.getByName('reobfJar').output
+        output = rootProject.file('src/main/resources/coremods/stack_sensitive.json')
+        methods {
+            canBeDepleted {
+                name = 'm_41465_'
+                cls = 'net/minecraftforge/common/extensions/IForgeItem'
+                replacement = 'isDamageable'
+                blacklist 'net/minecraft/world/item/enchantment/EnchantmentCategory$10' //no stack available
+            }
+        }
+    }
 
     task checkATs(type: CheckATs, dependsOn: [extractInheritance, createSrg2Mcp]) {
         inheritance = extractInheritance.output
@@ -1041,7 +1054,7 @@ project(':forge') {
         excs.from patcher.excs
     }
 
-    task checkAll(dependsOn: [checkATs, checkSAS, checkExcs, findFieldInstanceChecks]){}
+    task checkAll(dependsOn: [checkATs, checkSAS, checkExcs, findFieldInstanceChecks, findStackSensitiveChecks]){}
 
     task checkPatchesAndFix(type: CheckPatches, dependsOn: genPatches) {
         patchDir = file("$rootDir/patches")

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/StackSensitiveFinder.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/StackSensitiveFinder.groovy
@@ -1,0 +1,147 @@
+package net.minecraftforge.forge.tasks
+
+import groovy.transform.EqualsAndHashCode
+
+import java.util.HashMap
+import java.util.stream.IntStream
+import java.util.TreeMap
+import java.util.TreeSet
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.*
+
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodNode
+
+import static org.objectweb.asm.Opcodes.*
+
+abstract class StackSensitiveFinder extends BytecodeFinder {
+
+    @Nested
+    Map<String, Search> methods = [:] as HashMap //maps non-stack sensitive to stack sensitive
+    @Internal
+    Map<String, String> methodsReverse = [:] as HashMap //maps non-stack sensitive method to name
+    @Internal
+    Map<String, Set<StackSensitiveTarget>> targets = [:] as TreeMap //maps non-stack sensitive method to targets
+
+    private static final String ITEMSTACK_DESC = 'Lnet/minecraft/world/item/ItemStack;'
+    private static final String GET_ITEM = 'm_41720_' //ItemStack#getItem method
+
+    @Override
+    protected pre() {
+        methods.each { k, v -> logger.lifecycle('Methods: ' + v) }
+    }
+
+    @Override
+    protected process(ClassNode parent, MethodNode node) {
+        def parentInstance = new ObjectTarget(owner: parent.name, name: '', desc: '')
+        def lastItemStack = null
+        def startLabel = IntStream.range(0, node.instructions.size())
+            .mapToObj({ i -> node.instructions.get(i) })
+            .filter({ n -> n.getType() == AbstractInsnNode.LABEL })
+            .findFirst()
+            .orElse(null)
+
+        for (int x = 0; x < node.instructions.size(); x++) {
+            def current = node.instructions.get(x)
+            if (current.getType() == AbstractInsnNode.METHOD_INSN) {
+                def target = methods.get(current.name)
+                if (target != null) {
+                    def instance = new ObjectTarget(owner: parent.name, name: node.name, desc: node.desc)
+                    if (target.blacklist == null || (!target.blacklist.contains(instance) && !target.blacklist.contains(parentInstance))) {
+                        if (lastItemStack == null && node.localVariables != null && startLabel != null) {
+                            //no call to 'ItemStack#getItem' found, check if 'this' is an itemStack or if there is an ItemStack parameter
+                            lastItemStack = node.localVariables.stream()
+                                .filter({ n -> n.desc.equals(ITEMSTACK_DESC) })
+                                .filter({ n -> n.start == startLabel || n.name.equals('this') }) //only keep ItemStack parameter and 'this' if its an ItemStack
+                                .findFirst()
+                                .orElse(null)
+                        }
+
+                        if (lastItemStack != null) {
+                            targets.computeIfAbsent(current.name, { k -> new TreeSet() }).add(new StackSensitiveTarget(owner: parent.name, name: node.name, desc: node.desc, varIndex: lastItemStack.index))
+                        }else {
+                            logger.warn('no ItemStack available: ' + parent.name + '.' + node.name + node.desc)
+                        }
+                    }
+                }else if (current.name.equals(GET_ITEM)) {
+                    def lastIns = node.instructions.get(x - 1)
+                    if (lastIns.getType() == AbstractInsnNode.VAR_INSN && node.localVariables != null) {
+                        //Check if pushed var is itemStack, than save it
+                        lastItemStack = node.localVariables.stream()
+                            .filter({ n -> n.index == lastIns.var })
+                            .filter({ n -> n.desc.equals(ITEMSTACK_DESC) })
+                            .findFirst()
+                            .orElse(lastItemStack)
+                    }
+                }
+            }
+        }
+    }
+
+    @Internal
+    @Override
+    protected Object getData() {
+        def ret = [:] as HashMap
+        targets.forEach { k, v ->
+            def e = methods.get(k)
+            ret[methodsReverse.get(k)] = [
+                cls: e.cls,
+                name: e.name,
+                replacement: e.replacement,
+                targets: v
+            ]
+        }
+        return ret
+    }
+
+    @EqualsAndHashCode(excludes = ['replacement', 'blacklist'])
+    public static class Search {
+
+        @Input
+        String name //The non-stack sensitive method
+
+        @Input
+        String cls //The class containing the stack sensitive method
+
+        @Input
+        String replacement //The stack sensitive method
+
+        @Nested
+        @Optional
+        Set<ObjectTarget> blacklist
+
+        @Override
+        String toString() {
+            return name + ' -> ' + cls + '.' + replacement
+        }
+
+        def blacklist(def owner, def name, def desc) {
+            if (blacklist == null) {
+                blacklist = new HashSet()
+            }
+            blacklist.add(new ObjectTarget(owner: owner, name: name, desc: desc))
+        }
+        def blacklist(def owner) {
+            blacklist(owner, '', '')
+        }
+
+    }
+
+    private static class StackSensitiveTarget extends ObjectTarget {
+        @Input
+        int varIndex;
+    }
+
+    def methods(Closure cl) {
+        new ClosureHelper(cl, { name, ccl ->
+            def search = ClosureHelper.apply(new Search(), ccl)
+            search.blacklist(search.cls) //don't redirect stack sensitive method implementation
+            this.methods.put(search.name, search)
+            this.methodsReverse.put(search.name, name)
+        })
+    }
+
+}

--- a/patches/minecraft/net/minecraft/network/FriendlyByteBuf.java.patch
+++ b/patches/minecraft/net/minecraft/network/FriendlyByteBuf.java.patch
@@ -25,13 +25,11 @@
        if (p_130056_.m_41619_()) {
           this.writeBoolean(false);
        } else {
-@@ -447,8 +_,8 @@
-          this.m_130130_(Item.m_41393_(item));
+@@ -448,7 +_,7 @@
           this.writeByte(p_130056_.m_41613_());
           CompoundTag compoundtag = null;
--         if (item.m_41465_() || item.m_41468_()) {
+          if (item.m_41465_() || item.m_41468_()) {
 -            compoundtag = p_130056_.m_41783_();
-+         if (item.isDamageable(p_130056_) || item.m_41468_()) {
 +            compoundtag = limitedTag ? p_130056_.getShareTag() : p_130056_.m_41783_();
           }
  

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -23,7 +23,7 @@
     }
  
     public void m_5929_(Level p_41428_, LivingEntity p_41429_, ItemStack p_41430_, int p_41431_) {
-@@ -138,10 +_,12 @@
+@@ -138,14 +_,17 @@
        return this.m_41472_() ? p_41411_.m_5584_(p_41410_, p_41409_) : p_41409_;
     }
  
@@ -35,6 +35,11 @@
 +   @Deprecated // Use ItemStack sensitive version.
     public final int m_41462_() {
        return this.f_41371_;
+    }
+ 
++   @Deprecated // Use ItemStack sensitive version. Calls to this method are redirected to stack sensitive method in vanilla if an ItemStack is available using the the stack_sensitive coremod transformer.
+    public boolean m_41465_() {
+       return this.f_41371_ > 0;
     }
 @@ -216,10 +_,12 @@
     }
@@ -54,7 +59,7 @@
  
     public boolean m_8120_(ItemStack p_41456_) {
 -      return this.m_41459_() == 1 && this.m_41465_();
-+      return this.getItemStackLimit(p_41456_) == 1 && this.isDamageable(p_41456_);
++      return this.getItemStackLimit(p_41456_) == 1 && this.m_41465_();
     }
  
     protected static BlockHitResult m_41435_(Level p_41436_, Player p_41437_, ClipContext.Fluid p_41438_) {

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -26,7 +26,6 @@
 -   public ItemStack(ItemLike p_41601_, int p_41602_) {
 -      this.f_41589_ = p_41601_ == null ? null : p_41601_.m_5456_();
 -      this.f_41587_ = p_41602_;
--      if (this.f_41589_ != null && this.f_41589_.m_41465_()) {
 +   public ItemStack(ItemLike p_41601_, int p_41602_) { this(p_41601_, p_41602_, (CompoundTag) null); }
 +   public ItemStack(ItemLike p_41604_, int p_41605_, @Nullable CompoundTag p_41606_) {
 +      super(ItemStack.class);
@@ -34,7 +33,7 @@
 +      this.f_41589_ = p_41604_ == null ? null : p_41604_.m_5456_();
 +      this.delegate = p_41604_ == null ? null : p_41604_.m_5456_().delegate;
 +      this.f_41587_ = p_41605_;
-+      if (this.f_41589_ != null && this.f_41589_.isDamageable(this)) {
+       if (this.f_41589_ != null && this.f_41589_.m_41465_()) {
           this.m_41721_(this.m_41773_());
        }
  
@@ -43,7 +42,7 @@
     }
  
     private void m_41617_() {
-@@ -143,18 +_,23 @@
+@@ -143,7 +_,11 @@
     }
  
     private ItemStack(CompoundTag p_41608_) {
@@ -55,12 +54,7 @@
        this.f_41587_ = p_41608_.m_128445_("Count");
        if (p_41608_.m_128425_("tag", 10)) {
           this.f_41590_ = p_41608_.m_128469_("tag");
-          this.m_41720_().m_142312_(this.f_41590_);
-       }
- 
--      if (this.m_41720_().m_41465_()) {
-+      if (this.m_41720_().isDamageable(this)) {
-          this.m_41721_(this.m_41773_());
+@@ -155,6 +_,7 @@
        }
  
        this.m_41617_();
@@ -195,15 +189,6 @@
 +         return (this.f_41590_ == null || this.f_41590_.equals(p_41745_.f_41590_)) && this.areCapsCompatible(p_41745_);
        }
     }
- 
-@@ -529,7 +_,7 @@
- 
-    public void m_41751_(@Nullable CompoundTag p_41752_) {
-       this.f_41590_ = p_41752_;
--      if (this.m_41720_().m_41465_()) {
-+      if (this.m_41720_().isDamageable(this)) {
-          this.m_41721_(this.m_41773_());
-       }
  
 @@ -729,6 +_,7 @@
           }

--- a/patches/minecraft/net/minecraft/world/item/trading/MerchantOffer.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/trading/MerchantOffer.java.patch
@@ -9,12 +9,3 @@
        return itemstack;
     }
  
-@@ -179,7 +_,7 @@
-          return true;
-       } else {
-          ItemStack itemstack = p_45366_.m_41777_();
--         if (itemstack.m_41720_().m_41465_()) {
-+         if (itemstack.m_41720_().isDamageable(itemstack)) {
-             itemstack.m_41721_(itemstack.m_41773_());
-          }
- 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -793,6 +793,7 @@ public interface IForgeItem
     /**
      * Used to test if this item can be damaged, but with the ItemStack in question.
      * Please note that in some cases no ItemStack is available, so the stack-less method will be used.
+     * Called from vanilla where {@link Item#isDamageable()} is called and an ItemStack is available using the stack_sensitive coremod transformer
      *
      * @param stack       ItemStack in the Chest slot of the entity.
      */

--- a/src/main/resources/META-INF/coremods.json
+++ b/src/main/resources/META-INF/coremods.json
@@ -1,5 +1,6 @@
 {
   "field_to_method": "coremods/field_to_method.js",
   "field_to_instanceof": "coremods/field_to_instanceof.js",
-  "add_bouncer_method": "coremods/add_bouncer_method.js"
+  "add_bouncer_method": "coremods/add_bouncer_method.js",
+  "stack_sensitive": "coremods/stack_sensitive.js"
 }

--- a/src/main/resources/coremods/stack_sensitive.js
+++ b/src/main/resources/coremods/stack_sensitive.js
@@ -1,0 +1,57 @@
+var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI')
+var Opcodes = Java.type('org.objectweb.asm.Opcodes')
+var AbstractInsnNode = Java.type('org.objectweb.asm.tree.AbstractInsnNode')
+
+function initializeCoreMod() {
+    var data = ASMAPI.loadData('coremods/stack_sensitive.json')
+    //ASMAPI.log('DEBUG', JSON.stringify(data, null, 2))
+
+    var ret = {}
+    for (name in data) {
+        addTargets(ret, name, data[name])
+    }
+    return ret
+}
+
+function addTargets(ret, name, data) {
+    var owner = data.cls
+    var method = ASMAPI.mapMethod(data.name)
+    var replacement = data.replacement
+    for (x = 0; x < data.targets.length; x++) {
+        var key = name + '.' + x
+        var entry = data.targets[x]
+
+        //ASMAPI.log('DEBUG', 'Entry ' + key + ' ' + JSON.stringify(entry))
+
+        ret[key] = {
+            'target': {
+                'type': 'METHOD',
+                'class': entry.owner,
+                'methodName': entry.name,
+                'methodDesc': entry.desc
+            },
+            'transformer': function(entry) { return function(node) {
+                return transform(node, entry, owner, method, replacement)
+            }}(entry) // We have to do this annoying double function imediate call, so that JS will capture the entry value
+        }
+    }
+}
+
+function transform(node, entry, owner, method, replacement) {
+    var count = 0
+    for (x = 0; x < node.instructions.size(); x++) {
+        var current = node.instructions.get(x)
+        if (current.getType() == AbstractInsnNode.METHOD_INSN) {
+            if (current.name == method) {
+                var returnType = current.desc.split(')').pop()
+                node.instructions.insertBefore(current, new org.objectweb.asm.tree.VarInsnNode(Opcodes.ALOAD, entry.varIndex))
+                node.instructions.set(current, new org.objectweb.asm.tree.MethodInsnNode(Opcodes.INVOKEINTERFACE, owner, replacement, "(Lnet/minecraft/world/item/ItemStack;)" + returnType))
+                x++
+                count++
+            }
+        }
+    }
+    //ASMAPI.log('DEBUG', 'Transforming: ' + entry.owner + '.' + node.name + node.desc)
+    //ASMAPI.log('DEBUG', 'stack_sensitive: Replaced {} checks', count)
+    return node
+}

--- a/src/main/resources/coremods/stack_sensitive.json
+++ b/src/main/resources/coremods/stack_sensitive.json
@@ -1,0 +1,45 @@
+{
+    "canBeDepleted": {
+        "cls": "net/minecraftforge/common/extensions/IForgeItem",
+        "name": "m_41465_",
+        "replacement": "isDamageable",
+        "targets": [
+            {
+                "varIndex": 1,
+                "owner": "net/minecraft/network/FriendlyByteBuf",
+                "name": "writeItemStack",
+                "desc": "(Lnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/network/FriendlyByteBuf;"
+            },
+            {
+                "varIndex": 1,
+                "owner": "net/minecraft/world/item/Item",
+                "name": "m_8120_",
+                "desc": "(Lnet/minecraft/world/item/ItemStack;)Z"
+            },
+            {
+                "varIndex": 0,
+                "owner": "net/minecraft/world/item/ItemStack",
+                "name": "<init>",
+                "desc": "(Lnet/minecraft/nbt/CompoundTag;)V"
+            },
+            {
+                "varIndex": 0,
+                "owner": "net/minecraft/world/item/ItemStack",
+                "name": "<init>",
+                "desc": "(Lnet/minecraft/world/level/ItemLike;ILnet/minecraft/nbt/CompoundTag;)V"
+            },
+            {
+                "varIndex": 0,
+                "owner": "net/minecraft/world/item/ItemStack",
+                "name": "m_41751_",
+                "desc": "(Lnet/minecraft/nbt/CompoundTag;)V"
+            },
+            {
+                "varIndex": 3,
+                "owner": "net/minecraft/world/item/trading/MerchantOffer",
+                "name": "m_45365_",
+                "desc": "(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
A port of #7638 to 1.17

This PR adds a stack_sensitive coremod transformer to change calls to non stack sensitive methods to stack sensitive methods,
similar to the field_to_instanceof transformer added in f169c99
Currently all calls to Item#canBeDepleted() (m_41465_) are replaced with calls to IForgeItem#isDamageable(ItemStack), but I can add more if needed.

The script does the following transformations:

    itemstack.getItem().foo() => itemstack.getItem().bar(itemstack)
    item.foo() => item.foo(this), if 'this' is an ItemStack
    void bizz(ItemStack stack){ item.foo() } => void bizz(ItemStack stack){ item.bar(stack) }

The script assumes the following things:

    The non stack sensitive method takes no arguments
    The stack sensitive method only takes only one argument, an ItemStack
    The non stack sensitive method and the stack sensitve method have the same return type
    The stack sensitive method is a interface method

The added findStackSensitiveChecks task in the build.gradle uses the output from reobfJar as input, while the findFieldInstanceChecks uses the output from the createJoinedSRG task.
It looks like createJoinedSRG jar does not have the forge patches applied. Because forge changes some method signatures
(e.g. here: https://github.com/MinecraftForge/MinecraftForge/blob/b027a92dd287d6810a9fdae4d4b1e1432d7dc9cc/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch#L26-L31) these changes are not present in the createJoinedSRG created jar.
Therefore the generated JSON file would contain the old method signature (ItemStack(IItemProvider, int)) not the new one (ItemStack(IItemProvider, int, CompoundNBT)).
Is this correct or am I missing something?