### PR TITLE
[1.17.x] make RecipeManager#byType public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -265,6 +265,7 @@ public net.minecraft.world.item.crafting.Ingredient$ItemValue <init>(Lnet/minecr
 public net.minecraft.world.item.crafting.Ingredient$TagValue
 public net.minecraft.world.item.crafting.Ingredient$TagValue <init>(Lnet/minecraft/tags/Tag;)V # constructor
 public net.minecraft.world.item.crafting.Ingredient$Value
+public net.minecraft.world.item.crafting.RecipeManager m_44054_(Lnet/minecraft/world/item/crafting/RecipeType;)Ljava/util/Map; # byType
 public net.minecraft.world.level.GameRules m_46189_(Ljava/lang/String;Lnet/minecraft/world/level/GameRules$Category;Lnet/minecraft/world/level/GameRules$Type;)Lnet/minecraft/world/level/GameRules$Key; # register
 public net.minecraft.world.level.Level f_46437_ # oRainLevel
 public net.minecraft.world.level.Level f_46438_ # rainLevel


### PR DESCRIPTION
make RecipeManager#byType public so not every mod that needs access to the recipe by type map needs to use reflection/mixins/coremods/at