### PR TITLE
Re-implement linear filtering text render types

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
@@ -1,0 +1,36 @@
+--- a/net/minecraft/client/renderer/RenderType.java
++++ b/net/minecraft/client/renderer/RenderType.java
+@@ -288,27 +_,27 @@
+    }
+ 
+    public static RenderType m_110497_(ResourceLocation p_110498_) {
+-      return f_173173_.apply(p_110498_);
++      return net.minecraftforge.client.ForgeRenderTypes.getText(p_110498_);
+    }
+ 
+    public static RenderType m_173237_(ResourceLocation p_173238_) {
+-      return f_173174_.apply(p_173238_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensity(p_173238_);
+    }
+ 
+    public static RenderType m_181444_(ResourceLocation p_181445_) {
+-      return f_181442_.apply(p_181445_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextPolygonOffset(p_181445_);
+    }
+ 
+    public static RenderType m_181446_(ResourceLocation p_181447_) {
+-      return f_181443_.apply(p_181447_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensityPolygonOffset(p_181447_);
+    }
+ 
+    public static RenderType m_110500_(ResourceLocation p_110501_) {
+-      return f_173175_.apply(p_110501_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextSeeThrough(p_110501_);
+    }
+ 
+    public static RenderType m_173240_(ResourceLocation p_173241_) {
+-      return f_173176_.apply(p_173241_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensitySeeThrough(p_173241_);
+    }
+ 
+    public static RenderType m_110502_() {

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -376,8 +376,8 @@ public enum ForgeRenderTypes
                 this.mipmap = mipmap.get();
                 RenderSystem.enableTexture();
                 TextureManager texturemanager = Minecraft.getInstance().getTextureManager();
-                texturemanager.bindForSetup(resLoc);
                 texturemanager.getTexture(resLoc).setFilter(this.blur, this.mipmap);
+                RenderSystem.setShaderTexture(0, resLoc);
             };
         }
     }

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -342,7 +342,7 @@ public enum ForgeRenderTypes
         public static Function<ResourceLocation, RenderType> TEXT_SEETHROUGH = Util.memoize(Internal::getTextSeeThrough);
         private static RenderType getTextSeeThrough(ResourceLocation locationIn) {
             RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
-                    .setShaderState(RENDERTYPE_TEXT_SHADER)
+                    .setShaderState(RENDERTYPE_TEXT_SEE_THROUGH_SHADER)
                     .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
                     .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
                     .setLightmapState(LIGHTMAP)

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -136,11 +136,43 @@ public enum ForgeRenderTypes
     }
 
     /**
+     * @return Replacement of {@link RenderType#textIntensity(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getTextIntensity(ResourceLocation locationIn)
+    {
+        return Internal.TEXT_INTENSITY.apply(locationIn);
+    }
+
+    /**
+     * @return Replacement of {@link RenderType#textPolygonOffset(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getTextPolygonOffset(ResourceLocation locationIn)
+    {
+        return Internal.TEXT_POLYGON_OFFSET.apply(locationIn);
+    }
+
+    /**
+     * @return Replacement of {@link RenderType#textIntensityPolygonOffset(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getTextIntensityPolygonOffset(ResourceLocation locationIn)
+    {
+        return Internal.TEXT_INTENSITY_POLYGON_OFFSET.apply(locationIn);
+    }
+
+    /**
      * @return Replacement of {@link RenderType#textSeeThrough(ResourceLocation)}, but with optional linear texture filtering.
      */
     public static RenderType getTextSeeThrough(ResourceLocation locationIn)
     {
         return Internal.TEXT_SEETHROUGH.apply(locationIn);
+    }
+
+    /**
+     * @return Replacement of {@link RenderType#textIntensitySeeThrough(ResourceLocation)}, but with optional linear texture filtering.
+     */
+    public static RenderType getTextIntensitySeeThrough(ResourceLocation locationIn)
+    {
+        return Internal.TEXT_INTENSITY_SEETHROUGH.apply(locationIn);
     }
 
     // ----------------------------------------
@@ -272,10 +304,58 @@ public enum ForgeRenderTypes
             return create("forge_text", DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
         }
 
+        public static Function<ResourceLocation, RenderType> TEXT_INTENSITY = Util.memoize(Internal::getTextIntensity);
+        private static RenderType getTextIntensity(ResourceLocation locationIn) {
+            RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
+                    .setShaderState(RENDERTYPE_TEXT_INTENSITY_SHADER)
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .createCompositeState(false);
+            return create("text_intensity", DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
+        }
+
+        public static Function<ResourceLocation, RenderType> TEXT_POLYGON_OFFSET = Util.memoize(Internal::getTextPolygonOffset);
+        private static RenderType getTextPolygonOffset(ResourceLocation locationIn) {
+            RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
+                    .setShaderState(RENDERTYPE_TEXT_SHADER)
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .setLayeringState(POLYGON_OFFSET_LAYERING)
+                    .createCompositeState(false);
+            return create("text_intensity", DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
+        }
+
+        public static Function<ResourceLocation, RenderType> TEXT_INTENSITY_POLYGON_OFFSET = Util.memoize(Internal::getTextIntensityPolygonOffset);
+        private static RenderType getTextIntensityPolygonOffset(ResourceLocation locationIn) {
+            RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
+                    .setShaderState(RENDERTYPE_TEXT_INTENSITY_SHADER)
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .setLayeringState(POLYGON_OFFSET_LAYERING)
+                    .createCompositeState(false);
+            return create("text_intensity", DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
+        }
+
         public static Function<ResourceLocation, RenderType> TEXT_SEETHROUGH = Util.memoize(Internal::getTextSeeThrough);
         private static RenderType getTextSeeThrough(ResourceLocation locationIn) {
             RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
                     .setShaderState(RENDERTYPE_TEXT_SHADER)
+                    .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .setDepthTestState(NO_DEPTH_TEST)
+                    .setWriteMaskState(COLOR_WRITE)
+                    .createCompositeState(false);
+            return create("forge_text_see_through", DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
+        }
+
+        public static Function<ResourceLocation, RenderType> TEXT_INTENSITY_SEETHROUGH = Util.memoize(Internal::getTextIntensitySeeThrough);
+        private static RenderType getTextIntensitySeeThrough(ResourceLocation locationIn) {
+            RenderType.CompositeState rendertype$state = RenderType.CompositeState.builder()
+                    .setShaderState(RENDERTYPE_TEXT_INTENSITY_SEE_THROUGH_SHADER)
                     .setTextureState(new CustomizableTextureState(locationIn, () -> ForgeRenderTypes.enableTextTextureLinearFiltering, () -> false))
                     .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
                     .setLightmapState(LIGHTMAP)


### PR DESCRIPTION
This PR closes #7996 by re-implementing the custom Forge render types for texts which have optional linear filtering enabled and the patches necessary for them to work. In addition, this PR also adds new custom render types of the same vein for the new text render types, which means there are 6 text render types in total: `TEXT`, `TEXT_INTENSITY`, `TEXT_POLYGON_OFFSET`, `TEXT_INTENSITY_POLYGON_OFFSET`, `TEXT_SEE_THROUGH`, and `TEXT_INTENSITY_SEE_THROUGH`.

The existing `TEXT_SEE_THROUGH` Forge render type is slightly modified to match its vanilla counterpart, and the same with the `CustomizableTextureState` with its superclass, `TextureStateShard`.

**Screenshot with the test mod enabled:** _(note how the text is 'blurred' slightly)_
![Screenshot 2021-09-01 212642](https://user-images.githubusercontent.com/21304337/131703375-3cc4ac64-7c63-4c33-b8fa-a10301e77f88.png)