### PR TITLE
Remove crufty config entries.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -33,18 +33,12 @@ import net.minecraftforge.common.ForgeConfigSpec.IntValue;
 public class ForgeConfig
 {
     public static class Server {
-        public final BooleanValue removeErroringEntities;
         public final BooleanValue removeErroringBlockEntities;
 
         public final BooleanValue fullBoundingBoxLadders;
 
         public final DoubleValue zombieBaseSummonChance;
         public final DoubleValue zombieBabyChance;
-
-        public final BooleanValue logCascadingWorldGeneration;
-        public final BooleanValue fixVanillaCascading;
-
-        public final IntValue dimensionUnloadQueueDelay;
 
         public final BooleanValue treatEmptyTagsAsAir;
 
@@ -53,12 +47,6 @@ public class ForgeConfig
         Server(ForgeConfigSpec.Builder builder) {
             builder.comment("Server configuration settings")
                    .push("server");
-
-            removeErroringEntities = builder
-                    .comment("Set this to true to remove any Entity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
-                    .translation("forge.configgui.removeErroringEntities")
-                    .worldRestart()
-                    .define("removeErroringEntities", false);
 
             removeErroringBlockEntities = builder
                     .comment("Set this to true to remove any BlockEntity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
@@ -83,21 +71,6 @@ public class ForgeConfig
                     .translation("forge.configgui.zombieBabyChance")
                     .worldRestart()
                     .defineInRange("zombieBabyChance", 0.05D, 0.0D, 1.0D);
-
-            logCascadingWorldGeneration = builder
-                    .comment("Log cascading chunk generation issues during terrain population.")
-                    .translation("forge.configgui.logCascadingWorldGeneration")
-                    .define("logCascadingWorldGeneration", true);
-
-            fixVanillaCascading = builder
-                    .comment("Fix vanilla issues that cause worldgen cascading. This DOES change vanilla worldgen so DO NOT report bugs related to world differences if this flag is on.")
-                    .translation("forge.configgui.fixVanillaCascading")
-                    .define("fixVanillaCascading", false);
-
-            dimensionUnloadQueueDelay = builder
-                    .comment("The time in ticks the server will wait when a dimension was queued to unload. This can be useful when rapidly loading and unloading dimensions, like e.g. throwing items through a nether portal a few time per second.")
-                    .translation("forge.configgui.dimensionUnloadQueueDelay")
-                    .defineInRange("dimensionUnloadQueueDelay", 0, 0, Integer.MAX_VALUE);
 
             treatEmptyTagsAsAir = builder
                     .comment("Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.")
@@ -139,15 +112,8 @@ public class ForgeConfig
      * Client specific configuration - only loaded clientside from forge-client.toml
      */
     public static class Client {
-        public final BooleanValue zoomInMissingModelTextInGui;
-
-        public final BooleanValue forgeCloudsEnabled;
-
-        public final BooleanValue disableStairSlabCulling;
-
         public final BooleanValue alwaysSetupTerrainOffThread;
 
-        public final BooleanValue forgeLightPipelineEnabled;
         public final BooleanValue experimentalForgeLightPipelineEnabled;
 
         public final BooleanValue selectiveResourceReloadEnabled;
@@ -160,21 +126,6 @@ public class ForgeConfig
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
 
-            zoomInMissingModelTextInGui = builder
-                .comment("Toggle off to make missing model text in the gui fit inside the slot.")
-                .translation("forge.configgui.zoomInMissingModelTextInGui")
-                .define("zoomInMissingModelTextInGui", false);
-
-            forgeCloudsEnabled = builder
-                .comment("Enable uploading cloud geometry to the GPU for faster rendering.")
-                .translation("forge.configgui.forgeCloudsEnabled")
-                .define("forgeCloudsEnabled", true);
-
-            disableStairSlabCulling = builder
-                .comment("Disable culling of hidden faces next to stairs and slabs. Causes extra rendering, but may fix some resource packs that exploit this vanilla mechanic.")
-                .translation("forge.configgui.disableStairSlabCulling")
-                .define("disableStairSlabCulling", false);
-
             alwaysSetupTerrainOffThread = builder
                 .comment("Enable Forge to queue all chunk updates to the Chunk Update thread.",
                         "May increase FPS significantly, but may also cause weird rendering lag.",
@@ -182,10 +133,6 @@ public class ForgeConfig
                 .translation("forge.configgui.alwaysSetupTerrainOffThread")
                 .define("alwaysSetupTerrainOffThread", false);
 
-            forgeLightPipelineEnabled = builder
-                .comment("Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
-                .translation("forge.configgui.forgeLightPipelineEnabled")
-                .define("forgeLightPipelineEnabled", true);
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
                 .translation("forge.configgui.forgeLightPipelineEnabled")


### PR DESCRIPTION
So forge's configs are populated with a bunch of things that (I checked) are never used in either 1.17.x, or 1.16.x (in case they were just not yet implemented in 1.17). I removed all the above. `logCascadingWorldGeneration` and `fixVanillaCascading` were the initial two I noticed, these haven't been relevant or in use since 1.12. I then just went ahead and removed any others that haven't been used since (at least) before 1.15 because why are we keeping old unused config entries around.