### PR TITLE
Remove Generic from ProjectileImpactEvent

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -624,9 +624,9 @@ public class ForgeEventFactory
         return event.getCharge();
     }
 
-    public static <T extends Projectile> boolean onProjectileImpact(T projectile, HitResult ray)
+    public static boolean onProjectileImpact(Projectile projectile, HitResult ray)
     {
-        return MinecraftForge.EVENT_BUS.post(new ProjectileImpactEvent<>(projectile, ray));
+        return MinecraftForge.EVENT_BUS.post(new ProjectileImpactEvent(projectile, ray));
     }
 
     public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTables lootTableManager)

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -35,12 +35,12 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * Killing or other handling of the entity after event cancellation is up to the modder.
  */
 @Cancelable
-public class ProjectileImpactEvent<T extends Projectile> extends EntityEvent
+public class ProjectileImpactEvent extends EntityEvent
 {
     private final HitResult ray;
-    private final T projectile;
+    private final Projectile projectile;
 
-    public ProjectileImpactEvent(T projectile, HitResult ray)
+    public ProjectileImpactEvent(Projectile projectile, HitResult ray)
     {
         super(projectile);
         this.ray = ray;
@@ -52,7 +52,7 @@ public class ProjectileImpactEvent<T extends Projectile> extends EntityEvent
         return ray;
     }
 
-    public T getProjectile()
+    public Projectile getProjectile()
     {
         return projectile;
     }

--- a/src/test/java/net/minecraftforge/debug/entity/FishingBobberEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/FishingBobberEventTest.java
@@ -43,9 +43,9 @@ public class FishingBobberEventTest
         }
     }
 
-    public static void handleImpact(ProjectileImpactEvent<FishingHook> event)
+    public static void handleImpact(ProjectileImpactEvent event)
     {
-        FishingHook fishingHook = event.getProjectile();
+        if(!(event.getProjectile() instanceof FishingHook fishingHook)) return;
         HitResult trace = event.getRayTraceResult();
         if (trace.getType() == HitResult.Type.ENTITY)
         {


### PR DESCRIPTION
Generification of this event was half-done and has been aborted, leaving the generic parameter in place just creates confusion and crashes