### PR TITLE
[1.17.1] Add the ability to handle custom cooldowns

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -124,12 +124,16 @@
 -            if (!itemstack.m_41619_() && !p_105263_.m_36335_().m_41519_(itemstack.m_41720_())) {
 -               UseOnContext useoncontext = new UseOnContext(p_105263_, p_105265_, p_105266_);
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return InteractionResult.PASS;
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.m_41619_() && !p_105263_.m_36335_().m_41519_(itemstack.m_41720_()))) {
++            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.m_41619_() && !itemstack.isOnCooldown(p_105263_))) {
                 InteractionResult interactionresult1;
                 if (this.f_105197_.m_46408_()) {
                    int i = itemstack.m_41613_();
-@@ -311,10 +_,13 @@
-          if (p_105236_.m_36335_().m_41519_(itemstack.m_41720_())) {
+@@ -308,13 +_,16 @@
+          this.f_105190_.m_104955_(new ServerboundMovePlayerPacket.PosRot(p_105236_.m_20185_(), p_105236_.m_20186_(), p_105236_.m_20189_(), p_105236_.m_146908_(), p_105236_.m_146909_(), p_105236_.m_20096_()));
+          this.f_105190_.m_104955_(new ServerboundUseItemPacket(p_105238_));
+          ItemStack itemstack = p_105236_.m_21120_(p_105238_);
+-         if (p_105236_.m_36335_().m_41519_(itemstack.m_41720_())) {
++         if (itemstack.isOnCooldown(p_105236_)) {
              return InteractionResult.PASS;
           } else {
 +            InteractionResult cancelResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_105236_, p_105238_);

--- a/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
@@ -76,6 +76,15 @@
              this.m_115152_(bufferbuilder, p_115177_ + 2, p_115178_ + 13, 13, 2, 0, 0, 0, 255);
              this.m_115152_(bufferbuilder, p_115177_ + 2, p_115178_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
              RenderSystem.m_69478_();
+@@ -348,7 +_,7 @@
+          }
+ 
+          LocalPlayer localplayer = Minecraft.m_91087_().f_91074_;
+-         float f = localplayer == null ? 0.0F : localplayer.m_36335_().m_41521_(p_115176_.m_41720_(), Minecraft.m_91087_().m_91296_());
++         float f = localplayer == null ? 0.0F : p_115176_.getCooldownPercent(localplayer, Minecraft.m_91087_().m_91296_());
+          if (f > 0.0F) {
+             RenderSystem.m_69465_();
+             RenderSystem.m_69472_();
 @@ -377,5 +_,14 @@
  
     public void m_6213_(ResourceManager p_115105_) {

--- a/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
@@ -27,8 +27,9 @@
           return p_174652_ != null && p_174652_.m_5737_() != HumanoidArm.RIGHT ? 1.0F : 0.0F;
        });
 -      m_174581_(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
+-         return p_174647_ instanceof Player ? ((Player)p_174647_).m_36335_().m_41521_(p_174645_.m_41720_(), 0.0F) : 0.0F;
 +      registerGeneric(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
-          return p_174647_ instanceof Player ? ((Player)p_174647_).m_36335_().m_41521_(p_174645_.m_41720_(), 0.0F) : 0.0F;
++         return p_174645_.getCooldownPercent(p_174647_, 0);
        });
        m_174579_((p_174640_, p_174641_, p_174642_, p_174643_) -> {
           return p_174640_.m_41782_() ? (float)p_174640_.m_41783_().m_128451_("CustomModelData") : 0.0F;

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -35,7 +35,7 @@
           return false;
        } else {
           BlockEntity blockentity = this.f_9244_.m_7702_(p_9281_);
-@@ -223,30 +_,42 @@
+@@ -223,38 +_,52 @@
           if (block instanceof GameMasterBlock && !this.f_9245_.m_36337_()) {
              this.f_9244_.m_7260_(p_9281_, blockstate, blockstate, 3);
              return false;
@@ -85,8 +85,10 @@
     }
  
     public InteractionResult m_6261_(ServerPlayer p_9262_, Level p_9263_, ItemStack p_9264_, InteractionHand p_9265_) {
-@@ -255,6 +_,8 @@
-       } else if (p_9262_.m_36335_().m_41519_(p_9264_.m_41720_())) {
+       if (this.f_9247_ == GameType.SPECTATOR) {
+          return InteractionResult.PASS;
+-      } else if (p_9262_.m_36335_().m_41519_(p_9264_.m_41720_())) {
++      } else if (p_9264_.isOnCooldown(p_9262_)) {
           return InteractionResult.PASS;
        } else {
 +         InteractionResult cancelResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_9262_, p_9265_);
@@ -127,7 +129,7 @@
  
 -         if (!p_9268_.m_41619_() && !p_9266_.m_36335_().m_41519_(p_9268_.m_41720_())) {
 -            UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.m_41619_() && !p_9266_.m_36335_().m_41519_(p_9268_.m_41720_()))) {
++         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.m_41619_() && !p_9268_.isOnCooldown(p_9266_))) {
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return InteractionResult.PASS;
              InteractionResult interactionresult1;
              if (this.m_9295_()) {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -21,6 +21,15 @@
     }
  
     public void m_7376_(ServerboundAcceptTeleportationPacket p_9835_) {
+@@ -948,7 +_,7 @@
+          return false;
+       } else {
+          Item item = p_9792_.m_41720_();
+-         return (item instanceof BlockItem || item instanceof BucketItem) && !p_9791_.m_36335_().m_41519_(item);
++         return (item instanceof BlockItem || item instanceof BucketItem) && !p_9792_.isOnCooldown(p_9791_);
+       }
+    }
+ 
 @@ -963,7 +_,9 @@
        this.f_9743_.m_9243_();
        int i = this.f_9743_.f_19853_.m_151558_();

--- a/patches/minecraft/net/minecraft/world/item/ItemCooldowns.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemCooldowns.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/item/ItemCooldowns.java
++++ b/net/minecraft/world/item/ItemCooldowns.java
+@@ -10,10 +_,12 @@
+    private final Map<Item, ItemCooldowns.CooldownInstance> f_41515_ = Maps.newHashMap();
+    private int f_41516_;
+ 
++   @Deprecated // Forge: use IForgeItemStack#isOnCooldown instead
+    public boolean m_41519_(Item p_41520_) {
+       return this.m_41521_(p_41520_, 0.0F) > 0.0F;
+    }
+ 
++   @Deprecated // Forge: use IForgeItemStack#getCooldownPercent instead
+    public float m_41521_(Item p_41522_, float p_41523_) {
+       ItemCooldowns.CooldownInstance itemcooldowns$cooldowninstance = this.f_41515_.get(p_41522_);
+       if (itemcooldowns$cooldowninstance != null) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.Multimap;
@@ -795,5 +796,30 @@ public interface IForgeItem
     default boolean isDamageable(ItemStack stack)
     {
         return self().canBeDepleted();
+    }
+    
+    /**
+     * Check if this item is on cooldown for an entity
+     * 
+     * @param entity the entity holding the item 
+     * @param stack the ItemStack
+     * @return if this item is on cooldow
+     */
+    default boolean isOnCooldown(@Nonnull Entity entity, @Nonnull ItemStack stack)
+    {
+        return this.getCooldownPercent(entity, stack, 0) > 0;
+    }
+
+    /**
+     * get this item cooldown for an entity
+     * 
+     * @param entity the entity holding the item 
+     * @param stack the ItemStack
+     * @param partialTick the partial render tick
+     * @return this item cooldow  percent
+     */
+    default float getCooldownPercent(@Nonnull Entity entity, @Nonnull ItemStack stack, float partialTick)
+    {
+        return entity instanceof Player player ? player.getCooldowns().getCooldownPercent(self(), partialTick) : 0;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.tags.Tag;
@@ -494,5 +495,28 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     default boolean elytraFlightTick(LivingEntity entity, int flightTicks)
     {
         return self().getItem().elytraFlightTick(self(), entity, flightTicks);
+    }
+    
+    /**
+     * Check if this item stack is on cooldown for an entity
+     * 
+     * @param entity the entity holding the item stack
+     * @return if this item stack is on cooldow
+     */
+    default boolean isOnCooldown(@Nonnull Entity entity)
+    {
+        return self().getItem().isOnCooldown(entity, self());
+    }
+
+    /**
+     * get this item stack cooldown for an entity
+     * 
+     * @param entity      the entity holding the item stack
+     * @param partialTick the partial render tick
+     * @return this item stack cooldow percent
+     */
+    default float getCooldownPercent(@Nonnull Entity entity, float partialTick)
+    {
+        return self().getItem().getCooldownPercent(entity, self(), partialTick);
     }
 }


### PR DESCRIPTION
This PR goal is to offers the ability for mods to add custom cooldown handling on their items. To do so it adds two new methods `IForgeItem#isOnCooldown` and `IForgeItem#getCooldownPercent` that expose the vanilla cooldown behavior.
