### PR TITLE
Add new tool action for shield blocking, replacing `IForgeItem#isShield`

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -575,7 +575,7 @@
              return EquipmentSlot.CHEST;
           } else {
 -            return p_147234_.m_150930_(Items.f_42740_) ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND;
-+            return p_147234_.isShield(null) ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND;
++            return p_147234_.canPerformAction(net.minecraftforge.common.ToolActions.SHIELD_BLOCK) ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND;
           }
        } else {
           return EquipmentSlot.HEAD;

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -505,12 +505,10 @@
     }
  
     public boolean m_5830_() {
-@@ -3198,6 +_,64 @@
- 
-    public void m_21190_(InteractionHand p_21191_) {
+@@ -3200,6 +_,64 @@
        this.m_21166_(p_21191_ == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-+   }
-+
+    }
+ 
 +   /* ==== FORGE START ==== */
 +   /***
 +    * Removes all potion effects that have curativeItem as a curative item for its effect
@@ -567,6 +565,17 @@
 +   public void reviveCaps() {
 +      super.reviveCaps();
 +      handlers = net.minecraftforge.items.wrapper.EntityEquipmentInvWrapper.create(this);
-    }
- 
++   }
++
     public AABB m_6921_() {
+       if (this.m_6844_(EquipmentSlot.HEAD).m_150930_(Items.f_42683_)) {
+          float f = 0.5F;
+@@ -3217,7 +_,7 @@
+          } else if (p_147234_.m_150930_(Items.f_42741_)) {
+             return EquipmentSlot.CHEST;
+          } else {
+-            return p_147234_.m_150930_(Items.f_42740_) ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND;
++            return p_147234_.isShield(null) ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND;
+          }
+       } else {
+          return EquipmentSlot.HEAD;

--- a/patches/minecraft/net/minecraft/world/entity/monster/piglin/StopHoldingItemIfNoLongerAdmiring.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/piglin/StopHoldingItemIfNoLongerAdmiring.java.patch
@@ -5,7 +5,7 @@
  
     protected boolean m_6114_(ServerLevel p_35255_, E p_35256_) {
 -      return !p_35256_.m_21206_().m_41619_() && !p_35256_.m_21206_().m_150930_(Items.f_42740_);
-+      return !p_35256_.m_21206_().m_41619_() && !p_35256_.m_21206_().isShield(p_35256_);
++      return !p_35256_.m_21206_().m_41619_() && !p_35256_.m_21206_().canPerformAction(net.minecraftforge.common.ToolActions.SHIELD_BLOCK);
     }
  
     protected void m_6735_(ServerLevel p_35258_, E p_35259_, long p_35260_) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -129,7 +129,7 @@
  
     protected void m_7909_(float p_36383_) {
 -      if (this.f_20935_.m_150930_(Items.f_42740_)) {
-+      if (this.f_20935_.isShield(this)) {
++      if (this.f_20935_.canPerformAction(net.minecraftforge.common.ToolActions.SHIELD_BLOCK)) {
           if (!this.f_19853_.f_46443_) {
              this.m_36246_(Stats.f_12982_.m_12902_(this.f_20935_.m_41720_()));
           }

--- a/patches/minecraft/net/minecraft/world/item/ShieldItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ShieldItem.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/item/ShieldItem.java
++++ b/net/minecraft/world/item/ShieldItem.java
+@@ -49,4 +_,11 @@
+    public static DyeColor m_43102_(ItemStack p_43103_) {
+       return DyeColor.m_41053_(p_43103_.m_41698_("BlockEntityTag").m_128451_("Base"));
+    }
++
++   /* ******************** FORGE START ******************** */
++
++   @Override
++   public boolean canPerformAction(ItemStack stack, net.minecraftforge.common.ToolAction toolAction) {
++      return net.minecraftforge.common.ToolActions.DEFAULT_SHIELD_ACTIONS.contains(toolAction);
++   }
+ }

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -109,6 +109,10 @@ public class ToolActions
     // */
     // TODO: public static final ToolAction HOE_TILL = ToolAction.get("till");
 
+    /**
+     * A tool action corresponding to the 'block' action of shields.
+     */
+    public static final ToolAction SHIELD_BLOCK = ToolAction.get("shield_block");
 
     // Default actions supported by each tool type
     public static final Set<ToolAction> DEFAULT_AXE_ACTIONS = of(AXE_DIG, AXE_STRIP, AXE_SCRAPE, AXE_WAX_OFF);
