### PR TITLE
Remove old Log4j thread cache invalidation

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/client/Minecraft.java
 +++ b/net/minecraft/client/Minecraft.java
-@@ -390,6 +_,7 @@
-    public Minecraft(GameConfig p_91084_) {
-       super("Client");
-       f_90981_ = this;
-+      net.minecraftforge.client.ForgeHooksClient.invalidateLog4jThreadCache();
-       this.f_91069_ = p_91084_.f_101907_.f_101916_;
-       File file1 = p_91084_.f_101907_.f_101918_;
-       this.f_90985_ = p_91084_.f_101907_.f_101917_;
 @@ -397,14 +_,13 @@
        this.f_91029_ = p_91084_.f_101908_.f_101928_;
        this.f_90986_ = p_91084_.f_101905_.f_101944_;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -106,15 +106,12 @@ import net.minecraftforge.resource.VanillaResourceType;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.async.ThreadNameCachingStrategy;
-import org.apache.logging.log4j.core.impl.ReusableLogEventFactory;
 import org.lwjgl.opengl.GL13;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -712,26 +709,6 @@ public class ForgeHooksClient
     {
         Event event = new RecipesUpdatedEvent(mgr);
         MinecraftForge.EVENT_BUS.post(event);
-    }
-
-    // Resets cached thread fields in ThreadNameCachingStrategy and ReusableLogEventFactory to be repopulated during their next access.
-    // This serves a workaround for no built-in method of triggering this type of refresh as brought up by LOG4J2-2178.
-    public static void invalidateLog4jThreadCache()
-    {
-        if (System.getProperty("java.version").compareTo("1.8.0_102") >= 0) return; // skip for later JDKs, because it's not CACHED see LOG4J2-2052
-        try
-        {
-            Field nameField = ThreadNameCachingStrategy.class.getDeclaredField("THREADLOCAL_NAME");
-            Field logEventField = ReusableLogEventFactory.class.getDeclaredField("mutableLogEventThreadLocal");
-            nameField.setAccessible(true);
-            logEventField.setAccessible(true);
-            ((ThreadLocal<?>) nameField.get(null)).set(null);
-            ((ThreadLocal<?>) logEventField.get(null)).set(null);
-        }
-        catch (ReflectiveOperationException | NoClassDefFoundError e)
-        {
-            LOGGER.error("Unable to invalidate log4j thread cache, thread fields in logs may be inaccurate", e);
-        }
     }
 
     public static void fireMouseInput(int button, int action, int mods)


### PR DESCRIPTION
As minecraft now requires java 16, the code wasn't even running anymore due to the java version check.