### PR TITLE
[1.15.x] Extendible categories in recipe book 

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
@@ -26,11 +26,10 @@
           }).findFirst().orElse((RecipeTabToggleWidget)null);
        }
  
-@@ -104,7 +107,18 @@
+@@ -104,7 +107,17 @@
  
        this.field_191913_x.func_191753_b(true);
        this.func_193003_g(false);
-+      // remove tabs that does not contains recipes
 +      this.field_193018_j.removeIf(tabToggleWidget -> this.field_193964_s.getRecipes(tabToggleWidget.getRecipeBookCategory()).stream().noneMatch(recipeList -> recipeList.func_194209_a() && recipeList.func_194212_c()));
        this.func_193949_f();
 +      this.up = new net.minecraftforge.client.UpDownButton(i - 23, j + 1, 17, 11, false, p_onPress_1_ -> {
@@ -45,7 +44,7 @@
     }
  
     public boolean changeFocus(boolean p_changeFocus_1_) {
-@@ -119,6 +133,8 @@
+@@ -119,6 +132,8 @@
        this.field_193962_q = null;
        this.field_191913_x = null;
        this.field_191888_F.field_195559_v.func_197967_a(false);
@@ -54,7 +53,7 @@
     }
  
     public int func_193011_a(boolean p_193011_1_, int p_193011_2_, int p_193011_3_) {
-@@ -160,7 +176,7 @@
+@@ -160,7 +175,7 @@
     }
  
     private void func_193003_g(boolean p_193003_1_) {
@@ -63,7 +62,7 @@
        list.forEach((p_193944_1_) -> {
           p_193944_1_.func_194210_a(this.field_193965_u, this.field_201522_g.func_201770_g(), this.field_201522_g.func_201772_h(), this.field_193964_s);
        });
-@@ -190,13 +206,15 @@
+@@ -190,13 +205,15 @@
  
     private void func_193949_f() {
        int i = (this.field_191904_o - 147) / 2 - this.field_191903_n - 30;
@@ -82,7 +81,7 @@
              if (recipetabtogglewidget.func_199500_a(this.field_193964_s)) {
                 recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
                 recipetabtogglewidget.func_193918_a(this.field_191888_F);
-@@ -205,6 +223,10 @@
+@@ -205,6 +222,10 @@
              recipetabtogglewidget.visible = true;
              recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
           }
@@ -93,7 +92,7 @@
        }
  
     }
-@@ -243,6 +265,8 @@
+@@ -243,6 +264,8 @@
  
           this.field_193960_m.render(p_render_1_, p_render_2_, p_render_3_);
           this.field_193022_s.func_194191_a(i, j, p_render_1_, p_render_2_, p_render_3_);
@@ -102,7 +101,7 @@
           RenderSystem.popMatrix();
        }
     }
-@@ -307,6 +331,9 @@
+@@ -307,6 +330,9 @@
              return true;
           } else if (this.field_193962_q.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
              return true;
@@ -112,7 +111,7 @@
           } else if (this.field_193960_m.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
              boolean flag = this.func_201521_f();
              this.field_193960_m.func_191753_b(flag);
-@@ -417,7 +444,7 @@
+@@ -417,7 +443,7 @@
  
           languagemanager.func_135045_a(language);
           this.field_191888_F.field_71474_y.field_74363_ab = language.getCode();
@@ -121,13 +120,15 @@
           this.field_191888_F.field_71466_p.func_78275_b(languagemanager.func_135044_b());
           this.field_191888_F.field_71474_y.func_74303_b();
        }
-@@ -465,4 +492,9 @@
+@@ -465,4 +491,11 @@
        }
  
     }
 +
++   /*================================ FORGE START ================================================*/
 +   private void updateButtons() {
 +      this.up.visible = this.offset > 0 && this.field_193018_j.size() > 5;
 +      this.down.visible = this.field_193018_j.size() > 5 && this.offset < this.field_193018_j.size() - 5;
 +   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
@@ -1,15 +1,118 @@
 --- a/net/minecraft/client/gui/recipebook/RecipeBookGui.java
 +++ b/net/minecraft/client/gui/recipebook/RecipeBookGui.java
-@@ -88,7 +88,7 @@
+@@ -52,6 +52,9 @@
+    protected final RecipeItemHelper field_193965_u = new RecipeItemHelper();
+    private int field_193966_v;
+    private boolean field_199738_u;
++   private net.minecraftforge.client.UpDownButton up;
++   private net.minecraftforge.client.UpDownButton down;
++   private int offset;
+ 
+    public void func_201520_a(int p_201520_1_, int p_201520_2_, Minecraft p_201520_3_, boolean p_201520_4_, RecipeBookContainer<?> p_201520_5_) {
+       this.field_191888_F = p_201520_3_;
+@@ -88,13 +91,13 @@
        this.func_205702_a();
        this.field_193018_j.clear();
  
 -      for(RecipeBookCategories recipebookcategories : ClientRecipeBook.func_216769_b(this.field_201522_g)) {
-+      for(RecipeBookCategories recipebookcategories : this.field_201522_g.getRecipeBookCategories()) {
++      for(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories : this.field_201522_g.getRecipeBookCategories()) {
           this.field_193018_j.add(new RecipeTabToggleWidget(recipebookcategories));
        }
  
-@@ -417,7 +417,7 @@
+       if (this.field_191913_x != null) {
+          this.field_191913_x = this.field_193018_j.stream().filter((p_209505_1_) -> {
+-            return p_209505_1_.func_201503_d().equals(this.field_191913_x.func_201503_d());
++            return p_209505_1_.getRecipeBookCategory().equals(this.field_191913_x.getRecipeBookCategory());
+          }).findFirst().orElse((RecipeTabToggleWidget)null);
+       }
+ 
+@@ -104,7 +107,18 @@
+ 
+       this.field_191913_x.func_191753_b(true);
+       this.func_193003_g(false);
++      // remove tabs that does not contains recipes
++      this.field_193018_j.removeIf(tabToggleWidget -> this.field_193964_s.getRecipes(tabToggleWidget.getRecipeBookCategory()).stream().noneMatch(recipeList -> recipeList.func_194209_a() && recipeList.func_194212_c()));
+       this.func_193949_f();
++      this.up = new net.minecraftforge.client.UpDownButton(i - 23, j + 1, 17, 11, false, p_onPress_1_ -> {
++         this.offset = Math.max(0, this.offset - 1);
++         this.updateButtons();
++      });
++      this.down = new net.minecraftforge.client.UpDownButton(i - 23, j + 154, 17, 11, true, p_onPress_1_ -> {
++         this.offset = Math.min(this.field_193018_j.size() - 5, this.offset + 1);
++         this.updateButtons();
++      });
++      this.updateButtons();
+    }
+ 
+    public boolean changeFocus(boolean p_changeFocus_1_) {
+@@ -119,6 +133,8 @@
+       this.field_193962_q = null;
+       this.field_191913_x = null;
+       this.field_191888_F.field_195559_v.func_197967_a(false);
++      this.up = null;
++      this.down = null;
+    }
+ 
+    public int func_193011_a(boolean p_193011_1_, int p_193011_2_, int p_193011_3_) {
+@@ -160,7 +176,7 @@
+    }
+ 
+    private void func_193003_g(boolean p_193003_1_) {
+-      List<RecipeList> list = this.field_193964_s.func_202891_a(this.field_191913_x.func_201503_d());
++      List<RecipeList> list = this.field_193964_s.getRecipes(this.field_191913_x.getRecipeBookCategory());
+       list.forEach((p_193944_1_) -> {
+          p_193944_1_.func_194210_a(this.field_193965_u, this.field_201522_g.func_201770_g(), this.field_201522_g.func_201772_h(), this.field_193964_s);
+       });
+@@ -190,13 +206,15 @@
+ 
+    private void func_193949_f() {
+       int i = (this.field_191904_o - 147) / 2 - this.field_191903_n - 30;
+-      int j = (this.field_191905_p - 166) / 2 + 3;
++      int j = (this.field_191905_p - 166) / 2 + (this.field_193018_j.size() > 5 ? 16 : 3);
+       int k = 27;
+       int l = 0;
+ 
++      int x = 0;
+       for(RecipeTabToggleWidget recipetabtogglewidget : this.field_193018_j) {
+-         RecipeBookCategories recipebookcategories = recipetabtogglewidget.func_201503_d();
+-         if (recipebookcategories != RecipeBookCategories.SEARCH && recipebookcategories != RecipeBookCategories.FURNACE_SEARCH) {
++         if (x >= this.offset && x < Math.min(this.field_193018_j.size(), this.offset + 5)) {
++            net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories = recipetabtogglewidget.getRecipeBookCategory();
++         if (!recipebookcategories.isSearch()) {
+             if (recipetabtogglewidget.func_199500_a(this.field_193964_s)) {
+                recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
+                recipetabtogglewidget.func_193918_a(this.field_191888_F);
+@@ -205,6 +223,10 @@
+             recipetabtogglewidget.visible = true;
+             recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
+          }
++         } else {
++            recipetabtogglewidget.visible = false;
++         }
++         x++;
+       }
+ 
+    }
+@@ -243,6 +265,8 @@
+ 
+          this.field_193960_m.render(p_render_1_, p_render_2_, p_render_3_);
+          this.field_193022_s.func_194191_a(i, j, p_render_1_, p_render_2_, p_render_3_);
++         this.up.render(p_render_1_, p_render_2_, p_render_3_);
++         this.down.render(p_render_1_, p_render_2_, p_render_3_);
+          RenderSystem.popMatrix();
+       }
+    }
+@@ -307,6 +331,9 @@
+             return true;
+          } else if (this.field_193962_q.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
+             return true;
++         } else if (this.up.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_) || this.down.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
++            this.func_193949_f();
++            return true;
+          } else if (this.field_193960_m.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
+             boolean flag = this.func_201521_f();
+             this.field_193960_m.func_191753_b(flag);
+@@ -417,7 +444,7 @@
  
           languagemanager.func_135045_a(language);
           this.field_191888_F.field_71474_y.field_74363_ab = language.getCode();
@@ -18,3 +121,13 @@
           this.field_191888_F.field_71466_p.func_78275_b(languagemanager.func_135044_b());
           this.field_191888_F.field_71474_y.func_74303_b();
        }
+@@ -465,4 +492,9 @@
+       }
+ 
+    }
++
++   private void updateButtons() {
++      this.up.visible = this.offset > 0 && this.field_193018_j.size() > 5;
++      this.down.visible = this.field_193018_j.size() > 5 && this.offset < this.field_193018_j.size() - 5;
++   }
+ }

