### PR TITLE
[1.17] Add an event when a shootable item tries to find a projectile item.

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -346,6 +346,28 @@
        return this.m_36218_(mutablecomponent);
     }
  
+@@ -1882,18 +_,18 @@
+          Predicate<ItemStack> predicate = ((ProjectileWeaponItem)p_36349_.m_41720_()).m_6442_();
+          ItemStack itemstack = ProjectileWeaponItem.m_43010_(this, predicate);
+          if (!itemstack.m_41619_()) {
+-            return itemstack;
++            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_36349_, itemstack);
+          } else {
+             predicate = ((ProjectileWeaponItem)p_36349_.m_41720_()).m_6437_();
+ 
+             for(int i = 0; i < this.f_36093_.m_6643_(); ++i) {
+                ItemStack itemstack1 = this.f_36093_.m_8020_(i);
+                if (predicate.test(itemstack1)) {
+-                  return itemstack1;
++                  return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_36349_, itemstack1);
+                }
+             }
+ 
+-            return this.f_36077_.f_35937_ ? new ItemStack(Items.f_42412_) : ItemStack.f_41583_;
++            return net.minecraftforge.common.ForgeHooks.findProjectile(this, p_36349_, this.f_36077_.f_35937_ ? new ItemStack(Items.f_42412_) : ItemStack.f_41583_);
+          }
+       }
+    }
 @@ -1978,5 +_,63 @@
        public Component m_36423_() {
           return this.f_36413_;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -154,6 +154,7 @@ import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.entity.player.PlayerFindProjectileEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -1003,6 +1004,22 @@ public class ForgeHooks
         ItemAttributeModifierEvent event = new ItemAttributeModifierEvent(stack, equipmentSlot, attributes);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getModifiers();
+    }
+
+    /**
+     * Hook to fire {@link PlayerFindProjectileEvent}. Returns the ammo to be used.
+     */
+    public static ItemStack findProjectile(Player player, ItemStack shootable, ItemStack ammo)
+    {
+        PlayerFindProjectileEvent event = new PlayerFindProjectileEvent(player, shootable, ammo);
+        if (MinecraftForge.EVENT_BUS.post(event))
+        {
+            return player.isCreative() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
+        }
+        else
+        {
+            return event.getProjectile();
+        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFindProjectileEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+/**
+ * This event is fired when a player attempts to use an item that is an {@link net.minecraft.item.ShootableItem}
+ * that requires some ammo. (For example a bow which will search for arrows in the players inventory)
+ * <br>
+ * This event is {@link net.minecraftforge.eventbus.api.Cancelable}. If the event is canceled, in survival mode
+ * no projectile will be found and in creative mode a plain arrow will be returned. This equals vanilla behaviour
+ * when no arrow is in the players inventory.
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class PlayerFindProjectileEvent extends PlayerEvent
+{
+    private final ItemStack shootable;
+    private ItemStack projectile;
+
+    public PlayerFindProjectileEvent(Player player, ItemStack shootable, ItemStack ammo)
+    {
+        super(player);
+        this.shootable = shootable;
+        this.projectile = ammo;
+    }
+
+    /**
+     * Gets the shootable item that is looking for a projectile.
+     */
+    public ItemStack getShootable()
+    {
+        return this.shootable;
+    }
+
+    /**
+     * Gets the projectile found. Initially this is set to the projectile found by vanilla behaviour.
+     */
+    public ItemStack getProjectile()
+    {
+        return this.projectile;
+    }
+
+    /**
+     * Sets the projectile to be used. Whenever the projectile is fired/consumed the stack will be
+     * shrunk by one. To disable this behaviour you can copy the stack before giving it to the event.
+     * For bows you can use {@link ArrowLooseEvent} to remove the arrow yourself.
+     */
+    public void setProjectile(ItemStack projectile)
+    {
+        this.projectile = projectile;
+    }
+}


### PR DESCRIPTION
Look at #7715 for more information about it.
This is just the 1.17 version for it.