### PR TITLE
Fix TierSortingRegistry crashing on server startup during forgedev due to eclipse compiler

### DIFF
--- a/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
+++ b/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
@@ -68,6 +68,7 @@ import java.util.stream.Collectors;
 public class TierSortingRegistry
 {
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final ResourceLocation ITEM_TIER_ORDERING_JSON = new ResourceLocation("forge", "item_tier_ordering.json");
 
     /**
      * Registers a tier into the tier sorting registry.
@@ -258,8 +259,6 @@ public class TierSortingRegistry
     {
         return new SimplePreparableReloadListener<JsonObject>()
         {
-            static final ResourceLocation ITEM_TIER_ORDERING_JSON = new ResourceLocation("forge", "item_tier_ordering.json");
-
             final Gson gson = (new GsonBuilder()).create();
 
             @Nonnull


### PR DESCRIPTION
When starting any server during forgedev in eclipse, a static-initialized ResourceLocation in an anonymous class in TierSortingRegistry is null when referenced. This seems to be due to a bug(?) in the eclipse compiler where static fields in anonymous classes aren't handled correctly (or at all).

This PR works around this by moving the static resourcelocation field to the outer class.

I've reported the upstream bug to eclipse as well
https://bugs.eclipse.org/bugs/show_bug.cgi?id=575495