### PR TITLE
Fix misapplied patch for getSlotColor

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -13,7 +13,7 @@
              int l = slot.f_40220_;
              int i1 = slot.f_40221_;
 -            m_169606_(p_97795_, l, i1, this.m_93252_());
-+            renderSlotHighlight(p_97795_, l, i1, this.m_93252_(), this.getSlotColor(i1));
++            renderSlotHighlight(p_97795_, l, i1, this.m_93252_(), this.getSlotColor(k));
           }
        }
  


### PR DESCRIPTION
Reported on the forums: https://forums.minecraftforge.net/topic/104040-1171-wrong-local-method-variables-mapping/