### PR TITLE
[1.17.x] Add access transformer to make Features.Decorators class public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -187,6 +187,7 @@ protected net.minecraft.data.recipes.RecipeProvider m_126013_(Lnet/minecraft/dat
 protected net.minecraft.data.recipes.RecipeProvider m_176531_(Ljava/util/function/Consumer;)V # buildCraftingRecipes
 public net.minecraft.data.recipes.ShapedRecipeBuilder$Result
 protected net.minecraft.data.tags.TagsProvider f_126543_ # builders
+public net.minecraft.data.worldgen.Features$Decorators
 public net.minecraft.network.protocol.status.ClientboundStatusResponsePacket f_134885_ # GSON
 protected net.minecraft.server.MinecraftServer f_129726_ # nextTickTime
 public net.minecraft.server.dedicated.DedicatedServer f_139600_ # consoleInput


### PR DESCRIPTION
This adds an access transformer to make the `net.minecraft.data.worldgen.Features.Decorators` class public again, like it was in 1.16.x.

Fixes #7905.