### PR TITLE
Expose the world's default seed for modded ChunkGenerators and BiomeSources

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/WorldGenSettings.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/WorldGenSettings.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/level/levelgen/WorldGenSettings.java
 +++ b/net/minecraft/world/level/levelgen/WorldGenSettings.java
+@@ -70,6 +_,7 @@
+ 
+    private WorldGenSettings(long p_64614_, boolean p_64615_, boolean p_64616_, MappedRegistry<LevelStem> p_64617_, Optional<String> p_64618_) {
+       this.f_64602_ = p_64614_;
++      net.minecraftforge.common.world.DefaultWorldSeed.setSeedInternal(f_64602_);
+       this.f_64603_ = p_64615_;
+       this.f_64604_ = p_64616_;
+       this.f_64605_ = p_64617_;
 @@ -183,7 +_,7 @@
        String s3 = (String)p_64649_.get("level-type");
        String s4 = Optional.ofNullable(s3).map((p_64651_) -> {

--- a/patches/minecraft/net/minecraft/world/level/levelgen/WorldGenSettings.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/WorldGenSettings.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/world/level/levelgen/WorldGenSettings.java
 +++ b/net/minecraft/world/level/levelgen/WorldGenSettings.java
-@@ -70,6 +_,7 @@
- 
-    private WorldGenSettings(long p_64614_, boolean p_64615_, boolean p_64616_, MappedRegistry<LevelStem> p_64617_, Optional<String> p_64618_) {
-       this.f_64602_ = p_64614_;
-+      net.minecraftforge.common.world.DefaultWorldSeed.setSeedInternal(f_64602_);
-       this.f_64603_ = p_64615_;
+@@ -74,6 +_,7 @@
        this.f_64604_ = p_64616_;
        this.f_64605_ = p_64617_;
+       this.f_64606_ = p_64618_;
++      net.minecraftforge.common.world.DefaultWorldSeed.setSeedInternal(f_64602_);
+    }
+ 
+    public static WorldGenSettings m_64645_(RegistryAccess p_64646_) {
 @@ -183,7 +_,7 @@
        String s3 = (String)p_64649_.get("level-type");
        String s4 = Optional.ofNullable(s3).map((p_64651_) -> {

--- a/src/main/java/net/minecraftforge/common/world/DefaultWorldSeed.java
+++ b/src/main/java/net/minecraftforge/common/world/DefaultWorldSeed.java
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.world;
+
+public class DefaultWorldSeed {
+
+    private static long SEED = 0;
+
+    /**
+     * Call this in a mod's BiomeSource, ChunkGenerator, etc to have access to the default seed given to the server.
+     * @return The server's default seed if it exist. Otherwise, returns 0
+     */
+    public static long getSeed() {
+        return SEED;
+    }
+
+    /**
+     * DO NOT USE THIS METHOD
+     * For internal Forge use only
+     */
+    public static long setSeedInternal(long seed) {
+        SEED = seed;
+        return seed;
+    }
+}


### PR DESCRIPTION
 ChunkGenerators and BiomeSources require a seed in their constructor that basically controls the terrain and biome layout. By default, vanilla dimension json files only allow modders to have a fixed seed field which means every world will have the same exact dimension layout in terms of terrain and biome layout. Getting the default seed (what goes into the seed text box and all), is not possible in ChunkGenerators and BiomeSources constructors as all it gets is the biome registry.

This PR creates a DefaultWorldSeed class with a public static getSeed method for any modder to get the seed anywhere they need it. Especially for ChunkGenerators and BiomeSources constructors but other places can also use it in case I miss any other use case. Only issue is that the setSeedInternal has to be public static as well since it has to grab the seed from WorldGenSettings.