### PR TITLE
[1.15.x] Fix latest version not being changed for promotion file when updating

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,11 @@ pipeline {
                     }
                 }
             }
+            post {
+                success {
+                    build job: 'filegenerator', parameters: [string(name: 'COMMAND', value: "promote net.minecraftforge:forge ${env.MYVERSION} latest")], propagate: false, wait: false
+                }
+            }
         }
         stage('test_publish_pr') { //Publish to local repo to test full process, but don't include credentials so it can't sign/publish to maven
             when {


### PR DESCRIPTION
This is the missing part from the Jenkinsfile which is present in `1.16.x` and `1.17.x`.
This *should* fix the problem when a new 1.15 version is released, that it's not changed in https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json
Obviously, I couldn't test it. 