### PR TITLE
[1.16.x] Extendible categories in recipe book

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
@@ -1,14 +1,115 @@
 --- a/net/minecraft/client/gui/recipebook/RecipeBookGui.java
 +++ b/net/minecraft/client/gui/recipebook/RecipeBookGui.java
-@@ -95,7 +_,7 @@
+@@ -95,13 +_,13 @@
        this.func_205702_a();
        this.field_193018_j.clear();
  
 -      for(RecipeBookCategories recipebookcategories : RecipeBookCategories.func_243236_a(this.field_201522_g.func_241850_m())) {
-+      for(RecipeBookCategories recipebookcategories : this.field_201522_g.getRecipeBookCategories()) {
++      for(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories : this.field_201522_g.getRecipeBookCategories()) {
           this.field_193018_j.add(new RecipeTabToggleWidget(recipebookcategories));
        }
  
+       if (this.field_191913_x != null) {
+          this.field_191913_x = this.field_193018_j.stream().filter((p_209505_1_) -> {
+-            return p_209505_1_.func_201503_d().equals(this.field_191913_x.func_201503_d());
++            return p_209505_1_.getRecipeBookCategory().equals(this.field_191913_x.getRecipeBookCategory());
+          }).findFirst().orElse((RecipeTabToggleWidget)null);
+       }
+ 
+@@ -111,7 +_,17 @@
+ 
+       this.field_191913_x.func_191753_b(true);
+       this.func_193003_g(false);
++      this.field_193018_j.removeIf(tabToggleWidget -> this.field_193964_s.getRecipes(tabToggleWidget.getRecipeBookCategory()).stream().noneMatch(recipeList -> recipeList.func_194209_a() && recipeList.func_194212_c()));
+       this.func_193949_f();
++      this.up = new net.minecraftforge.client.UpDownButton(i - 23, j + 1, 17, 11, false, p_onPress_1_ -> {
++         this.offset = Math.max(0, this.offset - 1);
++         this.updateButtons();
++      });
++      this.down = new net.minecraftforge.client.UpDownButton(i - 23, j + 154, 17, 11, true, p_onPress_1_ -> {
++         this.offset = Math.min(this.field_193018_j.size() - 5, this.offset + 1);
++         this.updateButtons();
++      });
++      this.updateButtons();
+    }
+ 
+    public boolean func_231049_c__(boolean p_231049_1_) {
+@@ -126,6 +_,8 @@
+       this.field_193962_q = null;
+       this.field_191913_x = null;
+       this.field_191888_F.field_195559_v.func_197967_a(false);
++      this.up = null;
++      this.down = null;
+    }
+ 
+    public int func_193011_a(boolean p_193011_1_, int p_193011_2_, int p_193011_3_) {
+@@ -167,10 +_,13 @@
+    }
+ 
+    private void func_193003_g(boolean p_193003_1_) {
+-      List<RecipeList> list = this.field_193964_s.func_202891_a(this.field_191913_x.func_201503_d());
+-      list.forEach((p_193944_1_) -> {
+-         p_193944_1_.func_194210_a(this.field_193965_u, this.field_201522_g.func_201770_g(), this.field_201522_g.func_201772_h(), this.field_193964_s);
+-      });
++      for (net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> category : net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues()) {
++         List<RecipeList> list = this.field_193964_s.getRecipes(category);
++         list.forEach((p_193944_1_) -> {
++            p_193944_1_.func_194210_a(this.field_193965_u, this.field_201522_g.func_201770_g(), this.field_201522_g.func_201772_h(), this.field_193964_s);
++         });
++      }
++      List<RecipeList> list = this.field_193964_s.getRecipes(this.field_191913_x.getRecipeBookCategory());
+       List<RecipeList> list1 = Lists.newArrayList(list);
+       list1.removeIf((p_193952_0_) -> {
+          return !p_193952_0_.func_194209_a();
+@@ -197,13 +_,15 @@
+ 
+    private void func_193949_f() {
+       int i = (this.field_191904_o - 147) / 2 - this.field_191903_n - 30;
+-      int j = (this.field_191905_p - 166) / 2 + 3;
++      int j = (this.field_191905_p - 166) / 2 + (this.field_193018_j.size() > 5 ? 16 : 3);
+       int k = 27;
+       int l = 0;
+ 
++      int x = 0;
+       for(RecipeTabToggleWidget recipetabtogglewidget : this.field_193018_j) {
+-         RecipeBookCategories recipebookcategories = recipetabtogglewidget.func_201503_d();
+-         if (recipebookcategories != RecipeBookCategories.CRAFTING_SEARCH && recipebookcategories != RecipeBookCategories.FURNACE_SEARCH) {
++         if (x >= this.offset && x < Math.min(this.field_193018_j.size(), this.offset + 5)) {
++            net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories = recipetabtogglewidget.getRecipeBookCategory();
++         if (!recipebookcategories.isUnfiltered()) {
+             if (recipetabtogglewidget.func_199500_a(this.field_193964_s)) {
+                recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
+                recipetabtogglewidget.func_193918_a(this.field_191888_F);
+@@ -212,6 +_,10 @@
+             recipetabtogglewidget.field_230694_p_ = true;
+             recipetabtogglewidget.func_191752_c(i, j + 27 * l++);
+          }
++         } else {
++            recipetabtogglewidget.field_230694_p_ = false;
++         }
++         x++;
+       }
+ 
+    }
+@@ -255,6 +_,8 @@
+ 
+          this.field_193960_m.func_230430_a_(p_230430_1_, p_230430_2_, p_230430_3_, p_230430_4_);
+          this.field_193022_s.func_238927_a_(p_230430_1_, i, j, p_230430_2_, p_230430_3_, p_230430_4_);
++         this.up.func_230430_a_(p_230430_1_, p_230430_2_, p_230430_3_, p_230430_4_);
++         this.down.func_230430_a_(p_230430_1_, p_230430_2_, p_230430_3_, p_230430_4_);
+          RenderSystem.popMatrix();
+       }
+    }
+@@ -323,6 +_,9 @@
+             return true;
+          } else if (this.field_193962_q.func_231044_a_(p_231044_1_, p_231044_3_, p_231044_5_)) {
+             return true;
++         } else if (this.up.func_231044_a_(p_231044_1_, p_231044_3_, p_231044_5_) || this.down.func_231044_a_(p_231044_1_, p_231044_3_, p_231044_5_)) {
++            this.func_193949_f();
++            return true;
+          } else if (this.field_193960_m.func_231044_a_(p_231044_1_, p_231044_3_, p_231044_5_)) {
+             boolean flag = this.func_201521_f();
+             this.field_193960_m.func_191753_b(flag);
 @@ -434,7 +_,7 @@
  
           languagemanager.func_135045_a(language);
@@ -18,3 +119,28 @@
           this.field_191888_F.field_71474_y.func_74303_b();
        }
  
+@@ -449,7 +_,7 @@
+       if (this.func_191878_b()) {
+          this.func_193003_g(false);
+       }
+-
++      this.updateButtons();
+    }
+ 
+    public void func_193001_a(List<IRecipe<?>> p_193001_1_) {
+@@ -484,4 +_,15 @@
+       }
+ 
+    }
++
++   /*================================ FORGE START ================================================*/
++   private net.minecraftforge.client.UpDownButton up;
++   private net.minecraftforge.client.UpDownButton down;
++   private int offset;
++
++   private void updateButtons() {
++      this.up.field_230694_p_ = this.offset > 0 && this.field_193018_j.size() > 5;
++      this.down.field_230694_p_ = this.field_193018_j.size() > 5 && this.offset < this.field_193018_j.size() - 5;
++   }
++   /*================================ FORGE END ================================================*/
+ }

