### PR TITLE
Track the active mod within DeferredWorkQueue

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -116,13 +116,13 @@ public abstract class ModContainer
             final Executor executor) {
         return CompletableFuture
                 .runAsync(() -> {
-                    ModLoadingContext.get().setActiveContainer(target, target.contextExtension.get());
+                    ModLoadingContext.get().setActiveContainer(target);
                     target.activityMap.getOrDefault(target.modLoadingStage, ()->{}).run();
                     target.acceptEvent(eventGenerator.apply(target));
                 }, executor)
                 .whenComplete((mc, exception) -> {
                     target.modLoadingStage = stateChangeHandler.apply(target.modLoadingStage, exception);
-                    ModLoadingContext.get().setActiveContainer(null, null);
+                    ModLoadingContext.get().setActiveContainer(null);
                 });
     }
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
@@ -36,9 +36,9 @@ public class ModLoadingContext
 
     private ModContainer activeContainer;
 
-    public void setActiveContainer(final ModContainer container, final Object languageExtension) {
+    public void setActiveContainer(final ModContainer container) {
         this.activeContainer = container;
-        this.languageExtension = languageExtension;
+        this.languageExtension = container == null ? null : container.contextExtension.get();
     }
 
     public ModContainer getActiveContainer() {

--- a/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
+++ b/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
@@ -40,10 +40,10 @@ public class ParallelDispatchEvent extends ModLifecycleEvent {
     }
 
     public CompletableFuture<Void> enqueueWork(Runnable work) {
-        return getQueue().map(q->q.enqueueWork(getContainer().getModInfo(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
+        return getQueue().map(q->q.enqueueWork(getContainer(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
     }
 
     public <T> CompletableFuture<T> enqueueWork(Supplier<T> work) {
-        return getQueue().map(q->q.enqueueWork(getContainer().getModInfo(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
+        return getQueue().map(q->q.enqueueWork(getContainer(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
     }
 }


### PR DESCRIPTION
When working with non-`ForgeRegistry` registries (such as `ArgumentType`), one needs to be careful to only interact with them on the main thread. To do this, mods either piggyback on another Registry event or use the `DeferredWorkQueue`.

My mod exposes an API which allows other mods to register upgrades. We use `ModLoadingContext.get().getActiveContainer()` to determine which mod registered an upgrade.

Unfortunately, using `DeferredWorkQueue` means you lose information about which mod tried to register something. This patch changes the queue to set the current mod container when running each task.

I'm aware this patch is probably a little contentious, and does involve several minor breaking changes (hence targetting 1.17). I just felt it was sufficiently useful that it was worth submitting.