### PR TITLE
[1.16.5] Bump Mixin to 0.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,7 +431,7 @@ project(':forge') {
         installer 'org.apache.logging.log4j:log4j-core:2.11.2'
         installer 'net.minecrell:terminalconsoleappender:1.2.0'
         installer 'net.sf.jopt-simple:jopt-simple:5.0.4'
-        installer 'org.spongepowered:mixin:0.8.2'
+        installer 'org.spongepowered:mixin:0.8.4'
         // This is org.openjdk.nashorn:nashorn-core:15.1.1 repackaged so it doesn't crash on JREs < 15.
         // See: https://github.com/LexManos/NashornLegacyPackager
         installer 'net.minecraftforge:nashorn-core-compat:15.1.1.1'

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import javax.annotation.Nullable;

--- a/src/test/java/net/minecraftforge/debug/misc/OnDatapackSynctEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/OnDatapackSynctEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.misc;
 
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
This should be a fairly trivial dependency bump/backport of the equivalent change to 1.17.

I've tested with SpongeForge, and a misc reasonably large modpack off CurseForge (that I don't wish to promote since it's not exactly well put together), and all of our Mixins seem to apply without issue. 

Between dev and prod environments, I have hit Java 8, 11, and 16 versions.