### PR TITLE
Prevents Tile Entity data leak by copying CompoundNBT before writing

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -151,7 +151,7 @@
  
 +         CompoundTag caps = serializeCaps();
 +         if (caps != null) p_20241_.m_128365_("ForgeCaps", caps);
-+         if (persistentData != null) p_20241_.m_128365_("ForgeData", persistentData);
++         if (persistentData != null) p_20241_.m_128365_("ForgeData", persistentData.m_6426_());
 +
           this.m_7380_(p_20241_);
           if (this.m_20160_()) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -37,7 +37,7 @@
           p_58895_.m_128405_("x", this.f_58858_.m_123341_());
           p_58895_.m_128405_("y", this.f_58858_.m_123342_());
           p_58895_.m_128405_("z", this.f_58858_.m_123343_());
-+         if (this.customTileData != null) p_58895_.m_128365_("ForgeData", this.customTileData);
++         if (this.customTileData != null) p_58895_.m_128365_("ForgeData", this.customTileData.m_6426_());
 +         if (getCapabilities() != null) p_58895_.m_128365_("ForgeCaps", serializeCaps());
           return p_58895_;
        }


### PR DESCRIPTION
Prevents Tile Entity data leak by copying CompoundNBT before writing and closes #7760.