### PR TITLE
[1.18.x] Move .is check with ItemStack to the Item and expand on BookItem and EnchantedBookItem functionality

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -27,7 +27,7 @@
           if (!itemstack2.m_41619_()) {
 -            boolean flag = itemstack2.m_150930_(Items.f_42690_) && !EnchantedBookItem.m_41163_(itemstack2).isEmpty();
 +            if (!net.minecraftforge.common.ForgeHooks.onAnvilChange(this, itemstack, itemstack2, f_39768_, f_39001_, j, this.f_39771_)) return;
-+            flag = itemstack2.m_41720_() == Items.f_42690_ && !EnchantedBookItem.m_41163_(itemstack2).isEmpty();
++            flag = itemstack2.m_150930_(Items.f_42690_) && !EnchantedBookItem.m_41163_(itemstack2).isEmpty();
              if (itemstack1.m_41763_() && itemstack1.m_41720_().m_6832_(itemstack, itemstack2)) {
                 int l2 = Math.min(itemstack1.m_41773_(), itemstack1.m_41776_() / 4);
                 if (l2 <= 0) {

--- a/patches/minecraft/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -37,6 +37,15 @@
                 }
  
                 for(int l = 0; l < 3; ++l) {
+@@ -146,7 +_,7 @@
+                   p_39465_.m_7408_(itemstack, i);
+                   boolean flag = itemstack.m_150930_(Items.f_42517_);
+                   if (flag) {
+-                     itemstack2 = new ItemStack(Items.f_42690_);
++                     itemstack2 = ((net.minecraft.world.item.BookItem) itemstack.m_41720_()).createEnchantedBook(itemstack);
+                      CompoundTag compoundtag = itemstack.m_41783_();
+                      if (compoundtag != null) {
+                         itemstack2.m_41751_(compoundtag.m_6426_());
 @@ -235,7 +_,7 @@
              if (!this.m_38903_(itemstack1, 2, 38, true)) {
                 return ItemStack.f_41583_;

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -19,3 +19,12 @@
                 if (!ItemStack.m_41728_(itemstack, itemstack1)) {
                    this.f_39559_.m_6836_(0, ItemStack.f_41583_);
                    this.m_38946_();
+@@ -201,7 +_,7 @@
+       EnchantmentHelper.m_44865_(map, itemstack);
+       itemstack.m_41742_(0);
+       if (itemstack.m_150930_(Items.f_42690_) && map.size() == 0) {
+-         itemstack = new ItemStack(Items.f_42517_);
++         itemstack = ((net.minecraft.world.item.EnchantedBookItem) itemstack.m_41720_()).createUnenchantedBook(itemstack);
+          if (p_39580_.m_41788_()) {
+             itemstack.m_41714_(p_39580_.m_41786_());
+          }

--- a/patches/minecraft/net/minecraft/world/item/BookItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BookItem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/BookItem.java
++++ b/net/minecraft/world/item/BookItem.java
+@@ -12,4 +_,8 @@
+    public int m_6473_() {
+       return 1;
+    }
++
++   public ItemStack createEnchantedBook(ItemStack stack) {
++      return new ItemStack(Items.f_42690_);
++   }
+ }

--- a/patches/minecraft/net/minecraft/world/item/EnchantedBookItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/EnchantedBookItem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/EnchantedBookItem.java
++++ b/net/minecraft/world/item/EnchantedBookItem.java
+@@ -87,4 +_,8 @@
+       }
+ 
+    }
++
++   public ItemStack createUnenchantedBook(ItemStack stack) {
++      return new ItemStack(Items.f_42517_);
++   }
+ }

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -69,6 +69,15 @@
     }
  
     public boolean m_204117_(TagKey<Item> p_204118_) {
+@@ -198,7 +_,7 @@
+    }
+ 
+    public boolean m_150930_(Item p_150931_) {
+-      return this.m_41720_() == p_150931_;
++      return this.m_41720_().is(this, p_150931_);
+    }
+ 
+    public Stream<TagKey<Item>> m_204131_() {
 @@ -206,6 +_,15 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -9,6 +9,15 @@
        if (i <= 0) {
           return 0;
        } else {
+@@ -319,7 +_,7 @@
+       List<EnchantmentInstance> list = m_44909_(p_44878_, p_44879_, p_44880_, p_44881_);
+       boolean flag = p_44879_.m_150930_(Items.f_42517_);
+       if (flag) {
+-         p_44879_ = new ItemStack(Items.f_42690_);
++         p_44879_ = ((net.minecraft.world.item.BookItem) p_44879_.m_41720_()).createEnchantedBook(p_44879_);
+       }
+ 
+       for(EnchantmentInstance enchantmentinstance : list) {
 @@ -336,7 +_,7 @@
     public static List<EnchantmentInstance> m_44909_(Random p_44910_, ItemStack p_44911_, int p_44912_, boolean p_44913_) {
        List<EnchantmentInstance> list = Lists.newArrayList();

--- a/patches/minecraft/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java
++++ b/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java
+@@ -66,7 +_,7 @@
+    private static ItemStack m_80424_(ItemStack p_80425_, Enchantment p_80426_, Random p_80427_) {
+       int i = Mth.m_14072_(p_80427_, p_80426_.m_44702_(), p_80426_.m_6586_());
+       if (p_80425_.m_150930_(Items.f_42517_)) {
+-         p_80425_ = new ItemStack(Items.f_42690_);
++         p_80425_ = ((net.minecraft.world.item.BookItem) p_80425_.m_41720_()).createEnchantedBook(p_80425_);
+          EnchantedBookItem.m_41153_(p_80425_, new EnchantmentInstance(p_80426_, i));
+       } else {
+          p_80425_.m_41663_(p_80426_, i);

--- a/patches/minecraft/net/minecraft/world/level/storage/loot/functions/SetEnchantmentsFunction.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/loot/functions/SetEnchantmentsFunction.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/functions/SetEnchantmentsFunction.java
++++ b/net/minecraft/world/level/storage/loot/functions/SetEnchantmentsFunction.java
+@@ -53,7 +_,7 @@
+          object2intmap.put(p_165353_, p_165354_.m_142683_(p_165347_));
+       });
+       if (p_165346_.m_41720_() == Items.f_42517_) {
+-         ItemStack itemstack = new ItemStack(Items.f_42690_);
++         ItemStack itemstack = ((net.minecraft.world.item.BookItem) p_165346_.m_41720_()).createEnchantedBook(p_165346_);
+          object2intmap.forEach((p_165343_, p_165344_) -> {
+             EnchantedBookItem.m_41153_(itemstack, new EnchantmentInstance(p_165343_, p_165344_));
+          });

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -782,4 +782,20 @@ public interface IForgeItem
         return 0;
     }
 
+    /**
+     * Used to test if this item is "sufficiently equivalent" to another item.<br>
+     * Overriding this can be used to "impersonate" a particular item for certain comparison operations.<br>
+     * <br>
+     * "Sufficiently Equivalent" implies that this item is a drop-in replacement for the "other" item, and should be able to handle
+     * all operations the "other" item would need to. This requires being a subclass or instance of the "other" item's class.<br>
+     * <br>
+     * Contractually, returning true to this method implies <pre>other.getClass().isInstance(this) == true</pre>
+     *
+     * @param stack An ItemStack containing this item.
+     * @param other The Item being checked against.
+     * @return If this item is "sufficiently equivalent" to the other item.
+     */
+    default boolean is(ItemStack stack, Item other) {
+        return self() == other;
+    }
 }


### PR DESCRIPTION
Move the .is(Item) Check to the Item you are checking against allowing this to be modified on a per-item basis.

Implement the .is check in SetEnchantmentsFunction where it was currently an == check seems to have been missed by Mojang

Implement a method on BookItem and EnchantedBookItem for createEnchantedBook and createUnenchantedBook for mods to be able to expand on enchanted books and have compatibility with other mods