### PR TITLE
Fix BaseRailBlock not implementing SimpleWaterloggedBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/BaseRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BaseRailBlock.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.world.phys.shapes.VoxelShape;
  
 -public abstract class BaseRailBlock extends Block implements SimpleWaterloggedBlock {
-+public abstract class BaseRailBlock extends Block implements net.minecraftforge.common.extensions.IForgeBaseRailBlock {
++public abstract class BaseRailBlock extends Block implements SimpleWaterloggedBlock, net.minecraftforge.common.extensions.IForgeBaseRailBlock {
     protected static final VoxelShape f_49355_ = Block.m_49796_(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D);
     protected static final VoxelShape f_49356_ = Block.m_49796_(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D);
     public static final BooleanProperty f_152149_ = BlockStateProperties.f_61362_;


### PR DESCRIPTION
This was likely erroneously removed during the porting process, resulting in bucket interaction with rail blocks not working as intended (the [current patch](https://github.com/MinecraftForge/MinecraftForge/blob/be5446b91c17a3dbed880028741c430610bd59f1/patches/minecraft/net/minecraft/world/level/block/BaseRailBlock.java.patch#L7-L8) removes implementing SimpleWaterloggedBlock). With this PR's change applied, rightclicking with a water bucket on a rail block will again correctly waterlog it, and rightclicking with an empty bucket on a waterlogged rail block will correctly remove the water.