### PR TITLE
Fix ExtendedButton and LoadingErrorScreen rendering

### DIFF
--- a/src/main/java/net/minecraftforge/fmlclient/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fmlclient/gui/GuiUtils.java
@@ -140,6 +140,7 @@ public class GuiUtils
     public static void drawContinuousTexturedBox(PoseStack matrixStack, ResourceLocation res, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
                                                  int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
     {
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
         RenderSystem.setShaderTexture(0, res);
         drawContinuousTexturedBox(matrixStack, x, y, u, v, width, height, textureWidth, textureHeight, topBorder, bottomBorder, leftBorder, rightBorder, zLevel);
     }
@@ -164,13 +165,12 @@ public class GuiUtils
      * @param rightBorder the size of the box's right border
      * @param zLevel the zLevel to draw at
      */
-    @SuppressWarnings("deprecation")
     public static void drawContinuousTexturedBox(PoseStack matrixStack, int x, int y, int u, int v, int width, int height, int textureWidth, int textureHeight,
                                                  int topBorder, int bottomBorder, int leftBorder, int rightBorder, float zLevel)
     {
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.enableBlend();
-        RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+        RenderSystem.defaultBlendFunc();
 
         int fillerWidth = textureWidth - leftBorder - rightBorder;
         int fillerHeight = textureHeight - topBorder - bottomBorder;
@@ -288,7 +288,7 @@ public class GuiUtils
     /**
      * Use this version if calling from somewhere where ItemStack context is available.
      *
-     * @see #drawHoveringText(MatrixStack, List, int, int, int, int, int, int, int, int, FontRenderer)
+     * @see #drawHoveringText(PoseStack, List, int, int, int, int, int, int, int, int, Font)
      */
     //TODO, Validate rendering is the same as the original
     public static void drawHoveringText(@Nonnull final ItemStack stack, PoseStack pStack, List<? extends FormattedText> textLines, int mouseX, int mouseY,
@@ -433,7 +433,6 @@ public class GuiUtils
         }
     }
 
-    @SuppressWarnings("deprecation")
     public static void drawGradientRect(Matrix4f mat, int zLevel, int left, int top, int right, int bottom, int startColor, int endColor)
     {
         float startAlpha = (float)(startColor >> 24 & 255) / 255.0F;

--- a/src/main/java/net/minecraftforge/fmlclient/gui/screen/LoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fmlclient/gui/screen/LoadingErrorScreen.java
@@ -91,7 +91,7 @@ public class LoadingErrorScreen extends ErrorScreen {
         }
 
         this.entryList = new LoadingEntryList(this, this.modLoadErrors, this.modLoadWarnings);
-        this.addRenderableWidget(this.entryList);
+        this.addWidget(this.entryList);
         this.setFocused(this.entryList);
     }
 

--- a/src/main/java/net/minecraftforge/fmlclient/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/fmlclient/gui/widget/ExtendedButton.java
@@ -51,23 +51,19 @@ public class ExtendedButton extends Button
     @Override
     public void renderButton(PoseStack mStack, int mouseX, int mouseY, float partial)
     {
-        if (this.visible)
-        {
-            Minecraft mc = Minecraft.getInstance();
-            this.isHovered = mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
-            int k = this.getYImage(this.isHovered());
-            GuiUtils.drawContinuousTexturedBox(mStack, WIDGETS_LOCATION, this.x, this.y, 0, 46 + k * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, this.getBlitOffset());
-            this.renderBg(mStack, mc, mouseX, mouseY);
+        Minecraft mc = Minecraft.getInstance();
+        int k = this.getYImage(this.isHovered());
+        GuiUtils.drawContinuousTexturedBox(mStack, WIDGETS_LOCATION, this.x, this.y, 0, 46 + k * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, this.getBlitOffset());
+        this.renderBg(mStack, mc, mouseX, mouseY);
 
-            Component buttonText = this.getMessage();
-            int strWidth = mc.font.width(buttonText);
-            int ellipsisWidth = mc.font.width("...");
+        Component buttonText = this.getMessage();
+        int strWidth = mc.font.width(buttonText);
+        int ellipsisWidth = mc.font.width("...");
 
-            if (strWidth > width - 6 && strWidth > ellipsisWidth)
-                //TODO, srg names make it hard to figure out how to append to an ITextProperties from this trim operation, wraping this in StringTextComponent is kinda dirty.
-                buttonText = new TextComponent(mc.font.substrByWidth(buttonText, width - 6 - ellipsisWidth).getString() + "...");
+        if (strWidth > width - 6 && strWidth > ellipsisWidth)
+            //TODO, srg names make it hard to figure out how to append to an ITextProperties from this trim operation, wraping this in StringTextComponent is kinda dirty.
+            buttonText = new TextComponent(mc.font.substrByWidth(buttonText, width - 6 - ellipsisWidth).getString() + "...");
 
-            drawCenteredString(mStack, mc.font, buttonText, this.x + this.width / 2, this.y + (this.height - 8) / 2, getFGColor());
-        }
+        drawCenteredString(mStack, mc.font, buttonText, this.x + this.width / 2, this.y + (this.height - 8) / 2, getFGColor());
     }
 }


### PR DESCRIPTION
- Fixed `GuiUtils#drawContinuousTexturedBox` assuming what the current shader is so not working if called when in the wrong state such as after drawing text
- Fixed LoadingErrorScreen covering the buttons and header text when drawing the entryList
- Slightly modernized `ExtendedButton#renderButton` to be like how vanilla's renderButton is in that: visibility is checked and current hovered state is set in render just before renderButton is called