### PR TITLE
[1.17.x] EntityMountEvent Infinite Client Loop Fix

### DIFF
--- a/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
@@ -37,6 +37,14 @@
              this.f_108617_.m_104955_(new ServerboundPlayerCommandPacket(this, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
           }
        }
+@@ -807,6 +_,7 @@
+ 
+    public void m_6083_() {
+       super.m_6083_();
++      if (this.m_36342_() && this.m_20159_()) this.f_108618_.f_108573_ = false;
+       this.f_108611_ = false;
+       if (this.m_20202_() instanceof Boat) {
+          Boat boat = (Boat)this.m_20202_();
 @@ -1004,6 +_,18 @@
        } else {
           return super.m_7398_(p_108758_);


### PR DESCRIPTION
Port of #7125 to 1.17.

> Whenever EntityMountEvent was cancelled to dismount the player, there would be an infinite loop triggered on the client side. This is because the client player overrides the standard sneaking methods to use movement inputs instead, so the checks used to see if the player is dismounting a passenger results in something different. Movement inputs are only updated when the client player is ticked. However, since the client player is always riding a passenger, the player gets stuck in an infinite loop on the client.