--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java.patch
@@ -1,0 +1,68 @@
+--- a/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java
++++ b/net/minecraft/client/gui/recipebook/RecipeTabToggleWidget.java
+@@ -16,18 +_,19 @@
+ 
+ @OnlyIn(Dist.CLIENT)
+ public class RecipeTabToggleWidget extends ToggleWidget {
+-   private RecipeBookCategories field_193921_u;
++   @Deprecated private RecipeBookCategories field_193921_u; // use recipeBookCategory instead
+    private float field_193922_v;
+ 
++   @Deprecated // use RecipeTabToggleWidget(IForgeRecipeBookCategory) instead
+    public RecipeTabToggleWidget(RecipeBookCategories p_i51075_1_) {
+       super(0, 0, 35, 27, false);
+-      this.field_193921_u = p_i51075_1_;
++      this.recipeBookCategory = p_i51075_1_;
+       this.func_191751_a(153, 2, 35, 0, RecipeBookGui.field_191894_a);
+    }
+ 
+    public void func_193918_a(Minecraft p_193918_1_) {
+       ClientRecipeBook clientrecipebook = p_193918_1_.field_71439_g.func_199507_B();
+-      List<RecipeList> list = clientrecipebook.func_202891_a(this.field_193921_u);
++      List<RecipeList> list = clientrecipebook.getRecipes(this.recipeBookCategory);
+       if (p_193918_1_.field_71439_g.field_71070_bA instanceof RecipeBookContainer) {
+          for(RecipeList recipelist : list) {
+             for(IRecipe<?> irecipe : recipelist.func_194208_a(clientrecipebook.func_242141_a((RecipeBookContainer)p_193918_1_.field_71439_g.field_71070_bA))) {
+@@ -80,7 +_,7 @@
+    }
+ 
+    private void func_193920_a(ItemRenderer p_193920_1_) {
+-      List<ItemStack> list = this.field_193921_u.func_202903_a();
++      List<ItemStack> list = this.recipeBookCategory.getIcon();
+       int i = this.field_191755_p ? -2 : 0;
+       if (list.size() == 1) {
+          p_193920_1_.func_239390_c_(list.get(0), this.field_230690_l_ + 9 + i, this.field_230691_m_ + 5);
+@@ -91,12 +_,13 @@
+ 
+    }
+ 
++   @Deprecated // use getRecipeBookCategory() instead
+    public RecipeBookCategories func_201503_d() {
+       return this.field_193921_u;
+    }
+ 
+    public boolean func_199500_a(ClientRecipeBook p_199500_1_) {
+-      List<RecipeList> list = p_199500_1_.func_202891_a(this.field_193921_u);
++      List<RecipeList> list = p_199500_1_.getRecipes(this.recipeBookCategory);
+       this.field_230694_p_ = false;
+       if (list != null) {
+          for(RecipeList recipelist : list) {
+@@ -109,4 +_,18 @@
+ 
+       return this.field_230694_p_;
+    }
++   
++   /*================================ FORGE START ================================================*/
++   private final net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipeBookCategory;
++
++   public RecipeTabToggleWidget(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> p_i51075_1_) {
++      super(0, 0, 35, 27, false);
++      this.recipeBookCategory = p_i51075_1_;
++      this.func_191751_a(153, 2, 35, 0, RecipeBookGui.field_191894_a);
++   }
++
++   public net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> getRecipeBookCategory() {
++      return this.recipeBookCategory;
++   }
++   /*================================ FORGE END ================================================*/
+ }

--- a/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/ClientRecipeBook.java.patch
@@ -1,0 +1,104 @@
+--- a/net/minecraft/client/util/ClientRecipeBook.java
++++ b/net/minecraft/client/util/ClientRecipeBook.java
+@@ -26,48 +_,51 @@
+ @OnlyIn(Dist.CLIENT)
+ public class ClientRecipeBook extends RecipeBook {
+    private static final Logger field_241555_k_ = LogManager.getLogger();
+-   private Map<RecipeBookCategories, List<RecipeList>> field_197931_e = ImmutableMap.of();
++   @Deprecated private Map<RecipeBookCategories, List<RecipeList>> field_197931_e = ImmutableMap.of(); // use forgeRecipeBookCategories instead
+    private List<RecipeList> field_197932_f = ImmutableList.of();
+ 
+    public void func_243196_a(Iterable<IRecipe<?>> p_243196_1_) {
+-      Map<RecipeBookCategories, List<List<IRecipe<?>>>> map = func_243201_b(p_243196_1_);
+-      Map<RecipeBookCategories, List<RecipeList>> map1 = Maps.newHashMap();
++      Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<List<IRecipe<?>>>> map = func_243201_b(p_243196_1_);
++      Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<RecipeList>> map1 = Maps.newHashMap();
+       Builder<RecipeList> builder = ImmutableList.builder();
+       map.forEach((p_243197_2_, p_243197_3_) -> {
+          List list = map1.put(p_243197_2_, p_243197_3_.stream().map(RecipeList::new).peek(builder::add).collect(ImmutableList.toImmutableList()));
+       });
+-      RecipeBookCategories.field_243235_w.forEach((p_243199_1_, p_243199_2_) -> {
++      /*RecipeBookCategories.AGGREGATE_CATEGORIES.forEach((p_243199_1_, p_243199_2_) -> {
+          List list = map1.put(p_243199_1_, p_243199_2_.stream().flatMap((p_243198_1_) -> {
+             return map1.getOrDefault(p_243198_1_, ImmutableList.of()).stream();
+          }).collect(ImmutableList.toImmutableList()));
+-      });
+-      this.field_197931_e = ImmutableMap.copyOf(map1);
++      });*/
++      this.forgeRecipeBookCategories = ImmutableMap.copyOf(map1);
+       this.field_197932_f = builder.build();
+    }
+ 
+-   private static Map<RecipeBookCategories, List<List<IRecipe<?>>>> func_243201_b(Iterable<IRecipe<?>> p_243201_0_) {
+-      Map<RecipeBookCategories, List<List<IRecipe<?>>>> map = Maps.newHashMap();
+-      Table<RecipeBookCategories, String, List<IRecipe<?>>> table = HashBasedTable.create();
++   private static Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<List<IRecipe<?>>>> func_243201_b(Iterable<IRecipe<?>> p_243201_0_) {
++      Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<List<IRecipe<?>>>> map = Maps.newHashMap();
++      Table<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, String, List<IRecipe<?>>> table = HashBasedTable.create();
+ 
+       for(IRecipe<?> irecipe : p_243201_0_) {
+          if (!irecipe.func_192399_d()) {
+-            RecipeBookCategories recipebookcategories = func_202887_g(irecipe);
+-            String s = irecipe.func_193358_e();
+-            if (s.isEmpty()) {
+-               map.computeIfAbsent(recipebookcategories, (p_243202_0_) -> {
+-                  return Lists.newArrayList();
+-               }).add(ImmutableList.of(irecipe));
+-            } else {
+-               List<IRecipe<?>> list = table.get(recipebookcategories, s);
+-               if (list == null) {
+-                  list = Lists.newArrayList();
+-                  table.put(recipebookcategories, s, list);
+-                  map.computeIfAbsent(recipebookcategories, (p_202890_0_) -> {
+-                     return Lists.newArrayList();
+-                  }).add(list);
++            for (net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> recipebookcategories : net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues()) {
++               if (recipebookcategories.getRecipeType() == irecipe.func_222127_g() && (recipebookcategories.isUnfiltered() || !recipebookcategories.isUnfiltered() && recipebookcategories.getPredicate().test(irecipe))) {
++                  String s = irecipe.func_193358_e();
++                  if (s.isEmpty()) {
++                     map.computeIfAbsent(recipebookcategories, (p_243202_0_) -> {
++                        return Lists.newArrayList();
++                     }).add(ImmutableList.of(irecipe));
++                  } else {
++                     List<IRecipe<?>> list = table.get(recipebookcategories, s);
++                     if (list == null) {
++                        list = Lists.newArrayList();
++                        table.put(recipebookcategories, s, list);
++                        map.computeIfAbsent(recipebookcategories, (p_202890_0_) -> {
++                           return Lists.newArrayList();
++                        }).add(list);
++                     }
++
++                     list.add(irecipe);
++                  }
+                }
+-
+-               list.add(irecipe);
+             }
+          }
+       }
+@@ -75,6 +_,7 @@
+       return map;
+    }
+ 
++   @Deprecated
+    private static RecipeBookCategories func_202887_g(IRecipe<?> p_202887_0_) {
+       IRecipeType<?> irecipetype = p_202887_0_.func_222127_g();
+       if (irecipetype == IRecipeType.field_222149_a) {
+@@ -116,6 +_,14 @@
+    }
+ 
+    public List<RecipeList> func_202891_a(RecipeBookCategories p_202891_1_) {
+-      return this.field_197931_e.getOrDefault(p_202891_1_, Collections.emptyList());
+-   }
++      return this.forgeRecipeBookCategories.getOrDefault(p_202891_1_, Collections.emptyList());
++   }
++   
++   /*================================ FORGE START ================================================*/
++   private Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, List<RecipeList>> forgeRecipeBookCategories = Maps.newHashMap();
++
++   public List<RecipeList> getRecipes(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> forgeRecipeBookCategory) {
++      return this.forgeRecipeBookCategories.getOrDefault(forgeRecipeBookCategory, Collections.emptyList());
++   }
++   /*================================ FORGE END ================================================*/
+ }

--- a/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeBookCategories.java.patch
@@ -1,0 +1,193 @@
+--- a/net/minecraft/client/util/RecipeBookCategories.java
++++ b/net/minecraft/client/util/RecipeBookCategories.java
+@@ -12,7 +_,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public enum RecipeBookCategories {
++public enum RecipeBookCategories implements net.minecraftforge.common.extensions.IForgeRecipeBookCategory<net.minecraft.item.crafting.IRecipeType<?>> {
+    CRAFTING_SEARCH(new ItemStack(Items.field_151111_aL)),
+    CRAFTING_BUILDING_BLOCKS(new ItemStack(Blocks.field_196584_bK)),
+    CRAFTING_REDSTONE(new ItemStack(Items.field_151137_ax)),
+@@ -61,4 +_,181 @@
+    public List<ItemStack> func_202903_a() {
+       return this.field_202904_j;
+    }
++
++   /*================================ FORGE START ================================================*/
++   private net.minecraft.util.ResourceLocation registryName;
++   private boolean isUnfiltered;
++   private net.minecraft.item.crafting.IRecipeType<?> recipeType;
++   private java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate;
++   private final com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> token = new com.google.common.reflect.TypeToken<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>>(getClass()){};
++
++   public static void registerCategories() {
++      java.util.Arrays.stream(RecipeBookCategories.values()).filter((category) -> category != RecipeBookCategories.UNKNOWN).forEach((category) -> {
++         switch (category) {
++            case CRAFTING_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222149_a);
++               break;
++            case CRAFTING_BUILDING_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::buildingBlocksPredicate);
++               break;
++            case CRAFTING_REDSTONE:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::redstonePredicate);
++               break;
++            case CRAFTING_EQUIPMENT:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::equipmentPredicate);
++               break;
++            case CRAFTING_MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222149_a, RecipeBookCategories::miscPredicate);
++               break;
++            case FURNACE_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222150_b);
++               break;
++            case FURNACE_FOOD:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::foodPredicate);
++               break;
++            case FURNACE_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::furnaceBlocksPredicate);
++               break;
++            case FURNACE_MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222150_b, RecipeBookCategories::furnaceMiscPredicate);
++               break;
++            case BLAST_FURNACE_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222151_c);
++               break;
++            case BLAST_FURNACE_BLOCKS:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222151_c, RecipeBookCategories::blastFurnaceBlocksPredicate);
++               break;
++            case BLAST_FURNACE_MISC:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222151_c, RecipeBookCategories::blastFurnaceMiscPredicate);
++               break;
++            case SMOKER_SEARCH:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222152_d);
++               break;
++            case SMOKER_FOOD:
++               category.setupFilter(net.minecraft.item.crafting.IRecipeType.field_222152_d, RecipeBookCategories::foodPredicate);
++               break;
++            case STONECUTTER:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222154_f);
++               break;
++            case CAMPFIRE:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_222153_e);
++               break;
++            case SMITHING:
++               category.setupSearch(net.minecraft.item.crafting.IRecipeType.field_234827_g_);
++               break;
++         }
++
++         register(category, category.name().toLowerCase());
++      });
++   }
++
++   @Override
++   public final RecipeBookCategories setRegistryName(net.minecraft.util.ResourceLocation name) {
++      return setRegistryName(name.toString());
++   }
++
++   @javax.annotation.Nullable
++   @Override
++   public net.minecraft.util.ResourceLocation getRegistryName() {
++      return registryName;
++   }
++
++   @Override
++   public Class<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>> getRegistryType() {
++      return (Class<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<? extends net.minecraft.item.crafting.IRecipeType<?>>>)token.getRawType();
++   }
++
++   public final RecipeBookCategories setRegistryName(String modID, String name) {
++      return setRegistryName(modID + ":" + name);
++   }
++
++   public final RecipeBookCategories setRegistryName(String name) {
++      if (getRegistryName() != null) {
++         throw new IllegalStateException("Attempted to set registry name with existing registry name! New: " + name + " Old: " + getRegistryName());
++      }
++
++      this.registryName = net.minecraftforge.registries.GameData.checkPrefix(name, true);
++      return this;
++   }
++
++   public List<ItemStack> getIcon() {
++      return this.field_202904_j;
++   }
++
++   @Override
++   public boolean isUnfiltered() {
++      return isUnfiltered;
++   }
++
++   @Override
++   public java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> getPredicate() {
++      return predicate;
++   }
++
++   @Override
++   public net.minecraft.item.crafting.IRecipeType<?> getRecipeType() {
++      return recipeType;
++   }
++
++   private void setupSearch(net.minecraft.item.crafting.IRecipeType<?> recipeType) {
++      this.isUnfiltered = true;
++      this.predicate = recipe -> true;
++      this.recipeType = recipeType;
++   }
++
++   private void setupFilter(net.minecraft.item.crafting.IRecipeType<?> recipeType, java.util.function.Predicate<net.minecraft.item.crafting.IRecipe<?>> predicate) {
++      this.isUnfiltered = false;
++      this.predicate = predicate;
++      this.recipeType = recipeType;
++   }
++
++   private static void register(RecipeBookCategories category, String resourceName) {
++      category.setRegistryName(resourceName);
++      net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.register(category);
++   }
++
++   private static boolean buildingBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78030_b;
++   }
++
++   private static boolean redstonePredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78028_d;
++   }
++
++   private static boolean miscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup != net.minecraft.item.ItemGroup.field_78028_d && itemgroup != net.minecraft.item.ItemGroup.field_78040_i && itemgroup != net.minecraft.item.ItemGroup.field_78037_j;
++   }
++
++   private static boolean equipmentPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      ItemStack itemstack = recipe.func_77571_b();
++      net.minecraft.item.ItemGroup itemgroup = itemstack.func_77973_b().func_77640_w();
++      return itemgroup == net.minecraft.item.ItemGroup.field_78040_i || itemgroup == net.minecraft.item.ItemGroup.field_78037_j;
++   }
++
++   private static boolean foodPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return recipe.func_77571_b().func_77973_b().func_219971_r();
++   }
++
++   private static boolean furnaceBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !recipe.func_77571_b().func_77973_b().func_219971_r() && recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem;
++   }
++
++   private static boolean furnaceMiscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !recipe.func_77571_b().func_77973_b().func_219971_r() && !(recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem);
++   }
++
++   private static boolean blastFurnaceBlocksPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem;
++   }
++
++   private static boolean blastFurnaceMiscPredicate(net.minecraft.item.crafting.IRecipe<?> recipe) {
++      return !(recipe.func_77571_b().func_77973_b() instanceof net.minecraft.item.BlockItem);
++   }
++   /*================================ FORGE END ================================================*/
+ }

