### PR TITLE
Add modder-friendly way to edit the boat model / texture in custom boats

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
@@ -9,7 +9,7 @@
        ResourceLocation resourcelocation = pair.getFirst();
        BoatModel boatmodel = pair.getSecond();
        p_113932_.m_85841_(-1.0F, -1.0F, 1.0F);
-@@ -69,7 +_,13 @@
+@@ -69,7 +_,10 @@
        super.m_7392_(p_113929_, p_113930_, p_113931_, p_113932_, p_113933_, p_113934_);
     }
  
@@ -17,10 +17,7 @@
     public ResourceLocation m_5478_(Boat p_113927_) {
 -      return this.f_173934_.get(p_113927_.m_38387_()).getFirst();
 +      return getModelWithLocation(p_113927_).getFirst();
-+   }
-+
-+   public Pair<ResourceLocation, BoatModel> getModelWithLocation(Boat boat)
-+   {
-+       return this.f_173934_.get(boat.m_38387_());
     }
++
++   public Pair<ResourceLocation, BoatModel> getModelWithLocation(Boat boat) { return this.f_173934_.get(boat.m_38387_()); }
  }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/client/renderer/entity/BoatRenderer.java
++++ b/net/minecraft/client/renderer/entity/BoatRenderer.java
+@@ -52,7 +_,7 @@
+          p_113932_.m_85845_(new Quaternion(new Vector3f(1.0F, 0.0F, 1.0F), p_113929_.m_38352_(p_113931_), true));
+       }
+ 
+-      Pair<ResourceLocation, BoatModel> pair = this.f_173934_.get(p_113929_.m_38387_());
++      Pair<ResourceLocation, BoatModel> pair = getModelWithLocation(p_113929_);
+       ResourceLocation resourcelocation = pair.getFirst();
+       BoatModel boatmodel = pair.getSecond();
+       p_113932_.m_85841_(-1.0F, -1.0F, 1.0F);
+@@ -69,7 +_,13 @@
+       super.m_7392_(p_113929_, p_113930_, p_113931_, p_113932_, p_113933_, p_113934_);
+    }
+ 
++   @Deprecated // forge: override getModelWithLocation to change the texture / model
+    public ResourceLocation m_5478_(Boat p_113927_) {
+-      return this.f_173934_.get(p_113927_.m_38387_()).getFirst();
++      return getModelWithLocation(p_113927_).getFirst();
++   }
++
++   public Pair<ResourceLocation, BoatModel> getModelWithLocation(Boat boat)
++   {
++       return this.f_173934_.get(boat.m_38387_());
+    }
+ }


### PR DESCRIPTION
Currently the calls to change the boat model being rendered are hardcoded to a field populated by the boat enum. To prevent modders having to copy over the whole render method in their custom boat classes just to change the texture, I patched a couple places to use a new method they can override.