### PR TITLE
Fix all layers of ItemLayerModel being fullbright

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -112,8 +112,9 @@ public final class ItemLayerModel implements IModelGeometry<ItemLayerModel>
         for(int i = 0; i < textures.size(); i++)
         {
             TextureAtlasSprite tas = spriteGetter.apply(textures.get(i));
-            RenderType rt = getLayerRenderType(fullbrightLayers.contains(i));
-            builder.addQuads(rt, getQuadsForSprite(i, tas, transform, true));
+            boolean fullbright = fullbrightLayers.contains(i);
+            RenderType rt = getLayerRenderType(fullbright);
+            builder.addQuads(rt, getQuadsForSprite(i, tas, transform, fullbright));
         }
 
         return builder.build();


### PR DESCRIPTION
This PR fixes #8007 by properly passing on the fullbrightness of a layer to the method which creates the quads for the sprite, as noted in the linked issue.

The issue seems to have been introduced in commit https://github.com/MinecraftForge/MinecraftForge/commit/ce3d8b40cf37924caf1708cdde6842ae6fdcee31#diff-faf15b5b7caaccd4c0f4a3c1aa1ca361092e2e0bb83577188760148de7f8bf5eR108 by gigaherz on Jul 3, 2020. This means that (as noted in the issue) this bug also occurs in 1.16.x. A separate PR will be made to address that once this one has been reviewed.

**Screenshot of the implemented fix:**
![](https://user-images.githubusercontent.com/21304337/131464619-3199a677-d21e-4dd0-b703-24156fa74439.png)

(_as compared with the photo from the linked issue:_)
![](https://user-images.githubusercontent.com/15868585/129455764-9b000da5-c349-47aa-8ebb-e32fa427c6c4.png)
