### PR TITLE
Add CapabilityReference, alternative to @CapabilityInject

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -61,7 +61,7 @@ public class Scanner {
             ModClassVisitor mcv = new ModClassVisitor();
             ClassReader cr = new ClassReader(in);
             cr.accept(mcv, 0);
-            mcv.buildData(result.getClasses(), result.getAnnotations());
+            mcv.buildData(result.getClasses(), result.getAnnotations(), result.getGenericFields());
         } catch (IOException | IllegalArgumentException e) {
             // mark path bad
         }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.common.capabilities;
+
+import org.objectweb.asm.Type;
+
+import java.util.Optional;
+
+public final class CapabilityReference<T>
+{
+
+    private Optional<Capability<T>> capability = Optional.empty();
+
+    private CapabilityReference()
+    {
+    }
+
+    public static <T> CapabilityReference<T> create()
+    {
+        return new CapabilityReference<>();
+    }
+
+    public Optional<Capability<T>> resolve()
+    {
+        return capability;
+    }
+
+    void inject(Capability<T> capability)
+    {
+        this.capability = Optional.of(capability);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityReference.java
@@ -1,7 +1,5 @@
 package net.minecraftforge.common.capabilities;
 
-import org.objectweb.asm.Type;
-
 import java.util.Optional;
 
 public final class CapabilityReference<T>

--- a/src/main/java/net/minecraftforge/common/capabilities/SimpleGenericTypeExtractor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/SimpleGenericTypeExtractor.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.common.capabilities;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.signature.SignatureVisitor;
+
+class SimpleGenericTypeExtractor extends SignatureVisitor
+{
+
+    String typeArgumentClass = null;
+    private boolean seenTypeArgument = false;
+
+    public SimpleGenericTypeExtractor()
+    {
+        super(Opcodes.ASM9);
+    }
+
+    @Override
+    public void visitClassType(String name)
+    {
+        if (seenTypeArgument && this.typeArgumentClass == null)
+        {
+            this.typeArgumentClass = name;
+        }
+    }
+
+    @Override
+    public SignatureVisitor visitTypeArgument(char wildcard) {
+        if (seenTypeArgument) {
+            throw new IllegalStateException("Unexpected multiple arguments for generic signature");
+        }
+        if (wildcard != '=') {
+            throw new IllegalStateException("Unexpected non-invariant type parameter for generic signature");
+        }
+        seenTypeArgument = true;
+        return this;
+    }
+
+    @Override
+    public void visitEnd() {
+        super.visitEnd();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/SimpleGenericTypeExtractor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/SimpleGenericTypeExtractor.java
@@ -24,19 +24,12 @@ class SimpleGenericTypeExtractor extends SignatureVisitor
     }
 
     @Override
-    public SignatureVisitor visitTypeArgument(char wildcard) {
-        if (seenTypeArgument) {
-            throw new IllegalStateException("Unexpected multiple arguments for generic signature");
+    public SignatureVisitor visitTypeArgument(char wildcard)
+    {
+        if (wildcard == '=')
+        {
+            seenTypeArgument = true;
         }
-        if (wildcard != '=') {
-            throw new IllegalStateException("Unexpected non-invariant type parameter for generic signature");
-        }
-        seenTypeArgument = true;
         return this;
-    }
-
-    @Override
-    public void visitEnd() {
-        super.visitEnd();
     }
 }

--- a/src/test/java/net/minecraftforge/debug/misc/CapabilityReferenceTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/CapabilityReferenceTest.java
@@ -1,0 +1,36 @@
+package net.minecraftforge.debug.misc;
+
+import net.minecraftforge.common.capabilities.CapabilityReference;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.items.IItemHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Mod("capability_reference_test")
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = "capability_reference_test")
+public class CapabilityReferenceTest
+{
+
+    private static final CapabilityReference<IItemHandler> CAP_REF = CapabilityReference.create();
+    private static final CapabilityReference<MustNotLoad> CAP_REF2 = CapabilityReference.create();
+    private static final Logger LOGGER = LoggerFactory.getLogger("CapabilityReferenceTest");
+
+    @SubscribeEvent
+    public static void commonSetupHandler(FMLCommonSetupEvent event)
+    {
+        LOGGER.info("CAP_REF: {}", CAP_REF.resolve().orElse(null));
+        LOGGER.info("CAP_REF2: {}", CAP_REF2.resolve().orElse(null));
+    }
+
+    static class MustNotLoad
+    {
+        static
+        {
+            // javac doesn't allow just throwing an exception
+            if (true) throw new RuntimeException("CapabilityReference soft reference failed.");
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -154,5 +154,7 @@ license="LGPL v2.1"
     modId="custom_shield_test"
 [[mods]]
     modId="lazy_capabilities_on_items"
+[[mods]]
+    modId="capability_reference_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This is a safer alternative to `@CapabilityInject`, working without definalizing or "magic field injection".
WIP and open for comments, requires Forge SPI update (and associated pull request) before merge.

See https://github.com/MinecraftForge/ForgeSPI/compare/master...diesieben07:feature/generic-field-data for the necessary changes in ForgeSPI.