### PR TITLE
Prevent call to Item#initializeClient when in datagen

### DIFF
--- a/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
+++ b/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
@@ -17,7 +17,7 @@
     }
  
     public void m_6742_(LivingEntity p_19467_, int p_19468_) {
-@@ -179,4 +_,28 @@
+@@ -179,4 +_,29 @@
     public boolean m_19486_() {
        return this.f_19447_ == MobEffectCategory.BENEFICIAL;
     }
@@ -34,7 +34,8 @@
 +   }
 +
 +   private void initClient() {
-+      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT) {
++      // Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
++      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT && !net.minecraftforge.fml.loading.FMLLoader.getLaunchHandler().isData()) {
 +         initializeClient(properties -> {
 +            this.effectRenderer = properties;
 +         });

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -104,7 +104,7 @@
     }
  
     public ItemStack m_7968_() {
-@@ -371,6 +_,31 @@
+@@ -371,6 +_,32 @@
        return true;
     }
  
@@ -120,7 +120,8 @@
 +   }
 +
 +   private void initClient() {
-+      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT) {
++      // Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
++      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT && !net.minecraftforge.fml.loading.FMLLoader.getLaunchHandler().isData()) {
 +         initializeClient(properties -> {
 +            if (properties == this)
 +               throw new IllegalStateException("Don't extend IItemRenderProperties in your item, use an anonymous class instead.");

--- a/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
@@ -91,7 +91,7 @@
     }
  
     public void m_5871_(ItemStack p_49816_, @Nullable BlockGetter p_49817_, List<Component> p_49818_, TooltipFlag p_49819_) {
-@@ -486,6 +_,81 @@
+@@ -486,6 +_,82 @@
     protected ImmutableMap<BlockState, VoxelShape> m_152458_(Function<BlockState, VoxelShape> p_152459_) {
        return this.f_49792_.m_61056_().stream().collect(ImmutableMap.toImmutableMap(Function.identity(), p_152459_));
     }
@@ -110,7 +110,8 @@
 +   }
 +
 +   private void initClient() {
-+      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT) {
++      // Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
++      if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT && !net.minecraftforge.fml.loading.FMLLoader.getLaunchHandler().isData()) {
 +         initializeClient(properties -> {
 +            if (properties == this)
 +               throw new IllegalStateException("Don't extend IBlockRenderProperties in your block, use an anonymous class instead.");


### PR DESCRIPTION
When running under data-generation, the `Minecraft` singleton is unavailable even though the operating env is under the `CLIENT` dist. Along with the fact that most uses of IItemRenderProperties (usually to provide a custom BEWLR) make use of the `Minecraft` singleton, this means that developers unaware of `Minecraft`'s unavailability will encounter a null pointer exception when they try to access its singleton.

This PR adds a check to prevent the `Item#initializeClient` method from being called during data-generation, to prevent the situation described before from causing an NPE. As `IItemRenderProperties` has nothing which might be used by datageneration, this is safe to do.

This PR is inspired by a [Discord conversation][discord] on The Forge Project discord server wherein @gigaherz expressed that this method shouldn't be called in datagen but this check was forgotten, and that it should be PR-ed.

[discord]: https://discord.com/channels/313125603924639766/867851603468615740/888932184122069036