### PR TITLE
[1.16] Pass IModelData through IForgeBakedModel#getModelData() before using it to get the particle texture

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/BlockModelShapes.java
 +++ b/net/minecraft/client/renderer/BlockModelShapes.java
-@@ -24,8 +_,14 @@
+@@ -24,8 +_,15 @@
        this.field_178128_c = p_i46245_1_;
     }
  
@@ -12,7 +12,8 @@
 +
 +   public TextureAtlasSprite getTexture(BlockState state, net.minecraft.world.World world, net.minecraft.util.math.BlockPos pos) {
 +      net.minecraftforge.client.model.data.IModelData data = net.minecraftforge.client.model.ModelDataManager.getModelData(world, pos);
-+      return this.func_178125_b(state).getParticleTexture(data == null ? net.minecraftforge.client.model.data.EmptyModelData.INSTANCE : data);
++      IBakedModel model = this.func_178125_b(state);
++      return model.getParticleTexture(model.getModelData(world, pos, state, data == null ? net.minecraftforge.client.model.data.EmptyModelData.INSTANCE : data));
     }
  
     public IBakedModel func_178125_b(BlockState p_178125_1_) {


### PR DESCRIPTION
This is the LTS backport of #8106.

This PR modifies the `IModelData`-aware particle texture getter in `BlockModelShaper` to pass the `IModelData` through `IForgeBakedModel#getModelData()` to allow custom baked models that either do not use the `ModelDataManager` from the `BlockEntity` or are used for a `Block` that doesn't even have a `BlockEntity` to alter the particle texture based on the `IModelData`.