### PR TITLE
[1.17.x] Add BER Registering to RegisterRenderers event

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -24,6 +24,8 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.geom.EntityModelSet;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.EntityRenderers;
@@ -32,6 +34,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -72,6 +76,17 @@ public class EntityRenderersEvent extends Event implements IModBusEvent
         public <T extends Entity> void registerEntityRenderer(EntityType<? extends T> entityType, EntityRendererProvider<T> entityRendererProvider)
         {
             EntityRenderers.register(entityType, entityRendererProvider);
+        }
+
+        /**
+         * Registers a block entity renderer.
+         *
+         * @param blockEntityType The BlockEntityType to register a renderer for
+         * @param blockEntityRendererProvider The renderer provider, can be a lambda like MyRenderer::new
+         */
+        public <T extends BlockEntity> void registerBlockEntityRenderer(BlockEntityType<? extends T> blockEntityType, BlockEntityRendererProvider<T> blockEntityRendererProvider)
+        {
+            BlockEntityRenderers.register(blockEntityType, blockEntityRendererProvider);
         }
     }
 


### PR DESCRIPTION
Block entity renderers fall into the same timezone as when EntityRenderers should be registered since they both require a context that borrows from the layer definition. This adds in an additional method to the event to support registering BERs at the same time because of their similarity.