### PR TITLE
Match ignore logic in ClasspathLocator with bootstraplauncher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -391,7 +391,7 @@ def sharedFmlonlyForge = { Project prj ->
         }
 
         // SecureJarHandler bootstrap values.
-        run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,mclanguage,${prj.name}-"
+        run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,mclanguage,${prj.name}-${prj.version},${prj.rootProject.ext.MC_VERSION}-${prj.name}${prj.version.substring(prj.rootProject.ext.MC_VERSION.length())}"
         run.property 'mergeModules', 'jna-5.8.0.jar,jna-platform-58.0.jar,java-objc-bridge-1.0.0.jar'
         if (userdevRuns.contains(run)) {
             run.property 'legacyClassPath.file', '{minecraft_classpath_file}'

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -77,7 +77,7 @@ public class ClasspathLocator extends AbstractJarFileLocator {
         while (resources.hasMoreElements()) {
             URL url = resources.nextElement();
             Path path = LibraryFinder.findJarPathFor(resource, name, url);
-            if (ignoreList.stream().anyMatch(path.toString()::contains) || Files.isDirectory(path))
+            if (ignoreList.stream().anyMatch(path.toString()::startsWith) || Files.isDirectory(path))
                 continue;
 
             ModJarMetadata.buildFile(this, filter, path).ifPresent(mf -> {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ClasspathLocator.java
@@ -77,7 +77,8 @@ public class ClasspathLocator extends AbstractJarFileLocator {
         while (resources.hasMoreElements()) {
             URL url = resources.nextElement();
             Path path = LibraryFinder.findJarPathFor(resource, name, url);
-            if (ignoreList.stream().anyMatch(path.toString()::startsWith) || Files.isDirectory(path))
+            String filename = path.getFileName().toString();
+            if (ignoreList.stream().anyMatch(filename::startsWith) || Files.isDirectory(path))
                 continue;
 
             ModJarMetadata.buildFile(this, filter, path).ifPresent(mf -> {


### PR DESCRIPTION
This PR fixes #8063 by matching the ignore list filtering logic in `ClasspathLocator` to the current logic in [MinecraftForge/bootstraplauncher](https://github.com/MinecraftForge/bootstraplauncher), as of commit [`ba5f05c32d302a2e66649579188a64bef7dfeef3`](https://github.com/MinecraftForge/bootstraplauncher/commit/ba5f05c32d302a2e66649579188a64bef7dfeef3). 

The change in this PR and from the linked commit switches the filtering from using `String.contains` to `String.startsWith`, to prevent folders or files which merely contains the words in the ignore list (which includes `forge-` and `asm`) from being ignored entirely. While BSL was fixed to use `startsWith`, `ClasspathLocator` wasn't, which caused any mods which contained the words from the ignore list (which includes `forge-`) to be excluded from further processing. 

This is visibly seen when depending on the [Curios API](https://github.com/TheIllusiveC4/Curios) by @TheIllusiveC4, as the mod's JARs contains the substring `forge-` -- for example, `curios-forge-1.17.1-5.0.0.1_mapped_parchment_2021.08.29-1.17.1.jar`.

This also includes a fix from @SizableShrimp's PR #7976 which amends the ignore list to change `forge-` into `forge-<forge version>` and `<mc version>-forge-<forge version>`. This is required with the previous change, as in the production/end-user environment, the Forge JAR's filename does not start with `forge-` as the vanilla JAR for Forge is named by the vanilla launcher according to the version ID, which is `<mc version>-forge-<forge version>`.

## Testing
To test the fix:
 - Clone down this PR branch. (`git clone -b 1.17/GH-8063 https://github.com/sciwhiz12/MinecraftForge.git sciwhiz12-8063`)
 - Run the `publishToMavenLocal` task in the project. (`cd sciwhiz12-8063 && gradlew publishToMavenLocal`)
 - Open a project suitable for testing (such as a fresh MDK).
 - Change the Forge version (as indicated in the `dependencies` block) to `1.17.1-37.0.56-1.17-GH-8063`.
 - Add the required mavens to the buildscript (`build.gradle`):
   ```gradle
   repositories {
      maven { url = 'https://maven.theillusivec4.top/' }
      mavenLocal()
   }
   ```
 - Add the Curios API dependencies to the buildscript:
   ```gradle
   dependencies {
      compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.17.1-5.0.0.1:api")
      runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.17.1-5.0.0.1")
   }
   ```
 - **(If in IDE)**: Refresh the project and regenerate run configs via your IDE's task.
 - Run the client. (`./gradlew runClient` or via your IDE)

Observe that after the game loads into the main menu, the listed mods in the Mods screen include Curios API. If the above steps are repeated but without changing the Forge version from an officially published version, observe that the Curios API is missing from the same screen.