### PR TITLE
Fix Behavior With Unknown Items in Recipes

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -78,7 +78,7 @@
 -            return new ItemStack(item, i);
 -         }
 -      }
-+      return net.minecraftforge.common.crafting.CraftingHelper.getItemStack(p_151275_, true, true);
++      return net.minecraftforge.common.crafting.CraftingHelper.getItemStack(p_151275_, true, false); // TODO: Swap false to true in 1.18 to mimic vanilla behavior
     }
  
     public static Item m_151278_(JsonObject p_151279_) {

--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -78,7 +78,7 @@
 -            return new ItemStack(item, i);
 -         }
 -      }
-+      return net.minecraftforge.common.crafting.CraftingHelper.getItemStack(p_151275_, true);
++      return net.minecraftforge.common.crafting.CraftingHelper.getItemStack(p_151275_, true, true);
     }
  
     public static Item m_151278_(JsonObject p_151279_) {

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -159,11 +159,14 @@ public class CraftingHelper
     public static ItemStack getItemStack(JsonObject json, boolean readNBT)
     {
         String itemName = GsonHelper.getAsString(json, "item");
+        ResourceLocation itemKey = new ResourceLocation(itemName);
 
-        Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName));
-
-        if (item == Items.AIR)
+        if (!ForgeRegistries.ITEMS.containsKey(itemKey))
+            throw new JsonSyntaxException("Unknown item '" + itemName + "'");
+        else if (ForgeRegistries.ITEMS.getDefaultKey().equals(itemKey))
             throw new JsonSyntaxException("Invalid item: " + itemName);
+
+        Item item = ForgeRegistries.ITEMS.getValue(itemKey);
 
         if (readNBT && json.has("nbt"))
         {

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -38,7 +38,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.crafting.conditions.IConditionSerializer;

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -162,8 +162,6 @@ public class CraftingHelper
 
         Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName));
 
-        if (item == null)
-            throw new JsonSyntaxException("Unknown item '" + itemName + "'");
         if (item == Items.AIR)
             throw new JsonSyntaxException("Invalid item: " + itemName);
 

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -38,6 +38,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
@@ -163,6 +164,8 @@ public class CraftingHelper
 
         if (item == null)
             throw new JsonSyntaxException("Unknown item '" + itemName + "'");
+        if (item == Items.AIR)
+            throw new JsonSyntaxException("Invalid item: " + itemName);
 
         if (readNBT && json.has("nbt"))
         {

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -38,6 +38,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
@@ -157,15 +158,21 @@ public class CraftingHelper
 
     public static ItemStack getItemStack(JsonObject json, boolean readNBT)
     {
+        return getItemStack(json, readNBT, false);
+    }
+
+    public static ItemStack getItemStack(JsonObject json, boolean readNBT, boolean disallowsAirInRecipe)
+    {
         String itemName = GsonHelper.getAsString(json, "item");
         ResourceLocation itemKey = new ResourceLocation(itemName);
 
         if (!ForgeRegistries.ITEMS.containsKey(itemKey))
             throw new JsonSyntaxException("Unknown item '" + itemName + "'");
-        else if (ForgeRegistries.ITEMS.getDefaultKey().equals(itemKey))
-            throw new JsonSyntaxException("Invalid item: " + itemName);
 
         Item item = ForgeRegistries.ITEMS.getValue(itemKey);
+
+        if (disallowsAirInRecipe && item == Items.AIR)
+            throw new JsonSyntaxException("Invalid item: " + itemName);
 
         if (readNBT && json.has("nbt"))
         {


### PR DESCRIPTION
As mentioned by #8086, `ForgeRegistry#getValue` will only return null if there is no default value. However, the `ITEM` registry will always default to `#AIR` if no item is available. With normal vanilla behavior (as defined by `ShapedRecipe#itemFromJson`, this returns a `JsonSyntaxException` mentioning that the air item is invalid.

This PR readds that check for `Items#AIR` and returns the same error message as vanilla would.