### PR TITLE
Changed Monster Requirement to Mob in RangedBowAttackGoal

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
@@ -9,6 +9,17 @@
     private final T f_25782_;
     private final double f_25783_;
     private int f_25784_;
+@@ -19,6 +_,10 @@
+    private boolean f_25789_;
+    private int f_25790_ = -1;
+ 
++   public <M extends Monster & RangedAttackMob> RangedBowAttackGoal(M p_25792_, double p_25793_, int p_25794_, float p_25795_){
++      this((T) p_25792_, p_25793_, p_25794_, p_25795_);
++   }
++
+    public RangedBowAttackGoal(T p_25792_, double p_25793_, int p_25794_, float p_25795_) {
+       this.f_25782_ = p_25792_;
+       this.f_25783_ = p_25793_;
 @@ -36,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java
+@@ -8,7 +_,7 @@
+ import net.minecraft.world.item.BowItem;
+ import net.minecraft.world.item.Items;
+ 
+-public class RangedBowAttackGoal<T extends Monster & RangedAttackMob> extends Goal {
++public class RangedBowAttackGoal<T extends net.minecraft.world.entity.Mob & RangedAttackMob> extends Goal {
+    private final T f_25782_;
+    private final double f_25783_;
+    private int f_25784_;
 @@ -36,7 +_,7 @@
     }
  


### PR DESCRIPTION
RangedBowAttackGoal requires the goal owner to be an instance of Monster even though none of the required methods for the goal owner are from Monster. The methods of the goal owner are all from Mob or below, so the goal owner's type can be broadened to Mob without issues in order to allow for easier use of RangedBowAttackGoal. 