--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
@@ -77,7 +77,7 @@
 -         if (recipebookcategories != RecipeBookCategories.SEARCH && recipebookcategories != RecipeBookCategories.FURNACE_SEARCH) {
 +         if (x >= this.offset && x < Math.min(this.field_193018_j.size(), this.offset + 5)) {
 +            net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories = recipetabtogglewidget.getRecipeBookCategory();
-+         if (!recipebookcategories.isSearch()) {
++         if (!recipebookcategories.isUnfiltered()) {
              if (recipetabtogglewidget.func_199500_a(this.field_193964_s)) {
                 recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
                 recipetabtogglewidget.func_193918_a(this.field_191888_F);

--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
@@ -5,10 +5,10 @@
  @OnlyIn(Dist.CLIENT)
  public class RecipeTabToggleWidget extends ToggleWidget {
 -   private RecipeBookCategories field_193921_u;
-+   @Deprecated private RecipeBookCategories field_193921_u;
++   @Deprecated private RecipeBookCategories field_193921_u; // use recipeBookCategory instead
     private float field_193922_v;
  
-+   @Deprecated
++   @Deprecated // use RecipeTabToggleWidget(IForgeRecipeBookCategory) instead
     public RecipeTabToggleWidget(RecipeBookCategories p_i51075_1_) {
        super(0, 0, 35, 27, false);
 -      this.field_193921_u = p_i51075_1_;
@@ -36,7 +36,7 @@
  
     }
  
-+   @Deprecated
++   @Deprecated // use getRecipeBookCategory() instead
     public RecipeBookCategories func_201503_d() {
        return this.field_193921_u;
     }
@@ -47,12 +47,13 @@
        this.visible = false;
        if (list != null) {
           for(RecipeList recipelist : list) {
-@@ -119,4 +121,16 @@
+@@ -119,4 +121,18 @@
  
        return this.visible;
     }
 +
-+   private net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipeBookCategory;
++   /*================================ FORGE START ================================================*/
++   private final net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipeBookCategory;
 +
 +   public RecipeTabToggleWidget(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> p_i51075_1_) {
 +      super(0, 0, 35, 27, false);
@@ -63,4 +64,5 @@
 +   public net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getRecipeBookCategory() {
 +      return this.recipeBookCategory;
 +   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
@@ -1,0 +1,66 @@
+--- a/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java
++++ b/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java
+@@ -16,18 +16,19 @@
+ 
+ @OnlyIn(Dist.CLIENT)
+ public class RecipeTabToggleWidget extends ToggleWidget {
+-   private RecipeBookCategories field_193921_u;
++   @Deprecated private RecipeBookCategories field_193921_u;
+    private float field_193922_v;
+ 
++   @Deprecated
+    public RecipeTabToggleWidget(RecipeBookCategories p_i51075_1_) {
+       super(0, 0, 35, 27, false);
+-      this.field_193921_u = p_i51075_1_;
++      this.recipeBookCategory = p_i51075_1_;
+       this.func_191751_a(153, 2, 35, 0, RecipeBookGui.field_191894_a);
+    }
+ 
+    public void func_193918_a(Minecraft p_193918_1_) {
+       ClientRecipeBook clientrecipebook = p_193918_1_.field_71439_g.func_199507_B();
+-      List<RecipeList> list = clientrecipebook.func_202891_a(this.field_193921_u);
++      List<RecipeList> list = clientrecipebook.getRecipes(this.recipeBookCategory);
+       if (p_193918_1_.field_71439_g.field_71070_bA instanceof RecipeBookContainer) {
+          label25:
+          for(RecipeList recipelist : list) {
+@@ -90,7 +91,7 @@
+    }
+ 
+    private void func_193920_a(ItemRenderer p_193920_1_) {
+-      List<ItemStack> list = this.field_193921_u.func_202903_a();
++      List<ItemStack> list = this.recipeBookCategory.getIcon();
+       int i = this.field_191755_p ? -2 : 0;
+       if (list.size() == 1) {
+          p_193920_1_.func_180450_b(list.get(0), this.x + 9 + i, this.y + 5);
+@@ -101,12 +102,13 @@
+ 
+    }
+ 
++   @Deprecated
+    public RecipeBookCategories func_201503_d() {
+       return this.field_193921_u;
+    }
+ 
+    public boolean func_199500_a(ClientRecipeBook p_199500_1_) {
+-      List<RecipeList> list = p_199500_1_.func_202891_a(this.field_193921_u);
++      List<RecipeList> list = p_199500_1_.getRecipes(this.recipeBookCategory);
+       this.visible = false;
+       if (list != null) {
+          for(RecipeList recipelist : list) {
+@@ -119,4 +121,16 @@
+ 
+       return this.visible;
+    }
++
++   private net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipeBookCategory;
++
++   public RecipeTabToggleWidget(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> p_i51075_1_) {
++      super(0, 0, 35, 27, false);
++      this.recipeBookCategory = p_i51075_1_;
++      this.func_191751_a(153, 2, 35, 0, RecipeBookGui.field_191894_a);
++   }
++
++   public net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getRecipeBookCategory() {
++      return this.recipeBookCategory;
++   }
+ }

--- a/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
@@ -1,0 +1,82 @@
+--- a/net/minecraft/client/util/ClientRecipeBook.java
++++ b/net/minecraft/client/util/ClientRecipeBook.java
+@@ -27,7 +27,7 @@
+ @OnlyIn(Dist.CLIENT)
+ public class ClientRecipeBook extends RecipeBook {
+    private final RecipeManager field_199645_e;
+-   private final Map<RecipeBookCategories, List<RecipeList>> field_197931_e = Maps.newHashMap();
++   @Deprecated private final Map<RecipeBookCategories, List<RecipeList>> field_197931_e = Maps.newHashMap();
+    private final List<RecipeList> field_197932_f = Lists.newArrayList();
+ 
+    public ClientRecipeBook(RecipeManager p_i48186_1_) {
+@@ -36,20 +36,20 @@
+ 
+    public void func_199644_c() {
+       this.field_197932_f.clear();
+-      this.field_197931_e.clear();
+-      Table<RecipeBookCategories, String, RecipeList> table = HashBasedTable.create();
++      this.forgeRecipeBookCategories.clear();
++      Table<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, String, RecipeList> table = HashBasedTable.create();
+ 
+       for(IRecipe<?> irecipe : this.field_199645_e.func_199510_b()) {
+          if (!irecipe.func_192399_d()) {
+-            RecipeBookCategories recipebookcategories = func_202887_g(irecipe);
++            net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories = func_202887_g(irecipe);
+             String s = irecipe.func_193358_e();
+             RecipeList recipelist;
+             if (s.isEmpty()) {
+-               recipelist = this.func_202889_b(recipebookcategories);
++               recipelist = this.newRecipeList(irecipe);
+             } else {
+                recipelist = table.get(recipebookcategories, s);
+                if (recipelist == null) {
+-                  recipelist = this.func_202889_b(recipebookcategories);
++                  recipelist = this.newRecipeList(irecipe);
+                   table.put(recipebookcategories, s, recipelist);
+                }
+             }
+@@ -63,7 +63,7 @@
+    private RecipeList func_202889_b(RecipeBookCategories p_202889_1_) {
+       RecipeList recipelist = new RecipeList();
+       this.field_197932_f.add(recipelist);
+-      this.field_197931_e.computeIfAbsent(p_202889_1_, (p_202890_0_) -> {
++      this.forgeRecipeBookCategories.computeIfAbsent(p_202889_1_, (p_202890_0_) -> {
+          return Lists.newArrayList();
+       }).add(recipelist);
+       if (p_202889_1_ != RecipeBookCategories.FURNACE_BLOCKS && p_202889_1_ != RecipeBookCategories.FURNACE_FOOD && p_202889_1_ != RecipeBookCategories.FURNACE_MISC) {
+@@ -88,7 +88,7 @@
+    }
+ 
+    private void func_216767_a(RecipeBookCategories p_216767_1_, RecipeList p_216767_2_) {
+-      this.field_197931_e.computeIfAbsent(p_216767_1_, (p_216768_0_) -> {
++      this.forgeRecipeBookCategories.computeIfAbsent(p_216767_1_, (p_216768_0_) -> {
+          return Lists.newArrayList();
+       }).add(p_216767_2_);
+    }
+@@ -141,6 +141,25 @@
+    }
+ 
+    public List<RecipeList> func_202891_a(RecipeBookCategories p_202891_1_) {
+-      return this.field_197931_e.getOrDefault(p_202891_1_, Collections.emptyList());
++      return this.forgeRecipeBookCategories.getOrDefault(p_202891_1_, Collections.emptyList());
+    }
++
++   private final Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<RecipeList>> forgeRecipeBookCategories = Maps.newHashMap();
++
++   private RecipeList newRecipeList(IRecipe<?> recipe) {
++      RecipeList recipelist = new RecipeList();
++      this.field_197932_f.add(recipelist);
++      net.minecraftforge.common.ForgeRecipeBookCategories.getValidCategories(recipe).forEach(category -> addToForgeRecipeBookCategories(category, recipelist));
++      return recipelist;
++   }
++
++   private void addToForgeRecipeBookCategories(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> forgeRecipeBookCategory, RecipeList recipeList) {
++      this.forgeRecipeBookCategories.computeIfAbsent(forgeRecipeBookCategory, (category) -> {
++         return Lists.newArrayList();
++      }).add(recipeList);
++   }
++
++   public List<RecipeList> getRecipes(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> forgeRecipeBookCategory) {
++      return this.forgeRecipeBookCategories.getOrDefault(forgeRecipeBookCategory, Collections.emptyList());
++   }
+ }

--- a/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
@@ -5,7 +5,7 @@
  public class ClientRecipeBook extends RecipeBook {
     private final RecipeManager field_199645_e;
 -   private final Map<RecipeBookCategories, List<RecipeList>> field_197931_e = Maps.newHashMap();
-+   @Deprecated private final Map<RecipeBookCategories, List<RecipeList>> field_197931_e = Maps.newHashMap();
++   @Deprecated private final Map<RecipeBookCategories, List<RecipeList>> field_197931_e = Maps.newHashMap(); // use forgeRecipeBookCategories instead
     private final List<RecipeList> field_197932_f = Lists.newArrayList();
  
     public ClientRecipeBook(RecipeManager p_i48186_1_) {
@@ -35,7 +35,11 @@
                    table.put(recipebookcategories, s, recipelist);
                 }
              }
-@@ -63,7 +63,7 @@
+@@ -60,10 +60,11 @@
+ 
+    }
+ 
++   @Deprecated // use newRecipeList(IForgeRecipeBookCategory) instead
     private RecipeList func_202889_b(RecipeBookCategories p_202889_1_) {
        RecipeList recipelist = new RecipeList();
        this.field_197932_f.add(recipelist);
@@ -44,7 +48,7 @@
           return Lists.newArrayList();
        }).add(recipelist);
        if (p_202889_1_ != RecipeBookCategories.FURNACE_BLOCKS && p_202889_1_ != RecipeBookCategories.FURNACE_FOOD && p_202889_1_ != RecipeBookCategories.FURNACE_MISC) {
-@@ -88,7 +88,7 @@
+@@ -88,7 +89,7 @@
     }
  
     private void func_216767_a(RecipeBookCategories p_216767_1_, RecipeList p_216767_2_) {
@@ -53,7 +57,15 @@
           return Lists.newArrayList();
        }).add(p_216767_2_);
     }
-@@ -141,6 +141,25 @@
+@@ -122,6 +123,7 @@
+       }
+    }
+ 
++   @Deprecated // use RecipeBookContainer.getRecipeBookCategories() instead
+    public static List<RecipeBookCategories> func_216769_b(RecipeBookContainer<?> p_216769_0_) {
+       if (!(p_216769_0_ instanceof WorkbenchContainer) && !(p_216769_0_ instanceof PlayerContainer)) {
+          if (p_216769_0_ instanceof FurnaceContainer) {
+@@ -141,6 +143,27 @@
     }
  
     public List<RecipeList> func_202891_a(RecipeBookCategories p_202891_1_) {
@@ -61,12 +73,13 @@
 +      return this.forgeRecipeBookCategories.getOrDefault(p_202891_1_, Collections.emptyList());
     }
 +
++   /*================================ FORGE START ================================================*/
 +   private final Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<RecipeList>> forgeRecipeBookCategories = Maps.newHashMap();
 +
 +   private RecipeList newRecipeList(IRecipe<?> recipe) {
 +      RecipeList recipelist = new RecipeList();
 +      this.field_197932_f.add(recipelist);
-+      net.minecraftforge.common.ForgeRecipeBookCategories.getValidCategories(recipe).forEach(category -> addToForgeRecipeBookCategories(category, recipelist));
++      net.minecraftforge.common.ForgeRecipeBookCategory.getValidCategories(recipe).forEach(category -> addToForgeRecipeBookCategories(category, recipelist));
 +      return recipelist;
 +   }
 +
@@ -79,4 +92,5 @@
 +   public List<RecipeList> getRecipes(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> forgeRecipeBookCategory) {
 +      return this.forgeRecipeBookCategories.getOrDefault(forgeRecipeBookCategory, Collections.emptyList());
 +   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
@@ -1,0 +1,188 @@
+--- a/net/minecraft/client/util/RecipeBookCategories.java
++++ b/net/minecraft/client/util/RecipeBookCategories.java
+@@ -9,7 +9,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public enum RecipeBookCategories {
++public enum RecipeBookCategories implements net.minecraftforge.common.extensions.IForgeRecipeBookCategory<net.minecraft.item.crafting.IRecipeType<?>> {
+    SEARCH(new ItemStack(Items.field_151111_aL)),
+    BUILDING_BLOCKS(new ItemStack(Blocks.field_196584_bK)),
+    REDSTONE(new ItemStack(Items.field_151137_ax)),
+@@ -36,4 +36,176 @@
+    public List<ItemStack> func_202903_a() {
+       return this.field_202904_j;
+    }
++
++   //--FORGE
++   private net.minecraft.util.ResourceLocation registryName;
++   private boolean isSearch;
++   private net.minecraft.item.crafting.IRecipeType<?> recipeType;
++   private java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate;
++
++   static {
++      for (RecipeBookCategories category : RecipeBookCategories.values()) {
++         switch (category) {
++            case SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222149_a);
++               break;
++            case BUILDING_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::buildingBlocksPredicate);
++               break;
++            case REDSTONE:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::redstonePredicate);
++               break;
++            case EQUIPMENT:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::equipmentPredicate);
++               break;
++            case MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::miscPredicate);
++               break;
++            case FURNACE_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222150_b);
++               break;
++            case FURNACE_FOOD:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::foodPredicate);
++               break;
++            case FURNACE_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::furnaceBlocksPredicate);
++               break;
++            case FURNACE_MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::furnaceMiscPredicate);
++               break;
++            case BLAST_FURNACE_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222151_c);
++               break;
++            case BLAST_FURNACE_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222151_c, RecipeBookCategories::blastFurnaceBlocksPredicate);
++               break;
++            case BLAST_FURNACE_MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222151_c, RecipeBookCategories::blastFurnaceMiscPredicate);
++               break;
++            case SMOKER_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222152_d);
++               break;
++            case SMOKER_FOOD:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222152_d, RecipeBookCategories::foodPredicate);
++               break;
++            case STONECUTTER:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222154_f);
++               break;
++            case CAMPFIRE:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222153_e);
++         }
++
++         register(category, category.name().toLowerCase());
++      }
++   }
++
++   @Override
++   public final RecipeBookCategories setRegistryName(net.minecraft.util.ResourceLocation name) {
++      return setRegistryName(name.toString());
++   }
++
++   @javax.annotation.Nullable
++   @Override
++   public net.minecraft.util.ResourceLocation getRegistryName() {
++      return registryName;
++   }
++
++   @Override
++   public Class<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> getRegistryType() {
++      //return RecipeBookCategories.class;
++      return null;
++   }
++
++   public final RecipeBookCategories setRegistryName(String modID, String name) {
++      return setRegistryName(modID + ":" + name);
++   }
++
++   public final RecipeBookCategories setRegistryName(String name) {
++      if (getRegistryName() != null) {
++         throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryName());
++      }
++
++      this.registryName = net.minecraftforge.registries.GameData.checkPrefix(name, true);
++      return this;
++   }
++
++   public List<ItemStack> getIcon() {
++      return this.field_202904_j;
++   }
++
++   @Override
++   public boolean isSearch() {
++      return isSearch;
++   }
++
++   @Override
++   public java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> getPredicate() {
++      return predicate;
++   }
++
++   @Override
++   public net.minecraft.item.crafting.IRecipeType<?> getRecipeType() {
++      return recipeType;
++   }
++
++   private void setupSearch(net.minecraft.item.crafting.IRecipeType<?> recipeType) {
++      this.isSearch = true;
++      this.predicate = recipe -> true;
++      this.recipeType = recipeType;
++   }
++
++   private void setupFilter(net.minecraft.item.crafting.IRecipeType<?> recipeType, java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate) {
++      this.isSearch = false;
++      this.predicate = predicate;
++      this.recipeType = recipeType;
++   }
++
++   private static void register(RecipeBookCategories category, String resourceName) {
++      category.setRegistryName(resourceName);
++      net.minecraft.util.registry.Registry.func_218322_a(net.minecraft.util.registry.Registry.RECIPE_BOOK_CATEGORIES, new net.minecraft.util.ResourceLocation(resourceName), category);
++   }
++
++   private static boolean buildingBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78030_b;
++   }
++
++   private static boolean redstonePredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78028_d;
++   }
++
++   private static boolean miscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup != net.minecraft.item.ItemGroup.field_78028_d && itemgroup != net.minecraft.item.ItemGroup.field_78040_i && itemgroup != net.minecraft.item.ItemGroup.field_78037_j;
++   }
++
++   private static boolean equipmentPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78040_i || itemgroup == net.minecraft.item.ItemGroup.field_78037_j;
++   }
++
++   private static boolean foodPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return recipe.func_77571_b().func_77973_b().func_219971_r();
++   }
++
++   private static boolean furnaceBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !recipe.func_77571_b().func_77973_b().func_219971_r() && recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem;
++   }
++
++   private static boolean furnaceMiscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !recipe.func_77571_b().func_77973_b().func_219971_r() && !(recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem);
++   }
++
++   private static boolean blastFurnaceBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem;
++   }
++
++   private static boolean blastFurnaceMiscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !(recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem);
++   }
+ }

