### PR TITLE
add AT entry for availableGoals

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -220,6 +220,7 @@ public net.minecraft.world.entity.ExperienceOrb f_20770_ # value
 public net.minecraft.world.entity.Mob f_21345_ # goalSelector
 public net.minecraft.world.entity.Mob f_21346_ # targetSelector
 public net.minecraft.world.entity.SpawnPlacements m_21754_(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/entity/SpawnPlacements$Type;Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/world/entity/SpawnPlacements$SpawnPredicate;)V # register
+public net.minecraft.world.entity.ai.goal.GoalSelector f_25345_ # availableGoals
 public net.minecraft.world.entity.ai.memory.MemoryModuleType <init>(Ljava/util/Optional;)V # constructor
 public net.minecraft.world.entity.ai.sensing.SensorType <init>(Ljava/util/function/Supplier;)V # constructor
 public net.minecraft.world.entity.ai.village.poi.PoiType <init>(Ljava/lang/String;Ljava/util/Set;II)V # constructor


### PR DESCRIPTION
Modders need a way to remove goals from the goal list when creating entity AI to replace it with their own logic. To use `removeGoal` you need the actual goal instance, which is impossible a lot of the time. So we should just make this public and let modders remove stuff in easier ways.