### PR TITLE
It's intended!

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -895,7 +895,7 @@ public class GameData
         String prefix = mc == null || (mc instanceof InjectedModContainer && ((InjectedModContainer)mc).wrappedContainer instanceof FMLContainer) ? "minecraft" : mc.getModId().toLowerCase(Locale.ROOT);
         if (warnOverrides && !oldPrefix.equals(prefix) && oldPrefix.length() > 0)
         {
-            FMLLog.log.warn("Potentially Dangerous alternative prefix `{}` for name `{}`, expected `{}`. This could be a intended override, but in most cases indicates a broken mod.", oldPrefix, name, prefix);
+            FMLLog.log.warn("Potentially Dangerous alternative prefix `{}` for name `{}`, expected `{}`. This could be a broken mod, but in most cases indicates an intended override.", oldPrefix, name, prefix);
             prefix = oldPrefix;
         }
         return new ResourceLocation(prefix, name);


### PR DESCRIPTION
Replace
`This could be an intended override, but in most cases indicates a broken mod.`
with
`This could be a broken mod, but in most cases indicates an intended override.`
I've seen this message over ten thousand times, and it has never actually been a sign of a broken mod. This has also confused some of my friends who were new to modding.
You may also want to consider suppressing this warning, as on most modpacks(tested on Omnifactory) this one message takes up a whopping **37%** of the log. I couldn't find where that would be handled.