### PR TITLE
Re-add call to `Ingredient#invalidateAll()`

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -24,6 +24,7 @@ import net.minecraft.commands.synchronization.ArgumentTypes;
 import net.minecraft.commands.synchronization.ArgumentSerializer;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.item.Items;
 import net.minecraft.sounds.SoundEvent;
@@ -225,6 +226,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 
     public void mappingChanged(FMLModIdMappingEvent evt)
     {
+        Ingredient.invalidateAll();
     }
 
     @Override


### PR DESCRIPTION
`invalidateAll()` is never called, in 1.17.x or 1.16.x. This seems to have no point anymore. So out it goes!