### PR TITLE
Fixed wrong SRG name in ForgeHooks used with ObfuscationReflectionHelper

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1336,7 +1336,7 @@ public class ForgeHooks
             if (!currentDimNames.containsAll(VANILLA_DIMS))
             {
                 LOGGER.warn("Detected missing vanilla dimensions from the world!");
-                RegistryAccess regs = ObfuscationReflectionHelper.getPrivateValue(RegistryReadOps.class, ops, "f_179860_");
+                RegistryAccess regs = ObfuscationReflectionHelper.getPrivateValue(RegistryReadOps.class, ops, "f_17986" + "0_");
                 if (regs == null) // should not happen, but it could after a MC version update.
                     throw new RuntimeException("Could not access dynamic registries using reflection. " +
                             "The world was detected to have missing vanilla dimensions and the attempted fix did not work.");

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1336,7 +1336,7 @@ public class ForgeHooks
             if (!currentDimNames.containsAll(VANILLA_DIMS))
             {
                 LOGGER.warn("Detected missing vanilla dimensions from the world!");
-                RegistryAccess regs = ObfuscationReflectionHelper.getPrivateValue(RegistryReadOps.class, ops, "f_13563" + "6_");
+                RegistryAccess regs = ObfuscationReflectionHelper.getPrivateValue(RegistryReadOps.class, ops, "f_179860_");
                 if (regs == null) // should not happen, but it could after a MC version update.
                     throw new RuntimeException("Could not access dynamic registries using reflection. " +
                             "The world was detected to have missing vanilla dimensions and the attempted fix did not work.");


### PR DESCRIPTION
Currently this throws an `ObfuscationReflectionHelper$UnableToFindFieldException` as the used SRG name existed in 1.16.5 but does no longer exist in 1.17.1.