--- a/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
@@ -1,13 +1,74 @@
 --- a/net/minecraft/inventory/container/RecipeBookContainer.java
 +++ b/net/minecraft/inventory/container/RecipeBookContainer.java
-@@ -33,6 +_,10 @@
-    @OnlyIn(Dist.CLIENT)
-    public abstract int func_203721_h();
+@@ -35,4 +_,71 @@
  
-+   public java.util.List<net.minecraft.client.util.RecipeBookCategories> getRecipeBookCategories() {
-+      return net.minecraft.client.util.RecipeBookCategories.func_243236_a(this.func_241850_m());
-+   }
-+
     @OnlyIn(Dist.CLIENT)
     public abstract RecipeBookCategory func_241850_m();
++   
++   /*================================ FORGE START ================================================*/
++   public net.minecraft.item.crafting.IRecipeType<?> getRecipeType() {
++      if (this instanceof FurnaceContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222150_b;
++      } else if (this instanceof SmokerContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222152_d;
++      } else if (this instanceof BlastFurnaceContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222151_c;
++      } else if (this instanceof PlayerContainer || this instanceof WorkbenchContainer) {
++         return net.minecraft.item.crafting.IRecipeType.field_222149_a;
++      } else {
++         throw new IllegalStateException("Unexpected RecipeBookContainer override, please override this method in your own class!");
++      }
++   }
++
++   public java.util.List<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>> getRecipeBookCategories() {
++      return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
++         return category.getRecipeType().equals(this.getRecipeType());
++      }).sorted(RecipeBookContainer::compareTo).collect(java.util.stream.Collectors.toList());
++   }
++
++   private static final java.util.Map<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>, Integer> VANILLA_LIST  = new java.util.HashMap<>();
++
++   private static int compareTo(net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> from, net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?> to) {
++      if (from.equals(to)) {
++         return 0;
++      }
++
++      Integer thisValue = VANILLA_LIST.get(from);
++      Integer toValue = VANILLA_LIST.get(to);
++
++      if (thisValue == null && toValue == null) {
++         if (from.getRegistryName() != null) {
++            return from.getRegistryName().compareTo(to.getRegistryName());
++         } else {
++            return (from.hashCode() > to.hashCode()) ? 1 : -1;
++         }
++      } else if (thisValue == null) {
++         return 1;
++      } else if (toValue == null){
++         return -1;
++      }
++
++      return Integer.compare(thisValue, toValue);
++   }
++
++   static {
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CRAFTING_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CRAFTING_BUILDING_BLOCKS, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CRAFTING_REDSTONE, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CRAFTING_EQUIPMENT, 40);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CRAFTING_MISC, 50);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_FOOD, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_BLOCKS, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.FURNACE_MISC, 40);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_BLOCKS, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.BLAST_FURNACE_MISC, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SMOKER_SEARCH, 10);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SMOKER_FOOD, 20);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.STONECUTTER, 30);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.CAMPFIRE, 40);
++      VANILLA_LIST.put(net.minecraft.client.util.RecipeBookCategories.SMITHING, 50);
++   }
++   /*================================ FORGE END ================================================*/
  }

