### PR TITLE
[1.17.x] Expose RenderStateShard inner classes

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -75,6 +75,20 @@ protected-f net.minecraft.client.renderer.RenderStateShard f_110131_ # setupStat
 public net.minecraft.client.renderer.RenderStateShard$TextureStateShard
 protected-f net.minecraft.client.renderer.RenderStateShard$TextureStateShard f_110329_ # blur
 protected-f net.minecraft.client.renderer.RenderStateShard$TextureStateShard f_110330_ # mipmap
+public net.minecraft.client.renderer.RenderStateShard$BooleanStateShard
+public net.minecraft.client.renderer.RenderStateShard$CullStateShard
+public net.minecraft.client.renderer.RenderStateShard$DepthTestStateShard
+public net.minecraft.client.renderer.RenderStateShard$EmptyTextureStateShard
+public net.minecraft.client.renderer.RenderStateShard$LayeringStateShard
+public net.minecraft.client.renderer.RenderStateShard$LightmapStateShard
+public net.minecraft.client.renderer.RenderStateShard$MultiTextureStateShard
+public net.minecraft.client.renderer.RenderStateShard$OffsetTexturingStateShard
+public net.minecraft.client.renderer.RenderStateShard$OutputStateShard
+public net.minecraft.client.renderer.RenderStateShard$OverlayStateShard
+public net.minecraft.client.renderer.RenderStateShard$ShaderStateShard
+public net.minecraft.client.renderer.RenderStateShard$TransparencyStateShard
+public net.minecraft.client.renderer.RenderStateShard$TexturingStateShard
+public net.minecraft.client.renderer.RenderStateShard$WriteMaskStateShard
 public net.minecraft.client.renderer.RenderType m_173215_(Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType; # create
 public net.minecraft.client.renderer.RenderType$CompositeState
 public net.minecraft.client.renderer.block.model.BlockElement m_111320_(Lnet/minecraft/core/Direction;)[F # uvsByFace


### PR DESCRIPTION
In 1.17, all of the inner classes of `RenderStateShard` (`RenderStateShard.OverlayStateShard`, `RenderStateShard.WriteMaskStateShard`, etc.) have been changed to protected. These classes are needed however to create new `RenderType.CompositeRenderType`'s using `RenderType.CompositeState.CompositeStateBuilder`.
Since these are protected inner classes, their constructors also can't be directly be obtained using `ObfuscationReflectionHelper`.

Currently, any mod using custom `RenderType`'s will have to either:
- add their own access transformer for the inner classes, or
- extend `RenderStateShard` to access `RenderStateShard`'s inner classes, and extend `RenderType` to access `RenderType.CompositeRenderType`

This PR changes the visibility of `RenderStateShard`'s inner classes to public in Forge's `accesstransformer.cfg`.