### PR TITLE
Move ItemStack#forgeInit call earlier to allow earlier capability queries

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -19,7 +19,7 @@
     private static final Logger f_41585_ = LogManager.getLogger();
     public static final ItemStack f_41583_ = new ItemStack((Item)null);
     public static final DecimalFormat f_41584_ = Util.m_137469_(new DecimalFormat("#.##"), (p_41704_) -> {
-@@ -127,14 +_,19 @@
+@@ -127,10 +_,15 @@
        p_41606_.ifPresent(this::m_41751_);
     }
  
@@ -33,17 +33,13 @@
 +      this.capNBT = p_41606_;
 +      this.f_41589_ = p_41604_ == null ? null : p_41604_.m_5456_();
 +      this.delegate = p_41604_ == null ? null : p_41604_.m_5456_().delegate;
++      this.forgeInit();
 +      this.f_41587_ = p_41605_;
 +      if (this.f_41589_ != null && this.f_41589_.isDamageable(this)) {
           this.m_41721_(this.m_41773_());
        }
  
-       this.m_41617_();
-+      this.forgeInit();
-    }
- 
-    private void m_41617_() {
-@@ -143,18 +_,23 @@
+@@ -143,14 +_,19 @@
     }
  
     private ItemStack(CompoundTag p_41608_) {
@@ -52,6 +48,7 @@
 +      Item rawItem =
        this.f_41589_ = Registry.f_122827_.m_7745_(new ResourceLocation(p_41608_.m_128461_("id")));
 +      this.delegate = rawItem.delegate;
++      this.forgeInit();
        this.f_41587_ = p_41608_.m_128445_("Count");
        if (p_41608_.m_128425_("tag", 10)) {
           this.f_41590_ = p_41608_.m_128469_("tag");
@@ -63,11 +60,6 @@
           this.m_41721_(this.m_41773_());
        }
  
-       this.m_41617_();
-+      this.forgeInit();
-    }
- 
-    public static ItemStack m_41712_(CompoundTag p_41713_) {
 @@ -185,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -33,8 +33,8 @@
 +      this.capNBT = p_41606_;
 +      this.f_41589_ = p_41604_ == null ? null : p_41604_.m_5456_();
 +      this.delegate = p_41604_ == null ? null : p_41604_.m_5456_().delegate;
-+      this.forgeInit();
 +      this.f_41587_ = p_41605_;
++      this.forgeInit();
 +      if (this.f_41589_ != null && this.f_41589_.isDamageable(this)) {
           this.m_41721_(this.m_41773_());
        }
@@ -48,12 +48,12 @@
 +      Item rawItem =
        this.f_41589_ = Registry.f_122827_.m_7745_(new ResourceLocation(p_41608_.m_128461_("id")));
 +      this.delegate = rawItem.delegate;
-+      this.forgeInit();
        this.f_41587_ = p_41608_.m_128445_("Count");
        if (p_41608_.m_128425_("tag", 10)) {
           this.f_41590_ = p_41608_.m_128469_("tag");
           this.m_41720_().m_142312_(this.f_41590_);
        }
++      this.forgeInit();
  
 -      if (this.m_41720_().m_41465_()) {
 +      if (this.m_41720_().isDamageable(this)) {

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -90,7 +90,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
     {
         if (isLazy && !initialized)
         {
-            doGatherCapabilities(lazyParentSupplier.get());
+            doGatherCapabilities(lazyParentSupplier == null ? null : lazyParentSupplier.get());
             if (lazyData != null)
             {
                 deserializeCaps(lazyData);

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -90,7 +90,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
     {
         if (isLazy && !initialized)
         {
-            doGatherCapabilities(lazyParentSupplier == null ? null : lazyParentSupplier.get());
+            doGatherCapabilities(lazyParentSupplier.get());
             if (lazyData != null)
             {
                 deserializeCaps(lazyData);


### PR DESCRIPTION
This PR fixes #8093 by moving the initialization/gathering of `ItemStack` capabilities (and deserialization of their NBT data) to be after the item delegate (and other properties like the NBT tag and count of the stack) is initialized, and before any methods are called within the constructor (such as `ItemStack#getDamage(ItemStack)`). This ensures that the `lazyParentSupplier` field is initialized before it is needed for any capabilitiy queries (such as can be done from `getDamage` by mods' custom items), preventing the NPE from happening.

Originally, the fix as seen in the first comment was to guard against `lazyParentSupplier` being `null`, but upon comment by @OrionDevelopment (https://github.com/MinecraftForge/MinecraftForge/issues/8093#issuecomment-922518201) based on internal team discussions, the new fix is as suggested: moving `forgeInit` earlier so capabilities are ready for querying before `getDamage` is called.