### PR TITLE
[1.17.1] fix forge:nbt ingredient fails to sync to the client

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -69,7 +69,7 @@
 -      return m_43938_(p_43941_.m_178366_(FriendlyByteBuf::m_130267_).stream().map(Ingredient.ItemValue::new));
 +      var size = p_43941_.m_130242_();
 +      if (size == -1) return net.minecraftforge.common.crafting.CraftingHelper.getIngredient(p_43941_.m_130281_(), p_43941_);
-+      return m_43938_(p_43941_.readListWithSize(size, FriendlyByteBuf::m_130267_).stream().map(Ingredient.ItemValue::new));
++      return m_43938_(Stream.generate(() -> new Ingredient.ItemValue(p_43941_.m_130267_())).limit(size));
     }
  
     public static Ingredient m_43917_(@Nullable JsonElement p_43918_) {

--- a/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -62,7 +62,15 @@
     public static Ingredient m_43938_(Stream<? extends Ingredient.Value> p_43939_) {
        Ingredient ingredient = new Ingredient(p_43939_);
        return ingredient.f_43902_.length == 0 ? f_43901_ : ingredient;
-@@ -146,6 +_,8 @@
+@@ -141,11 +_,15 @@
+    }
+ 
+    public static Ingredient m_43940_(FriendlyByteBuf p_43941_) {
+-      return m_43938_(p_43941_.m_178366_(FriendlyByteBuf::m_130267_).stream().map(Ingredient.ItemValue::new));
++      var size = p_43941_.m_130242_();
++      if (size == -1) return net.minecraftforge.common.crafting.CraftingHelper.getIngredient(p_43941_.m_130281_(), p_43941_);
++      return m_43938_(p_43941_.readListWithSize(size, FriendlyByteBuf::m_130267_).stream().map(Ingredient.ItemValue::new));
+    }
  
     public static Ingredient m_43917_(@Nullable JsonElement p_43918_) {
        if (p_43918_ != null && !p_43918_.isJsonNull()) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
@@ -19,14 +19,6 @@
 
 package net.minecraftforge.common.extensions;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.IntFunction;
-
-import javax.annotation.Nonnull;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -37,6 +29,13 @@ import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 
 /**
  * Extension-Interface providing methods for writing registry-id's instead of their registry-names.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
@@ -19,7 +19,17 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+import javax.annotation.Nonnull;
+
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
@@ -27,9 +37,6 @@ import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
-
-import javax.annotation.Nonnull;
-import java.util.Objects;
 
 /**
  * Extension-Interface providing methods for writing registry-id's instead of their registry-names.
@@ -151,5 +158,26 @@ public interface IForgeFriendlyByteBuf
     default FluidStack readFluidStack()
     {
         return !self().readBoolean() ? FluidStack.EMPTY : FluidStack.readFromPacket(self());
+    }
+    
+    /**
+     * Read a Collection from this buffer with set size.
+     */
+    default <T, C extends Collection<T>> C readCollectionWithSize(int size, IntFunction<C> ctor, Function<FriendlyByteBuf, T> builder)
+    {
+        C c = ctor.apply(size);
+
+        for (int j = 0; j < size; ++j) {
+            c.add(builder.apply(self()));
+        }
+        return c;
+    }
+
+    /**
+     * Read a List from this buffer with set size.
+     */
+    default <T> List<T> readListWithSize(int size, Function<FriendlyByteBuf, T> builder)
+    {
+        return this.readCollectionWithSize(size, Lists::newArrayListWithCapacity, builder);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFriendlyByteBuf.java
@@ -20,8 +20,6 @@
 package net.minecraftforge.common.extensions;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
@@ -31,11 +29,7 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.IntFunction;
 
 /**
  * Extension-Interface providing methods for writing registry-id's instead of their registry-names.
@@ -157,26 +151,5 @@ public interface IForgeFriendlyByteBuf
     default FluidStack readFluidStack()
     {
         return !self().readBoolean() ? FluidStack.EMPTY : FluidStack.readFromPacket(self());
-    }
-    
-    /**
-     * Read a Collection from this buffer with set size.
-     */
-    default <T, C extends Collection<T>> C readCollectionWithSize(int size, IntFunction<C> ctor, Function<FriendlyByteBuf, T> builder)
-    {
-        C c = ctor.apply(size);
-
-        for (int j = 0; j < size; ++j) {
-            c.add(builder.apply(self()));
-        }
-        return c;
-    }
-
-    /**
-     * Read a List from this buffer with set size.
-     */
-    default <T> List<T> readListWithSize(int size, Function<FriendlyByteBuf, T> builder)
-    {
-        return this.readCollectionWithSize(size, Lists::newArrayListWithCapacity, builder);
     }
 }


### PR DESCRIPTION
This PR aim at fixing deserialization of forge custom ingredients (#7933) while keeping network compatibility with vanilla.