### PR TITLE
Use longs instead of ints for IEnergyStorage

### DIFF
--- a/src/main/java/net/minecraftforge/energy/EnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EnergyStorage.java
@@ -19,7 +19,7 @@
 
 package net.minecraftforge.energy;
 
-import net.minecraft.nbt.IntTag;
+import net.minecraft.nbt.LongTag;
 import net.minecraft.nbt.Tag;
 import net.minecraftforge.common.util.INBTSerializable;
 
@@ -31,27 +31,27 @@ import net.minecraftforge.common.util.INBTSerializable;
  */
 public class EnergyStorage implements IEnergyStorage, INBTSerializable<Tag>
 {
-    protected int energy;
-    protected int capacity;
-    protected int maxReceive;
-    protected int maxExtract;
+    protected long energy;
+    protected long capacity;
+    protected long maxReceive;
+    protected long maxExtract;
 
-    public EnergyStorage(int capacity)
+    public EnergyStorage(long capacity)
     {
         this(capacity, capacity, capacity, 0);
     }
 
-    public EnergyStorage(int capacity, int maxTransfer)
+    public EnergyStorage(long capacity, long maxTransfer)
     {
         this(capacity, maxTransfer, maxTransfer, 0);
     }
 
-    public EnergyStorage(int capacity, int maxReceive, int maxExtract)
+    public EnergyStorage(long capacity, long maxReceive, long maxExtract)
     {
         this(capacity, maxReceive, maxExtract, 0);
     }
 
-    public EnergyStorage(int capacity, int maxReceive, int maxExtract, int energy)
+    public EnergyStorage(long capacity, long maxReceive, long maxExtract, long energy)
     {
         this.capacity = capacity;
         this.maxReceive = maxReceive;
@@ -60,37 +60,37 @@ public class EnergyStorage implements IEnergyStorage, INBTSerializable<Tag>
     }
 
     @Override
-    public int receiveEnergy(int maxReceive, boolean simulate)
+    public long receiveEnergy(long maxReceive, boolean simulate)
     {
         if (!canReceive())
             return 0;
 
-        int energyReceived = Math.min(capacity - energy, Math.min(this.maxReceive, maxReceive));
+        long energyReceived = Math.min(capacity - energy, Math.min(this.maxReceive, maxReceive));
         if (!simulate)
             energy += energyReceived;
         return energyReceived;
     }
 
     @Override
-    public int extractEnergy(int maxExtract, boolean simulate)
+    public long extractEnergy(long maxExtract, boolean simulate)
     {
         if (!canExtract())
             return 0;
 
-        int energyExtracted = Math.min(energy, Math.min(this.maxExtract, maxExtract));
+        long energyExtracted = Math.min(energy, Math.min(this.maxExtract, maxExtract));
         if (!simulate)
             energy -= energyExtracted;
         return energyExtracted;
     }
 
     @Override
-    public int getEnergyStored()
+    public long getEnergyStored()
     {
         return energy;
     }
 
     @Override
-    public int getMaxEnergyStored()
+    public long getMaxEnergyStored()
     {
         return capacity;
     }
@@ -110,14 +110,14 @@ public class EnergyStorage implements IEnergyStorage, INBTSerializable<Tag>
     @Override
     public Tag serializeNBT()
     {
-        return IntTag.valueOf(this.getEnergyStored());
+        return LongTag.valueOf(this.getEnergyStored());
     }
 
     @Override
     public void deserializeNBT(Tag nbt)
     {
-        if (!(nbt instanceof IntTag intNbt))
+        if (!(nbt instanceof LongTag longNbt))
             throw new IllegalArgumentException("Can not deserialize to an instance that isn't the default implementation");
-        this.energy = intNbt.getAsInt();
+        this.energy = longNbt.getAsLong();
     }
 }

--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -39,7 +39,7 @@ public interface IEnergyStorage
     *            If TRUE, the insertion will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
     */
-    int receiveEnergy(int maxReceive, boolean simulate);
+    long receiveEnergy(long maxReceive, boolean simulate);
 
     /**
     * Removes energy from the storage. Returns quantity of energy that was removed.
@@ -50,17 +50,17 @@ public interface IEnergyStorage
     *            If TRUE, the extraction will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
     */
-    int extractEnergy(int maxExtract, boolean simulate);
+    long extractEnergy(long maxExtract, boolean simulate);
 
     /**
     * Returns the amount of energy currently stored.
     */
-    int getEnergyStored();
+    long getEnergyStored();
 
     /**
     * Returns the maximum amount of energy that can be stored.
     */
-    int getMaxEnergyStored();
+    long getMaxEnergyStored();
 
     /**
      * Returns if this storage can have energy extracted.


### PR DESCRIPTION
Switches IEnergyStorage to using longs instead of ints.

While it is still somewhat an edge case, there are cases of more than int max being used, and there are multiple extensions/implementations (or additional interfaces) to IEnergyStorage to allow the use of longs (or something very similar) in 1.16.x

Known mods with extensions:
[Phosphophyllite](https://github.com/BiggerSeries/Phosphophyllite/blob/8e037ed9260569ad22cce5c8466fa909da250753/src/main/java/net/roguelogix/phosphophyllite/energy/IPhosphophylliteEnergyStorage.java) (Bigger Reactors)
[BrandonsCore](https://github.com/brandon3055/BrandonsCore/blob/9c464f1dc0ea587bb2625f15c4bb659df2d8ad9b/src/main/java/com/brandon3055/brandonscore/api/power/IOPStorage.java) (Draconic Evolution)
[Industrial Foregoing](https://github.com/InnovativeOnlineIndustries/Industrial-Foregoing/blob/bdee4b2aba5c327b676d837933113e7297b9e437/src/main/java/com/buuz135/industrial/item/infinity/InfinityEnergyStorage.java)
[Mekanism](https://github.com/mekanism/Mekanism/blob/c5a752ff7d122799459ef53a8b6a6a263e212ec5/src/api/java/mekanism/api/energy/IStrictEnergyHandler.java)
[Flux Networks](https://github.com/SonarSonic/Flux-Networks/blob/45379d14358d95a46bc4ead6b903488686605ff2/src/main/java/sonar/fluxnetworks/api/energy/IFNEnergyStorage.java)
More, probably