### PR TITLE
[1.17.x] Add an API for dynamic dimensions

### DIFF
--- a/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DynamicDimensionManager.java
@@ -1,0 +1,320 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.progress.ChunkProgressListener;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.border.BorderChangeListener;
+import net.minecraft.world.level.border.WorldBorder;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.WorldGenSettings;
+import net.minecraft.world.level.storage.DerivedLevelData;
+import net.minecraft.world.level.storage.LevelStorageSource.LevelStorageAccess;
+import net.minecraft.world.level.storage.WorldData;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fmllegacy.network.NetworkHooks;
+
+/**
+ * API for creating and uncreating dynamic dimensions during game runtime. This
+ * should only be used for creating dynamic dimensions, whose quantity and
+ * properties aren't known until created by some game mechanic. Static
+ * dimensions (whose quantities and properties are fixed ahead of time) should
+ * be created using the vanilla json dimension system.
+ */
+@ParametersAreNonnullByDefault
+public class DynamicDimensionManager
+{
+    private static final Set<ResourceKey<Level>> VANILLA_WORLDS = ImmutableSet.of(Level.OVERWORLD, Level.NETHER, Level.END); 
+    private static Set<ResourceKey<Level>> pendingLevelsToUnregister = new HashSet<>();
+    
+    /**
+     * Retrieves the level for a given level key, registering and creating one if it doesn't already exist.
+     * 
+     * Levels created this way will be saved to the save folder's dimension registry
+     * and will be automatically loaded the next time the server starts. All registered levels will tick while they exist
+     * (though a level without any loaded chunks won't do much in the tick).
+     * 
+     * @param server a server
+     * @param levelKey The resource key for the world
+     * @param dimensionFactory The function to use to create the level's LevelStem instance if it doesn't already exist;
+     * the given LevelStem key will have the same ID as the given Level key
+     * @return A server level for the given key
+     * 
+     * @apiNote To retreive static dimensions that always exist, or to look up a (nullable) world without force-creating it,
+     * use {@link MinecraftServer#getLevel(ResourceKey)} instead.
+     * 
+     * To register a static dimension that always exists, make a json dimension instead; minecraft will load and register it automatically
+     * 
+     * To unregister a dynamic dimension level (preventing it from ticking, or from loading at server startup),
+     * use {@link DynamicDimensionManager#unregisterDimensions(MinecraftServer, Set)}.
+     */
+    public static ServerLevel getOrCreateLevel(final MinecraftServer server, final ResourceKey<Level> levelKey, final BiFunction<MinecraftServer, ResourceKey<LevelStem>, LevelStem> dimensionFactory)
+    {
+        // (we're doing the lookup this way because we'll need the map if we need to add a new level)
+        @SuppressWarnings("deprecation") // forgeGetWorldMap is deprecated because it's a forge-internal-use-only method
+        final Map<ResourceKey<Level>, ServerLevel> map = server.forgeGetWorldMap();
+        
+        // if the level already exists, return it
+        final @Nullable ServerLevel existingLevel = map.get(levelKey);
+        if (existingLevel != null)
+        {
+            return existingLevel;
+        }
+
+        final ServerLevel newLevel = createAndRegisterWorldAndDimension(server, map, levelKey, dimensionFactory);
+        return newLevel;
+    }
+    
+    /**
+     * Marks a level and its levelstem for unregistration. Unregistered levels will stop ticking,
+     * unregistered levelstems will not be loaded on server startup unless and until they are reregistered again.
+     * 
+     * Unregistration is delayed until the end of the server tick (just after the post-server-tick-event fires).
+     * 
+     * Players who are still in the given level at that time will be ejected to their respawn points.
+     * Players who have respawn points in levels being unloaded will have their spawn points reset to the overworld and respawned there.
+     * 
+     * Unregistering a level does not delete the region files or other data associated with the level's level folder.
+     * If a level is reregistered after unregistering it, the level will retain all prior data (unless manually deleted via server admin)
+     * 
+     * @param levelToRemove The key for the level to schedule for unregistration. Vanilla dimensions are not removable as they are
+     * generally assumed to exist (especially the overworld)
+     * 
+     * @apiNote Not intended for use with vanilla or json dimensions, doing so may cause strange problems.
+     * 
+     * However, if a vanilla or json dimension *is* removed, restarting the server will reconstitute it as
+     * vanilla automatically detects and registers these.
+     * 
+     * Mods whose dynamic dimensions require the ejection of players to somewhere other than their respawn point
+     * should teleport these worlds' players to appropriate locations before unregistering their dimensions.
+     */
+    public static void markDimensionForUnregistration(final MinecraftServer server, final ResourceKey<Level> levelToRemove)
+    {
+        if (!VANILLA_WORLDS.contains(levelToRemove))
+        {
+            DynamicDimensionManager.pendingLevelsToUnregister.add(levelToRemove);
+        }
+    }
+    
+    /**
+     * @return an immutable view of the levels pending to be unregistered and unloaded at the end of the current server tick
+     */
+    public static Set<ResourceKey<Level>> getWorldsPendingUnregistration()
+    {
+        return Collections.unmodifiableSet(DynamicDimensionManager.pendingLevelsToUnregister);
+    }
+    
+    /**
+     * called at the end of the server tick just before the post-server-tick-event
+     * @deprecated Internal forge method 
+     */
+    @Deprecated
+    public static void unregisterScheduledDimensions(final MinecraftServer server)
+    {
+        // flush the buffer
+        final Set<ResourceKey<Level>> keysToRemove = DynamicDimensionManager.pendingLevelsToUnregister;
+        DynamicDimensionManager.pendingLevelsToUnregister = new HashSet<>();
+        
+        // we need to remove the dimension/world form three places
+        // the server's dimension registry, the server's world registry, and the overworld's world border listener
+        // the world registry is just a simple map and the world border listener has a remove() method
+        // the dimension registry has five sub-collections that need to be cleaned up
+        // we should also eject players from the removed worlds or they could get stuck there
+        
+        final WorldGenSettings worldGenSettings = server.getWorldData().worldGenSettings();
+        final Set<ResourceKey<Level>> removedLevelKeys = new HashSet<>();
+        final ServerLevel overworld = server.getLevel(Level.OVERWORLD);
+        
+        for (final ResourceKey<Level> levelKeyToRemove : keysToRemove)
+        {
+            @Nullable ServerLevel removedLevel = server.forgeGetWorldMap().remove(levelKeyToRemove); // null if the specified key was not present
+            if (removedLevel != null) // if we removed the key from the map
+            {
+                // eject players from dead world
+                // iterate over a copy as the world will remove players from the original list
+                for (final ServerPlayer player : Lists.newArrayList(removedLevel.players()))
+                {
+                    // send players to their respawn point
+                    ResourceKey<Level> respawnKey = player.getRespawnDimension();
+                    // if we're removing their respawn world then just send them to the overworld
+                    if (keysToRemove.contains(respawnKey))
+                    {
+                        respawnKey = Level.OVERWORLD;
+                        player.setRespawnPosition(Level.OVERWORLD, null, 0, false, false);
+                    }
+                    if (respawnKey == null)
+                        respawnKey = Level.OVERWORLD;
+                    final ServerLevel destinationLevel = server.getLevel(respawnKey);
+                    BlockPos destinationPos = player.getRespawnPosition();
+                    if (destinationPos == null)
+                        destinationPos = destinationLevel.getSharedSpawnPos();
+                    final float respawnAngle = player.getRespawnAngle();
+                    // "respawning" the player via the player list schedules a task in the server to run after the post-server tick
+                    // that causes some minor logspam due to the player's world no longer being loaded
+                    // teleporting the player this way instead avoids this
+                    player.teleportTo(destinationLevel, destinationPos.getX(), destinationPos.getY(), destinationPos.getZ(), respawnAngle, 0F);
+                }
+                // save the world now or it won't be saved later and data that may be wanted to be kept may be lost
+                removedLevel.save(null, false, removedLevel.noSave());
+
+                // fire world unload event -- when the server stops, this would fire after worlds get saved, so we'll do that here too
+                MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(removedLevel));
+                
+                // remove the world border listener if possible
+                final WorldBorder overworldBorder = overworld.getWorldBorder();
+                final WorldBorder removedWorldBorder = removedLevel.getWorldBorder();
+                final List<BorderChangeListener> listeners = overworldBorder.listeners;
+                BorderChangeListener targetListener = null;
+                for (BorderChangeListener listener : listeners)
+                {
+                    if (listener instanceof BorderChangeListener.DelegateBorderChangeListener && removedWorldBorder == ((BorderChangeListener.DelegateBorderChangeListener)listener).worldBorder)
+                    {
+                        targetListener = listener;
+                        break;
+                    }
+                }
+                if (targetListener != null)
+                {
+                    overworldBorder.removeListener(targetListener);
+                }
+                
+                // track the removed world
+                removedLevelKeys.add(levelKeyToRemove);
+            }
+        }
+        
+        if (!removedLevelKeys.isEmpty())
+        {
+            // replace the old dimension registry with a new one containing the dimensions that weren't removed, in the same order
+            final MappedRegistry<LevelStem> oldRegistry = worldGenSettings.dimensions();
+            final MappedRegistry<LevelStem> newRegistry = new MappedRegistry<>(Registry.LEVEL_STEM_REGISTRY, oldRegistry.elementsLifecycle());
+            
+            for (final Entry<ResourceKey<LevelStem>, LevelStem> entry : oldRegistry.entrySet())
+            {
+                final ResourceKey<LevelStem> oldKey = entry.getKey();
+                final ResourceKey<Level> oldLevelKey = ResourceKey.create(Registry.DIMENSION_REGISTRY, oldKey.location());
+                final LevelStem dimension = entry.getValue();
+                if (oldKey != null && dimension != null && !removedLevelKeys.contains(oldLevelKey))
+                {
+                    newRegistry.register(oldKey, dimension, oldRegistry.lifecycle(dimension));
+                }
+            }
+            
+            // then replace the old registry with the new registry
+            worldGenSettings.dimensions = newRegistry;
+
+            // update the server's levels so dead levels don't get ticked
+            server.markWorldsDirty();
+            // client will need to be notified of the removed level for the dimension command suggester
+            NetworkHooks.updateClientDimensionLists(ImmutableSet.of(), removedLevelKeys);
+        }
+    }
+    
+    @SuppressWarnings("deprecation") // because we call the forge internal method server#markWorldsDirty
+    private static ServerLevel createAndRegisterWorldAndDimension(final MinecraftServer server, final Map<ResourceKey<Level>, ServerLevel> map, final ResourceKey<Level> worldKey, final BiFunction<MinecraftServer, ResourceKey<LevelStem>, LevelStem> dimensionFactory)
+    {
+        // get everything we need to create the dimension and the level
+        final ServerLevel overworld = server.getLevel(Level.OVERWORLD);
+        
+        // dimension keys have a 1:1 relationship with level keys, they have the same IDs as well
+        final ResourceKey<LevelStem> dimensionKey = ResourceKey.create(Registry.LEVEL_STEM_REGISTRY, worldKey.location());
+        final LevelStem dimension = dimensionFactory.apply(server, dimensionKey);
+
+        // the int in create() here is radius of chunks to watch, 11 is what the server uses when it initializes worlds
+        final ChunkProgressListener chunkProgressListener = server.progressListenerFactory.create(11);
+        final Executor executor = server.executor;
+        final LevelStorageAccess anvilConverter = server.storageSource;
+        final WorldData worldData = server.getWorldData();
+        final WorldGenSettings worldGenSettings = worldData.worldGenSettings();
+        final DerivedLevelData derivedLevelData = new DerivedLevelData(worldData, worldData.overworldData());
+        
+        // now we have everything we need to create the dimension and the level
+        // this is the same order server init creates levels:
+        // the dimensions are already registered when levels are created, we'll do that first
+        // then instantiate level, add border listener, add to map, fire world load event
+        
+        // register the actual dimension
+        worldGenSettings.dimensions().register(dimensionKey, dimension, Lifecycle.experimental());
+
+        // create the world instance
+        final ServerLevel newWorld = new ServerLevel(
+            server,
+            executor,
+            anvilConverter,
+            derivedLevelData,
+            worldKey,
+            dimension.type(),
+            chunkProgressListener,
+            dimension.generator(),
+            worldGenSettings.isDebug(),
+            net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(worldGenSettings.seed()),
+            ImmutableList.of(), // "special spawn list"
+                // phantoms, travelling traders, patrolling/sieging raiders, and cats are overworld special spawns
+                // this is always empty for non-overworld dimensions (including json dimensions)
+                // these spawners are ticked when the world ticks to do their spawning logic,
+                // mods that need "special spawns" for their own dimensions should implement them via tick events or other systems
+            false // "tick time", true for overworld, always false for nether, end, and json dimensions
+            );
+        
+        // add world border listener, for parity with json dimensions
+        // the vanilla behaviour is that world borders exist in every dimension simultaneously with the same size and position
+        // these border listeners are automatically added to the overworld as worlds are loaded, so we should do that here too
+        // TODO if world-specific world borders are ever added, change it here too
+        overworld.getWorldBorder().addListener(new BorderChangeListener.DelegateBorderChangeListener(newWorld.getWorldBorder()));
+        
+        // register level
+        map.put(worldKey, newWorld);
+        
+        // update forge's world cache so the new level can be ticked
+        server.markWorldsDirty();
+        
+        // fire world load event
+        MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(newWorld));
+        
+        // update clients' dimension lists
+        NetworkHooks.updateClientDimensionLists(ImmutableSet.of(worldKey), ImmutableSet.of());
+        
+        return newWorld;
+    }
+}