--- a/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
@@ -9,12 +9,12 @@
     SEARCH(new ItemStack(Items.field_151111_aL)),
     BUILDING_BLOCKS(new ItemStack(Blocks.field_196584_bK)),
     REDSTONE(new ItemStack(Items.field_151137_ax)),
-@@ -36,4 +36,176 @@
+@@ -36,4 +36,177 @@
     public List<ItemStack> func_202903_a() {
        return this.field_202904_j;
     }
 +
-+   //--FORGE
++   /*================================ FORGE START ================================================*/
 +   private net.minecraft.util.ResourceLocation registryName;
 +   private boolean isSearch;
 +   private net.minecraft.item.crafting.IRecipeType<?> recipeType;
@@ -185,4 +185,5 @@
 +   private static boolean blastFurnaceMiscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
 +      return !(recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem);
 +   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
@@ -19,6 +19,7 @@
 +   private boolean isSearch;
 +   private net.minecraft.item.crafting.IRecipeType<?> recipeType;
 +   private java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate;
++   private final com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> token = new com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>>(getClass()){};
 +
 +   static {
 +      for (RecipeBookCategories category : RecipeBookCategories.values()) {
@@ -89,8 +90,7 @@
 +
 +   @Override
 +   public Class<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> getRegistryType() {
-+      //return RecipeBookCategories.class;
-+      return null;
++      return (Class<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>>)token.getRawType();
 +   }
 +
 +   public final RecipeBookCategories setRegistryName(String modID, String name) {

--- a/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
@@ -16,7 +16,7 @@
 +
 +   /*================================ FORGE START ================================================*/
 +   private net.minecraft.util.ResourceLocation registryName;
-+   private boolean isSearch;
++   private boolean isUnfiltered;
 +   private net.minecraft.item.crafting.IRecipeType<?> recipeType;
 +   private java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate;
 +   private final com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> token = new com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>>(getClass()){};
@@ -111,8 +111,8 @@
 +   }
 +
 +   @Override
-+   public boolean isSearch() {
-+      return isSearch;
++   public boolean isUnfiltered() {
++      return isUnfiltered;
 +   }
 +
 +   @Override
@@ -126,13 +126,13 @@
 +   }
 +
 +   private void setupSearch(net.minecraft.item.crafting.IRecipeType<?> recipeType) {
-+      this.isSearch = true;
++      this.isUnfiltered = true;
 +      this.predicate = recipe -> true;
 +      this.recipeType = recipeType;
 +   }
 +
 +   private void setupFilter(net.minecraft.item.crafting.IRecipeType<?> recipeType, java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate) {
-+      this.isSearch = false;
++      this.isUnfiltered = false;
 +      this.predicate = predicate;
 +      this.recipeType = recipeType;
 +   }

--- a/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/inventory/container/RecipeBookContainer.java
 +++ b/net/minecraft/inventory/container/RecipeBookContainer.java
-@@ -31,4 +31,69 @@
+@@ -31,4 +31,70 @@
  
     @OnlyIn(Dist.CLIENT)
     public abstract int func_203721_h();
 +
++   /*================================ FORGE START ================================================*/
 +   public net.minecraft.item.crafting.IRecipeType<?> getRecipeType() {
 +      if (this instanceof FurnaceContainer) {
 +         return net.minecraft.item.crafting.IRecipeType.field_222150_b;
@@ -51,7 +52,6 @@
 +   }
 +
 +   static {
-+      // priority map to stick with vanilla tabs order, custom tabs goes under them
 +      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SEARCH, 10);
 +      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BUILDING_BLOCKS, 20);
 +      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.REDSTONE, 30);
@@ -69,4 +69,5 @@
 +      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.STONECUTTER, 30);
 +      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CAMPFIRE, 40);
 +   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
