### PR TITLE
[1.16.x] Add workaround for pairs of ' being stripped 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
+++ b/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
@@ -28,7 +28,19 @@ import java.util.List;
 public class TextComponentMessageFormatHandler {
     public static int handle(final TranslationTextComponent parent, final List<ITextProperties> children, final Object[] formatArgs, final String format) {
         try {
-            StringTextComponent component = new StringTextComponent(ForgeI18n.parseFormat(format, formatArgs));
+            final String formattedString = ForgeI18n.parseFormat(format, formatArgs);
+
+            // See MinecraftForge/MinecraftForge#7396
+            if (format.indexOf('\'') != -1) {
+                final boolean onlyMissingQuotes = format.chars()
+                        .filter(ch -> formattedString.indexOf((char) ch) == -1)
+                        .allMatch(ch -> ch == '\'');
+                if (onlyMissingQuotes) {
+                    return 0;
+                }
+            }
+
+            StringTextComponent component = new StringTextComponent(formattedString);
             component.getStyle().applyTo(parent.getStyle());
             children.add(component);
             return format.length();


### PR DESCRIPTION
This PR is an LTS backport of #8050. See that PR for details.

**Screenshot of the backported fix using the steps from the linked issue in the linked PR:**
![](https://user-images.githubusercontent.com/21304337/132864365-1d40a7b1-2174-4cc7-bcec-c73c18bb2419.png)