--- a/src/main/java/net/minecraftforge/fmllegacy/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/hooks/BasicEventHooks.java
@@ -24,11 +24,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.client.model.animation.Animation;
+import net.minecraftforge.common.DynamicDimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fmllegacy.server.ServerLifecycleHooks;
 import net.minecraftforge.event.TickEvent;
 
 public class BasicEventHooks
@@ -118,5 +121,10 @@ public class BasicEventHooks
     public static void onPostServerTick()
     {
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
+        MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+        if (server != null)
+        {
+            DynamicDimensionManager.unregisterScheduledDimensions(server);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
@@ -42,12 +42,14 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
@@ -265,5 +267,21 @@ public class NetworkHooks
     public static FMLConnectionData getConnectionData(Connection mgr)
     {
         return mgr.channel().attr(FMLNetworkConstants.FML_CONNECTION_DATA).get();
+    }
+    
+    /**
+     * Notifies clients that their list of dimension IDs needs to be updated.
+     * This clientside list is normally only used for the command suggester.
+     * 
+     * @param newDimensions keys to add to clients' dimension lists
+     * @param removedDimensions keys to remove from clients' dimension lists
+     * 
+     * @apiNote Internal; this is invoked by {@link DynamicDimensionManager}
+     * when that's used to add or remove dynamic dimensions,
+     * so mods shouldn't need to call this themselves
+     */
+    public static void updateClientDimensionLists(Set<ResourceKey<Level>> newDimensions, Set<ResourceKey<Level>> removedDimensions)
+    {
+        FMLNetworkConstants.playChannel.send(PacketDistributor.ALL.noArg(), new FMLPlayMessages.SyncDimensionListChanges(newDimensions,removedDimensions));
     }
 }

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkInitialization.java
@@ -110,6 +110,12 @@ class NetworkInitialization {
               consumer(FMLPlayMessages.SyncCustomTagTypes::handle).
               add();
 
+        playChannel.messageBuilder(FMLPlayMessages.SyncDimensionListChanges.class, 4).
+            decoder(FMLPlayMessages.SyncDimensionListChanges::decode).
+            encoder(FMLPlayMessages.SyncDimensionListChanges::encode).
+            consumer(FMLPlayMessages.SyncDimensionListChanges::handle).
+            add();
+
         return playChannel;
     }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -189,6 +189,9 @@ public net.minecraft.data.recipes.ShapedRecipeBuilder$Result
 protected net.minecraft.data.tags.TagsProvider f_126543_ # builders
 public net.minecraft.network.protocol.status.ClientboundStatusResponsePacket f_134885_ # GSON
 protected net.minecraft.server.MinecraftServer f_129726_ # nextTickTime
+public net.minecraft.server.MinecraftServer f_129738_ # executor
+public net.minecraft.server.MinecraftServer f_129744_ # storageSource
+public net.minecraft.server.MinecraftServer f_129756_ # progressListenerFactory
 public net.minecraft.server.dedicated.DedicatedServer f_139600_ # consoleInput
 public net.minecraft.server.level.ServerChunkCache f_8328_ # generator
 public net.minecraft.server.level.ServerChunkCache f_8329_ # level
@@ -386,6 +389,8 @@ public net.minecraft.world.level.block.entity.BlockEntityType$BlockEntitySupplie
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59395_(I)V # setCooldown
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59409_()Z # isOnCustomCooldown
 public net.minecraft.world.level.block.state.properties.WoodType m_61844_(Lnet/minecraft/world/level/block/state/properties/WoodType;)Lnet/minecraft/world/level/block/state/properties/WoodType; # register
+public net.minecraft.world.level.border.BorderChangeListener$DelegateBorderChangeListener f_61864_ # worldBorder
+public net.minecraft.world.level.border.WorldBorder f_61905_ # listeners
 public net.minecraft.world.level.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/level/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/level/chunk/ChunkStatus$ChunkType;Lnet/minecraft/world/level/chunk/ChunkStatus$GenerationTask;Lnet/minecraft/world/level/chunk/ChunkStatus$LoadingTask;)V # constructor
 private-f net.minecraft.world.level.levelgen.DebugLevelSource f_64114_ # ALL_BLOCKS
 private-f net.minecraft.world.level.levelgen.DebugLevelSource f_64115_ # GRID_WIDTH
