### PR TITLE
Fix update checker to use runtime minecraft version

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -22,7 +22,7 @@ package net.minecraftforge.fml;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import net.minecraftforge.fml.loading.FMLConfig;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
+import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +33,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -180,8 +179,7 @@ public class VersionChecker
                     Map<String, String> promos = (Map<String, String>)json.get("promos");
                     display_url = (String)json.get("homepage");
 
-//                    String mcVersion = MCPVersion.getMCVersion();
-                    var mcVersion = "1.17";
+                    var mcVersion = FMLLoader.versionInfo().mcVersion();
                     String rec = promos.get(mcVersion + "-recommended");
                     String lat = promos.get(mcVersion + "-latest");
                     ComparableVersion current = new ComparableVersion(mod.getVersion().toString());


### PR DESCRIPTION
Sometime during the update process, the line grabbing the current minecraft version in `VersionChecker` was commented out and manually replaced with `1.17`. This is broken because Forge is only released for `1.17.1`. The commented out line has been deleted and the Minecraft version is now retrieved from the version info stored in `FMLLoader`. This fixes Forge's version checker and the version checker for every 1.17.1 mod utilizing the feature.