### PR TITLE
Re-add patch to release buffer in custom payload packet

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -85,7 +85,7 @@
           this.f_104895_ = tagcontainer;
           if (!this.f_104885_.m_129531_()) {
              tagcontainer.m_13431_();
-@@ -1780,10 +_,12 @@
+@@ -1780,7 +_,8 @@
              int i5 = friendlybytebuf.m_130242_();
              this.f_104888_.f_91064_.f_173815_.m_173830_(positionsource, i5);
           } else {
@@ -95,7 +95,3 @@
           }
        } finally {
           if (friendlybytebuf != null) {
-+            if (false) // Forge: let packet handle releasing buffer
-             friendlybytebuf.release();
-          }
- 

--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -9,3 +9,11 @@
     private static final int f_178834_ = 1048576;
     public static final ResourceLocation f_132012_ = new ResourceLocation("brand");
     public static final ResourceLocation f_132013_ = new ResourceLocation("debug/path");
+@@ -52,6 +_,7 @@
+ 
+    public void m_5797_(ClientGamePacketListener p_132041_) {
+       p_132041_.m_7413_(this);
++      this.f_132030_.release(); // FORGE: Fix network buffer leaks (MC-121884)
+    }
+ 
+    public ResourceLocation m_132042_() {


### PR DESCRIPTION
This PR fixes #7486 by readding the patch from #4512 to release the buffer in `SCustomPayloadPacket` -- see https://github.com/MinecraftForge/MinecraftForge/commit/baaa6c65056ba71fe5e3d85e60ebb6ddbfc5370c#diff-0f241acf691432d38feb5d53220be71e25f194858ac81a938263fc107c59eae4R17-R18.
A separate commit also removes another patch which prevented the copy of the custom payload packet's data buffer from being released properly.

To paraphrase @gigaherz's [analysis in a conversation we had](https://discord.com/channels/313125603924639766/852298000042164244/882232990464372738) in the discord about this:
> So it seem that deep deep down, Netty uses `alloc.ioBuffer`, which can either use a direct buffer or a heap buffer depending on how that shit is set up.
> On LocalChannels (singleplayer), it seems to use a prefer-heap allocator. On multiplayer, it probably uses direct buffers though.
> So it could be the case that in multiplayer/LAN connections we have a real memory leak but in singleplayer it's only a counting leak.

This issue also exists in 1.16, and a backport PR will be made to address that once this one has been reviewed.