@@ -404,6 +409,7 @@ public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_64474_(Lcom/m
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_64478_(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings;)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # register
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_64487_()Z # disableMobGeneration
 #endgroup
+public-f net.minecraft.world.level.levelgen.WorldGenSettings f_64605_ # dimensions
 public net.minecraft.world.level.levelgen.feature.blockplacers.BlockPlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor

--- a/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/DynamicDimensionManagerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import java.util.Objects;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.arguments.DimensionArgument;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.OverworldBiomeSource;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraftforge.common.DynamicDimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+@Mod(DynamicDimensionManagerTest.MODID)
+public class DynamicDimensionManagerTest
+{
+    public static final String MODID = "dynamic_dimension_manager_test";
+    public static final String NEW_DIMENSION_NAME = "new_dimension_name";
+    public static final String DIMENSION = "dimension";
+    
+    public DynamicDimensionManagerTest()
+    {
+        final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        final IEventBus forgeBus = MinecraftForge.EVENT_BUS;
+        
+        forgeBus.addListener(this::onRegisterCommands);
+    }
+    
+    private void onRegisterCommands(final RegisterCommandsEvent event)
+    {
+        final CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        dispatcher.register(Commands.literal(MODID)
+            .requires(DynamicDimensionManagerTest::isCommandSourceServerAdmin)
+            .then(Commands.literal("add")
+                .then(Commands.argument(NEW_DIMENSION_NAME, ResourceLocationArgument.id())
+                    .suggests((context,builder) -> SharedSuggestionProvider.suggest(new String[]{"<new_dimension_name>"}, builder))
+                    .executes(DynamicDimensionManagerTest::addNewDimension)))
+            .then(Commands.literal("remove")
+                .then(Commands.argument(DIMENSION, DimensionArgument.dimension())
+                    .executes(DynamicDimensionManagerTest::removeDimension)))
+            );
+    }
+    
+    private static boolean isCommandSourceServerAdmin(final CommandSourceStack source)
+    {
+        return source.hasPermission(4);
+    }
+    
+    private static int addNewDimension(final CommandContext<CommandSourceStack> context)
+    {
+        final CommandSourceStack source = context.getSource();
+        final ResourceLocation rawID = ResourceLocationArgument.getId(context, NEW_DIMENSION_NAME);
+        // convert minecraft namespace to modid
+        final ResourceLocation worldID = rawID.getNamespace() == "minecraft" ? new ResourceLocation(MODID, rawID.getPath()) : rawID;
+        final ResourceKey<Level> worldKey = ResourceKey.create(Registry.DIMENSION_REGISTRY, worldID);
+        final MinecraftServer server = source.getServer();
+        final ServerLevel existingWorld = server.getLevel(worldKey);
+        if (existingWorld != null)
+        {
+            source.sendFailure(new TextComponent(String.format("World with id %s already exists", worldID)));
+            return 0;
+        }
+        DynamicDimensionManager.getOrCreateLevel(server, worldKey, DynamicDimensionManagerTest::makeDimension);
+        source.sendSuccess(new TextComponent(String.format("Created world with id %s", worldID)), true);
+        return 1;
+    }
+    
+    private static int removeDimension(final CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+    {
+        final CommandSourceStack source = context.getSource();
+        final MinecraftServer server = source.getServer();
+        final ServerLevel worldToRemove = DimensionArgument.getDimension(context, DIMENSION);
+        final ResourceKey<Level> key = worldToRemove.dimension();
+        source.sendSuccess(new TextComponent(String.format("Unregistering dimension %s", key.location())), true);
+        DynamicDimensionManager.markDimensionForUnregistration(server, key);
+        return 1;
+    }
+    
+    private static LevelStem makeDimension(final MinecraftServer server, final ResourceKey<LevelStem> key)
+    {
+        final long seed = Objects.hash(server.getLevel(Level.OVERWORLD).getSeed(), key.location());
+        final RegistryAccess registries = server.registryAccess();
+        final DimensionType overworldDimensionType = registries.registryOrThrow(Registry.DIMENSION_TYPE_REGISTRY).get(DimensionType.OVERWORLD_LOCATION);
+        final BiomeSource biomeProvider = new OverworldBiomeSource(seed, false, false, registries.registryOrThrow(Registry.BIOME_REGISTRY));
+        final NoiseGeneratorSettings noiseSettings = registries.registryOrThrow(Registry.NOISE_GENERATOR_SETTINGS_REGISTRY).get(NoiseGeneratorSettings.OVERWORLD);
+        final ChunkGenerator chunkGenerator = new NoiseBasedChunkGenerator(biomeProvider, seed, () -> noiseSettings);
+        return new LevelStem(() -> overworldDimensionType, chunkGenerator);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -142,5 +142,7 @@ license="LGPL v2.1"
     modId="overlay_layers_test"
 [[mods]]
     modId="entity_renderer_events_test"
+[[mods]]
+    modId="dynamic_dimension_manager_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR is #7862 but ported from 1.16.x to 1.17.x.

## What's this add?
* An API for adding and removing dimensions during server runtime

## Why's this add that?
* This API allows mods to generate indefinitely many concurrently-existing worlds whose properties and quantity are not necessarily known ahead of time
* Mods would be able to use this API to (for example) add random dungeon dimensions, per-player personal spaces, or dimensions whose properties are determined via player input.
* The ability to remove or unregister dimensions is needed by mods that add many dynamic dimensions, as registered worlds are kept in memory; this allows mods to completely unload worlds while they are not in use.

## Public APIs
* The new DynamicDimensionManager class contains all public APIs for this feature:
  * `getOrCreateLevel` returns a world for a specified world key, creating and registering the world and dimension if the world doesn't already exist.
    * This also fires a world load event once the world has been registered into the server.
  * `markDimensionForUnregistration` schedules a world and dimension to be unregistered and unloaded at the end of the current server tick, just after the post-server-tick-event fires.
    * World unload events are fired for each world in sequence, before any worlds and dimensions are removed from the registries.
    * If any players remain in a world when the world is unloaded, they will be ejected to their respawn point (or to the overworld if their respawn point was in a world-being-removed). Mods whose dynamic dimensions require players to be ejected elsewhere should manually teleport them before scheduling dimension removal.
  * `getWorldsPendingUnregistration` returns an immutable view of the world keys scheduled for unregistration.

## Other Features
* When dimensions are added or removed, a syncing packet is sent to clients to update their dimension ID list.
  * This list is normally only used for suggesting dimension IDs for commands; minecraft does not normally sync any information about dimensions other than their IDs.
  * This syncing feature is only available to clients if the client also has an up-to-date build of forge with the features added in this PR, as vanilla clients are only able to update their dimension ID lists on login. Vanilla clients and older forge clients (using forge builds without this PR's features) will be able to connect to forge servers, but are unable to handle the syncing packet when the servers' dimensions update during runtime, so these clients' dimension ID lists will remain outdated until they leave and rejoin the server.

## Effects on Existing Mods
* This PR adds no patches to vanilla sources, and does not directly cause any binary-breaking changes; if a server updates to a new build of forge with this PR without updating any existing mods installed on the server, then the server will experience no problems.
* However, the existence of a mod *using* the features added in this PR does change the assumptions that other mods are allowed to make (meaning that mods that start using the dynamic dimensions API may lose compatibility with other mods whose assumptions have been broken, until the other mods update to account for these changes):
  * This PR definalizes the dimension registry field of the server's DimensionGeneratorSettings, so that when dimensions are unregistered, the server's dimension registry can be replaced with a new registry containing only the keys and dimensions that were not removed (which is substantially simpler than removing dimensions from the existing registry). Any mod that is caching the server's dimension registry would need to update to not cache the server's dimension registry in order to be compatible with mods that use the dimension removal API. The probability of such a mod existing is not expected to be high.
  * This PR breaks the assumption that a world or dimension present in the server's world registry or dimension registry at any given point in time will continue to be present in the server's world or dimension registry at any point in the future (or that a world not being present will continue to not be present). Mods that assume this would need to update to be compatible with mods that use the dynamic dimension API. I have seen at least one existing mod (in 1.16) that makes this assumption.

## Other Concerns
* While the dimension removal API does prevent the vanilla dimensions from being unregistered, currently there are no safeguards to prevent mods from using the dynamic dimension API to remove json dimensions. This is because A) this would be difficult to implement (json dimensions are loaded in the same manner as previously-registered dynamic dimensions), and B) unregistering a json dimension generally doesn't cause significant problems (the server will automatically reregister the dimension the next time the server starts).
* If a player leaves the server, then a dimension is removed from the server, then the player rejoins the server, they will be placed into the overworld instead (this is a vanilla failsafe).
* This API is not intended to replace the JSON dimension system; static dimensions should still be defined via JSONs.