### PR TITLE
Add workaround for pairs of `'` being stripped

### DIFF
--- a/src/main/java/net/minecraftforge/fmllegacy/TextComponentMessageFormatHandler.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/TextComponentMessageFormatHandler.java
@@ -36,7 +36,6 @@ public class TextComponentMessageFormatHandler {
                         .filter(ch -> formattedString.indexOf((char) ch) == -1)
                         .allMatch(ch -> ch == '\'');
                 if (onlyMissingQuotes) {
-                    System.out.println("only misses quote char: " + formattedString + " ; original: " + format);
                     return 0;
                 }
             }

--- a/src/main/java/net/minecraftforge/fmllegacy/TextComponentMessageFormatHandler.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/TextComponentMessageFormatHandler.java
@@ -28,7 +28,20 @@ import java.util.List;
 public class TextComponentMessageFormatHandler {
     public static int handle(final TranslatableComponent parent, final List<FormattedText> children, final Object[] formatArgs, final String format) {
         try {
-            TextComponent component = new TextComponent(ForgeI18n.parseFormat(format, formatArgs));
+            final String formattedString = ForgeI18n.parseFormat(format, formatArgs);
+
+            // See MinecraftForge/MinecraftForge#7396
+            if (format.indexOf('\'') != -1) {
+                final boolean onlyMissingQuotes = format.chars()
+                        .filter(ch -> formattedString.indexOf((char) ch) == -1)
+                        .allMatch(ch -> ch == '\'');
+                if (onlyMissingQuotes) {
+                    System.out.println("only misses quote char: " + formattedString + " ; original: " + format);
+                    return 0;
+                }
+            }
+
+            TextComponent component = new TextComponent(formattedString);
             component.getStyle().applyTo(parent.getStyle());
             children.add(component);
             return format.length();


### PR DESCRIPTION
This PR fixes #7396, where if a translated string with balanced pairs of single quote characters (`'`) passes through ForgeI18n, the quotes are stripped because of `ExtendedMessageFormat`. This is most notable in languages where `'` is used frequently, like Canadian French from the linked issue.

The workaround is simple: when comparing the original string and the output of `ForgeI18n`, if the only characters missing from the output are `'`, then return immediately (which causes the original string to be appended as normal). The workaround only applies if `'` appears in the original format string, to save on unnecessarily applying it to strings which cannot be affected.

Note that unbalanced pairs of `'` cause an `IllegalArgumentException` in `ExtendedMessageFormat`, which means the original string is not affected and thus the issue does not trigger. Notably, this also means that `ForgeI18n` cannot be used when an odd amount of `'` exist in the original string.

A long-term solution would be moving away from `ExtendedMessageFormat`, but that is out of scope of this PR and would need more discussion as to a suitable replacement (one which preferrably doesn't need alterating all existing Forge translations which make use of `ExtendedMessageFormat`).

As this issue also exists for 1.16, a separate PR will be made to address that once this one has been reviewed.

**Screenshot of the implemented fix using the steps in the linked issue:**
![](https://user-images.githubusercontent.com/21304337/131659630-98fb3e00-42ba-41bc-98ff-d742e17e058c.png)