@@ -117,6 +121,7 @@ public class ToolActions
     public static final Set<ToolAction> DEFAULT_PICKAXE_ACTIONS = of(PICKAXE_DIG);
     public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = of(SWORD_DIG, SWORD_SWEEP);
     public static final Set<ToolAction> DEFAULT_SHEARS_ACTIONS = of(SHEARS_DIG, SHEARS_HARVEST, SHEARS_CARVE, SHEARS_DISARM);
+    public static final Set<ToolAction> DEFAULT_SHIELD_ACTIONS = of(SHIELD_BLOCK);
 
     private static Set<ToolAction> of(ToolAction... actions) {
         return Stream.of(actions).collect(Collectors.toCollection(Sets::newIdentityHashSet));

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -695,7 +695,7 @@ public interface IForgeItem
      * @param stack  the item stack
      * @param entity the entity holding the item stack
      * @deprecated To be removed in 1.18. Override {@link #canPerformAction(ItemStack, ToolAction)} and return
-     * {@code true} if the passed in tool action is contained in {@link ToolActions#DEFAULT_SHOVEL_ACTIONS} or is
+     * {@code true} if the passed in tool action is contained in {@link ToolActions#DEFAULT_SHIELD_ACTIONS} or is
      * equals to {@link ToolActions#SHIELD_BLOCK}.
      */
     @Deprecated(since = "1.17.1", forRemoval = true)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -526,7 +526,7 @@ public interface IForgeItem
     default boolean canPerformAction(ItemStack stack, ToolAction toolAction)
     {
         // Temporary patch to keep #isShield working until its removed; change to `return false` once removed
-        return ToolActions.DEFAULT_SHIELD_ACTIONS.contains(toolAction) && isShield(stack, null);
+        return isShield(stack, null) && ToolActions.DEFAULT_SHIELD_ACTIONS.contains(toolAction);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -51,6 +51,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
 
 // TODO review most of the methods in this "patch"
 public interface IForgeItem
@@ -524,7 +525,8 @@ public interface IForgeItem
      */
     default boolean canPerformAction(ItemStack stack, ToolAction toolAction)
     {
-        return false;
+        // Temporary patch to keep #isShield working until its removed; change to `return false` once removed
+        return ToolActions.DEFAULT_SHIELD_ACTIONS.contains(toolAction) && isShield(stack, null);
     }
 
     /**
@@ -685,6 +687,21 @@ public interface IForgeItem
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {
         return this instanceof AxeItem;
+    }
+
+    /**
+     * {@return {@code true} if this item is considered a shield}
+     *
+     * @param stack  the item stack
+     * @param entity the entity holding the item stack
+     * @deprecated To be removed in 1.18. Override {@link #canPerformAction(ItemStack, ToolAction)} and return
+     * {@code true} if the passed in tool action is contained in {@link ToolActions#DEFAULT_SHOVEL_ACTIONS} or is
+     * equals to {@link ToolActions#SHIELD_BLOCK}.
+     */
+    @Deprecated(since = "1.17.1", forRemoval = true)
+    default boolean isShield(ItemStack stack, @Nullable LivingEntity entity)
+    {
+        return stack.getItem() == Items.SHIELD;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -688,18 +688,6 @@ public interface IForgeItem
     }
 
     /**
-     * Is this Item a shield
-     *
-     * @param stack  The ItemStack
-     * @param entity The Entity holding the ItemStack
-     * @return True if the ItemStack is considered a shield
-     */
-    default boolean isShield(ItemStack stack, @Nullable LivingEntity entity)
-    {
-        return stack.getItem() == Items.SHIELD;
-    }
-
-    /**
      * @return the fuel burn time for this itemStack in a furnace. Return 0 to make
      *         it not act as a fuel. Return -1 to let the default vanilla logic
      *         decide.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -207,17 +207,6 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Is this Item a shield
-     *
-     * @param entity The Entity holding the ItemStack
-     * @return True if the ItemStack is considered a shield
-     */
-    default boolean isShield(@Nullable LivingEntity entity)
-    {
-        return self().getItem().isShield(self(), entity);
-    }
-
-    /**
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -43,6 +43,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 
 /*
@@ -204,6 +205,20 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     default boolean canDisableShield(ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {
         return self().getItem().canDisableShield(self(), shield, entity, attacker);
+    }
+
+    /**
+     * {@return {@code true} if this item is considered a shield}
+     *
+     * @param entity the entity holding the item stack
+     * @deprecated To be removed in 1.18. Call {@link #canPerformAction(ToolAction)} with
+     * {@link ToolActions#SHIELD_BLOCK} instead.
+     */
+    @SuppressWarnings("removal")
+    @Deprecated(since = "1.17.1", forRemoval = true)
+    default boolean isShield(@Nullable LivingEntity entity)
+    {
+        return self().getItem().isShield(self(), entity);
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fmllegacy.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+
+import javax.annotation.Nullable;
+
+@Mod("custom_shield_test")
+public class CustomShieldTest {
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Item.class, "custom_shield_test");
+
+    private static final RegistryObject<CustomShieldItem> CUSTOM_SHIELD_ITEM = ITEMS.register("custom_shield",
+            () -> new CustomShieldItem((new Item.Properties()).durability(336).tab(CreativeModeTab.TAB_COMBAT)));
+
+    public CustomShieldTest() {
+        ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
+
+    private static class CustomShieldItem extends Item {
+        public CustomShieldItem(Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        public UseAnim getUseAnimation(ItemStack stack) {
+            return UseAnim.BLOCK;
+        }
+
+        @Override
+        public int getUseDuration(ItemStack stack) {
+            return 72000;
+        }
+
+        @Override
+        public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
+            ItemStack itemstack = player.getItemInHand(hand);
+            player.startUsingItem(hand);
+            return InteractionResultHolder.consume(itemstack);
+        }
+
+        @Override
+        public boolean isShield(ItemStack stack, @Nullable LivingEntity entity) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
@@ -36,40 +36,48 @@ import net.minecraftforge.registries.DeferredRegister;
 import javax.annotation.Nullable;
 
 @Mod("custom_shield_test")
-public class CustomShieldTest {
+public class CustomShieldTest
+{
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Item.class, "custom_shield_test");
 
     private static final RegistryObject<CustomShieldItem> CUSTOM_SHIELD_ITEM = ITEMS.register("custom_shield",
             () -> new CustomShieldItem((new Item.Properties()).durability(336).tab(CreativeModeTab.TAB_COMBAT)));
 
-    public CustomShieldTest() {
+    public CustomShieldTest()
+    {
         ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
 
-    private static class CustomShieldItem extends Item {
-        public CustomShieldItem(Properties properties) {
+    private static class CustomShieldItem extends Item
+    {
+        public CustomShieldItem(Properties properties)
+        {
             super(properties);
         }
 
         @Override
-        public UseAnim getUseAnimation(ItemStack stack) {
+        public UseAnim getUseAnimation(ItemStack stack)
+        {
             return UseAnim.BLOCK;
         }
 
         @Override
-        public int getUseDuration(ItemStack stack) {
+        public int getUseDuration(ItemStack stack)
+        {
             return 72000;
         }
 
         @Override
-        public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
+        public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand)
+        {
             ItemStack itemstack = player.getItemInHand(hand);
             player.startUsingItem(hand);
             return InteractionResultHolder.consume(itemstack);
         }
 
         @Override
-        public boolean isShield(ItemStack stack, @Nullable LivingEntity entity) {
+        public boolean isShield(ItemStack stack, @Nullable LivingEntity entity)
+        {
             return true;
         }
     }

--- a/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.world.InteractionHand;

--- a/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
@@ -21,19 +21,18 @@ package net.minecraftforge.debug.item;
 
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fmllegacy.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
-
-import javax.annotation.Nullable;
 
 @Mod("custom_shield_test")
 public class CustomShieldTest
@@ -76,9 +75,9 @@ public class CustomShieldTest
         }
 
         @Override
-        public boolean isShield(ItemStack stack, @Nullable LivingEntity entity)
+        public boolean canPerformAction(ItemStack stack, ToolAction toolAction)
         {
-            return true;
+            return toolAction.equals(ToolActions.SHIELD_BLOCK);
         }
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -148,5 +148,7 @@ license="LGPL v2.1"
     modId="tag_based_tool_types"
 [[mods]]
     modId="check_spawn_event_test"
+[[mods]]
+    modId="custom_shield_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
~~This PR fixes #8054 by re-adding the missing patch for `IForgeItem#isShield` back to `LivingEntiy#getEquipmentSlotForItem`, as noted in the linked issue. This also adds a test mod which adds a custom shield item, to allow testing this PR specifically and the `isShield` feature in general.~~

This PR fixes #8054 by adding a new tool action for shield blocking, `ToolActions#SHIELD_BLOCK`, and adding the necessary patches to make it work correctly. The `isShield` methods are kept for backwards compatibility, deprecated as to be removed in the next major version, and preserved in mods that already use this by redirecting calls of `canPerformAction` with the shield block action to this method.

**Screenshot of the implemented fix using the steps from the linked issue**:
![](https://user-images.githubusercontent.com/21304337/131725804-d406e274-4a6a-476a-8a05-12c92d5a78c7.png)
