### PR TITLE
[1.17.1] Add custom attack sweep

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -209,7 +209,7 @@
                 i = i + EnchantmentHelper.m_44894_(this);
                 if (this.m_20142_() && flag) {
                    this.f_19853_.m_6263_((Player)null, this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12314_, this.m_5720_(), 1.0F, 1.0F);
-@@ -1055,18 +_,20 @@
+@@ -1055,8 +_,10 @@
  
                 boolean flag2 = flag && this.f_19789_ > 0.0F && !this.f_19861_ && !this.m_6147_() && !this.m_20069_() && !this.m_21023_(MobEffects.f_19610_) && !this.m_20159_() && p_36347_ instanceof LivingEntity;
                 flag2 = flag2 && !this.m_20142_();
@@ -221,16 +221,14 @@
                 }
  
                 f = f + f1;
-                boolean flag3 = false;
-+               AABB sweepAABB = null;
+@@ -1064,9 +_,7 @@
                 double d0 = (double)(this.f_19787_ - this.f_19867_);
                 if (flag && !flag2 && !flag1 && this.f_19861_ && d0 < (double)this.m_6113_()) {
                    ItemStack itemstack = this.m_21120_(InteractionHand.MAIN_HAND);
 -                  if (itemstack.m_41720_() instanceof SwordItem) {
 -                     flag3 = true;
 -                  }
-+                  sweepAABB = itemstack.getSweepHitBox(this, p_36347_);
-+                  flag3 = sweepAABB != null;
++                  flag3 = itemstack.canPerformAction(net.minecraftforge.common.ToolActions.SWORD_SWEEP);
                 }
  
                 float f4 = 0.0F;
