### PR TITLE
Add more sensitive goal remover to GoalSelector

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/GoalSelector.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/GoalSelector.java.patch
@@ -1,0 +1,9 @@
+--- a/net/minecraft/world/entity/ai/goal/GoalSelector.java
++++ b/net/minecraft/world/entity/ai/goal/GoalSelector.java
+@@ -116,4 +_,6 @@
+       }
+ 
+    }
++
++    public void removeGoalIf(java.util.function.Predicate<? super Goal> filter) { this.f_25345_.stream().filter(filter).filter(WrappedGoal::m_7620_).forEach(WrappedGoal::m_8041_); this.f_25345_.removeIf(filter); }
+ }


### PR DESCRIPTION
When extending vanilla entity classes, it's pretty common to want to remove vanilla goals to replace them with your own AI. However `removeGoal` requires you to have the actual instance of the goal, which in almost every case is impossible. While you can AT `availableGoals`, Mojang's design is to avoid ever modifying the set directly, to prevent unsafe operations. Thus exposing `removeIf` allows modders to remove goals based on `instanceof` or the priority, which is much easier and covers almost every case.