### PR TITLE
Add basic Mixin support for use by mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
     BOOTSTRAPLAUNCHER_VERSION = '0.1.17'
     ASM_VERSION = '9.1'
     INSTALLER_VERSION = '2.1.5'
+    MIXIN_VERSION = '0.8.4'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)
@@ -248,7 +249,7 @@ def sharedDeps = {
     installer 'org.jline:jline-reader:3.12.+'   //Dep of TerminaalConsoleeAppender
     installer 'org.jline:jline-terminal:3.12.+' //Dep of TerminaalConsoleeAppender
     installer 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    // installer 'org.spongepowered:mixin:0.8.3'
+    installer "org.spongepowered:mixin:${MIXIN_VERSION}"
     installer 'org.openjdk.nashorn:nashorn-core:15.1.1'
     installer 'com.google.guava:guava:21.0'
     installer 'com.google.code.gson:gson:2.8.0'


### PR DESCRIPTION
This PR *purely* adds back Mixin 0.8.4 to the installer list for Forge 1.17. It is a subset of what is added by #8075 while it is waiting, namely on mirroring MixinGradle, to help mods not have to rely on external mixin bootstrap projects / shading for mod development.

See #8075 for a larger version of this PR which also adds support to use mixins for Forge development.