### PR TITLE
Fix entities not spawning in structures

### DIFF
--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -77,7 +77,7 @@
 -   protected static class TagAppender<T> {
 +   public static class TagAppender<T> implements net.minecraftforge.common.extensions.IForgeTagAppender<T> {
        private final Tag.Builder f_126568_;
-       private final Registry<T> f_126569_;
+       public final Registry<T> f_126569_;
        private final String f_126570_;
 @@ -114,7 +_,7 @@
           return this;

--- a/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
+++ b/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
@@ -76,7 +76,7 @@ public class StructureSpawnManager
         ImmutableMap.Builder<net.minecraft.world.entity.MobCategory, WeightedRandomList<MobSpawnSettings.SpawnerData>> builder = ImmutableMap.builder();
         event.getEntitySpawns().forEach((classification, spawns) -> {
             if (!spawns.isEmpty())
-                builder.put(classification, WeightedRandomList.create());
+                builder.put(classification, WeightedRandomList.create(spawns));
         });
         ImmutableMap<MobCategory, WeightedRandomList<MobSpawnSettings.SpawnerData>> entitySpawns = builder.build();
         if (!entitySpawns.isEmpty())


### PR DESCRIPTION
A line was incorrectly changed in the 1.17 update process, leading to entity spawn data for structures always being empty. In vanilla, this affects swamp huts, pillager outposts, ocean monuments, and nether fortresses. This PR fixes the issue explained [on the forums](https://forums.minecraftforge.net/topic/103549-forge-server-1171-nothing-spawns-in-nether-fortresses/).

A patch file was also changed as a result of a context line being modified from an AT. It looks like the PR that added this AT never ran `genPatches`, so it is changed here.