### PR TITLE
Fix userdev mod deps on the classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     EVENTBUS_VERSION = '5.0.3'
     MODLAUNCHER_VERSION = '9.0.7'
     SECUREJARHANDLER_VERSION = '0.9.46'
-    BOOTSTRAPLAUNCHER_VERSION = '0.1.15'
+    BOOTSTRAPLAUNCHER_VERSION = '0.1.16'
     ASM_VERSION = '9.1'
     INSTALLER_VERSION = '2.1.4'
 
@@ -391,12 +391,13 @@ def sharedFmlonlyForge = { Project prj ->
         }
 
         // SecureJarHandler bootstrap values.
-        run.property 'legacyClassPath', '{runtime_classpath}'
-        run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name}.join(',') + ",client-extra,fmlcore,javafmllanguage,mclanguage,${prj.name}-${prj.version},${prj.rootProject.ext.MC_VERSION}-${prj.name}${prj.version.substring(prj.rootProject.ext.MC_VERSION.length())}"
+        run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,mclanguage,${prj.name}-"
         run.property 'mergeModules', 'jna-5.8.0.jar,jna-platform-58.0.jar,java-objc-bridge-1.0.0.jar'
         if (userdevRuns.contains(run)) {
+            run.property 'legacyClassPath.file', '{minecraft_classpath_file}'
             run.jvmArgs '-p', '{modules}'
         } else {
+            run.property 'legacyClassPath.file', '{runtime_classpath_file}'
             run.jvmArgs '-p', prj.configurations.moduleonly.files.collect { it.path }.join(File.pathSeparator)
         }
         run.jvmArgs '--add-modules', 'ALL-MODULE-PATH'
@@ -570,8 +571,7 @@ project(':fmlonly') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ['-DlegacyClassPath=${classpath}',
-                          "-DignoreList=${fmlonly_client.properties.ignoreList}",
+                    jvm: ["-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${fmlonly_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{"\${library_directory}/${it.downloads.artifact.path}"}.join('${classpath_separator}'),
@@ -1078,8 +1078,7 @@ project(':forge') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ['-DlegacyClassPath=${classpath}',
-                          "-DignoreList=${forge_client.properties.ignoreList}",
+                    jvm: ["-DignoreList=${forge_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${forge_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{'${library_directory}/' + it.downloads.artifact.path}.join('${classpath_separator}'),

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -138,9 +138,10 @@ public class FMLLoader
         }
     }
 
-    static void setupLaunchHandler(final IEnvironment environment, final Map<String, ?> arguments)
+    static void setupLaunchHandler(final IEnvironment environment, final Map<String, Object> arguments)
     {
         final String launchTarget = environment.getProperty(IEnvironment.Keys.LAUNCHTARGET.get()).orElse("MISSING");
+        arguments.put("launchTarget", launchTarget);
         final Optional<ILaunchHandlerService> launchHandler = environment.findLaunchHandler(launchTarget);
         LOGGER.debug(CORE, "Using {} as launch service", launchTarget);
         if (launchHandler.isEmpty()) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -242,6 +242,6 @@ public class ModSorter
     private boolean modVersionNotContained(final IModInfo.ModVersion mv, final Map<String, ArtifactVersion> modVersions)
     {
         return !(VersionSupportMatrix.testVersionSupportMatrix(mv.getVersionRange(), mv.getModId(), "mod", (modId, range) -> modVersions.containsKey(modId) &&
-                (range.containsVersion(modVersions.get(modId)) || modVersions.get(modId).toString().equals("NONE"))));
+                (range.containsVersion(modVersions.get(modId)) || modVersions.get(modId).toString().equals("0.0NONE"))));
     }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -1,0 +1,103 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.loading.moddiscovery;
+
+import cpw.mods.jarhandling.SecureJar;
+import net.minecraftforge.fml.loading.LibraryFinder;
+import net.minecraftforge.forgespi.locating.IModFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.jar.JarInputStream;
+import java.util.stream.Stream;
+import java.util.zip.ZipInputStream;
+
+import static net.minecraftforge.fml.loading.LogMarkers.CORE;
+
+public class ClasspathLocator extends AbstractJarFileLocator {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final String MODS_TOML = "META-INF/mods.toml";
+    private static final String MANIFEST = "META-INF/MANIFEST.MF";
+    private final List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
+    private boolean enabled = false;
+
+    @Override
+    public String name() {
+        return "userdev classpath";
+    }
+
+    @Override
+    public List<IModFile> scanMods() {
+        if (!enabled)
+            return List.of();
+        try {
+            var modCoords = Stream.<IModFile>builder();
+            locateMods(modCoords, MODS_TOML, "classpath_mod", sj -> true);
+            locateMods(modCoords, MANIFEST, "manifest_jar", sj -> isValidManifest(sj) && sj.getManifest().getMainAttributes().getValue(ModFile.TYPE) != null);
+            return modCoords.build().toList();
+        } catch (IOException e) {
+            LOGGER.fatal(CORE, "Error trying to find resources", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Stream<Path> scanCandidates() {
+        return Stream.of();
+    }
+
+    private void locateMods(Stream.Builder<IModFile> modCoords, String resource, String name, Predicate<SecureJar> filter) throws IOException {
+        final Enumeration<URL> resources = ClassLoader.getSystemClassLoader().getResources(resource);
+        while (resources.hasMoreElements()) {
+            URL url = resources.nextElement();
+            Path path = LibraryFinder.findJarPathFor(resource, name, url);
+            if (ignoreList.stream().anyMatch(path.toString()::contains) || Files.isDirectory(path))
+                continue;
+
+            ModJarMetadata.buildFile(this, filter, path).ifPresent(mf -> {
+                LOGGER.debug(CORE, "Found classpath mod: {}", path);
+                modCoords.add(mf);
+            });
+        }
+    }
+
+    @Override
+    public void initArguments(Map<String, ?> arguments) {
+        var launchTarget = (String) arguments.get("launchTarget");
+        enabled = launchTarget != null && launchTarget.contains("dev");
+    }
+
+    private static boolean isValidManifest(SecureJar sj) {
+        try (var jis = new JarInputStream(Files.newInputStream(sj.getRootPath()))) {
+            return jis.getManifest() != null;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/fmlloader/src/main/resources/META-INF/services/net.minecraftforge.forgespi.locating.IModLocator
+++ b/fmlloader/src/main/resources/META-INF/services/net.minecraftforge.forgespi.locating.IModLocator
@@ -2,3 +2,4 @@ net.minecraftforge.fml.loading.moddiscovery.ModsFolderLocator
 net.minecraftforge.fml.loading.moddiscovery.MavenDirectoryLocator
 net.minecraftforge.fml.loading.moddiscovery.ExplodedDirectoryLocator
 net.minecraftforge.fml.loading.moddiscovery.MinecraftLocator
+net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator


### PR DESCRIPTION
This PR fixes userdev mod dependencies not being loaded off of the classpath. ClasspathLocator has been reinstated from Forge 1.16 but in fmlloader and only loaded conditionally if the launch target contains `dev` so that it works in both forgedev and userdev. This is so the class can be found at runtime correctly since the IModLocators are loaded from the service layer, which does not have the userdev jar that would have worked in 1.16. The `ignoreList` property has been updated to remove version information so that jars are filtered regardless of version. `${version_name}.jar` is now added to the ignoreList for the launcher json to fix issues with external launchers. Userdev run configs have been updated to use `{minecraft_classpath}` instead of `{runtime_classpath}` for the `legacyClassPath` property, so that only forge deps are on the legacy class path and userdev-deps are loaded from the actual class path.