### PR TITLE
[1.17.x] Fix the loading of lang providers and libraries in dev.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -943,8 +943,7 @@ project(':forge') {
             '/': [
                 'Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                 'GitCommit': gradleutils.gitInfo.abbreviatedId,
-                'Git-Branch': gradleutils.gitInfo.branch,
-                'FMLModType': 'MOD',//This is needed. Else it gets loaded in the wrong module layer!
+                'Git-Branch': gradleutils.gitInfo.branch
             ] as LinkedHashMap,
             'net/minecraftforge/versions/forge/': [
                 'Specification-Title':      'Forge',

--- a/build.gradle
+++ b/build.gradle
@@ -943,7 +943,8 @@ project(':forge') {
             '/': [
                 'Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                 'GitCommit': gradleutils.gitInfo.abbreviatedId,
-                'Git-Branch': gradleutils.gitInfo.branch
+                'Git-Branch': gradleutils.gitInfo.branch,
+                'FMLModType': 'MOD',//This is needed. Else it gets loaded in the wrong module layer!
             ] as LinkedHashMap,
             'net/minecraftforge/versions/forge/': [
                 'Specification-Title':      'Forge',

--- a/fmlcore/build.gradle
+++ b/fmlcore/build.gradle
@@ -23,7 +23,7 @@ task sourcesJar(type: Jar) {
 ext {
     MANIFESTS = [
         '': [
-            'FMLModType': 'LIBRARY',
+            'FMLModType': 'LANGPROVIDER',                        //This is needed. Else it gets loaded in the wrong module layer!
             'Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
             'Git-Commit': GIT_INFO.abbreviatedId,
             'Git-Branch': GIT_INFO.branch,

--- a/fmlcore/build.gradle
+++ b/fmlcore/build.gradle
@@ -23,7 +23,7 @@ task sourcesJar(type: Jar) {
 ext {
     MANIFESTS = [
         '': [
-            'FMLModType': 'LANGPROVIDER',                        //This is needed. Else it gets loaded in the wrong module layer!
+            'FMLModType': 'LANGPROVIDER',//This is needed. Else it gets loaded in the wrong module layer!
             'Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
             'Git-Commit': GIT_INFO.abbreviatedId,
             'Git-Branch': GIT_INFO.branch,

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -94,7 +94,7 @@ public class ClasspathLocator extends AbstractJarFileLocator {
     }
 
     private static boolean isValidManifest(SecureJar sj) {
-        try (var jis = new JarInputStream(Files.newInputStream(sj.getRootPath()))) {
+        try (var jis = new JarInputStream(Files.newInputStream(sj.getPrimaryPath()))) {
             return jis.getManifest() != null;
         } catch (IOException e) {
             return false;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml.loading.moddiscovery;
 
+import com.google.common.collect.Lists;
 import cpw.mods.jarhandling.SecureJar;
 import net.minecraftforge.fml.loading.LibraryFinder;
 import net.minecraftforge.forgespi.locating.IModFile;
@@ -29,10 +30,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.jar.JarInputStream;
 import java.util.stream.Stream;
@@ -47,6 +46,8 @@ public class ClasspathLocator extends AbstractJarFileLocator {
     private final List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
     private boolean enabled = false;
 
+    private static final Predicate<SecureJar> ACCEPT_ALL_FILTER = sj -> true;
+
     @Override
     public String name() {
         return "userdev classpath";
@@ -58,8 +59,12 @@ public class ClasspathLocator extends AbstractJarFileLocator {
             return List.of();
         try {
             var modCoords = Stream.<IModFile>builder();
-            locateMods(modCoords, MODS_TOML, "classpath_mod", sj -> true);
-            locateMods(modCoords, MANIFEST, "manifest_jar", sj -> isValidManifest(sj) && sj.getManifest().getMainAttributes().getValue(ModFile.TYPE) != null);
+            locateMods(modCoords, MODS_TOML, "classpath_mod", path ->  ModJarMetadata.buildFile(this, ACCEPT_ALL_FILTER, path));
+            locateMods(modCoords, MANIFEST, "manifest_jar", path -> Optional.of(path)
+              .map(SecureJar::from)
+              .filter(sj -> isValidManifest(sj) && sj.getManifest().getMainAttributes().getValue(ModFile.TYPE) != null)
+              .map(sj -> ModFile.newFMLInstance(this, sj))
+            );
             return modCoords.build().toList();
         } catch (IOException e) {
             LOGGER.fatal(CORE, "Error trying to find resources", e);
@@ -72,7 +77,7 @@ public class ClasspathLocator extends AbstractJarFileLocator {
         return Stream.of();
     }
 
-    private void locateMods(Stream.Builder<IModFile> modCoords, String resource, String name, Predicate<SecureJar> filter) throws IOException {
+    private void locateMods(Stream.Builder<IModFile> modCoords, String resource, String name, Function<Path, Optional<IModFile>> modFileBuilder) throws IOException {
         final Enumeration<URL> resources = ClassLoader.getSystemClassLoader().getResources(resource);
         while (resources.hasMoreElements()) {
             URL url = resources.nextElement();
@@ -80,7 +85,7 @@ public class ClasspathLocator extends AbstractJarFileLocator {
             if (ignoreList.stream().anyMatch(path.toString()::contains) || Files.isDirectory(path))
                 continue;
 
-            ModJarMetadata.buildFile(this, filter, path).ifPresent(mf -> {
+            modFileBuilder.apply(path).ifPresent(mf -> {
                 LOGGER.debug(CORE, "Found classpath mod: {}", path);
                 modCoords.add(mf);
             });

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -43,9 +43,9 @@ import static net.minecraftforge.fml.loading.LogMarkers.CORE;
 public class ClasspathLocator extends AbstractJarFileLocator {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String MODS_TOML = "META-INF/mods.toml";
-    private static final String       MANIFEST   = "META-INF/MANIFEST.MF";
-    private final        List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
-    private              boolean      enabled    = false;
+    private static final String MANIFEST = "META-INF/MANIFEST.MF";
+    private final List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
+    private boolean enabled = false;
 
     private static final Predicate<SecureJar> ACCEPT_ALL_FILTER = secureJar -> true;
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -19,34 +19,35 @@
 
 package net.minecraftforge.fml.loading.moddiscovery;
 
-import com.google.common.collect.Lists;
 import cpw.mods.jarhandling.SecureJar;
 import net.minecraftforge.fml.loading.LibraryFinder;
 import net.minecraftforge.forgespi.locating.IModFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.jar.JarInputStream;
 import java.util.stream.Stream;
-import java.util.zip.ZipInputStream;
 
 import static net.minecraftforge.fml.loading.LogMarkers.CORE;
 
 public class ClasspathLocator extends AbstractJarFileLocator {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String MODS_TOML = "META-INF/mods.toml";
-    private static final String MANIFEST = "META-INF/MANIFEST.MF";
-    private final List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
-    private boolean enabled = false;
+    private static final String       MANIFEST   = "META-INF/MANIFEST.MF";
+    private final        List<String> ignoreList = Arrays.stream(System.getProperty("ignoreList", "").split(",")).toList();
+    private              boolean      enabled    = false;
 
-    private static final Predicate<SecureJar> ACCEPT_ALL_FILTER = sj -> true;
+    private static final Predicate<SecureJar> ACCEPT_ALL_FILTER = secureJar -> true;
 
     @Override
     public String name() {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
@@ -60,7 +60,7 @@ public class ModDiscoverer {
 
     public ModValidator discoverMods() {
         LOGGER.debug(SCAN,"Scanning for mods and other resources to load. We know {} ways to find mods", locatorList.size());
-        var loadedFiles = new ArrayList<>();
+        var loadedFiles = new ArrayList<IModFile>();
         for (IModLocator locator : locatorList) {
             LOGGER.debug(SCAN,"Trying locator {}", locator);
             var modFiles = locator.scanMods();
@@ -70,6 +70,7 @@ public class ModDiscoverer {
             }
             loadedFiles.addAll(modFiles);
         }
+
         final var modFilesMap = loadedFiles.stream()
                 .map(ModFile.class::cast)
                 .collect(Collectors.groupingBy(IModFile::getType));

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -6,22 +6,21 @@ import cpw.mods.modlauncher.api.ITransformationService;
 import net.minecraftforge.fml.loading.*;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
 import net.minecraftforge.forgespi.locating.IModFile;
-import net.minecraftforge.forgespi.locating.ModFileFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static net.minecraftforge.fml.loading.LogMarkers.SCAN;
 
 public class ModValidator {
-    private static final Logger LOGGER = LogManager.getLogger();
-    private final Map<IModFile.Type, List<ModFile>> modFiles;
-    private final List<ModFile> candidatePlugins;
-    private final List<ModFile> candidateMods;
+    private static final Logger                            LOGGER = LogManager.getLogger();
+    private final        Map<IModFile.Type, List<ModFile>> modFiles;
+    private final        List<ModFile>                     candidatePlugins;
+    private final List<ModFile>                     candidateMods;
     private final List<ModFile> candidateLibraries;
     private LoadingModList loadingModList;
     private List<ModFile> brokenFiles;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -22,14 +22,15 @@ public class ModValidator {
     private final Map<IModFile.Type, List<ModFile>> modFiles;
     private final List<ModFile> candidatePlugins;
     private final List<ModFile> candidateMods;
+    private final List<ModFile> candidateLibraries;
     private LoadingModList loadingModList;
     private List<ModFile> brokenFiles;
 
     public ModValidator(final Map<IModFile.Type, List<ModFile>> modFiles) {
         this.modFiles = modFiles;
         this.candidateMods = new ArrayList<>(modFiles.getOrDefault(IModFile.Type.MOD, List.of()));
+        this.candidateLibraries = new ArrayList<>(modFiles.getOrDefault(IModFile.Type.LIBRARY, List.of()));
         this.candidatePlugins = new ArrayList<>(modFiles.getOrDefault(IModFile.Type.LANGPROVIDER, List.of()));
-        this.candidatePlugins.addAll(modFiles.getOrDefault(IModFile.Type.LIBRARY, List.of()));
     }
 
     public void stage1Validation() {
@@ -58,7 +59,11 @@ public class ModValidator {
     }
 
     public ITransformationService.Resource getModResources() {
-        return new ITransformationService.Resource(IModuleLayerManager.Layer.GAME, this.candidateMods.stream().map(ModFile::getSecureJar).toList());
+        final List<SecureJar> resources = new ArrayList<>();
+        resources.addAll(this.candidateMods.stream().map(ModFile::getSecureJar).toList());
+        resources.addAll(this.candidateLibraries.stream().map(ModFile::getSecureJar).toList());
+
+        return new ITransformationService.Resource(IModuleLayerManager.Layer.GAME, resources);
     }
 
     private List<EarlyLoadingException.ExceptionData> validateLanguages() {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -17,10 +17,10 @@ import java.util.Map;
 import static net.minecraftforge.fml.loading.LogMarkers.SCAN;
 
 public class ModValidator {
-    private static final Logger                            LOGGER = LogManager.getLogger();
-    private final        Map<IModFile.Type, List<ModFile>> modFiles;
-    private final        List<ModFile>                     candidatePlugins;
-    private final List<ModFile>                     candidateMods;
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final Map<IModFile.Type, List<ModFile>> modFiles;
+    private final List<ModFile> candidatePlugins;
+    private final List<ModFile> candidateMods;
     private final List<ModFile> candidateLibraries;
     private LoadingModList loadingModList;
     private List<ModFile> brokenFiles;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonLaunchHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonLaunchHandler.java
@@ -24,12 +24,12 @@ import cpw.mods.modlauncher.api.ITransformingClassLoaderBuilder;
 import net.minecraftforge.api.distmarker.Dist;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiPredicate;
@@ -71,6 +71,12 @@ public abstract class CommonLaunchHandler implements ILaunchHandlerService {
                 .map(inp -> inp.split("%%", 2))
                 .map(splitString -> new ExplodedModPath(splitString.length == 1 ? "defaultmodid" : splitString[0], Paths.get(splitString[splitString.length - 1])))
                 .collect(Collectors.groupingBy(ExplodedModPath::modid, Collectors.mapping(ExplodedModPath::path, Collectors.toList())));
+
+        // We need to REVERSE the passed in mod classes so that SJH takes it properly.
+        // The last path passed into SecureJar#from is the "main" path used to grab the manifest.
+        // ForgeGradle always passed in resources,classes with the expectation in 1.16 or lower that the resources would be checked first.
+        // So in 1.17+ FML/SJH, we need to reverse it.
+        modClassPaths.forEach((k, v) -> Collections.reverse(v));
 
         LOGGER.debug(CORE, "Found supplied mod coordinates [{}]", modClassPaths);
 


### PR DESCRIPTION
### General
This fixes the loading of lang providers and libraries in dev.
Changes.
- Make the ClasspathLocator (CPL) create proper none mods.toml dependent ModFile objects.
- Make the ModValidator aware of the concept of Jars which exist in the Mods Layer but do not need mod validation (Libraries)
- Load dependencies from Classpath in a development environment.

### Warnings:
**IF YOU INCLUDE MULTPLE OF THE SAME DEPENDENCY FML WILL STRIP OUT DUPLICATES AND ONLY INCLUDE THE FIRST FOUND**

### How to test:
1. Clone my fork.
2. Switch to the `fix/1.17.x/library-loading` branch
3. Run `gradle setup publishToMavenLocal`
4. Adapt your buildscript so you can load dependencies from your local maven repository:
```groovy
repositories {
   mavenLocal()
}
```
5. Change your forge version to what gradle printed out when running point 3.
6. Do a runClient.