@@ -1,11 +1,72 @@
 --- a/net/minecraft/inventory/container/RecipeBookContainer.java
 +++ b/net/minecraft/inventory/container/RecipeBookContainer.java
-@@ -31,4 +31,8 @@
+@@ -31,4 +31,69 @@
  
     @OnlyIn(Dist.CLIENT)
     public abstract int func_203721_h();
 +
-+   public java.util.List<net.minecraft.client.util.RecipeBookCategories> getRecipeBookCategories() {
-+      return net.minecraft.client.util.ClientRecipeBook.func_216769_b(this);
++   public net.minecraft.item.crafting.IRecipeType<?> getRecipeType() {
++      if (this instanceof FurnaceContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222150_b;
++      } else if (this instanceof SmokerContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222152_d;
++      } else if (this instanceof BlastFurnaceContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222151_c;
++      } else if (this instanceof PlayerContainer || this instanceof WorkbenchContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222149_a;
++      } else {
++         throw new IllegalStateException("Unexpected RecipeBookContainer override, please override this method in your own class!");
++      }
++   }
++
++   public java.util.List<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>> getRecipeBookCategories() {
++      return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
++         return category.getRecipeType().equals(this.getRecipeType());
++      }).sorted(RecipeBookContainer::compareTo).collect(java.util.stream.Collectors.toList());
++   }
++
++   private static final java.util.Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, Integer> VANILLA_LIST  = new java.util.HashMap<>();
++
++   private static int compareTo(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> from, net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> to) {
++      if (from.equals(to)) {
++         return 0;
++      }
++
++      Integer thisValue = VANILLA_LIST.get(from);
++      Integer toValue = VANILLA_LIST.get(to);
++
++      if (thisValue == null && toValue == null) {
++         if (from.getRegistryName() != null) {
++            return from.getRegistryName().compareTo(to.getRegistryName());
++         } else {
++            return (from.hashCode() > to.hashCode()) ? 1 : -1;
++         }
++      } else if (thisValue == null) {
++         return 1;
++      } else if (toValue == null){
++         return -1;
++      }
++
++      return Integer.compare(thisValue, toValue);
++   }
++
++   static {
++      // priority map to stick with vanilla tabs order, custom tabs goes under them
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BUILDING_BLOCKS, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.REDSTONE, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.EQUIPMENT, 40);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.MISC, 50);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_FOOD, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_BLOCKS, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_MISC, 40);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_BLOCKS, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_MISC, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SMOKER_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SMOKER_FOOD, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.STONECUTTER, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CAMPFIRE, 40);
 +   }
  }

--- a/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
@@ -165,9 +165,9 @@
        return Activity.field_221366_b;
     });
 +   @Deprecated public static final Registry<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = forge("recipe_book_categories",
-+           net.minecraftforge.common.extensions.IForgeRecipeBookCategory.class, Registry::getDefaultRecipeBook);
++           net.minecraftforge.common.extensions.IForgeRecipeBookCategory.class, Registry::getDefaultRecipeBookCategory);
  
-+   private static net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getDefaultRecipeBook() {
++   private static net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getDefaultRecipeBookCategory() {
 +      return net.minecraft.client.util.RecipeBookCategories.SEARCH;
 +   }
 +

--- a/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
@@ -118,7 +118,7 @@
     public static final Registry<IStructurePieceType> field_218362_C = func_222935_a("structure_piece", () -> {
        return IStructurePieceType.field_214782_c;
     });
-@@ -164,37 +166,37 @@
+@@ -164,40 +166,46 @@
     public static final Registry<IJigsawDeserializer> field_218365_F = func_222935_a("structure_pool_element", () -> {
        return IJigsawDeserializer.field_214931_e;
     });
@@ -164,8 +164,17 @@
 +   @Deprecated public static final Registry<Activity> field_218375_Q = forge("activity", Activity.class, () -> {
        return Activity.field_221366_b;
     });
++   @Deprecated public static final Registry<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = forge("recipe_book_categories",
++           net.minecraftforge.common.extensions.IForgeRecipeBookCategory.class, Registry::getDefaultRecipeBook);
  
-@@ -246,6 +248,14 @@
++   private static net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getDefaultRecipeBook() {
++      return net.minecraft.client.util.RecipeBookCategories.SEARCH;
++   }
++
+    private static <T> Registry<T> func_222935_a(String p_222935_0_, Supplier<T> p_222935_1_) {
+       return func_222939_a(p_222935_0_, new SimpleRegistry<>(), p_222935_1_);
+    }
+@@ -246,6 +254,14 @@
        return ((MutableRegistry<T>)p_218343_0_).func_218382_a(p_218343_1_, new ResourceLocation(p_218343_2_), p_218343_3_);
     }
  

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -23,35 +23,20 @@ public class UpDownButton extends net.minecraft.client.gui.widget.button.Button 
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        RenderSystem.pushMatrix();
+        RenderSystem.translatef(x, y, 0);
+        RenderSystem.scalef(-1, 1, 1);
+        RenderSystem.pushMatrix();
+        RenderSystem.translatef(5.5f, 8.5f, 0.0f);
+        RenderSystem.rotatef(90, 0, 0, 1);
+        RenderSystem.translatef(-8.5f, 5.5f, 0.0f);
         if (isDown) {
-            blit(this.x, this.y, 1, 208 + i * 18, 11, 17);
+            blit(0, 0, 1, 208 + i * 18, 11, 17);
         } else {
-            blit(this.x, this.y, 15, 208 + i * 18, 11, 17);
+            blit(0, 0, 15, 208 + i * 18, 11, 17);
         }
+        RenderSystem.popMatrix();
+        RenderSystem.popMatrix();
         this.renderBg(minecraft, mouseX, mouseY);
-    }
-
-    // re-implemented blit function for rotating and mirroring texture
-    public void blit(int x, int y, int u, int v, int w, int h) {
-        blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
-    }
-
-    public static void blit(int x, int y, int blitOffset, float u, float v, int w, int h, int textureW, int textureH) {
-        innerBlit(x, x + h, y, y + w, blitOffset, w, h, u, v, textureH, textureW);
-    }
-
-    private static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, int w, int h, float u, float v, int textureW, int textureH) {
-        innerBlit(minX, maxX, minY, maxY, blitOffset, u / textureW, (u + w) / textureW, v / textureH, (v + h) / textureH);
-    }
-
-    protected static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, float minU, float maxU, float minV, float maxV) {
-        net.minecraft.client.renderer.Tessellator tessellator = net.minecraft.client.renderer.Tessellator.getInstance();
-        net.minecraft.client.renderer.BufferBuilder bufferBuilder = tessellator.getBuffer();
-        bufferBuilder.begin(7, net.minecraft.client.renderer.vertex.DefaultVertexFormats.POSITION_TEX);
-        bufferBuilder.pos(minX, maxY, blitOffset).tex(maxU, minV).endVertex();
-        bufferBuilder.pos(maxX, maxY, blitOffset).tex(maxU, maxV).endVertex();
-        bufferBuilder.pos(maxX, minY, blitOffset).tex(minU, maxV).endVertex();
-        bufferBuilder.pos(minX, minY, blitOffset).tex(minU, minV).endVertex();
-        tessellator.draw();
     }
 }

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client;
 
 import com.mojang.blaze3d.platform.GlStateManager;

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -31,6 +31,7 @@ public class UpDownButton extends net.minecraft.client.gui.widget.button.Button 
         this.renderBg(minecraft, mouseX, mouseY);
     }
 
