### PR TITLE
[1.17.x] Change `fluid` field in `LiquidBlock` from protected to private to match 1.16

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/LiquidBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/LiquidBlock.java.patch
@@ -1,6 +1,12 @@
 --- a/net/minecraft/world/level/block/LiquidBlock.java
 +++ b/net/minecraft/world/level/block/LiquidBlock.java
-@@ -35,6 +_,7 @@
+@@ -30,11 +_,12 @@
+ 
+ public class LiquidBlock extends Block implements BucketPickup {
+    public static final IntegerProperty f_54688_ = BlockStateProperties.f_61422_;
+-   protected final FlowingFluid f_54689_;
++   private final FlowingFluid f_54689_;
+    private final List<FluidState> f_54691_;
     public static final VoxelShape f_54690_ = Block.m_49796_(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D);
     public static final ImmutableList<Direction> f_181233_ = ImmutableList.of(Direction.DOWN, Direction.SOUTH, Direction.NORTH, Direction.EAST, Direction.WEST);
  


### PR DESCRIPTION
Change `fluid` field from protected to private in `LiquidBlock` as per discussion on [Discord](https://discord.com/channels/313125603924639766/867851603468615740/868704757018153010) about crashes caused by `fluid` being protected in 1.17, while in 1.16 the field was private.