--- a/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
@@ -11,11 +11,12 @@
  public abstract class Registry<T> implements Codec<T>, Keyable, IObjectIntIterable<T> {
     protected static final Logger field_212616_e = LogManager.getLogger();
     private static final Map<ResourceLocation, Supplier<?>> field_218376_a = Maps.newLinkedHashMap();
-@@ -133,43 +_,43 @@
+@@ -133,43 +_,44 @@
     public static final RegistryKey<Registry<DimensionType>> field_239698_ad_ = func_239741_a_("dimension_type");
     public static final RegistryKey<Registry<World>> field_239699_ae_ = func_239741_a_("dimension");
     public static final RegistryKey<Registry<Dimension>> field_239700_af_ = func_239741_a_("dimension");
 -   public static final Registry<SoundEvent> field_212633_v = func_239746_a_(field_239708_i_, () -> {
++   public static final RegistryKey<Registry<net.minecraftforge.common.extensions.IForgeRecipeBookCategory<?>>> RECIPE_BOOK_CATEGORIES_REGISTRY = func_239741_a_("recipe_book_categories");
 +   @Deprecated public static final Registry<SoundEvent> field_212633_v = forge(field_239708_i_, () -> {
        return SoundEvents.field_187638_cR;
     });

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -39,6 +39,7 @@ public class UpDownButton extends Button {
         this.renderBg(matrixStack, minecraft, mouseX, mouseY);
     }
 
+    // re-implemented blit function for rotating and mirroring texture
     public void blit(int x, int y, int u, int v, int w, int h) {
         blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
     }

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.StringTextComponent;
+
+import javax.annotation.Nonnull;
+
+public class UpDownButton extends Button {
+    public static final ResourceLocation STATS_ICON_LOCATION = new ResourceLocation("textures/gui/recipe_book.png");
+    private final boolean isDown;
+
+    public UpDownButton(int x, int y, int width, int height, boolean isDown, IPressable onPress) {
+        super(x, y, width, height, new StringTextComponent(""), onPress);
+        this.isDown = isDown;
+    }
+
+    @Override
+    public void renderButton(@Nonnull MatrixStack matrixStack, int mouseX, int mouseY, float partial) {
+        Minecraft minecraft = Minecraft.getInstance();
+        minecraft.getTextureManager().bind(STATS_ICON_LOCATION);
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, this.alpha);
+        int i = (isHovered) ? 1 : 0;
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        if (isDown) {
+            blit(this.x, this.y, 1, 208 + i * 18, 11, 17);
+        } else {
+            blit(this.x, this.y, 15, 208 + i * 18, 11, 17);
+        }
+        this.renderBg(matrixStack, minecraft, mouseX, mouseY);
+    }
+
+    public void blit(int x, int y, int u, int v, int w, int h) {
+        blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
+    }
+
+    public static void blit(int x, int y, int blitOffset, float u, float v, int w, int h, int textureW, int textureH) {
+        innerBlit(x, x + h, y, y + w, blitOffset, w, h, u, v, textureH, textureW);
+    }
+
+    private static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, int w, int h, float u, float v, int textureW, int textureH) {
+        innerBlit(minX, maxX, minY, maxY, blitOffset, u / textureW, (u + w) / textureW, v / textureH, (v + h) / textureH);
+    }
+
+    protected static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, float minU, float maxU, float minV, float maxV) {
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder bufferBuilder = tessellator.getBuilder();
+        bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
+        bufferBuilder.vertex(minX, maxY, blitOffset).uv(maxU, minV).endVertex();
+        bufferBuilder.vertex(maxX, maxY, blitOffset).uv(maxU, maxV).endVertex();
+        bufferBuilder.vertex(maxX, minY, blitOffset).uv(minU, maxV).endVertex();
+        bufferBuilder.vertex(minX, minY, blitOffset).uv(minU, minV).endVertex();
+        tessellator.end();
+    }
+}

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -48,6 +48,7 @@ public class UpDownButton extends Button {
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        RenderSystem.disableCull();
         matrixStack.pushPose();
         matrixStack.translate(x, y, 0);
         matrixStack.scale(-1, 1, 1);
@@ -62,6 +63,7 @@ public class UpDownButton extends Button {
         }
         matrixStack.popPose();
         matrixStack.popPose();
+        RenderSystem.enableCull();
         this.renderBg(matrixStack, minecraft, mouseX, mouseY);
     }
 }

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client;
 
 import com.mojang.blaze3d.matrix.MatrixStack;