+    // re-implemented blit function for rotating and mirroring texture
     public void blit(int x, int y, int u, int v, int w, int h) {
         blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
     }

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.client;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
+
+public class UpDownButton extends net.minecraft.client.gui.widget.button.Button {
+    public static final ResourceLocation STATS_ICON_LOCATION = new ResourceLocation("textures/gui/recipe_book.png");
+    private final boolean isDown;
+
+    public UpDownButton(int x, int y, int width, int height, boolean isDown, IPressable onPress) {
+        super(x, y, width, height, "", onPress);
+        this.isDown = isDown;
+    }
+
+    @Override
+    public void renderButton(int mouseX, int mouseY, float partial) {
+        Minecraft minecraft = Minecraft.getInstance();
+        minecraft.getTextureManager().bindTexture(STATS_ICON_LOCATION);
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, this.alpha);
+        int i = (isHovered) ? 1 : 0;
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        if (isDown) {
+            blit(this.x, this.y, 1, 208 + i * 18, 11, 17);
+        } else {
+            blit(this.x, this.y, 15, 208 + i * 18, 11, 17);
+        }
+        this.renderBg(minecraft, mouseX, mouseY);
+    }
+
+    public void blit(int x, int y, int u, int v, int w, int h) {
+        blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
+    }
+
+    public static void blit(int x, int y, int blitOffset, float u, float v, int w, int h, int textureW, int textureH) {
+        innerBlit(x, x + h, y, y + w, blitOffset, w, h, u, v, textureH, textureW);
+    }
+
+    private static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, int w, int h, float u, float v, int textureW, int textureH) {
+        innerBlit(minX, maxX, minY, maxY, blitOffset, u / textureW, (u + w) / textureW, v / textureH, (v + h) / textureH);
+    }
+
+    protected static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, float minU, float maxU, float minV, float maxV) {
+        net.minecraft.client.renderer.Tessellator tessellator = net.minecraft.client.renderer.Tessellator.getInstance();
+        net.minecraft.client.renderer.BufferBuilder bufferBuilder = tessellator.getBuffer();
+        bufferBuilder.begin(7, net.minecraft.client.renderer.vertex.DefaultVertexFormats.POSITION_TEX);
+        bufferBuilder.pos(minX, maxY, blitOffset).tex(maxU, minV).endVertex();
+        bufferBuilder.pos(maxX, maxY, blitOffset).tex(maxU, maxV).endVertex();
+        bufferBuilder.pos(maxX, minY, blitOffset).tex(minU, maxV).endVertex();
+        bufferBuilder.pos(minX, minY, blitOffset).tex(minU, minV).endVertex();
+        tessellator.draw();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategories.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategories.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.common;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class ForgeRecipeBookCategories<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+    private final List<ItemStack> icons;
+    private final boolean isSearch;
+    private final T recipeType;
+    private final Predicate<IRecipe<?>> predicate;
+
+    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, ItemStack... icons) {
+        this(isSearch, recipeType, recipe -> true, icons);
+    }
+
+    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+        this.isSearch = isSearch;
+        this.recipeType = recipeType;
+        this.predicate = predicate;
+        this.icons = ImmutableList.copyOf(icons);
+    }
+
+    @Override
+    public boolean isSearch() {
+        return this.isSearch;
+    }
+
+    @Override
+    public Predicate<IRecipe<?>> getPredicate() {
+        return this.predicate;
+    }
+
+    @Override
+    public T getRecipeType() {
+        return this.recipeType;
+    }
+
+    @Override
+    public List<ItemStack> getIcon() {
+        return this.icons;
+    }
+
+    public static List<IForgeRecipeBookCategory<?>> getValidCategories(IRecipe<?> recipe) {
+        return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
+            return recipe.getType().equals(category.getRecipeType()) && category.getPredicate().test(recipe);
+        }).collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -5,11 +5,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
     private final boolean isSearch;
     private final T recipeType;
@@ -58,7 +60,7 @@ public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minec
     }
 
     public static List<IForgeRecipeBookCategory<?>> getValidCategories(IRecipe<?> recipe) {
-        return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
+        return ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
             return recipe.getType().equals(category.getRecipeType()) && category.getPredicate().test(recipe);
         }).collect(java.util.stream.Collectors.toList());
     }

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -9,17 +9,28 @@ import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class ForgeRecipeBookCategories<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
     private final boolean isSearch;
     private final T recipeType;
     private final Predicate<IRecipe<?>> predicate;
 
-    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, ItemStack... icons) {
+    /**
+     * @param isSearch If tab is search
+     * @param recipeType Recipe type
+     * @param icons Recipe tab icons
+     */
+    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, ItemStack... icons) {
         this(isSearch, recipeType, recipe -> true, icons);
     }
 
-    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+    /**
+     * @param isSearch If tab is search
+     * @param recipeType Recipe type
+     * @param predicate Filtering function
+     * @param icons Recipe tab icons
+     */
+    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
         this.isSearch = isSearch;
         this.recipeType = recipeType;
         this.predicate = predicate;

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common;
 
 import com.google.common.collect.ImmutableList;
@@ -13,35 +32,35 @@ import java.util.function.Predicate;
 
 public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
-    private final boolean isSearch;
+    private final boolean isUnfiltered;
     private final T recipeType;
     private final Predicate<IRecipe<?>> predicate;
 
     /**
-     * @param isSearch If tab is search
+     * @param isUnfiltered If tab is without filter
      * @param recipeType Recipe type
      * @param icons Recipe tab icons
      */
-    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, ItemStack... icons) {
-        this(isSearch, recipeType, recipe -> true, icons);
+    public ForgeRecipeBookCategory(boolean isUnfiltered, T recipeType, ItemStack... icons) {
+        this(isUnfiltered, recipeType, recipe -> true, icons);
     }
 
     /**
-     * @param isSearch If tab is search
+     * @param isUnfiltered If tab is without filter
      * @param recipeType Recipe type
      * @param predicate Filtering function
      * @param icons Recipe tab icons
      */
-    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
-        this.isSearch = isSearch;
+    public ForgeRecipeBookCategory(boolean isUnfiltered, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+        this.isUnfiltered = isUnfiltered;
         this.recipeType = recipeType;
         this.predicate = predicate;
         this.icons = ImmutableList.copyOf(icons);
     }
 
     @Override
-    public boolean isSearch() {
-        return this.isSearch;
+    public boolean isUnfiltered() {
+        return this.isUnfiltered;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
+    boolean isSearch();
+    Predicate<IRecipe<?>> getPredicate();
+    T getRecipeType();
+    List<ItemStack> getIcon();
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.item.ItemStack;
@@ -10,10 +29,10 @@ import java.util.function.Predicate;
 
 public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
     /**
-     * If tab is search - does not filter recipes and always is on most top position
-     * @return if tab is search
+     * If tab is without filter - does not filter recipes and always is on most top position
+     * @return if tab is without filter
      */
-    boolean isSearch();
+    boolean isUnfiltered();
 
     /**
      * Filter for displayed recipes

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -9,8 +9,27 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
+    /**
+     * If tab is search - does not filter recipes and always is on most top position
+     * @return if tab is search
+     */
     boolean isSearch();
+
+    /**
+     * Filter for displayed recipes
+     * @return filtering function
+     */
     Predicate<IRecipe<?>> getPredicate();
+
+    /**
+     * Recipe type of recipe book category
+     * @return recipe type
+     */
     T getRecipeType();
+
+    /**
+     * Recipe tab icons, can be 1 or 2 ItemStack
+     * @return recipe tab icons
+     */
     List<ItemStack> getIcon();
 }

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -53,6 +53,7 @@ import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraft.world.gen.treedecorator.TreeDecoratorType;
 import net.minecraftforge.common.ModDimension;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
@@ -81,6 +82,7 @@ public class ForgeRegistries
     public static final IForgeRegistry<PaintingType> PAINTING_TYPES = RegistryManager.ACTIVE.getRegistry(PaintingType.class);
     public static final IForgeRegistry<IRecipeSerializer<?>> RECIPE_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(IRecipeSerializer.class);
     public static final IForgeRegistry<StatType<?>> STAT_TYPES = RegistryManager.ACTIVE.getRegistry(StatType.class);
+    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
     
     // Villages
     public static final IForgeRegistry<VillagerProfession> PROFESSIONS = RegistryManager.ACTIVE.getRegistry(VillagerProfession.class);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -82,7 +82,6 @@ public class ForgeRegistries
     public static final IForgeRegistry<PaintingType> PAINTING_TYPES = RegistryManager.ACTIVE.getRegistry(PaintingType.class);
     public static final IForgeRegistry<IRecipeSerializer<?>> RECIPE_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(IRecipeSerializer.class);
     public static final IForgeRegistry<StatType<?>> STAT_TYPES = RegistryManager.ACTIVE.getRegistry(StatType.class);
-    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
     
     // Villages
     public static final IForgeRegistry<VillagerProfession> PROFESSIONS = RegistryManager.ACTIVE.getRegistry(VillagerProfession.class);
@@ -109,6 +108,7 @@ public class ForgeRegistries
     public static final IForgeRegistry<ModDimension> MOD_DIMENSIONS = RegistryManager.ACTIVE.getRegistry(ModDimension.class);
     public static final IForgeRegistry<DataSerializerEntry> DATA_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(DataSerializerEntry.class);
     public static final IForgeRegistry<GlobalLootModifierSerializer<?>> LOOT_MODIFIER_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(GlobalLootModifierSerializer.class);
+    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
 
     /**
      * This function is just to make sure static inializers in other classes have run and setup their registries before we query them.

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -126,6 +126,7 @@ public class GameData
     public static final ResourceLocation PAINTING_TYPES = new ResourceLocation("motive"); // sic
     public static final ResourceLocation RECIPE_SERIALIZERS = new ResourceLocation("recipe_serializer");
     public static final ResourceLocation STAT_TYPES = new ResourceLocation("stat_type");
+    public static final ResourceLocation RECIPE_BOOK_CATEGORIES = new ResourceLocation("recipe_book_categories");
     
     // Villages
     public static final ResourceLocation PROFESSIONS = new ResourceLocation("villager_profession");
@@ -197,6 +198,7 @@ public class GameData
         makeRegistry(PAINTING_TYPES, PaintingType.class, new ResourceLocation("kebab")).create();
         makeRegistry(RECIPE_SERIALIZERS, IRecipeSerializer.class).disableSaving().create();
         makeRegistry(STAT_TYPES, StatType.class).create();
+        makeRegistry(RECIPE_BOOK_CATEGORIES, net.minecraftforge.common.extensions.IForgeRecipeBookCategory.class).disableSaving().create();
         
         // Villagers
         makeRegistry(PROFESSIONS, VillagerProfession.class, new ResourceLocation("none")).create();

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -67,6 +67,7 @@ import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraft.world.gen.treedecorator.TreeDecoratorType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ModDimension;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.RegistryEvent.MissingMappings;
@@ -126,7 +127,6 @@ public class GameData
     public static final ResourceLocation PAINTING_TYPES = new ResourceLocation("motive"); // sic
     public static final ResourceLocation RECIPE_SERIALIZERS = new ResourceLocation("recipe_serializer");
     public static final ResourceLocation STAT_TYPES = new ResourceLocation("stat_type");
-    public static final ResourceLocation RECIPE_BOOK_CATEGORIES = new ResourceLocation("recipe_book_categories");
     
     // Villages
     public static final ResourceLocation PROFESSIONS = new ResourceLocation("villager_profession");
@@ -153,6 +153,7 @@ public class GameData
     public static final ResourceLocation MODDIMENSIONS = new ResourceLocation("forge:moddimensions");
     public static final ResourceLocation SERIALIZERS = new ResourceLocation("minecraft:dataserializers");
     public static final ResourceLocation LOOT_MODIFIER_SERIALIZERS = new ResourceLocation("forge:loot_modifier_serializers");
+    public static final ResourceLocation RECIPE_BOOK_CATEGORIES = new ResourceLocation("recipe_book_categories");
 
     private static final int MAX_VARINT = Integer.MAX_VALUE - 1; //We were told it is their intention to have everything in a reg be unlimited, so assume that until we find cases where it isnt.
 
@@ -198,7 +199,6 @@ public class GameData
         makeRegistry(PAINTING_TYPES, PaintingType.class, new ResourceLocation("kebab")).create();
         makeRegistry(RECIPE_SERIALIZERS, IRecipeSerializer.class).disableSaving().create();
         makeRegistry(STAT_TYPES, StatType.class).create();
-        makeRegistry(RECIPE_BOOK_CATEGORIES, net.minecraftforge.common.extensions.IForgeRecipeBookCategory.class).disableSaving().create();
         
         // Villagers
         makeRegistry(PROFESSIONS, VillagerProfession.class, new ResourceLocation("none")).create();
@@ -225,6 +225,7 @@ public class GameData
         makeRegistry(MODDIMENSIONS, ModDimension.class ).disableSaving().create();
         makeRegistry(SERIALIZERS, DataSerializerEntry.class, 256 /*vanilla space*/, MAX_VARINT).disableSaving().disableOverrides().addCallback(SerializerCallbacks.INSTANCE).create();
         makeRegistry(LOOT_MODIFIER_SERIALIZERS, GlobalLootModifierSerializer.class).disableSaving().disableSync().create();
+        makeRegistry(RECIPE_BOOK_CATEGORIES, IForgeRecipeBookCategory.class).disableSaving().create();
     }
 
     private static <T extends IForgeRegistryEntry<T>> RegistryBuilder<T> makeRegistry(ResourceLocation name, Class<T> type)

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -22,6 +22,7 @@ public net.minecraft.client.gui.ScreenManager func_216911_a(Lnet/minecraft/inven
 public net.minecraft.client.gui.ScreenManager$IScreenFactory
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211537_g # rayTraceBlock
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211538_h # rayTraceFluid
+private-f net.minecraft.client.gui.recipebook.RecipeTabToggleWidget field_193921_u # category
 protected net.minecraft.client.gui.widget.list.AbstractList$AbstractListEntry list # list
 public net.minecraft.client.particle.ParticleManager func_199283_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/IParticleFactory;)V # registerFactory
 public net.minecraft.client.particle.ParticleManager func_215234_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/ParticleManager$IParticleMetaFactory;)V # registerFactory

