### PR TITLE
[RFC] Cap Rework

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
+++ b/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.common.asm;
 
-import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,6 +32,7 @@ import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 /**
  * Removes the final modifier from fields with the @CapabilityInject annotation, prevents the JITer from in lining them so our runtime replacements can work.
  */
+@Deprecated(since = "1.18", forRemoval = true)
 public class CapabilityInjectDefinalize implements ILaunchPluginService {
 
     private final String CAP        = "Lnet/minecraftforge/common/capabilities/Capability;";       //Don't directly reference this to prevent class loading.

--- a/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
@@ -1,0 +1,121 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.asm;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.EnumSet;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
+
+/**
+ * Removes the final modifier from fields with the @CapabilityInject annotation, prevents the JITer from in lining them so our runtime replacements can work.
+ */
+public class CapabilityTokenSubclass implements ILaunchPluginService {
+
+	private final String FUNC_NAME = "getType";
+	private final String FUNC_DESC = "()Ljava/lang/String;";
+    private final String CAP_INJECT = "net/minecraftforge/common/capabilities/CapabilityToken"; //Don't directly reference this to prevent class loading.
+
+    @Override
+    public String name() {
+        return "capability_token_subclass";
+    }
+
+    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
+    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
+
+    @Override
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty)
+    {
+        return isEmpty ? NAY : YAY;
+    }
+
+    @Override
+    public int processClassWithFlags(final Phase phase, final ClassNode classNode, final Type classType, final String reason)
+    {
+    	if (CAP_INJECT.equals(classNode.name))
+    	{
+    		for (MethodNode mtd : classNode.methods)
+    		{
+    			if (FUNC_NAME.equals(mtd.name) && FUNC_DESC.equals(mtd.desc))
+    			{
+    				mtd.access &= ~Opcodes.ACC_FINAL; // We have it final in code so people don't override it, cuz that'd be stupid, and make our transformer more complicated.
+    			}
+    		}
+    		return ComputeFlags.SIMPLE_REWRITE;
+    	}
+    	else if (CAP_INJECT.equals(classNode.superName))
+    	{
+    		Holder cls = new Holder();
+
+    		SignatureReader reader = new SignatureReader(classNode.signature); // Having a node version of this would probably be useful.
+    		reader.accept(new SignatureVisitor(Opcodes.ASM9)
+    		{
+    			Deque<String> stack = new ArrayDeque<>();
+
+    			@Override
+    			public void visitClassType(final String name)
+    			{
+    				stack.push(name);
+    			}
+
+    			@Override
+    			public void visitInnerClassType(final String name)
+    			{
+    				stack.push(stack.pop() + '$' + name);
+    			}
+
+    			@Override
+    			public void visitEnd()
+    			{
+    				var val = stack.pop();
+    				if (!stack.isEmpty() && CAP_INJECT.equals(stack.peek()))
+    					cls.value = val;
+    			}
+    		});
+
+    		if (cls.value == null)
+    			throw new IllegalStateException("Could not find signature for CapabilityToken on " + classNode.name + " from " + classNode.signature);
+
+    		var mtd = classNode.visitMethod(Opcodes.ACC_PUBLIC, FUNC_NAME, FUNC_DESC, null, new String[0]);
+    		mtd.visitLdcInsn(cls.value);
+    		mtd.visitInsn(Opcodes.ARETURN);
+    		mtd.visitEnd();
+    		return ComputeFlags.COMPUTE_MAXS;
+    	}
+    	else
+    	{
+    		return ComputeFlags.NO_REWRITE;
+    	}
+    }
+
+    private static class Holder {
+    	String value;
+    }
+
+}