--- a/src/main/java/net/minecraftforge/client/UpDownButton.java
+++ b/src/main/java/net/minecraftforge/client/UpDownButton.java
@@ -5,10 +5,8 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.widget.button.Button;
-import net.minecraft.client.renderer.BufferBuilder;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.util.text.StringTextComponent;
 
 import javax.annotation.Nonnull;
@@ -31,35 +29,20 @@ public class UpDownButton extends Button {
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        matrixStack.pushPose();
+        matrixStack.translate(x, y, 0);
+        matrixStack.scale(-1, 1, 1);
+        matrixStack.pushPose();
+        matrixStack.translate(5.5f, 8.5f, 0.0f);
+        matrixStack.mulPose(Vector3f.ZP.rotationDegrees(90f));
+        matrixStack.translate(-8.5f, 5.5f, 0.0f);
         if (isDown) {
-            blit(this.x, this.y, 1, 208 + i * 18, 11, 17);
+            blit(matrixStack, 0, 0, 1, 208 + i * 18, 11, 17);
         } else {
-            blit(this.x, this.y, 15, 208 + i * 18, 11, 17);
+            blit(matrixStack, 0, 0, 15, 208 + i * 18, 11, 17);
         }
+        matrixStack.popPose();
+        matrixStack.popPose();
         this.renderBg(matrixStack, minecraft, mouseX, mouseY);
-    }
-
-    // re-implemented blit function for rotating and mirroring texture
-    public void blit(int x, int y, int u, int v, int w, int h) {
-        blit(x, y, 0, (float)u, (float)v, w, h, 256, 256);
-    }
-
-    public static void blit(int x, int y, int blitOffset, float u, float v, int w, int h, int textureW, int textureH) {
-        innerBlit(x, x + h, y, y + w, blitOffset, w, h, u, v, textureH, textureW);
-    }
-
-    private static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, int w, int h, float u, float v, int textureW, int textureH) {
-        innerBlit(minX, maxX, minY, maxY, blitOffset, u / textureW, (u + w) / textureW, v / textureH, (v + h) / textureH);
-    }
-
-    protected static void innerBlit(int minX, int maxX, int minY, int maxY, int blitOffset, float minU, float maxU, float minV, float maxV) {
-        Tessellator tessellator = Tessellator.getInstance();
-        BufferBuilder bufferBuilder = tessellator.getBuilder();
-        bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
-        bufferBuilder.vertex(minX, maxY, blitOffset).uv(maxU, minV).endVertex();
-        bufferBuilder.vertex(maxX, maxY, blitOffset).uv(maxU, maxV).endVertex();
-        bufferBuilder.vertex(maxX, minY, blitOffset).uv(minU, maxV).endVertex();
-        bufferBuilder.vertex(minX, minY, blitOffset).uv(minU, minV).endVertex();
-        tessellator.end();
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.client.util.RecipeBookCategories;
 import net.minecraft.command.arguments.ArgumentSerializer;
 import net.minecraft.command.arguments.ArgumentTypes;
 import net.minecraft.command.arguments.IArgumentSerializer;
@@ -160,6 +161,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         MinecraftForge.EVENT_BUS.register(this);
         BiomeDictionary.init();
+        RecipeBookCategories.registerCategories();
     }
 
     public void preInit(FMLCommonSetupEvent evt)

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategories.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategories.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.common;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class ForgeRecipeBookCategories<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+    private final List<ItemStack> icons;
+    private final boolean isSearch;
+    private final T recipeType;
+    private final Predicate<IRecipe<?>> predicate;
+
+    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, ItemStack... icons) {
+        this(isSearch, recipeType, recipe -> true, icons);
+    }
+
+    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+        this.isSearch = isSearch;
+        this.recipeType = recipeType;
+        this.predicate = predicate;
+        this.icons = ImmutableList.copyOf(icons);
+    }
+
+    @Override
+    public boolean isSearch() {
+        return this.isSearch;
+    }
+
+    @Override
+    public Predicate<IRecipe<?>> getPredicate() {
+        return this.predicate;
+    }
+
+    @Override
+    public T getRecipeType() {
+        return this.recipeType;
+    }
+
+    @Override
+    public List<ItemStack> getIcon() {
+        return this.icons;
+    }
+
+    public static List<IForgeRecipeBookCategory<?>> getValidCategories(IRecipe<?> recipe) {
+        return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
+            return recipe.getType().equals(category.getRecipeType()) && category.getPredicate().test(recipe);
+        }).collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -5,11 +5,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
     private final boolean isSearch;
     private final T recipeType;
