### PR TITLE
[1.17.x] Make Broken Blocks Display Associated FluidState

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -536,7 +536,7 @@ public class ForgeHooks
         // Tell client the block is gone immediately then process events
         if (world.getBlockEntity(pos) == null)
         {
-            entityPlayer.connection.send(new ClientboundBlockUpdatePacket(DUMMY_WORLD, pos));
+            entityPlayer.connection.send(new ClientboundBlockUpdatePacket(pos, world.getFluidState(pos).createLegacyBlock()));
         }
 
         // Post the block break event
@@ -1059,36 +1059,6 @@ public class ForgeHooks
             return !event.isCanceled();
         }
         return false;
-    }
-
-
-    private static final DummyBlockReader DUMMY_WORLD = new DummyBlockReader();
-    private static class DummyBlockReader implements BlockGetter {
-
-        @Override
-        public BlockEntity getBlockEntity(BlockPos pos) {
-            return null;
-        }
-
-        @Override
-        public BlockState getBlockState(BlockPos pos) {
-            return Blocks.AIR.defaultBlockState();
-        }
-
-        @Override
-        public FluidState getFluidState(BlockPos pos) {
-            return Fluids.EMPTY.defaultFluidState();
-        }
-
-        @Override
-        public int getHeight() {
-            return 0;
-        }
-
-        @Override
-        public int getMinBuildHeight() {
-            return 0;
-        }
     }
 
     public static int onNoteChange(Level world, BlockPos pos, BlockState state, int old, int _new) {


### PR DESCRIPTION
This addresses #7253 for 1.17. When breaking a block within `ForgeHooks#onBlockBreakEvent`, Forge tells the client the block is gone for non-block entities. However, this just sets the block to air through the use of a dummy world. This would be fine normally; however, the addition of waterlogged blocks means that the `FluidState` of the block must also be taken into consideration.

This PR fixes that by returning the `BlockState` of the current fluid at the position. This also removes the `DUMMY_WORLD` as it seems it was only implemented for this express purpose (see [initial commit](https://github.com/MinecraftForge/MinecraftForge/commit/cdfa7caaeb85283f33e0a7d70840fa2e53568cbd#diff-a0412d7ac689ab1c48becee0dd0e7d0c2aea7fb6f82d2985cb124268ff7b1909L844-R803)).