### PR TITLE
Re-add missing patch for IForgeItem#getEquipmentSlot

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -505,12 +505,10 @@
     }
  
     public boolean m_5830_() {
-@@ -3198,6 +_,64 @@
- 
-    public void m_21190_(InteractionHand p_21191_) {
+@@ -3200,6 +_,64 @@
        this.m_21166_(p_21191_ == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-+   }
-+
+    }
+ 
 +   /* ==== FORGE START ==== */
 +   /***
 +    * Removes all potion effects that have curativeItem as a curative item for its effect
@@ -567,6 +565,17 @@
 +   public void reviveCaps() {
 +      super.reviveCaps();
 +      handlers = net.minecraftforge.items.wrapper.EntityEquipmentInvWrapper.create(this);
++   }
++
+    public AABB m_6921_() {
+       if (this.m_6844_(EquipmentSlot.HEAD).m_150930_(Items.f_42683_)) {
+          float f = 0.5F;
+@@ -3210,6 +_,8 @@
     }
  
-    public AABB m_6921_() {
+    public static EquipmentSlot m_147233_(ItemStack p_147234_) {
++      final EquipmentSlot slot = p_147234_.getEquipmentSlot();
++      if (slot != null) return slot; // FORGE: Allow modders to set a non-default equipment slot for a stack; e.g. a non-armor chestplate-slot item
+       Item item = p_147234_.m_41720_();
+       if (!p_147234_.m_150930_(Items.f_42047_) && (!(item instanceof BlockItem) || !(((BlockItem)item).m_40614_() instanceof AbstractSkullBlock))) {
+          if (item instanceof ArmorItem) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -373,7 +373,7 @@ public interface IForgeItem
     /**
      * Override this to set a non-default armor slot for an ItemStack, but <em>do
      * not use this to get the armor slot of said stack; for that, use
-     * {@link net.minecraft.entity.LivingEntity#getSlotForItemStack(ItemStack)}.</em>
+     * {@link net.minecraft.world.entity.LivingEntity#getEquipmentSlotForItem(ItemStack)}..</em>
      *
      * @param stack the ItemStack
      * @return the armor slot of the ItemStack, or {@code null} to let the default

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -181,7 +181,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     /**
      * Override this to set a non-default armor slot for an ItemStack, but <em>do
      * not use this to get the armor slot of said stack; for that, use
-     * {@link net.minecraft.entity.LivingEntity#getSlotForItemStack(ItemStack)}.</em>
+     * {@link net.minecraft.world.entity.LivingEntity#getEquipmentSlotForItem(ItemStack)}.</em>
      *
      * @return the armor slot of the ItemStack, or {@code null} to let the default
      *         vanilla logic as per {@code LivingEntity.getSlotForItemStack(stack)}


### PR DESCRIPTION
This PR fixes #7940 by re-adding the missing patch which calls `IForgeItem#getEquipmentSlot`. This also corrects the linking error in the javadocs for that method and its corresponding one in `IForgeItemStack`.

The missing patch is at `MobEntity` in 1.16.x (the method being patched was moved to `Mob` in 1.17.x): https://github.com/MinecraftForge/MinecraftForge/blob/a2bd95ca39a1908fa06e0859760d7482cf6fe23e/patches/minecraft/net/minecraft/entity/MobEntity.java.patch#L35-L43

Tested in-game through the Forge test client, by equipping the custom elytra item (added by a test mod) manually.  I note that when I tested for the behavior in 1.16 (where the functionality still works), it does not allow right-click equipping of the custom elytra. From my brief look, it seems that the quick right-click equip is done in `ArmorItem`.

~~For future note to myself and others, there is also the matter of the other missing patch in the same linked 1.16.x patch file, for `isShield`. I suspect this is used when zombies pick up a shield and equip it, but further testing by others or by myself is needed.~~ See #8055.