### PR TITLE
Add system property for test command

### DIFF
--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/commands/Commands.java
 +++ b/net/minecraft/commands/Commands.java
+@@ -169,7 +_,7 @@
+       TriggerCommand.m_139141_(this.f_82090_);
+       WeatherCommand.m_139166_(this.f_82090_);
+       WorldBorderCommand.m_139246_(this.f_82090_);
+-      if (SharedConstants.f_136183_) {
++      if (Boolean.parseBoolean(System.getProperty("forge.testFramework", "false"))) {
+          TestCommand.m_127946_(this.f_82090_);
+       }
+ 
 @@ -193,6 +_,7 @@
        if (p_82093_.f_82144_) {
           PublishCommand.m_138184_(this.f_82090_);


### PR DESCRIPTION
This PR add a system property for enable test command in-game.

This avoids to set IS_RUNNING_IN_IDE variable for dev and unset for build.