### PR TITLE
Patch ModSorter to include forge mod in forgeAndMC list

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -161,6 +161,10 @@ public class ModSorter
             forgeAndMC.add((ModFile) mc.get(0));
         else
             throw new IllegalStateException("Failed to find minecraft somehow?");
+        // TODO: remove this hardcoding and make it more flexible
+        var forge = modFilesByFirstId.get("forge");
+        if (forge != null && !forge.isEmpty())
+            forgeAndMC.add((ModFile) forge.get(0)); // Silently ignore if Forge isn't present
 
         // Select the newest by artifact version sorting of non-unique files thus identified
         this.modFiles = modFilesByFirstId.entrySet().stream()

--- a/src/main/java/net/minecraftforge/common/loot/CanToolPerformAction.java
+++ b/src/main/java/net/minecraftforge/common/loot/CanToolPerformAction.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot;
 
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import javax.annotation.Nullable;

--- a/src/test/java/net/minecraftforge/debug/entity/CheckSpawnEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/CheckSpawnEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.entity;
 
 import net.minecraft.world.entity.vehicle.MinecartSpawner;

--- a/src/test/java/net/minecraftforge/debug/misc/OnDatapackSynctEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/OnDatapackSynctEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.misc;
 
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
This PR fixes #7993 and fixes #8036 by adding a special case for the `forge` mod in `ModSorter`, to be added to the `forgeAndMC` mod file list. See [this comment by me on the first linked issue](https://github.com/MinecraftForge/MinecraftForge/issues/7993#issuecomment-909366998) for more details on how this fixes the underlying issue.

Note that this is only meant as a 'hotpatch' of sorts, to fix the behavior in a fail-safe manner until a more flexible API can be implemented to allow loading systems to specify additional mods to include in this list.

<details>
<summary>Screenshots of the implemented fix using the steps provided in each issue</summary>

**Image of the mod loading errors screen for the steps from issue #7993**:
![](https://user-images.githubusercontent.com/21304337/131545872-eb8f2dfb-6aac-44a7-b6f9-059e7750ea7a.png)
**Image of the mod loading errors screen for the steps and linked mod from issue #8036**:
![](https://user-images.githubusercontent.com/21304337/131545866-a36ac127-8746-46e9-9264-cd5fd5d5b2bc.png)
</details>
