### PR TITLE
Rename potion registry fields to match the mojang names

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1072,7 +1072,7 @@ public class ForgeHooks
             else if (item instanceof PotionItem || item instanceof TippedArrowItem)
             {
                 Potion potionType = PotionUtils.getPotion(itemStack);
-                ResourceLocation resourceLocation = ForgeRegistries.POTION_TYPES.getKey(potionType);
+                ResourceLocation resourceLocation = ForgeRegistries.POTIONS.getKey(potionType);
                 if (resourceLocation != null)
                 {
                     return resourceLocation.getNamespace();

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -72,9 +72,9 @@ public class ForgeRegistries
     public static final IForgeRegistry<Block> BLOCKS = RegistryManager.ACTIVE.getRegistry(Block.class);
     public static final IForgeRegistry<Fluid> FLUIDS = RegistryManager.ACTIVE.getRegistry(Fluid.class);
     public static final IForgeRegistry<Item> ITEMS = RegistryManager.ACTIVE.getRegistry(Item.class);
-    public static final IForgeRegistry<MobEffect> POTIONS = RegistryManager.ACTIVE.getRegistry(MobEffect.class);
+    public static final IForgeRegistry<MobEffect> MOB_EFFECTS = RegistryManager.ACTIVE.getRegistry(MobEffect.class);
     public static final IForgeRegistry<SoundEvent> SOUND_EVENTS = RegistryManager.ACTIVE.getRegistry(SoundEvent.class);
-    public static final IForgeRegistry<Potion> POTION_TYPES = RegistryManager.ACTIVE.getRegistry(Potion.class);
+    public static final IForgeRegistry<Potion> POTIONS = RegistryManager.ACTIVE.getRegistry(Potion.class);
     public static final IForgeRegistry<Enchantment> ENCHANTMENTS = RegistryManager.ACTIVE.getRegistry(Enchantment.class);
     public static final IForgeRegistry<EntityType<?>> ENTITIES = RegistryManager.ACTIVE.getRegistry(EntityType.class);
     public static final IForgeRegistry<BlockEntityType<?>> BLOCK_ENTITIES = RegistryManager.ACTIVE.getRegistry(BlockEntityType.class);
@@ -118,7 +118,7 @@ public class ForgeRegistries
         public static final ResourceKey<Registry<Block>>  BLOCKS  = key("block");
         public static final ResourceKey<Registry<Fluid>>  FLUIDS  = key("fluid");
         public static final ResourceKey<Registry<Item>>   ITEMS   = key("item");
-        public static final ResourceKey<Registry<MobEffect>> EFFECTS = key("mob_effect");
+        public static final ResourceKey<Registry<MobEffect>> MOB_EFFECTS = key("mob_effect");
         public static final ResourceKey<Registry<Potion>> POTIONS = key("potion");
         public static final ResourceKey<Registry<Attribute>> ATTRIBUTES = key("attribute");
         public static final ResourceKey<Registry<StatType<?>>> STAT_TYPES = key("stat_type");

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -141,7 +141,7 @@ public class GameData
         makeRegistry(BLOCKS, Block.class, "air").addCallback(BlockCallbacks.INSTANCE).legacyName("blocks").create();
         makeRegistry(FLUIDS, Fluid.class, "empty").create();
         makeRegistry(ITEMS, Item.class, "air").addCallback(ItemCallbacks.INSTANCE).legacyName("items").create();
-        makeRegistry(EFFECTS, MobEffect.class ).legacyName("potions").create();
+        makeRegistry(MOB_EFFECTS, MobEffect.class).legacyName("potions").create();
         //makeRegistry(BIOMES, Biome.class).legacyName("biomes").create();
         makeRegistry(SOUND_EVENTS, SoundEvent.class).legacyName("soundevents").create();
         makeRegistry(POTIONS, Potion.class, "empty").legacyName("potiontypes").tagFolder("potions").create();

--- a/src/test/java/net/minecraftforge/debug/misc/CustomTagTypesTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/CustomTagTypesTest.java
@@ -73,7 +73,7 @@ public class CustomTagTypesTest
     private static final Tag.Named<Custom> TESTS = ForgeTagHandler.createOptionalTag(customRegistryName, new ResourceLocation(MODID, "tests"), Sets.newHashSet(CUSTOM));
     private static final Tag.Named<Item> OPTIONAL_TEST = ItemTags.createOptional(new ResourceLocation(MODID, "optional_test"), Sets.newHashSet(() -> Items.BONE));
     private static final Tag.Named<Enchantment> FIRE = ForgeTagHandler.createOptionalTag(ForgeRegistries.ENCHANTMENTS, new ResourceLocation(MODID, "fire"));
-    private static final Tag.Named<Potion> DAMAGE = ForgeTagHandler.createOptionalTag(ForgeRegistries.POTION_TYPES, new ResourceLocation(MODID, "damage"));
+    private static final Tag.Named<Potion> DAMAGE = ForgeTagHandler.createOptionalTag(ForgeRegistries.POTIONS, new ResourceLocation(MODID, "damage"));
     private static final Tag.Named<BlockEntityType<?>> STORAGE = ForgeTagHandler.createOptionalTag(ForgeRegistries.BLOCK_ENTITIES, new ResourceLocation(MODID, "storage"));
 
     public CustomTagTypesTest()
@@ -177,7 +177,7 @@ public class CustomTagTypesTest
     {
         public PotionTags(DataGenerator gen, @Nullable ExistingFileHelper existingFileHelper)
         {
-            super(gen, ForgeRegistries.POTION_TYPES, MODID, existingFileHelper);
+            super(gen, ForgeRegistries.POTIONS, MODID, existingFileHelper);
         }
 
         @Override


### PR DESCRIPTION
Rename potion registry fields to match the mojang names (and the vanilla Registry Keys)