### PR TITLE
[1.17.x] Add `PickaxeItem` tooltype patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/PickaxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/PickaxeItem.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/item/PickaxeItem.java
++++ b/net/minecraft/world/item/PickaxeItem.java
+@@ -4,6 +4,6 @@
+ 
+   public class PickaxeItem extends DiggerItem {
+      public PickaxeItem(Tier p_42961_, int p_42962_, float p_42963_, Item.Properties p_42964_) {
+-        super((float)p_42962_, p_42963_, p_42961_, BlockTags.MINEABLE_WITH_PICKAXE, p_42964_);
++        super((float)p_42962_, p_42963_, p_42961_, BlockTags.MINEABLE_WITH_PICKAXE, p_42964_.addToolType(net.minecraftforge.common.ToolType.PICKAXE, p_42961_.m_6604_()));
+      }
+   }

--- a/patches/minecraft/net/minecraft/world/item/PickaxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/PickaxeItem.java.patch
@@ -1,10 +1,10 @@
 --- a/net/minecraft/world/item/PickaxeItem.java
 +++ b/net/minecraft/world/item/PickaxeItem.java
-@@ -4,6 +4,6 @@
+@@ -4,6 +_,6 @@
  
-   public class PickaxeItem extends DiggerItem {
-      public PickaxeItem(Tier p_42961_, int p_42962_, float p_42963_, Item.Properties p_42964_) {
--        super((float)p_42962_, p_42963_, p_42961_, BlockTags.MINEABLE_WITH_PICKAXE, p_42964_);
-+        super((float)p_42962_, p_42963_, p_42961_, BlockTags.MINEABLE_WITH_PICKAXE, p_42964_.addToolType(net.minecraftforge.common.ToolType.PICKAXE, p_42961_.m_6604_()));
-      }
-   }
+ public class PickaxeItem extends DiggerItem {
+    public PickaxeItem(Tier p_42961_, int p_42962_, float p_42963_, Item.Properties p_42964_) {
+-      super((float)p_42962_, p_42963_, p_42961_, BlockTags.f_144282_, p_42964_);
++      super((float)p_42962_, p_42963_, p_42961_, BlockTags.f_144282_, p_42964_.addToolType(net.minecraftforge.common.ToolType.PICKAXE, p_42961_.m_6604_()));
+    }
+ }


### PR DESCRIPTION
The `PickaxeItem` tooltype [patch from 1.16](https://github.com/MinecraftForge/MinecraftForge/blob/1.16.x/patches/minecraft/net/minecraft/item/PickaxeItem.java.patch) is currently missing.
This means any blocks that use `BlockBehaviour.Properties#setHarvestTool` with `ToolType.PICKAXE` currently don't work with vanilla pickaxes.

This PR adds back the tooltype patch.