--- a/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2019.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
@@ -59,7 +59,7 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeRecipeBookCategories;
+import net.minecraftforge.common.ForgeRecipeBookCategory;
 import net.minecraftforge.common.extensions.IForgeContainerType;
 import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import net.minecraftforge.event.RegistryEvent;
@@ -78,11 +78,11 @@ import java.util.Set;
 @Mod.EventBusSubscriber(bus = Bus.MOD)
 public class CraftingBookTest {
     @ObjectHolder("rare")
-    public static final ForgeRecipeBookCategories<?> rare = null;
+    public static final ForgeRecipeBookCategory<?> rare = null;
     @ObjectHolder("test")
-    public static final ForgeRecipeBookCategories<?> test = null;
+    public static final ForgeRecipeBookCategory<?> test = null;
     @ObjectHolder("test_uncommon")
-    public static final ForgeRecipeBookCategories<?> test_uncommon = null;
+    public static final ForgeRecipeBookCategory<?> test_uncommon = null;
 
     @ObjectHolder("test_block")
     public static final Block test_block = null;
@@ -102,13 +102,13 @@ public class CraftingBookTest {
     @SubscribeEvent
     public static void registerForgeRecipeBookCategories(RegistryEvent.Register<IForgeRecipeBookCategory<?>> event) {
         // search category for custom machine
-        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(true, TestRecipe.test, new ItemStack(Items.COMPASS)).setRegistryName("base_crafting_book_test", "test"));
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(true, TestRecipe.test, new ItemStack(Items.COMPASS)).setRegistryName("base_crafting_book_test", "test"));
         // custom machine category showing only uncommon recipes
-        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(false,
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false,
                 TestRecipe.test, recipe -> recipe.getRecipeOutput().getRarity() == Rarity.UNCOMMON, new ItemStack(Items.GOLDEN_AXE), new ItemStack(Items.STONE_PICKAXE))
                 .setRegistryName("base_crafting_book_test", "test_uncommon"));
         // added new category to crafting table & player displaying only rare output items recipes
-        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(false, IRecipeType.CRAFTING, recipe -> recipe.getRecipeOutput().getRarity() == Rarity.RARE, new ItemStack(Items.BEACON))
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false, IRecipeType.CRAFTING, recipe -> recipe.getRecipeOutput().getRarity() == Rarity.RARE, new ItemStack(Items.BEACON))
                 .setRegistryName("base_crafting_book_test", "rare"));
     }
 

