### PR TITLE
Fix broken fmlonly installer and promote it to page gen

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
                 }
                 script {
                     env.MYVERSION = sh(returnStdout: true, script: './gradlew :forge:properties -q | grep "^version:" | cut -d" " -f2').trim()
+                    env.FMLONLY_VERSION = sh(returnStdout: true, script: './gradlew :fmlonly:properties -q | grep "^version:" | cut -d" " -f2').trim()
                 }
             }
         }
@@ -76,6 +77,7 @@ pipeline {
             post {
                 success {
                     build job: 'filegenerator', parameters: [string(name: 'COMMAND', value: "promote net.minecraftforge:forge ${env.MYVERSION} latest")], propagate: false, wait: false
+                    build job: 'filegenerator', parameters: [string(name: 'COMMAND', value: "promote net.minecraftforge:fmlonly ${env.FMLONLY_VERSION} latest")], propagate: false, wait: false
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -586,7 +586,7 @@ project(':fmlonly') {
         }
     }
 
-    task installerJson(type: InstallerJson) {
+    task installerJson(type: InstallerJson, dependsOn: 'signUniversalJar') {
         icon = rootProject.file('icon.ico')
         packedDependencies = PACKED_DEPS
 
@@ -1094,7 +1094,7 @@ project(':forge') {
         }
     }
 
-    task installerJson(type: InstallerJson, dependsOn: [launcherJson, genClientBinPatches, applyClientBinPatches, applyServerBinPatches]) {
+    task installerJson(type: InstallerJson, dependsOn: [launcherJson, genClientBinPatches, applyClientBinPatches, applyServerBinPatches, 'signUniversalJar']) {
         ext {
             // remove :fatjar
             BIN_PATCHER = BINPATCH_TOOL.substring(0, BINPATCH_TOOL.length() - 1 - BINPATCH_TOOL.split(':')[3].length())

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210702220150+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Copyright 2015 the original author or authors.
@@ -172,14 +172,12 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     esac
 fi
 
-# Escape application args
-save () {
-    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
-    echo " "
-}
-APP_ARGS=`save "$@"`
+ARGV=("$@")
+eval set -- $DEFAULT_JVM_OPTS
 
-# Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+IFS=$'
+' read -rd '' -a JAVA_OPTS_ARR <<< "$(echo $JAVA_OPTS | xargs -n1)"
+IFS=$'
+' read -rd '' -a GRADLE_OPTS_ARR <<< "$(echo $GRADLE_OPTS | xargs -n1)"
 
-exec "$JAVACMD" "$@"
+exec "$JAVACMD" "$@" "${JAVA_OPTS_ARR[@]}" "${GRADLE_OPTS_ARR[@]}" "-Dorg.gradle.appname=$APP_BASE_NAME" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "${ARGV[@]}"


### PR DESCRIPTION
This PR fixes the fmlonly installer being broken, and promotes fmlonly to page generation now.

Previously, attempting to use the fmlonly installer resulted in the following error:
```
Considering library net.minecraftforge:fmlonly:1.17.1-37.0.44:universal
  Downloading library from https://maven.creeperhost.net/net/minecraftforge/fmlonly/1.17.1-37.0.44/fmlonly-1.17.1-37.0.44-universal.jar
    Download failed: Checksum invalid, deleting file:
      Expected: 1fdc3cb626372bf39801caa7733fdbfafbe69089
      Actual:   d655d641d2ae545073ae8347b3f4be536a853bc1
```

This was due to the fact that the universal jar was being signed *after* the installerJson task queried the SHA1 of the output file. This issue did not appear in the forge subproject because it explicitly specified `installerJar.dependsOn 'signUniversalJar'`. However, this is technically still incorrect as `installerJson` itself needs to depend on the sign task to ensure the correct SHA1, and the sign jar task being run before installerJson is not
explicitly defined. Gradle actually warns about inexplicit task dependencies now in Gradle 7, which can be seen [in the Jenkins output here](https://jenkins.minecraftforge.net/job/forge/job/forge/job/1.17.x/44/console#gradle-task-99).

The Gradle wrapper has also been updated from the previous snapshot version to Gradle 7.2.