@@ -58,7 +60,7 @@ public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minec
     }
 
     public static List<IForgeRecipeBookCategory<?>> getValidCategories(IRecipe<?> recipe) {
-        return net.minecraftforge.registries.ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
+        return ForgeRegistries.RECIPE_BOOK_CATEGORIES.getValues().stream().filter(category -> {
             return recipe.getType().equals(category.getRecipeType()) && category.getPredicate().test(recipe);
         }).collect(java.util.stream.Collectors.toList());
     }

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common;
 
 import com.google.common.collect.ImmutableList;
@@ -13,35 +32,35 @@ import java.util.function.Predicate;
 
 public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
-    private final boolean isSearch;
+    private final boolean isUnfiltered;
     private final T recipeType;
     private final Predicate<IRecipe<?>> predicate;
 
     /**
-     * @param isSearch If tab is search
+     * @param isUnfiltered If tab is without filter
      * @param recipeType Recipe type
      * @param icons Recipe tab icons
      */
-    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, ItemStack... icons) {
-        this(isSearch, recipeType, recipe -> true, icons);
+    public ForgeRecipeBookCategory(boolean isUnfiltered, T recipeType, ItemStack... icons) {
+        this(isUnfiltered, recipeType, recipe -> true, icons);
     }
 
     /**
-     * @param isSearch If tab is search
+     * @param isUnfiltered If tab is without filter
      * @param recipeType Recipe type
      * @param predicate Filtering function
      * @param icons Recipe tab icons
      */
-    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
-        this.isSearch = isSearch;
+    public ForgeRecipeBookCategory(boolean isUnfiltered, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+        this.isUnfiltered = isUnfiltered;
         this.recipeType = recipeType;
         this.predicate = predicate;
         this.icons = ImmutableList.copyOf(icons);
     }
 
     @Override
-    public boolean isSearch() {
-        return this.isSearch;
+    public boolean isUnfiltered() {
+        return this.isUnfiltered;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/ForgeRecipeBookCategory.java
@@ -9,17 +9,28 @@ import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class ForgeRecipeBookCategories<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
+public class ForgeRecipeBookCategory<T extends IRecipeType<?>> extends net.minecraftforge.registries.ForgeRegistryEntry<IForgeRecipeBookCategory<?>> implements IForgeRecipeBookCategory<T> {
     private final List<ItemStack> icons;
     private final boolean isSearch;
     private final T recipeType;
     private final Predicate<IRecipe<?>> predicate;
 
-    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, ItemStack... icons) {
+    /**
+     * @param isSearch If tab is search
+     * @param recipeType Recipe type
+     * @param icons Recipe tab icons
+     */
+    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, ItemStack... icons) {
         this(isSearch, recipeType, recipe -> true, icons);
     }
 
-    public ForgeRecipeBookCategories(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
+    /**
+     * @param isSearch If tab is search
+     * @param recipeType Recipe type
+     * @param predicate Filtering function
+     * @param icons Recipe tab icons
+     */
+    public ForgeRecipeBookCategory(boolean isSearch, T recipeType, Predicate<IRecipe<?>> predicate, ItemStack... icons) {
         this.isSearch = isSearch;
         this.recipeType = recipeType;
         this.predicate = predicate;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.item.ItemStack;
@@ -10,10 +29,10 @@ import java.util.function.Predicate;
 
 public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
     /**
-     * If tab is search - does not filter recipes and always is on most top position
-     * @return if tab is search
+     * If tab is without filter - does not filter recipes and always is on most top position
+     * @return if tab is without filter
      */
-    boolean isSearch();
+    boolean isUnfiltered();
 
     /**
      * Filter for displayed recipes

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
+    boolean isSearch();
+    Predicate<IRecipe<?>> getPredicate();
+    T getRecipeType();
+    List<ItemStack> getIcon();
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRecipeBookCategory.java
@@ -9,8 +9,27 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public interface IForgeRecipeBookCategory<T extends IRecipeType<?>> extends IForgeRegistryEntry<IForgeRecipeBookCategory<?>> {
+    /**
+     * If tab is search - does not filter recipes and always is on most top position
+     * @return if tab is search
+     */
     boolean isSearch();
+
+    /**
+     * Filter for displayed recipes
+     * @return filtering function
+     */
     Predicate<IRecipe<?>> getPredicate();
+
+    /**
+     * Recipe type of recipe book category
+     * @return recipe type
+     */
     T getRecipeType();
+
+    /**
+     * Recipe tab icons, can be 1 or 2 ItemStack
+     * @return recipe tab icons
+     */
     List<ItemStack> getIcon();
 }

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -114,6 +114,7 @@ public class ForgeRegistries
     public static final IForgeRegistry<DataSerializerEntry> DATA_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(DataSerializerEntry.class);
     public static final IForgeRegistry<GlobalLootModifierSerializer<?>> LOOT_MODIFIER_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(GlobalLootModifierSerializer.class);
     public static final IForgeRegistry<ForgeWorldType> WORLD_TYPES = RegistryManager.ACTIVE.getRegistry(ForgeWorldType.class);
+    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
 
     public static final class Keys {
         //Vanilla

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -56,6 +56,7 @@ import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraft.world.gen.treedecorator.TreeDecoratorType;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.world.ForgeWorldType;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -85,6 +86,7 @@ public class ForgeRegistries
     public static final IForgeRegistry<IRecipeSerializer<?>> RECIPE_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(IRecipeSerializer.class);
     public static final IForgeRegistry<Attribute> ATTRIBUTES = RegistryManager.ACTIVE.getRegistry(Attribute.class);
     public static final IForgeRegistry<StatType<?>> STAT_TYPES = RegistryManager.ACTIVE.getRegistry(StatType.class);
+    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
 
     // Villages
     public static final IForgeRegistry<VillagerProfession> PROFESSIONS = RegistryManager.ACTIVE.getRegistry(VillagerProfession.class);
@@ -155,6 +157,7 @@ public class ForgeRegistries
         public static final RegistryKey<Registry<DataSerializerEntry>> DATA_SERIALIZERS = key("data_serializers");
         public static final RegistryKey<Registry<GlobalLootModifierSerializer<?>>> LOOT_MODIFIER_SERIALIZERS = key("forge:loot_modifier_serializers");
         public static final RegistryKey<Registry<ForgeWorldType>> WORLD_TYPES = key("forge:world_types");
+        public static final RegistryKey<Registry<IForgeRecipeBookCategory<?>>> RECIPE_BOOK_CATEGORIES = key("forge:recipe_book_categories");
 
         private static <T> RegistryKey<Registry<T>> key(String name)
         {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -86,7 +86,6 @@ public class ForgeRegistries
     public static final IForgeRegistry<IRecipeSerializer<?>> RECIPE_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(IRecipeSerializer.class);
     public static final IForgeRegistry<Attribute> ATTRIBUTES = RegistryManager.ACTIVE.getRegistry(Attribute.class);
     public static final IForgeRegistry<StatType<?>> STAT_TYPES = RegistryManager.ACTIVE.getRegistry(StatType.class);
-    public static final IForgeRegistry<IForgeRecipeBookCategory<?>> RECIPE_BOOK_CATEGORIES = RegistryManager.ACTIVE.getRegistry(IForgeRecipeBookCategory.class);
 
     // Villages
     public static final IForgeRegistry<VillagerProfession> PROFESSIONS = RegistryManager.ACTIVE.getRegistry(VillagerProfession.class);

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -161,7 +161,6 @@ public class GameData
         makeRegistry(RECIPE_SERIALIZERS, c(IRecipeSerializer.class)).disableSaving().create();
         makeRegistry(ATTRIBUTES, Attribute.class).onValidate(AttributeCallbacks.INSTANCE).disableSaving().disableSync().create();
         makeRegistry(STAT_TYPES, c(StatType.class)).create();
-        makeRegistry(RECIPE_BOOK_CATEGORIES, c(IForgeRecipeBookCategory.class)).disableSaving().create();
 
         // Villagers
         makeRegistry(VILLAGER_PROFESSIONS, VillagerProfession.class, "none").create();
@@ -190,6 +189,7 @@ public class GameData
         makeRegistry(DATA_SERIALIZERS, DataSerializerEntry.class, 256 /*vanilla space*/, MAX_VARINT).disableSaving().disableOverrides().addCallback(SerializerCallbacks.INSTANCE).create();
         makeRegistry(LOOT_MODIFIER_SERIALIZERS, c(GlobalLootModifierSerializer.class)).disableSaving().disableSync().create();
         makeRegistry(WORLD_TYPES, ForgeWorldType.class).disableSaving().disableSync().create();
+        makeRegistry(RECIPE_BOOK_CATEGORIES, c(IForgeRecipeBookCategory.class)).disableSaving().create();
     }
     @SuppressWarnings("unchecked") //Ugly hack to let us pass in a typed Class object. Remove when we remove type specific references.
     private static <T> Class<T> c(Class<?> cls) { return (Class<T>)cls; }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -73,6 +73,7 @@ import net.minecraft.world.gen.treedecorator.TreeDecoratorType;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ForgeTagHandler;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.world.ForgeWorldType;
 import net.minecraftforge.event.RegistryEvent;
@@ -160,6 +161,7 @@ public class GameData
         makeRegistry(RECIPE_SERIALIZERS, c(IRecipeSerializer.class)).disableSaving().create();
         makeRegistry(ATTRIBUTES, Attribute.class).onValidate(AttributeCallbacks.INSTANCE).disableSaving().disableSync().create();
         makeRegistry(STAT_TYPES, c(StatType.class)).create();
+        makeRegistry(RECIPE_BOOK_CATEGORIES, c(IForgeRecipeBookCategory.class)).disableSaving().create();
 
         // Villagers
         makeRegistry(VILLAGER_PROFESSIONS, VillagerProfession.class, "none").create();

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -145,6 +145,7 @@ public net.minecraft.client.gui.ScreenManager func_216911_a(Lnet/minecraft/inven
 public net.minecraft.client.gui.ScreenManager$IScreenFactory
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211537_g # block
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211538_h # liquid
+private-f net.minecraft.client.gui.recipebook.RecipeTabToggleWidget field_193921_u # category
 public net.minecraft.client.gui.screen.WorldOptionsScreen func_239043_a_(Lnet/minecraft/world/gen/settings/DimensionGeneratorSettings;)V # updateSettings
 protected net.minecraft.client.gui.widget.list.AbstractList$AbstractListEntry field_230666_a_ # list
 public net.minecraft.client.particle.ParticleManager func_199283_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/IParticleFactory;)V # registerFactory

--- a/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CraftingBookTest.java
@@ -1,0 +1,63 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.block;
+
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraftforge.common.ForgeRecipeBookCategory;
+import net.minecraftforge.common.extensions.IForgeRecipeBookCategory;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.registries.ObjectHolder;
+
+@Mod("base_crafting_book_test")
+@Mod.EventBusSubscriber(bus = Bus.MOD)
+public class CraftingBookTest {
+    @ObjectHolder("damageable")
+    public static final ForgeRecipeBookCategory<?> damageable = null;
+    @ObjectHolder("edible")
+    public static final ForgeRecipeBookCategory<?> edible = null;
+    @ObjectHolder("enchantable")
+    public static final ForgeRecipeBookCategory<?> enchantable = null;
+    @ObjectHolder("stackable")
+    public static final ForgeRecipeBookCategory<?> stackable = null;
+
+    @SubscribeEvent
+    public static void registerForgeRecipeBookCategories(RegistryEvent.Register<IForgeRecipeBookCategory<?>> event) {
+        // category for damageable items
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false, IRecipeType.CRAFTING,
+                recipe -> recipe.getResultItem().isDamageableItem(), new ItemStack(Items.ZOMBIE_HEAD))
+                .setRegistryName("base_crafting_book_test", "damageable"));
+        // category for edible items
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false, IRecipeType.CRAFTING,
+                recipe -> recipe.getResultItem().isEdible(), new ItemStack(Items.ROTTEN_FLESH))
+                .setRegistryName("base_crafting_book_test", "edible"));
+        // category for enchantable items
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false, IRecipeType.CRAFTING,
+                recipe -> recipe.getResultItem().isEnchantable(), new ItemStack(Items.GOLDEN_AXE), new ItemStack(Items.GOLDEN_PICKAXE))
+                .setRegistryName("base_crafting_book_test", "enchantable"));
+        // category for stackable items
+        event.getRegistry().register(new ForgeRecipeBookCategory<IRecipeType<?>>(false, IRecipeType.CRAFTING,
+                recipe -> recipe.getResultItem().isStackable(), new ItemStack(Items.BEACON))
+                .setRegistryName("base_crafting_book_test", "stackable"));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -138,3 +138,5 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="base_crafting_book_test"


### PR DESCRIPTION
Basicaly allows modders to add recipe book into custom machines and add tabs into vanilla recipe book

- custom recipe book category can be registered via forge registries.
- constructor have `IRecipeType<?>` to set where recipe book category belongs
- modder can set if category is `search` - no filtering is applied for displayed recipes
- `setPredicate(IRecipe<?>)` non-search category with filtering
- `setIcon(ItemStack...)` recipe book category icon
```
    @SubscribeEvent
    public static void registerRecipeBookCategories(RegistryEvent.Register<RecipeBookCategories> event) {
        event.getRegistry().register(new RecipeBookCategories(TestRecipe.millstone).setSearch().setIcon(new ItemStack(Items.BELL)).setRegistryName("base_crafting_book_test", "test"));
    }
```
- Custom machine container must extends `RecipeBookContainer<C extends IInventory>` 
- Custom machine gui just render and handle recipe book as in e.g. AbstractFurnaceScreen