### PR TITLE
[1.17.x] Pass the 'includeName' flag to the ItemTossEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -76,7 +76,7 @@
     @Nullable
     public ItemEntity m_36176_(ItemStack p_36177_, boolean p_36178_) {
 -      return this.m_7197_(p_36177_, false, p_36178_);
-+      return net.minecraftforge.common.ForgeHooks.onPlayerTossEvent(this, p_36177_, false);
++      return net.minecraftforge.common.ForgeHooks.onPlayerTossEvent(this, p_36177_, p_36178_);
     }
  
     @Nullable


### PR DESCRIPTION
(Same as #7758 for 1.16, and #7875 for 1.15)
The `Player#drop(ItemStack, boolean)` method, does not pass the second argument, the 'includeName' flag, on to the `ItemTossEvent`.

This leads to situations where the player drops an item and the resulting `ItemEntity` does not have a thrower id.
For example, items thrown by a player from inside a `ContainerScreen` do not have a thrower id.

This pull request passes the 'includeName' flag on to the `ItemTossEvent`, thus resolving the issue.