@@ -239,7 +237,7 @@
                       float f3 = 1.0F + EnchantmentHelper.m_44821_(this) * f;
  
 -                     for(LivingEntity livingentity : this.f_19853_.m_45976_(LivingEntity.class, p_36347_.m_142469_().m_82377_(1.0D, 0.25D, 1.0D))) {
-+                     for(LivingEntity livingentity : this.f_19853_.m_45976_(LivingEntity.class, sweepAABB)) {
++                     for(LivingEntity livingentity : this.f_19853_.m_45976_(LivingEntity.class, this.m_21120_(InteractionHand.MAIN_HAND).getSweepHitBox(this, p_36347_))) {
                          if (livingentity != this && livingentity != p_36347_ && !this.m_7307_(livingentity) && (!(livingentity instanceof ArmorStand) || !((ArmorStand)livingentity).m_31677_()) && this.m_20280_(livingentity) < 9.0D) {
                             livingentity.m_147240_((double)0.4F, (double)Mth.m_14031_(this.m_146908_() * ((float)Math.PI / 180F)), (double)(-Mth.m_14089_(this.m_146908_() * ((float)Math.PI / 180F))));
                             livingentity.m_6469_(DamageSource.m_19344_(this), f3);

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -209,7 +209,7 @@
                 i = i + EnchantmentHelper.m_44894_(this);
                 if (this.m_20142_() && flag) {
                    this.f_19853_.m_6263_((Player)null, this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12314_, this.m_5720_(), 1.0F, 1.0F);
-@@ -1055,8 +_,10 @@
+@@ -1055,18 +_,20 @@
  
                 boolean flag2 = flag && this.f_19789_ > 0.0F && !this.f_19861_ && !this.m_6147_() && !this.m_20069_() && !this.m_21023_(MobEffects.f_19610_) && !this.m_20159_() && p_36347_ instanceof LivingEntity;
                 flag2 = flag2 && !this.m_20142_();
@@ -221,6 +221,28 @@
                 }
  
                 f = f + f1;
+                boolean flag3 = false;
++               AABB sweepAABB = null;
+                double d0 = (double)(this.f_19787_ - this.f_19867_);
+                if (flag && !flag2 && !flag1 && this.f_19861_ && d0 < (double)this.m_6113_()) {
+                   ItemStack itemstack = this.m_21120_(InteractionHand.MAIN_HAND);
+-                  if (itemstack.m_41720_() instanceof SwordItem) {
+-                     flag3 = true;
+-                  }
++                  sweepAABB = itemstack.getSweepHitBox(this, p_36347_);
++                  flag3 = sweepAABB != null;
+                }
+ 
+                float f4 = 0.0F;
+@@ -1097,7 +_,7 @@
+                   if (flag3) {
+                      float f3 = 1.0F + EnchantmentHelper.m_44821_(this) * f;
+ 
+-                     for(LivingEntity livingentity : this.f_19853_.m_45976_(LivingEntity.class, p_36347_.m_142469_().m_82377_(1.0D, 0.25D, 1.0D))) {
++                     for(LivingEntity livingentity : this.f_19853_.m_45976_(LivingEntity.class, sweepAABB)) {
+                         if (livingentity != this && livingentity != p_36347_ && !this.m_7307_(livingentity) && (!(livingentity instanceof ArmorStand) || !((ArmorStand)livingentity).m_31677_()) && this.m_20280_(livingentity) < 9.0D) {
+                            livingentity.m_147240_((double)0.4F, (double)Mth.m_14031_(this.m_146908_() * ((float)Math.PI / 180F)), (double)(-Mth.m_14089_(this.m_146908_() * ((float)Math.PI / 180F))));
+                            livingentity.m_6469_(DamageSource.m_19344_(this), f3);
 @@ -1139,13 +_,15 @@
                    EnchantmentHelper.m_44896_(this, p_36347_);
                    ItemStack itemstack1 = this.m_21205_();

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -21,6 +21,7 @@ package net.minecraftforge.common;
 
 import com.google.common.collect.Sets;
 import net.minecraftforge.common.extensions.IForgeBlock;
+import net.minecraftforge.common.extensions.IForgeItem;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -73,6 +74,13 @@ public class ToolActions
      */
     public static final ToolAction SHOVEL_FLATTEN = ToolAction.get("shovel_flatten");
 
+    /**
+     *  Used during player attack to figure out if a sweep attack should be performed
+     *  
+     *  @see {@link IForgeItem#getSweepHitBox}
+     */
+    public static final ToolAction SWORD_SWEEP = ToolAction.get("sword_sweep");
+    
     ///**
     // *  Passed onto {@link IForgeBlock#getToolModifiedState} when a hoe wants to turn dirt into soil
     // */
@@ -84,5 +92,5 @@ public class ToolActions
     public static final Set<ToolAction> DEFAULT_HOE_ACTIONS = Stream.of(HOE_DIG /* TODO: , HOE_TILL */).collect(Collectors.toCollection(Sets::newIdentityHashSet));
     public static final Set<ToolAction> DEFAULT_SHOVEL_ACTIONS = Stream.of(SHOVEL_DIG, SHOVEL_FLATTEN).collect(Collectors.toCollection(Sets::newIdentityHashSet));
     public static final Set<ToolAction> DEFAULT_PICKAXE_ACTIONS = Stream.of(PICKAXE_DIG).collect(Collectors.toCollection(Sets::newIdentityHashSet));
-    public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = Stream.of(SWORD_DIG).collect(Collectors.toCollection(Sets::newIdentityHashSet));
+    public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = Stream.of(SWORD_DIG, SWORD_SWEEP).collect(Collectors.toCollection(Sets::newIdentityHashSet));
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -801,7 +801,7 @@ public interface IForgeItem
      * @param statck the stack held by the player.
      * @param player the performing the attack the attack.
      * @param target the entity targeted by the attack.
-     * @return the bounding box or null if this item has no sweep attack.
+     * @return the bounding box.
      */
     @Nonnull
     default AABB getSweepHitBox(@Nonnull ItemStack stack, @Nonnull Player player, @Nonnull Entity target)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.common.extensions;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -28,9 +27,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.Multimap;
 
-import net.minecraft.tags.Tag;
 import net.minecraft.world.item.*;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.level.block.Blocks;
@@ -43,8 +40,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.monster.piglin.PiglinAi;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.SwordItem;
-import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -55,7 +50,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ToolAction;
 
 // TODO review most of the methods in this "patch"
@@ -809,12 +803,9 @@ public interface IForgeItem
      * @param target the entity targeted by the attack.
      * @return the bounding box or null if this item has no sweep attack.
      */
-    @Nullable
+    @Nonnull
     default AABB getSweepHitBox(@Nonnull ItemStack stack, @Nonnull Player player, @Nonnull Entity target)
     {
-        if (this instanceof SwordItem) {
-            return target.getBoundingBox().inflate(1.0D, 0.25D, 1.0D);
-        }
-        return null;
+        return target.getBoundingBox().inflate(1.0D, 0.25D, 1.0D);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.Multimap;
@@ -31,6 +32,7 @@ import net.minecraft.tags.Tag;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
@@ -41,6 +43,8 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.monster.piglin.PiglinAi;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.SwordItem;
+import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -795,5 +799,22 @@ public interface IForgeItem
     default boolean isDamageable(ItemStack stack)
     {
         return self().canBeDepleted();
+    }
+    
+    /**
+     * Get a bounding box ({@link AABB}) of a sweep attack.
+     * 
+     * @param statck the stack held by the player.
+     * @param player the performing the attack the attack.
+     * @param target the entity targeted by the attack.
+     * @return the bounding box or null if this item has no sweep attack.
+     */
+    @Nullable
+    default AABB getSweepHitBox(@Nonnull ItemStack stack, @Nonnull Player player, @Nonnull Entity target)
+    {
+        if (this instanceof SwordItem) {
+            return target.getBoundingBox().inflate(1.0D, 0.25D, 1.0D);
+        }
+        return null;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -22,12 +22,8 @@ package net.minecraftforge.common.extensions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.monster.EnderMan;
-import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -48,8 +44,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
-
-import java.util.List;
 
 /*
  * Extension added to ItemStack that bounces to ItemSack sensitive Item methods. Typically this is just for convince.
@@ -505,7 +499,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * @param target the entity targeted by the attack.
      * @return the bounding box or null if this item has no sweep attack.
      */
-    @Nullable
+    @Nonnull
     default AABB getSweepHitBox(@Nonnull Player player, @Nonnull Entity target)
     {
         return self().getItem().getSweepHitBox(self(), player, target);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.tags.Tag;
@@ -28,6 +29,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
@@ -494,5 +496,18 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     default boolean elytraFlightTick(LivingEntity entity, int flightTicks)
     {
         return self().getItem().elytraFlightTick(self(), entity, flightTicks);
+    }
+    
+    /**
+     * Get a bounding box ({@link AABB}) of a sweep attack.
+     * 
+     * @param player the performing the attack the attack.
+     * @param target the entity targeted by the attack.
+     * @return the bounding box or null if this item has no sweep attack.
+     */
+    @Nullable
+    default AABB getSweepHitBox(@Nonnull Player player, @Nonnull Entity target)
+    {
+        return self().getItem().getSweepHitBox(self(), player, target);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -497,7 +497,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * 
      * @param player the performing the attack the attack.
      * @param target the entity targeted by the attack.
-     * @return the bounding box or null if this item has no sweep attack.
+     * @return the bounding box.
      */
     @Nonnull
     default AABB getSweepHitBox(@Nonnull Player player, @Nonnull Entity target)


### PR DESCRIPTION
This PR adds `ItemStack#getSweepHitBox` and  `Item#getSweepHitBox`. This enable mods to create custom sweep box for their items.
theses methods return a `net.minecraft.world.phys.AABB` to offers more customisation over the current sword only sweep behavior.

It also makes sure swords keeps their own sweep.