--- a/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
@@ -33,7 +33,20 @@ import org.objectweb.asm.tree.MethodNode;
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 
 /**
- * Removes the final modifier from fields with the @CapabilityInject annotation, prevents the JITer from in lining them so our runtime replacements can work.
+ * Implements getType() in CapabilityTokeen subclasses.
+ *
+ * Using the class's signature to determine the generic type of TypeToken, and then implements getType() using that value.
+ * <pre>
+ * Example:
+ *
+ *  <code>new CapabilityToken&lt;String>(){}</code>
+ *  Has the signature <code>"CapabilityToken&lt;Ljava/lang/String;>"</code>
+ *
+ *  Implements the method:
+ *  <code>public String getType() {
+ *    return "java/lang/String";
+ *  }</code>
+ * </pre>
  */
 public class CapabilityTokenSubclass implements ILaunchPluginService {
 

--- a/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
@@ -33,7 +33,7 @@ import org.objectweb.asm.tree.MethodNode;
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 
 /**
- * Implements getType() in CapabilityTokeen subclasses.
+ * Implements getType() in CapabilityToken subclasses.
  *
  * Using the class's signature to determine the generic type of TypeToken, and then implements getType() using that value.
  * <pre>

--- a/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/common/asm/CapabilityTokenSubclass.java
@@ -37,8 +37,8 @@ import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
  */
 public class CapabilityTokenSubclass implements ILaunchPluginService {
 
-	private final String FUNC_NAME = "getType";
-	private final String FUNC_DESC = "()Ljava/lang/String;";
+    private final String FUNC_NAME = "getType";
+    private final String FUNC_DESC = "()Ljava/lang/String;";
     private final String CAP_INJECT = "net/minecraftforge/common/capabilities/CapabilityToken"; //Don't directly reference this to prevent class loading.
 
     @Override
@@ -58,64 +58,64 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
     @Override
     public int processClassWithFlags(final Phase phase, final ClassNode classNode, final Type classType, final String reason)
     {
-    	if (CAP_INJECT.equals(classNode.name))
-    	{
-    		for (MethodNode mtd : classNode.methods)
-    		{
-    			if (FUNC_NAME.equals(mtd.name) && FUNC_DESC.equals(mtd.desc))
-    			{
-    				mtd.access &= ~Opcodes.ACC_FINAL; // We have it final in code so people don't override it, cuz that'd be stupid, and make our transformer more complicated.
-    			}
-    		}
-    		return ComputeFlags.SIMPLE_REWRITE;
-    	}
-    	else if (CAP_INJECT.equals(classNode.superName))
-    	{
-    		Holder cls = new Holder();
+        if (CAP_INJECT.equals(classNode.name))
+        {
+            for (MethodNode mtd : classNode.methods)
+            {
+                if (FUNC_NAME.equals(mtd.name) && FUNC_DESC.equals(mtd.desc))
+                {
+                    mtd.access &= ~Opcodes.ACC_FINAL; // We have it final in code so people don't override it, cuz that'd be stupid, and make our transformer more complicated.
+                }
+            }
+            return ComputeFlags.SIMPLE_REWRITE;
+        }
+        else if (CAP_INJECT.equals(classNode.superName))
+        {
+            Holder cls = new Holder();
 
-    		SignatureReader reader = new SignatureReader(classNode.signature); // Having a node version of this would probably be useful.
-    		reader.accept(new SignatureVisitor(Opcodes.ASM9)
-    		{
-    			Deque<String> stack = new ArrayDeque<>();
+            SignatureReader reader = new SignatureReader(classNode.signature); // Having a node version of this would probably be useful.
+            reader.accept(new SignatureVisitor(Opcodes.ASM9)
+            {
+                Deque<String> stack = new ArrayDeque<>();
 
-    			@Override
-    			public void visitClassType(final String name)
-    			{
-    				stack.push(name);
-    			}
+                @Override
+                public void visitClassType(final String name)
+                {
+                    stack.push(name);
+                }
 
-    			@Override
-    			public void visitInnerClassType(final String name)
-    			{
-    				stack.push(stack.pop() + '$' + name);
-    			}
+                @Override
+                public void visitInnerClassType(final String name)
+                {
+                    stack.push(stack.pop() + '$' + name);
+                }
 
-    			@Override
-    			public void visitEnd()
-    			{
-    				var val = stack.pop();
-    				if (!stack.isEmpty() && CAP_INJECT.equals(stack.peek()))
-    					cls.value = val;
-    			}
-    		});
+                @Override
+                public void visitEnd()
+                {
+                    var val = stack.pop();
+                    if (!stack.isEmpty() && CAP_INJECT.equals(stack.peek()))
+                        cls.value = val;
+                }
+            });
 
-    		if (cls.value == null)
-    			throw new IllegalStateException("Could not find signature for CapabilityToken on " + classNode.name + " from " + classNode.signature);
+            if (cls.value == null)
+                throw new IllegalStateException("Could not find signature for CapabilityToken on " + classNode.name + " from " + classNode.signature);
 
-    		var mtd = classNode.visitMethod(Opcodes.ACC_PUBLIC, FUNC_NAME, FUNC_DESC, null, new String[0]);
-    		mtd.visitLdcInsn(cls.value);
-    		mtd.visitInsn(Opcodes.ARETURN);
-    		mtd.visitEnd();
-    		return ComputeFlags.COMPUTE_MAXS;
-    	}
-    	else
-    	{
-    		return ComputeFlags.NO_REWRITE;
-    	}
+            var mtd = classNode.visitMethod(Opcodes.ACC_PUBLIC, FUNC_NAME, FUNC_DESC, null, new String[0]);
+            mtd.visitLdcInsn(cls.value);
+            mtd.visitInsn(Opcodes.ARETURN);
+            mtd.visitEnd();
+            return ComputeFlags.COMPUTE_MAXS;
+        }
+        else
+        {
+            return ComputeFlags.NO_REWRITE;
+        }
     }
 
     private static class Holder {
-    	String value;
+        String value;
     }
 
 }

--- a/fmlloader/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
+++ b/fmlloader/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
@@ -2,3 +2,4 @@ net.minecraftforge.fml.loading.RuntimeDistCleaner
 net.minecraftforge.common.asm.RuntimeEnumExtender
 net.minecraftforge.common.asm.ObjectHolderDefinalize
 net.minecraftforge.common.asm.CapabilityInjectDefinalize
+net.minecraftforge.common.asm.CapabilityTokenSubclass

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -53,7 +53,7 @@ public class Capability<T>
      */
     public boolean isRegistered()
     {
-    	return this.listeners == null;
+        return this.listeners == null;
     }
 
     // INTERNAL
@@ -67,16 +67,16 @@ public class Capability<T>
 
     public synchronized Capability<T> addListener(Consumer<Capability<T>> listener)
     {
-    	if (this.isRegistered())
-    		listener.accept(this);
-    	else
-    		this.listeners.add(listener);
-    	return this;
+        if (this.isRegistered())
+            listener.accept(this);
+        else
+            this.listeners.add(listener);
+        return this;
     }
 
     void onRegister() {
-    	var listeners = this.listeners;
-    	this.listeners = null;
-    	listeners.forEach(l -> l.accept(this));
+        var listeners = this.listeners;
+        this.listeners = null;
+        listeners.forEach(l -> l.accept(this));
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -56,15 +56,13 @@ public class Capability<T>
         return this.listeners == null;
     }
 
-    // INTERNAL
-    private final String name;
-    List<Consumer<Capability<T>>> listeners = new ArrayList<>();
-
-    Capability(String name)
-    {
-        this.name = name;
-    }
-
+    /**
+     * Adds a listener to be called when someone registers this capability.
+     * May be called instantly if this is already registered.
+     *
+     * @param listener Function to fire when capability is registered.
+     * @return self, in case people want to use builder pattern.
+     */
     public synchronized Capability<T> addListener(Consumer<Capability<T>> listener)
     {
         if (this.isRegistered())
@@ -74,7 +72,17 @@ public class Capability<T>
         return this;
     }
 
-    void onRegister() {
+    // INTERNAL
+    private final String name;
+    List<Consumer<Capability<T>>> listeners = new ArrayList<>();
+
+    Capability(String name)
+    {
+        this.name = name;
+    }
+
+    void onRegister()
+    {
         var listeners = this.listeners;
         this.listeners = null;
         listeners.forEach(l -> l.accept(this));

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -21,6 +21,10 @@ package net.minecraftforge.common.capabilities;
 
 import net.minecraftforge.common.util.LazyOptional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -43,11 +47,36 @@ public class Capability<T>
         return this == toCheck ? inst.cast() : LazyOptional.empty();
     }
 
+    /**
+     * @return true if something has registered this capability to the Manager.
+     *   This is a marker that the class for this capability exists, and can be used.
+     */
+    public boolean isRegistered()
+    {
+    	return this.listeners == null;
+    }
+
     // INTERNAL
     private final String name;
+    List<Consumer<Capability<T>>> listeners = new ArrayList<>();
 
     Capability(String name)
     {
         this.name = name;
+    }
+
+    public synchronized Capability<T> addListener(Consumer<Capability<T>> listener)
+    {
+    	if (this.isRegistered())
+    		listener.accept(this);
+    	else
+    		this.listeners.add(listener);
+    	return this;
+    }
+
+    void onRegister() {
+    	var listeners = this.listeners;
+    	this.listeners = null;
+    	listeners.forEach(l -> l.accept(this));
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
@@ -45,9 +45,12 @@ import java.lang.annotation.*;
  *
  * <b>Warning</b>: Capability injections are run in the thread that the capablity is registered.
  * Due to parallel mod loading, this can potentially be off of the main thread.
+ *
+ * @deprecated Use  {@link CapabilityManager#get(CapabilityToken)}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
+@Deprecated(since = "1.18", forRemoval = true)
 public @interface CapabilityInject
 {
     /**

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -64,22 +64,22 @@ public enum CapabilityManager
 
     public static <T> Capability<T> get(CapabilityToken<T> type)
     {
-    	return INSTANCE.get(type.getType(), false);
+        return INSTANCE.get(type.getType(), false);
     }
 
     @SuppressWarnings("unchecked")
-	<T> Capability<T> get(String realName, boolean registering)
+    <T> Capability<T> get(String realName, boolean registering)
     {
         Capability<T> cap;
 
         synchronized (providers)
         {
             realName = realName.intern();
-        	cap = (Capability<T>)providers.get(realName);
+            cap = (Capability<T>)providers.get(realName);
             if (cap == null)
             {
-            	cap = new Capability<>(realName);
-            	providers.put(realName, cap);
+                cap = new Capability<>(realName);
+                providers.put(realName, cap);
             }
 
             if (cap.isRegistered() && registering)
@@ -92,11 +92,11 @@ public enum CapabilityManager
 
         if (!cap.isRegistered() && registering)
         {
-	        synchronized (cap)
-	        {
-		        if (!cap.isRegistered())
-		        	cap.onRegister();
-	        }
+            synchronized (cap)
+            {
+                if (!cap.isRegistered())
+                    cap.onRegister();
+            }
         }
 
         return cap;

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -22,7 +22,6 @@ package net.minecraftforge.common.capabilities;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -55,30 +54,56 @@ public enum CapabilityManager
      * @param type The class type to be registered
      * @deprecated use {@link RegisterCapabilitiesEvent}
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.18", forRemoval = true)
     public <T> void register(Class<T> type)
     {
         Objects.requireNonNull(type,"Attempted to register a capability with invalid type");
-        String realName = type.getName().intern();
+        get(Type.getType(type).toString(), true);
+    }
+
+
+    public static <T> Capability<T> get(CapabilityToken<T> type)
+    {
+    	return INSTANCE.get(type.getType(), false);
+    }
+
+    @SuppressWarnings("unchecked")
+	<T> Capability<T> get(String realName, boolean registering)
+    {
         Capability<T> cap;
 
         synchronized (providers)
         {
-            if (providers.containsKey(realName)) {
+            realName = realName.intern();
+        	cap = (Capability<T>)providers.get(realName);
+            if (cap == null)
+            {
+            	cap = new Capability<>(realName);
+            	providers.put(realName, cap);
+            }
+
+            if (cap.isRegistered() && registering)
+            {
                 LOGGER.error(CAPABILITIES, "Cannot register capability implementation multiple times : {}", realName);
                 throw new IllegalArgumentException("Cannot register a capability implementation multiple times : "+ realName);
             }
-
-            cap = new Capability<>(realName);
-            providers.put(realName, cap);
         }
 
-        fireCallbacks(this.callbacks, List.of(cap));
+
+        if (!cap.isRegistered() && registering)
+        {
+	        synchronized (cap)
+	        {
+		        if (!cap.isRegistered())
+		        	cap.onRegister();
+	        }
+        }
+
+        return cap;
     }
 
     // INTERNAL
     private final IdentityHashMap<String, Capability<?>> providers = new IdentityHashMap<>();
-    private volatile IdentityHashMap<String, List<Function<Capability<?>, Object>>> callbacks;
     public void injectCapabilities(List<ModFileScanData> data)
     {
         final List<ModFileScanData.AnnotationData> elementsToInject = data.stream()
@@ -91,22 +116,9 @@ public enum CapabilityManager
 
         var event = new RegisterCapabilitiesEvent();
         ModLoader.get().postEvent(event);
-        fireCallbacks(callbacks, event.getCapabilities().values());
-
-        // TODO 1.18: remove these fields
-        this.providers.putAll(event.getCapabilities());
-        this.callbacks = callbacks;
     }
 
-    private static void fireCallbacks(Map<String, List<Function<Capability<?>, Object>>> callbacks, Iterable<Capability<?>> caps)
-    {
-        for (var cap : caps)
-        {
-            callbacks.getOrDefault(cap.getName(), List.of()).forEach(f -> f.apply(cap));
-        }
-    }
-
-    private static void gatherCallbacks(Map<String, List<Function<Capability<?>, Object>>> callbacks, ModFileScanData.AnnotationData annotationData)
+    private void gatherCallbacks(Map<String, List<Function<Capability<?>, Object>>> callbacks, ModFileScanData.AnnotationData annotationData)
     {
         final String targetClass = annotationData.clazz().getClassName();
         final String targetName = annotationData.memberName();
@@ -116,13 +128,14 @@ public enum CapabilityManager
             LOGGER.warn(CAPABILITIES,"Unable to inject capability at {}.{} (Invalid Annotation)", targetClass, targetName);
             return;
         }
-        final String capabilityName = type.getInternalName().replace('/', '.').intern();
+        final String capabilityName = type.getInternalName();
 
-        List<Function<Capability<?>, Object>> list = callbacks.computeIfAbsent(capabilityName, k -> new ArrayList<>());
+        final Capability<?> cap = get(capabilityName, false);
 
         if (annotationData.memberName().indexOf('(') > 0)
         {
-            list.add(input -> {
+            cap.addListener(input ->
+            {
                 try
                 {
                     for (Method mtd : Class.forName(targetClass).getDeclaredMethods())
@@ -132,12 +145,12 @@ public enum CapabilityManager
                             if ((mtd.getModifiers() & Modifier.STATIC) != Modifier.STATIC)
                             {
                                 LOGGER.warn(CAPABILITIES,"Unable to inject capability {} at {}.{} (Non-Static)", capabilityName, targetClass, targetName);
-                                return null;
+                                return;
                             }
 
                             mtd.setAccessible(true);
                             mtd.invoke(null, input);
-                            return null;
+                            return;
                         }
                     }
                     LOGGER.warn(CAPABILITIES,"Unable to inject capability {} at {}.{} (Method Not Found)", capabilityName, targetClass, targetName);
@@ -146,19 +159,19 @@ public enum CapabilityManager
                 {
                     LOGGER.warn(CAPABILITIES,"Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName, e);
                 }
-                return null;
             });
         }
         else
         {
-            list.add(input -> {
+            cap.addListener(input ->
+            {
                 try
                 {
                     Field field = Class.forName(targetClass).getDeclaredField(targetName);
                     if ((field.getModifiers() & Modifier.STATIC) != Modifier.STATIC)
                     {
                         LOGGER.warn(CAPABILITIES,"Unable to inject capability {} at {}.{} (Non-Static)", capabilityName, targetClass, targetName);
-                        return null;
+                        return;
                     }
                     field.setAccessible(true);
                     field.set(null, input);
@@ -167,7 +180,6 @@ public enum CapabilityManager
                 {
                     LOGGER.warn(CAPABILITIES,"Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName, e);
                 }
-                return null;
             });
         }
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -1,12 +1,12 @@
 package net.minecraftforge.common.capabilities;
 
 public abstract class CapabilityToken<T> {
-	protected final String getType() {
-		throw new RuntimeException("This will be implemented by a transformer");
-	}
+    protected final String getType() {
+        throw new RuntimeException("This will be implemented by a transformer");
+    }
 
-	@Override
-	public String toString() {
-		return "CapabilityToken[" + getType() + "]";
-	}
+    @Override
+    public String toString() {
+        return "CapabilityToken[" + getType() + "]";
+    }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -1,12 +1,49 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.capabilities;
 
-public abstract class CapabilityToken<T> {
-    protected final String getType() {
+/**
+ * Inspired by {@link com.google.common.reflect.TypeToken TypeToken}, use a subclass to capture
+ * generic types. Then uses {@link net.minecraftforge.common.asm.CapabilityTokenSubclass a transformer}
+ * to convert that generic into a string returned by {@link #getType}
+ * This allows us to know the generic type, without having a hard reference to the
+ * class.
+ *
+ * Example usage:
+ * <pre>{@code
+ *    public static Capability<IDataHolder> DATA_HOLDER_CAPABILITY
+ *    		= CapabilityManager.get(new CapabilityToken<>(){});
+ *
+ * </pre>
+ *
+ */
+public abstract class CapabilityToken<T>
+{
+    protected final String getType()
+    {
         throw new RuntimeException("This will be implemented by a transformer");
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "CapabilityToken[" + getType() + "]";
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -1,0 +1,12 @@
+package net.minecraftforge.common.capabilities;
+
+public abstract class CapabilityToken<T> {
+	protected final String getType() {
+		throw new RuntimeException("This will be implemented by a transformer");
+	}
+
+	@Override
+	public String toString() {
+		return "CapabilityToken[" + getType() + "]";
+	}
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.common.capabilities;
 
 import java.util.Objects;
 
+import org.objectweb.asm.Type;
+
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 
@@ -40,6 +42,6 @@ public final class RegisterCapabilitiesEvent extends Event implements IModBusEve
     public <T> void register(Class<T> type)
     {
         Objects.requireNonNull(type,"Attempted to register a capability with invalid type");
-        CapabilityManager.INSTANCE.get(type.getName(), true);
+        CapabilityManager.INSTANCE.get(Type.getInternalName(type), true);
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -19,12 +19,10 @@
 
 package net.minecraftforge.common.capabilities;
 
+import java.util.Objects;
+
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
-
-import java.util.*;
-
-import static net.minecraftforge.fml.Logging.CAPABILITIES;
 
 /**
  * This event fires when it is time to register your capabilities.
@@ -32,9 +30,6 @@ import static net.minecraftforge.fml.Logging.CAPABILITIES;
  */
 public final class RegisterCapabilitiesEvent extends Event implements IModBusEvent
 {
-
-    private final IdentityHashMap<String, Capability<?>> capabilities = new IdentityHashMap<>();
-
     /**
      * Registers a capability to be consumed by others.
      * APIs who define the capability should call this.
@@ -45,16 +40,6 @@ public final class RegisterCapabilitiesEvent extends Event implements IModBusEve
     public <T> void register(Class<T> type)
     {
         Objects.requireNonNull(type,"Attempted to register a capability with invalid type");
-        String realName = type.getName().intern();
-        if (capabilities.putIfAbsent(realName, new Capability<>(realName)) != null) {
-            CapabilityManager.LOGGER.error(CAPABILITIES, "Cannot register capability implementation multiple times : {}", realName);
-            throw new IllegalArgumentException("Cannot register a capability implementation multiple times : "+ realName);
-        }
+        CapabilityManager.INSTANCE.get(type.getName(), true);
     }
-
-    IdentityHashMap<String, Capability<?>> getCapabilities()
-    {
-        return this.capabilities;
-    }
-
 }

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -21,7 +21,8 @@ package net.minecraftforge.common.model.animation;
 
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
@@ -31,8 +32,7 @@ import javax.annotation.Nullable;
 
 public class CapabilityAnimation
 {
-    @CapabilityInject(IAnimationStateMachine.class)
-    public static Capability<IAnimationStateMachine> ANIMATION_CAPABILITY = null;
+    public static Capability<IAnimationStateMachine> ANIMATION_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
     public static void register(RegisterCapabilitiesEvent event)
     {

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -23,8 +23,7 @@ import net.minecraftforge.common.capabilities.*;
 
 public class CapabilityEnergy
 {
-    @CapabilityInject(IEnergyStorage.class)
-    public static Capability<IEnergyStorage> ENERGY = null;
+    public static final Capability<IEnergyStorage> ENERGY = CapabilityManager.get(new CapabilityToken<>(){});;
 
     public static void register(RegisterCapabilitiesEvent event)
     {

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -20,15 +20,14 @@
 package net.minecraftforge.fluids.capability;
 
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityFluidHandler
 {
-    @CapabilityInject(IFluidHandler.class)
-    public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = null;
-    @CapabilityInject(IFluidHandlerItem.class)
-    public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = null;
+    public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
+    public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
     public static void register(RegisterCapabilitiesEvent event)
     {

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -20,13 +20,13 @@
 package net.minecraftforge.items;
 
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityItemHandler
 {
-    @CapabilityInject(IItemHandler.class)
-    public static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = null;
+    public static final Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
     public static void register(RegisterCapabilitiesEvent event)
     {


### PR DESCRIPTION
There has been a request too move away from reflection {which makes  sense because of J16} and synthetic final fields that can be null.

So here is is. The current system of @CapabilityInject in deprecated for removal in 1.18.
It still works as before, only being injected when the capability is registered. 

You now always get a non-null Capability. Using CapabiltyToken to specify the type.

```
public static Capability<IDataHolder> DATA_HOLDER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
```
Note the fact that it's a anon class. This forces the compiler to include the generic information we need.
We are not going to pass in a Class object because we need to keep the soft dependency system.

The general concept is Capability now has a 'isRegistered()' function instead of testing != null.
It also has a addListener(Consumer<Capability<T>>) function, which is analogous too the old @CapabilityInject on a method.

A note about my use of @Deprecated.
Recently they added a 'since' and 'forRemoval' field to this annotation, I have gotten in the habit of setting the 'since' to the MC version in which it should be removed. Ideally in the future we'll add a build step that verifies that no @Deprecations exist for the <= the current MC version.

Re: https://github.com/MinecraftForge/MinecraftForge/pull/8104