--- a/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
@@ -1,0 +1,552 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2020.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.block;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.blaze3d.platform.GlStateManager;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.client.gui.recipebook.AbstractRecipeBookGui;
+import net.minecraft.client.gui.recipebook.IRecipeShownListener;
+import net.minecraft.client.gui.recipebook.RecipeBookGui;
+import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.client.gui.widget.button.ImageButton;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.IRecipeHelperPopulator;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.container.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.SUpdateTileEntityPacket;
+import net.minecraft.tileentity.AbstractFurnaceTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeRecipeBookCategories;
+import net.minecraftforge.common.extensions.IForgeContainerType;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.network.NetworkHooks;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.ObjectHolder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+
+@Mod("base_crafting_book_test")
+@Mod.EventBusSubscriber(bus = Bus.MOD)
+public class CraftingBookTest {
+    @ObjectHolder("rare")
+    public static final ForgeRecipeBookCategories<?> rare = null;
+    @ObjectHolder("test")
+    public static final ForgeRecipeBookCategories<?> test = null;
+    @ObjectHolder("test_uncommon")
+    public static final ForgeRecipeBookCategories<?> test_uncommon = null;
+
+    @ObjectHolder("test_block")
+    public static final Block test_block = null;
+    @ObjectHolder("test_tile")
+    public static final TileEntityType<TestTile> test_tile = null;
+    @ObjectHolder("test_container")
+    public static final ContainerType<TestContainer> test_container = null;
+    @ObjectHolder("test_recipe")
+    public static final IRecipeSerializer<?> test_recipe = null;
+
+    @SubscribeEvent
+    public static void registerRecipe(@Nonnull RegistryEvent.Register<IRecipeSerializer<?>> event) {
+        IForgeRegistry<IRecipeSerializer<?>> registry = event.getRegistry();
+        registry.register(new TestRecipeSerializer<>(TestRecipe::new, 200).setRegistryName("base_crafting_book_test", "test_recipe"));
+    }
+
+    @SubscribeEvent
+    public static void registerForgeRecipeBookCategories(RegistryEvent.Register<IForgeRecipeBookCategory<?>> event) {
+        // search category for custom machine
+        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(true, TestRecipe.test, new ItemStack(Items.COMPASS)).setRegistryName("base_crafting_book_test", "test"));
+        // custom machine category showing only uncommon recipes
+        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(false,
+                TestRecipe.test, recipe -> recipe.getRecipeOutput().getRarity() == Rarity.UNCOMMON, new ItemStack(Items.GOLDEN_AXE), new ItemStack(Items.STONE_PICKAXE))
+                .setRegistryName("base_crafting_book_test", "test_uncommon"));
+        // added new category to crafting table & player displaying only rare output items recipes
+        event.getRegistry().register(new ForgeRecipeBookCategories<IRecipeType<?>>(false, IRecipeType.CRAFTING, recipe -> recipe.getRecipeOutput().getRarity() == Rarity.RARE, new ItemStack(Items.BEACON))
+                .setRegistryName("base_crafting_book_test", "rare"));
+    }
+
+    @SubscribeEvent
+    public static void registerBlocks(@Nonnull RegistryEvent.Register<Block> event) {
+        IForgeRegistry<Block> registry = event.getRegistry();
+        registry.register(new TestBlock().setRegistryName("base_crafting_book_test", "test_block"));
+    }
+
+    @SubscribeEvent
+    public static void registerItems(@Nonnull RegistryEvent.Register<Item> event) {
+        IForgeRegistry<Item> registry = event.getRegistry();
+        registry.register(new BlockItem(test_block, new Item.Properties().group(ItemGroup.BUILDING_BLOCKS))
+                .setRegistryName("base_crafting_book_test", "test_block"));
+    }
+
+    @SubscribeEvent
+    public static void registerTileEntity(@Nonnull RegistryEvent.Register<TileEntityType<?>> event) {
+        IForgeRegistry<TileEntityType<?>> registry = event.getRegistry();
+        registry.register(TileEntityType.Builder.create(TestTile::new, test_block)
+                .build(null).setRegistryName("base_crafting_book_test", "test_tile"));
+    }
+
+    @SubscribeEvent
+    public static void registerContainer(@Nonnull RegistryEvent.Register<ContainerType<?>> event) {
+        ContainerType<TestContainer> test_container = IForgeContainerType.create(TestContainer::new);
+        IForgeRegistry<ContainerType<?>> registry = event.getRegistry();
+        registry.register(test_container.setRegistryName("base_crafting_book_test", "test_container"));
+        ScreenManager.registerFactory(test_container, TestGui::new);
+    }
+
+    private static class TestRecipeBookGui extends AbstractRecipeBookGui {
+
+        @Override
+        protected boolean func_212962_b() {
+            return this.recipeBook.isFilteringCraftable();
+        }
+
+        @Override
+        protected void func_212959_a(boolean p_212959_1_) {
+            this.recipeBook.setFilteringCraftable(p_212959_1_);
+        }
+
+        @Override
+        protected boolean func_212963_d() {
+            return this.recipeBook.isGuiOpen();
+        }
+
+        @Override
+        protected void func_212957_c(boolean p_212957_1_) {
+            this.recipeBook.setGuiOpen(p_212957_1_);
+        }
+
+        @Override
+        protected String func_212960_g() {
+            return "gui.recipebook.toggleRecipes.craftable";
+        }
+
+        @Override
+        protected Set<Item> func_212958_h() {
+            return AbstractFurnaceTileEntity.getBurnTimes().keySet();
+        }
+    }
+
+    private static class TestGui extends ContainerScreen<TestContainer> implements IRecipeShownListener {
+        private static final ResourceLocation RECIPE_BUTTON = new ResourceLocation("textures/gui/recipe_button.png");
+        private static final ResourceLocation BACKGROUND = new ResourceLocation("textures/gui/container/furnace.png");
+        private final AbstractRecipeBookGui recipeBookGui;
+        private boolean narrowWidth;
+
+        private TestGui(TestContainer screenContainer, PlayerInventory inv, ITextComponent titleIn) {
+            super(screenContainer, inv, titleIn);
+            this.recipeBookGui = new TestRecipeBookGui();
+        }
+
+        @Override
+        public void init() {
+            super.init();
+            this.narrowWidth = this.width < 379;
+            this.recipeBookGui.init(this.width, this.height, this.minecraft, this.narrowWidth, this.container);
+            this.guiLeft = this.recipeBookGui.updateScreenPosition(this.narrowWidth, this.width, this.xSize);
+            this.addButton((new ImageButton(this.guiLeft + 20, this.height / 2 - 49, 20, 18, 0, 0, 19, RECIPE_BUTTON, (p_214087_1_) -> {
+                this.recipeBookGui.initSearchBar(this.narrowWidth);
+                this.recipeBookGui.toggleVisibility();
+                this.guiLeft = this.recipeBookGui.updateScreenPosition(this.narrowWidth, this.width, this.xSize);
+                ((ImageButton)p_214087_1_).setPosition(this.guiLeft + 20, this.height / 2 - 49);
+            })));
+        }
+
+        @Override
+        public void tick() {
+            super.tick();
+            this.recipeBookGui.tick();
+        }
+
+        @Override
+        public void render(int p_render_1_, int p_render_2_, float p_render_3_) {
+            this.renderBackground();
+            if (this.recipeBookGui.isVisible() && this.narrowWidth) {
+                this.drawGuiContainerBackgroundLayer(p_render_3_, p_render_1_, p_render_2_);
+                this.recipeBookGui.render(p_render_1_, p_render_2_, p_render_3_);
+            } else {
+                this.recipeBookGui.render(p_render_1_, p_render_2_, p_render_3_);
+                super.render(p_render_1_, p_render_2_, p_render_3_);
+                this.recipeBookGui.renderGhostRecipe(this.guiLeft, this.guiTop, true, p_render_3_);
+            }
+
+            this.renderHoveredToolTip(p_render_1_, p_render_2_);
+            this.recipeBookGui.renderTooltip(this.guiLeft, this.guiTop, p_render_1_, p_render_2_);
+        }
+
+        @Override
+        protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+            String s = this.title.getFormattedText();
+            this.font.drawString(s, (float)(this.xSize / 2 - this.font.getStringWidth(s) / 2), 6.0F, 4210752);
+            this.font.drawString(this.playerInventory.getDisplayName().getFormattedText(), 8.0F, (float)(this.ySize - 96 + 2), 4210752);
+        }
+
+        @Override
+        protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
+            GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+            this.minecraft.getTextureManager().bindTexture(BACKGROUND);
+            int i = this.guiLeft;
+            int j = this.guiTop;
+            this.blit(i, j, 0, 0, this.xSize, this.ySize);
+        }
+
+        @Override
+        public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
+            if (this.recipeBookGui.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
+                return true;
+            } else {
+                return this.narrowWidth && this.recipeBookGui.isVisible() ? true : super.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_);
+            }
+        }
+
+        @Override
+        protected void handleMouseClick(Slot slotIn, int slotId, int mouseButton, ClickType type) {
+            super.handleMouseClick(slotIn, slotId, mouseButton, type);
+            this.recipeBookGui.slotClicked(slotIn);
+        }
+
+        @Override
+        public boolean keyPressed(int p_keyPressed_1_, int p_keyPressed_2_, int p_keyPressed_3_) {
+            return this.recipeBookGui.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_) ? false : super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
+        }
+
+        @Override
+        protected boolean hasClickedOutside(double p_195361_1_, double p_195361_3_, int p_195361_5_, int p_195361_6_, int p_195361_7_) {
+            boolean flag = p_195361_1_ < (double)p_195361_5_ || p_195361_3_ < (double)p_195361_6_ || p_195361_1_ >= (double)(p_195361_5_ + this.xSize) || p_195361_3_ >= (double)(p_195361_6_ + this.ySize);
+            return this.recipeBookGui.func_195604_a(p_195361_1_, p_195361_3_, this.guiLeft, this.guiTop, this.xSize, this.ySize, p_195361_7_) && flag;
+        }
+
+        @Override
+        public boolean charTyped(char p_charTyped_1_, int p_charTyped_2_) {
+            return this.recipeBookGui.charTyped(p_charTyped_1_, p_charTyped_2_) ? true : super.charTyped(p_charTyped_1_, p_charTyped_2_);
+        }
+
+        @Override
+        public void recipesUpdated() {
+            this.recipeBookGui.recipesUpdated();
+        }
+
+        @Override
+        public RecipeBookGui getRecipeGui() {
+            return this.recipeBookGui;
+        }
+
+        @Override
+        public void removed() {
+            this.recipeBookGui.removed();
+            super.removed();
+        }
+    }
+
+    private static class TestBlock extends Block {
+        private TestBlock() {
+            super(Properties.create(Material.ROCK));
+        }
+
+        @Override
+        public boolean hasTileEntity(BlockState state) {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        public TileEntity createTileEntity(BlockState state, IBlockReader world) {
+            return new TestTile();
+        }
+        @SuppressWarnings("deprecation")
+        @Override
+        public ActionResultType onBlockActivated(@Nonnull BlockState state, World worldIn, @Nonnull BlockPos pos, @Nonnull PlayerEntity player,
+                                                 @Nonnull Hand handIn, @Nonnull BlockRayTraceResult hit) {
+            TestTile tile = (TestTile) worldIn.getTileEntity(pos);
+
+            if (tile != null) {
+                if (!worldIn.isRemote) {
+                    NetworkHooks.openGui((ServerPlayerEntity) player, tile, tile.getPos());
+                }
+                return ActionResultType.SUCCESS;
+            } else {
+                throw new IllegalStateException("Named container provider is missing");
+            }
+        }
+    }
+
+    private static class TestTile extends TileEntity implements INamedContainerProvider {
+
+        private TestTile() {
+            super(test_tile);
+        }
+
+        @Override
+        public ITextComponent getDisplayName() {
+            assert getType().getRegistryName() != null;
+            return new StringTextComponent(getType().getRegistryName().getPath());
+        }
+
+        @Nullable
+        @Override
+        public Container createMenu(int p_createMenu_1_, PlayerInventory p_createMenu_2_, PlayerEntity p_createMenu_3_) {
+            return new TestContainer(p_createMenu_1_, pos, world, p_createMenu_2_, p_createMenu_3_);
+        }
+
+        @Nullable
+        @Override
+        public SUpdateTileEntityPacket getUpdatePacket() {
+            return new SUpdateTileEntityPacket(getPos(), getType().hashCode(), getUpdateTag());
+        }
+
+        @Nonnull
+        @Override
+        public CompoundNBT getUpdateTag() {
+            return write(new CompoundNBT());
+        }
+
+        @Override
+        public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket pkt) {
+            super.onDataPacket(net, pkt);
+            read(pkt.getNbtCompound());
+        }
+    }
+
+    private static class TestContainer extends RecipeBookContainer<IInventory> {
+        protected final World world;
+        private final IInventory furnaceInventory;
+
+        private TestContainer(int windowId, @Nonnull PlayerInventory inv, @Nonnull PacketBuffer extraData) {
+            this(windowId, extraData.readBlockPos(), Minecraft.getInstance().world, inv, Minecraft.getInstance().player);
+        }
+
+        private TestContainer(int id, @Nonnull BlockPos pos, @Nonnull World world, @Nonnull PlayerInventory inventory, @Nonnull PlayerEntity player) {
+            super(test_container, id);
+            IInventory furnaceInventoryIn = new Inventory(3);
+            assertInventorySize(furnaceInventoryIn, 3);
+            this.furnaceInventory = furnaceInventoryIn;
+            this.world = inventory.player.world;
+            this.addSlot(new Slot(furnaceInventoryIn, 0, 56, 17));
+            this.addSlot(new Slot(furnaceInventoryIn, 1, 56, 53));
+            this.addSlot(new FurnaceResultSlot(inventory.player, furnaceInventoryIn, 2, 116, 35));
+
+            for(int i = 0; i < 3; ++i) {
+                for(int j = 0; j < 9; ++j) {
+                    this.addSlot(new Slot(inventory, j + i * 9 + 9, 8 + j * 18, 84 + i * 18));
+                }
+            }
+
+            for(int k = 0; k < 9; ++k) {
+                this.addSlot(new Slot(inventory, k, 8 + k * 18, 142));
+            }
+        }
+
+        @Override
+        public void fillStackedContents(RecipeItemHelper p_201771_1_) {
+            if (this.furnaceInventory instanceof IRecipeHelperPopulator) {
+                ((IRecipeHelperPopulator)this.furnaceInventory).fillStackedContents(p_201771_1_);
+            }
+        }
+
+        @Override
+        public void clear() {
+            this.furnaceInventory.clear();
+        }
+
+        @Override
+        public boolean matches(IRecipe<? super IInventory> recipeIn) {
+            return recipeIn.matches(this.furnaceInventory, this.world);
+        }
+
+        @Override
+        public int getOutputSlot() {
+            return 2;
+        }
+
+        @Override
+        public int getWidth() {
+            return 1;
+        }
+
+        @Override
+        public int getHeight() {
+            return 1;
+        }
+
+        @Override
+        public int getSize() {
+            return 3;
+        }
+
+        @Override
+        public IRecipeType<?> getRecipeType() {
+            return TestRecipe.test;
+        }
+
+        @Override
+        public boolean canInteractWith(PlayerEntity playerIn) {
+            return this.furnaceInventory.isUsableByPlayer(playerIn);
+        }
+
+        @Override
+        public ItemStack transferStackInSlot(PlayerEntity playerIn, int index) {
+            ItemStack itemstack = ItemStack.EMPTY;
+            Slot slot = this.inventorySlots.get(index);
+            if (slot != null && slot.getHasStack()) {
+                ItemStack itemstack1 = slot.getStack();
+                itemstack = itemstack1.copy();
+                if (index == 2) {
+                    if (!this.mergeItemStack(itemstack1, 3, 39, true)) {
+                        return ItemStack.EMPTY;
+                    }
+
+                    slot.onSlotChange(itemstack1, itemstack);
+                } else if (index != 1 && index != 0) {
+                    if (this.func_217057_a(itemstack1)) {
+                        if (!this.mergeItemStack(itemstack1, 0, 1, false)) {
+                            return ItemStack.EMPTY;
+                        }
+                    } else if (AbstractFurnaceTileEntity.isFuel(itemstack1)) {
+                        if (!this.mergeItemStack(itemstack1, 1, 2, false)) {
+                            return ItemStack.EMPTY;
+                        }
+                    } else if (index >= 3 && index < 30) {
+                        if (!this.mergeItemStack(itemstack1, 30, 39, false)) {
+                            return ItemStack.EMPTY;
+                        }
+                    } else if (index >= 30 && index < 39 && !this.mergeItemStack(itemstack1, 3, 30, false)) {
+                        return ItemStack.EMPTY;
+                    }
+                } else if (!this.mergeItemStack(itemstack1, 3, 39, false)) {
+                    return ItemStack.EMPTY;
+                }
+
+                if (itemstack1.isEmpty()) {
+                    slot.putStack(ItemStack.EMPTY);
+                } else {
+                    slot.onSlotChanged();
+                }
+
+                if (itemstack1.getCount() == itemstack.getCount()) {
+                    return ItemStack.EMPTY;
+                }
+
+                slot.onTake(playerIn, itemstack1);
+            }
+
+            return itemstack;
+        }
+
+        protected boolean func_217057_a(ItemStack p_217057_1_) {
+            return this.world.getRecipeManager().getRecipe(TestRecipe.test, new Inventory(p_217057_1_), this.world).isPresent();
+        }
+    }
+
+    private static class TestRecipe extends AbstractCookingRecipe {
+        private static final IRecipeType<TestRecipe> test = IRecipeType.register("test");
+
+        private TestRecipe(ResourceLocation idIn, String groupIn, Ingredient ingredientIn, ItemStack resultIn, float experienceIn, int cookTimeIn) {
+            super(test, idIn, groupIn, ingredientIn, resultIn, experienceIn, cookTimeIn);
+        }
+
+        @Override
+        public IRecipeSerializer<?> getSerializer() {
+            return test_recipe;
+        }
+    }
+
+    private static class TestRecipeSerializer<T extends AbstractCookingRecipe> extends net.minecraftforge.registries.ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<T> {
+        private final int field_222178_t;
+        private final IFactory<T> field_222179_u;
+
+        private TestRecipeSerializer(IFactory<T> p_i50025_1_, int p_i50025_2_) {
+            this.field_222178_t = p_i50025_2_;
+            this.field_222179_u = p_i50025_1_;
+        }
+
+        @Override
+        public T read(ResourceLocation recipeId, JsonObject json) {
+            String s = JSONUtils.getString(json, "group", "");
+            JsonElement jsonelement = (JsonElement)(JSONUtils.isJsonArray(json, "ingredient") ? JSONUtils.getJsonArray(json, "ingredient") : JSONUtils.getJsonObject(json, "ingredient"));
+            Ingredient ingredient = Ingredient.deserialize(jsonelement);
+            //Forge: Check if primitive string to keep vanilla or a object which can contain a count field.
+            if (!json.has("result")) throw new com.google.gson.JsonSyntaxException("Missing result, expected to find a string or object");
+            ItemStack itemstack;
+            if (json.get("result").isJsonObject()) itemstack = ShapedRecipe.deserializeItem(JSONUtils.getJsonObject(json, "result"));
+            else {
+                String s1 = JSONUtils.getString(json, "result");
+                ResourceLocation resourcelocation = new ResourceLocation(s1);
+                itemstack = new ItemStack(Registry.ITEM.getValue(resourcelocation).orElseThrow(() -> {
+                    return new IllegalStateException("Item: " + s1 + " does not exist");
+                }));
+            }
+            float f = JSONUtils.getFloat(json, "experience", 0.0F);
+            int i = JSONUtils.getInt(json, "cookingtime", this.field_222178_t);
+            return this.field_222179_u.create(recipeId, s, ingredient, itemstack, f, i);
+        }
+
+        @Override
+        public T read(ResourceLocation recipeId, PacketBuffer buffer) {
+            String s = buffer.readString(32767);
+            Ingredient ingredient = Ingredient.read(buffer);
+            ItemStack itemstack = buffer.readItemStack();
+            float f = buffer.readFloat();
+            int i = buffer.readVarInt();
+            return this.field_222179_u.create(recipeId, s, ingredient, itemstack, f, i);
+        }
+
+        @Override
+        public void write(PacketBuffer buffer, T recipe) {
+            buffer.writeString(recipe.getGroup());
+            recipe.getIngredients().get(0).write(buffer);
+            buffer.writeItemStack(recipe.getRecipeOutput());
+            buffer.writeFloat(recipe.getExperience());
+            buffer.writeVarInt(recipe.getCookTime());
+        }
+
+        interface IFactory<T extends AbstractCookingRecipe> {
+            T create(ResourceLocation p_create_1_, String p_create_2_, Ingredient p_create_3_, ItemStack p_create_4_, float p_create_5_, int p_create_6_);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -72,3 +72,5 @@ loaderVersion="[28,)"
     modId="player_name_event_test"
 [[mods]]
     modId="custom_elytra_test"
+[[mods]]
+    modId="base_crafting_book_test"

--- a/src/test/resources/data/base_crafting_book_test/advancements/elytra.json
+++ b/src/test/resources/data/base_crafting_book_test/advancements/elytra.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "base_crafting_book_test:elytra"
+    ]
+  },
+  "criteria": {
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:leather"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "base_crafting_book_test:elytra"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_planks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/test/resources/data/base_crafting_book_test/advancements/sugar.json
+++ b/src/test/resources/data/base_crafting_book_test/advancements/sugar.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "base_crafting_book_test:sugar"
+    ]
+  },
+  "criteria": {
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:sugar_cane"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "base_crafting_book_test:sugar"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_planks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/test/resources/data/base_crafting_book_test/recipes/elytra.json
+++ b/src/test/resources/data/base_crafting_book_test/recipes/elytra.json
@@ -1,0 +1,9 @@
+{
+  "type": "base_crafting_book_test:test_recipe",
+  "ingredient": {
+    "item": "minecraft:leather"
+  },
+  "result": "minecraft:elytra",
+  "experience": 0.35,
+  "cookingtime": 200
+}

--- a/src/test/resources/data/base_crafting_book_test/recipes/sugar.json
+++ b/src/test/resources/data/base_crafting_book_test/recipes/sugar.json
@@ -1,0 +1,9 @@
+{
+  "type": "base_crafting_book_test:test_recipe",
+  "ingredient": {
+    "item": "minecraft:sugar_cane"
+  },
+  "result": "minecraft:sugar",
+  "experience": 0.35,
+  "cookingtime": 200
+}


### PR DESCRIPTION
New PR of force closed #6790 (fucked up rebase)

Basicaly allows modders to add recipe book into custom machines and add tabs into vanilla recipe book

- custom recipe book category can be registered via forge registries.
- constructor have `IRecipeType<?>` to set where recipe book category belongs
- modder can set if category is `search` - no filtering is applied for displayed recipes
- `setPredicate(IRecipe<?>)` non-search category with filtering
- `setIcon(ItemStack...)` recipe book category icon
```
    @SubscribeEvent
    public static void registerRecipeBookCategories(RegistryEvent.Register<RecipeBookCategories> event) {
        event.getRegistry().register(new RecipeBookCategories(TestRecipe.millstone).setSearch().setIcon(new ItemStack(Items.BELL)).setRegistryName("base_crafting_book_test", "test"));
    }
```
- Custom machine container must extends `RecipeBookContainer<C extends IInventory>` 
- Custom machine gui just render and handle recipe book as in e.g. AbstractFurnaceScreen