### PR TITLE
Add a new CapabilityReference class

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -88,10 +88,12 @@ public enum CapabilityManager
             .collect(Collectors.toList());
         final IdentityHashMap<String, List<Function<Capability<?>, Object>>> callbacks = new IdentityHashMap<>();
         elementsToInject.forEach(entry -> gatherCallbacks(callbacks, entry));
+        CapabilityReference.addCallbacks(callbacks);
 
         var event = new RegisterCapabilitiesEvent();
         ModLoader.get().postEvent(event);
         fireCallbacks(callbacks, event.getCapabilities().values());
+        CapabilityReference.hasPreviouslyInjected = true;
 
         // TODO 1.18: remove these fields
         this.providers.putAll(event.getCapabilities());

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -168,17 +168,13 @@ public class CapabilityReference<T> implements Supplier<Capability<T>>
     // Used to log a warning whenever a CapabilityReference is created after capabilities have been injected
     static boolean hasPreviouslyInjected = false;
 
-    static void addCallbacks(Map<String, List<Function<Capability<?>, Object>>> callbacks)
+    static void addCallbacks(Map<String, List<Consumer<Capability<?>>>> callbacks)
     {
         for (CapabilityReference<?> capObject : ALL_REFERENCES)
         {
             final Class<?> capType = capObject.getCapabilityType();
             final String capName = capType.getTypeName();
-            callbacks.computeIfAbsent(capName, k -> new ArrayList<>())
-                    .add(capInst -> {
-                        capObject.setCapability(capInst);
-                        return null;
-                    });
+            callbacks.computeIfAbsent(capName, k -> new ArrayList<>()).add(capObject::setCapability);
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
@@ -1,0 +1,191 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A reference to a {@link Capability} object, whose value is injected at the appropriate time.
+ *
+ * <p>An instance of this class should be created and stored in a {@code static final} field, and referenced whenever
+ * the {@code Capability} object within is needed. </p>
+ *
+ * <p>A capability reference does not contain the Capability object for the specified type when constructed. The
+ * Capability value is injected at a later time by the {@link CapabilityManager}. To head off possible issues with
+ * creating capability references too late, a warning is logged for each time an instance is created after capability
+ * values have been injected.</p>
+ *
+ * <p>This serves as an alternative to annotating fields or methods with {@link CapabilityInject}. The most notable
+ * use is to store this reference in a field of a capability <em>interface</em>, which is impossible due to the
+ * de-finalizing effects of {@code CapabilityInject} conflicting with the JVM stipulation that all fields within an
+ * interface must be {@code public static final}.</p>
+ *
+ * @param <T> the type of the referenced capability
+ * @see CapabilityInject
+ * @see net.minecraftforge.common.asm.CapabilityInjectDefinalize
+ */
+public class CapabilityReference<T> implements Supplier<Capability<T>>
+{
+    /**
+     * Constructs a reference to the given capability specified by its {@link Class}.
+     *
+     * @param capabilityType class of the capability to be referenced
+     * @param <T>            the referenced capability type
+     * @return a reference to the given capability
+     * @throws NullPointerException     if the given {@code Class} is {@code null}
+     * @throws IllegalArgumentException if the given {@code Class} represents a {@linkplain Class#isPrimitive()
+     *                                  primitive type} or an {@linkplain Class#isArray() array class}.
+     */
+    public static <T> CapabilityReference<T> create(Class<T> capabilityType)
+    {
+        if (hasPreviouslyInjected)
+        {
+            CapabilityManager.LOGGER.warn("""
+                    A CapabilityReference was created after capabilities have been injected.
+                    This may not work properly -- please report this to the mod as indicated in the stacktrace.
+                    """, new RuntimeException("Mod created a CapabilityReference after injection -- this is only a stacktrace."));
+        }
+
+        final CapabilityReference<T> object = new CapabilityReference<>(capabilityType);
+
+        synchronized (ALL_REFERENCES)
+        {
+            ALL_REFERENCES.add(object);
+        }
+
+        return object;
+    }
+
+    private final Class<T> capabilityType;
+    @Nullable
+    private Capability<T> capability = null;
+
+    private CapabilityReference(Class<T> capabilityType)
+    {
+        checkNotNull(capabilityType, "Capability type must not be null");
+        checkArgument(!capabilityType.isPrimitive(), "Primitives are not valid capability types");
+        checkArgument(!capabilityType.isArray(), "Arrays are not valid capability types");
+
+        this.capabilityType = capabilityType;
+    }
+
+    /**
+     * {@return the {@code Class} for the capability referenced by this object}
+     */
+    public Class<T> getCapabilityType()
+    {
+        return capabilityType;
+    }
+
+    /**
+     * If the {@code Capability} object is present in this reference, returns the object, otherwise throws
+     * {@code NoSuchElementException}.
+     *
+     * @return the {@code Capability} object for the capability referenced by this object
+     * @throws NoSuchElementException if no {@code Capability} object is present
+     */
+    @Override
+    public Capability<T> get()
+    {
+        if (capability == null)
+        {
+            throw new NoSuchElementException("No such capability object for " + capabilityType.getName());
+        }
+        return capability;
+    }
+
+    /**
+     * If the {@code Capability} object is present in this reference, returns the object, otherwise returns {@code null}.
+     *
+     * @return the {@code Capability} object for the capability referenced by this object, or {@code null} if no
+     * object is present yet
+     */
+    @Nullable
+    public Capability<T> getOrNull()
+    {
+        return capability;
+    }
+
+    /**
+     * {@return an optional which may contain the {@code Capability} object for the referenced capability}
+     */
+    public Optional<Capability<T>> getOptional()
+    {
+        return Optional.ofNullable(capability);
+    }
+
+    /**
+     * {@return if this reference contains the {@link Capability} for its type}
+     */
+    public boolean isPresent()
+    {
+        return capability != null;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CapabilityReference[" + capabilityType.getName() + "]." + (capability == null ? "empty" : "present");
+    }
+
+    /* ***** Beyond here lies dragons and Forge API implementation details! ***** */
+
+    // Accesses to this set should be synchronized, because parallel mod construction which is when accesses to this
+    // map are most likely
+    // Uses a weak hash map wrapped as a set, to prevent us from accidentally preventing garbage collection
+    private static final Set<CapabilityReference<?>> ALL_REFERENCES = Collections.newSetFromMap(new WeakHashMap<>());
+
+    // Used to log a warning whenever a CapabilityReference is created after capabilities have been injected
+    static boolean hasPreviouslyInjected = false;
+
+    static void addCallbacks(Map<String, List<Function<Capability<?>, Object>>> callbacks)
+    {
+        for (CapabilityReference<?> capObject : ALL_REFERENCES)
+        {
+            final Class<?> capType = capObject.getCapabilityType();
+            final String capName = capType.getTypeName();
+            callbacks.computeIfAbsent(capName, k -> new ArrayList<>())
+                    .add(capInst -> {
+                        capObject.setCapability(capInst);
+                        return null;
+                    });
+        }
+    }
+
+    // This exists because the compiler won't let us cast different Capability<?> instances
+    @SuppressWarnings("unchecked")
+    private void setCapability(@Nullable Capability<?> capability)
+    {
+        this.capability = (Capability<T>) capability;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
@@ -173,7 +173,7 @@ public class CapabilityReference<T> implements Supplier<Capability<T>>
         for (CapabilityReference<?> capObject : ALL_REFERENCES)
         {
             final Class<?> capType = capObject.getCapabilityType();
-            final String capName = capType.getTypeName();
+            final String capName = capType.getTypeName().intern(); // Since the map passed in is IdentityHashMap
             callbacks.computeIfAbsent(capName, k -> new ArrayList<>()).add(capObject::setCapability);
         }
     }


### PR DESCRIPTION
This PR adds the new `CapabilityReference` class, which holds a possibly-empty reference to the `Capability` object for a capability. This is intended to be an alternative to the use of `@CapabilityInject`, akin to the use of `RegistryObject` as an alternative to `@ObjectHolder`.

There are multiple reasons why such an object would be useful to mod developers:
 - **It does not carry the same side-effect as `@CapabilityInject` with regards to `final` fields.**

   `@CapabilityInject` has the semi-documented side-effect of removing the `final` modifier from fields where it is present. This finality removal is done by the [`CapabilityInjectDefinalize`][cap-definalize] transformer, whose javadocs notes that the removal is done in order to prevent the JIT (just-in-time) compiler (from the HotSpot VM, the most popular JVM implementation) from inlining references to the field. 

   Additionally, the `final` modifier removal also allows reflective operations to set the value of a `static final` field to succeed, something which is otherwise not possible even with the use of [`AccessibleObject#setAccessible(boolean)`][setAccessible].<sup><a id="ret-fn-1" href="#footnote-1">1</a></sup>

   Additionally, the definalization also causes hotswapping of classes which contain a `@CapabilityInject`-annotated field to fail due to the changed class structure (specifically, the modifiers of the annoatated field), as at runtime the field is non-`final` but the hotswapping agent receives the to-be-hotswapped class bytes with the field as `final`.

 - **It allows storing a capability reference in an interface field.**
   
   Due to the above side-effect of de-finalizing the field, the `@CapabilityInject` must not be applied to interface fields. Doing so will lead to an error, as the Java Virtual Machine Specification mandates that the fields of interfaces must be `public static final`.<sup><a id="ret-fn-2" href="#footnote-2">2</a></sup>

 - **It is an alternative to the use of `@CapabilityInject`, akin to `RegistryObject`.**

   A developer may wish to not use in their `@CapabilityInject` code, whether due to the above noted side-effects or due to their own coding preferences as to the use of annotations. This class provides an API-provided way to retrieve `Capability` objects for their capabilities without the need of the annotation.

   Furthermore, various libraries may be interested in an API to programmatically obtain references to `Capability` objects of any arbitrary capability class or interface, such as those which reduce developer boilerplate by providing convenience classes or helpers which implement various functionality, without requiring the manual intervention of the developer to pass in the `Capability` object themselves from a `@CapabilityInject`-annotated field or method.

### Remaining tasks before ready for review
 - [ ] Add a new test mod / modify existing test mod to use and test `CapabilityReference`
 - [ ] Test that injection works as expected
   - [ ] Test the same but with multiple mods creating references to the same capability (to ensure the use of `Set` doesn't cause any problems)
 - [ ] Test that creating an instance during static initialization does not cause any issues
 - [ ] Test the warning when an instance is created after capabilities are injected
 - [ ] Test that no regression occurs by using in a medium-large modpack
 - [ ] Review javadocs to add missing information and clarify as needed

---

<span id="footnote-1"></span><sup><a href="#ret-fn-1">^</a> 1: Java SE Documentation, Java SE 16 & JDK 16, [`AccessibleObject#setAccessible(boolean)`][setAccessible]: "This method cannot be used to enable _write_ access to a _non-modifiable_ final field. The following fields are non-modifiable: - static final fields declared in any class or interface ..."</sup>
<span id="footnote-2"></span><sup><a href="#ret-fn-2">^</a> 2: The Java® Virtual Machine Specification, _Java SE 16 Edition_, [4.5. Fields][jvms-4.5]: "Fields of interfaces must have their `ACC_PUBLIC`, `ACC_STATIC`, and `ACC_FINAL` flags set; ..."</sup>

[cap-definalize]: https://github.com/MinecraftForge/MinecraftForge/blob/ca2023fa80b943cf595de53434a3c67f974e15f6/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
[setAccessible]: https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/reflect/AccessibleObject.html#setAccessible(boolean)
[jvms-4.5]: https://docs.oracle.com/javase/specs/jvms/se16/html/jvms-4.html#jvms-4.5