### PR TITLE
Add BaseSpawnerActivationEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/world/level/BaseSpawner.java
 +++ b/net/minecraft/world/level/BaseSpawner.java
+@@ -62,7 +_,9 @@
+    }
+ 
+    private boolean m_151343_(Level p_151344_, BlockPos p_151345_) {
+-      return p_151344_.m_45914_((double)p_151345_.m_123341_() + 0.5D, (double)p_151345_.m_123342_() + 0.5D, (double)p_151345_.m_123343_() + 0.5D, (double)this.f_45452_);
++      net.minecraftforge.eventbus.api.Event.Result result = net.minecraftforge.event.ForgeEventFactory.canSpawnerActivate(this, p_151344_, p_151345_, this.f_45452_);
++      if (result == net.minecraftforge.eventbus.api.Event.Result.DENY) return false;
++      return result == net.minecraftforge.eventbus.api.Event.Result.ALLOW || p_151344_.m_45914_(p_151345_.m_123341_() + 0.5D, p_151345_.m_123342_() + 0.5D, p_151345_.m_123343_() + 0.5D, this.f_45452_);
+    }
+ 
+    public void m_151319_(Level p_151320_, BlockPos p_151321_) {
 @@ -127,11 +_,12 @@
                    entity.m_7678_(entity.m_20185_(), entity.m_20186_(), entity.m_20189_(), p_151312_.f_46441_.nextFloat() * 360.0F, 0.0F);
                    if (entity instanceof Mob) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -134,6 +134,7 @@ import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
+import net.minecraftforge.event.world.SpawnerActivationEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
@@ -795,5 +796,12 @@ public class ForgeEventFactory
             return MinecraftForge.EVENT_BUS.post(new PermissionsChangedEvent(player, newLevel, oldLevel));
         }
         return false;
+    }
+
+    public static Result canSpawnerActivate(BaseSpawner spawner, Level level, BlockPos pos, int playerRange)
+    {
+        SpawnerActivationEvent event = new SpawnerActivationEvent(level, spawner, pos);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/SpawnerActivationEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SpawnerActivationEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.world;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BaseSpawner;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.Event.HasResult;
+
+/**
+ * This event is fired on every tick of a Spawner entity.<br>
+ * <br>
+ * This event has a {@link HasResult result}:
+ * <li>{@link Result#ALLOW} Allows Spawner activation.</li>
+ * <li>{@link Result#DEFAULT} Use vanilla Spawner activation rules.</li>
+ * <li>{@link Result#DENY} Deny Spawner activation.</li><br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@HasResult
+public class SpawnerActivationEvent extends Event
+{
+    private final Level level;
+    private final BaseSpawner spawner;
+    private final BlockPos pos;
+
+    public SpawnerActivationEvent(Level level, BaseSpawner spawner, BlockPos pos)
+    {
+        this.level = level;
+        this.spawner = spawner;
+        this.pos = pos;
+    }
+
+    public Level getLevel()
+    {
+        return level;
+    }
+
+    public BaseSpawner getSpawner()
+    {
+        return spawner;
+    }
+
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/SpawnerActivationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/SpawnerActivationEventTest.java
@@ -1,0 +1,73 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.SpawnerActivationEvent;
+import net.minecraftforge.eventbus.api.Event.Result;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("spawner_activation_event_test")
+public class SpawnerActivationEventTest
+{
+    public static final boolean enabled = false;
+
+    public SpawnerActivationEventTest()
+    {
+         if (enabled)
+         {
+             MinecraftForge.EVENT_BUS.addListener(SpawnerActivationEventTest::changeSpawnerActivationBehavior);
+         }
+    }
+
+    public static void changeSpawnerActivationBehavior(SpawnerActivationEvent event)
+    {
+        Level level = event.getLevel();
+        BlockPos pos = event.getPos();
+        Difficulty difficulty = level.getCurrentDifficultyAt(pos).getDifficulty();
+        int playerRange = 0;
+
+        switch(difficulty)
+        {
+            case PEACEFUL:
+                event.setResult(Result.DENY);
+                return;
+            case EASY:
+                playerRange = 4;
+                break;
+            case NORMAL:
+                playerRange = 8;
+                break;
+            default: // We don't change anything for hard difficulty.
+                return;
+        }
+
+        if (level.hasNearbyAlivePlayer(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, playerRange))
+        {
+            event.setResult(Result.ALLOW);
+            return;
+        }
+
+        event.setResult(Result.DENY);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -156,5 +156,7 @@ license="LGPL v2.1"
     modId="custom_shield_test"
 [[mods]]
     modId="lazy_capabilities_on_items"
+[[mods]]
+    modId="spawner_activation_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This event allows a mod to control the activation conditions of
net.minecraft.world.level.BaseSpawner. The event class contains documentation on
how to use the event.

This commit also contains a test mod, disabled bye default, that changes a
vanilla mob spawner activation range based on the world difficulty setting.

Rationale:
I am writing a mod where I want to control the range at which a spawner activates based on attributes that nearby players have. Whilst it is possible to modify requiredPlayerRange through NBT, that does not feel nearly as clean a solution to me, particularly since I then want to make sure that change is not written to disk, in case the user decides to remove my mod, and wants spawners to revert to vanilla behavior.

I am happy to enable the test mod by default if desired, and am also happy to split things out into separate commits if preferred.

Thank you in advance for your time and consideration.