### PR TITLE
Fix inverted hooks for PermissionsChangedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -82,7 +82,7 @@
     }
  
     public void m_5749_(GameProfile p_11254_) {
-+      if (!net.minecraftforge.event.ForgeEventFactory.onPermissionChanged(p_11254_, this.f_11195_.m_7022_(), this)) return;
++      if (net.minecraftforge.event.ForgeEventFactory.onPermissionChanged(p_11254_, this.f_11195_.m_7022_(), this)) return;
        this.f_11200_.m_11381_(new ServerOpListEntry(p_11254_, this.f_11195_.m_7022_(), this.f_11200_.m_11351_(p_11254_)));
        ServerPlayer serverplayer = this.m_11259_(p_11254_.getId());
        if (serverplayer != null) {
@@ -90,7 +90,7 @@
     }
  
     public void m_5750_(GameProfile p_11281_) {
-+      if (!net.minecraftforge.event.ForgeEventFactory.onPermissionChanged(p_11281_, 0, this)) return;
++      if (net.minecraftforge.event.ForgeEventFactory.onPermissionChanged(p_11281_, 0, this)) return;
        this.f_11200_.m_11393_(p_11281_);
        ServerPlayer serverplayer = this.m_11259_(p_11281_.getId());
        if (serverplayer != null) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -794,6 +794,6 @@ public class ForgeEventFactory
         {
             return MinecraftForge.EVENT_BUS.post(new PermissionsChangedEvent(player, newLevel, oldLevel));
         }
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
This PR fixes #8088 by inverting the patched-in hooks and the default return value of the `ForgeHooks` method for `PermissionsChangedEvent`,.

Because `IEventBus#post` returns `true` on cancellation and the patched-in hooks inverts the return of the `ForgeHooks` method, if the player whose permission level is being changed is online and the event is _not_ cancelled, the permission change _is_ cancelled. Inverting the hooks and the default return value fixes this so the permission change is only cancelled if the event is cancelled.