### PR TITLE
[1.16.x] Make Broken Blocks Display Associated FluidState

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -592,7 +592,7 @@ public class ForgeHooks
         // Tell client the block is gone immediately then process events
         if (world.getBlockEntity(pos) == null)
         {
-            entityPlayer.connection.send(new SChangeBlockPacket(DUMMY_WORLD, pos));
+            entityPlayer.connection.send(new SChangeBlockPacket(pos, world.getFluidState(pos).createLegacyBlock()));
         }
 
         // Post the block break event
@@ -1146,26 +1146,6 @@ public class ForgeHooks
             Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
-    }
-
-    private static final DummyBlockReader DUMMY_WORLD = new DummyBlockReader();
-    private static class DummyBlockReader implements IBlockReader {
-
-        @Override
-        public TileEntity getBlockEntity(BlockPos pos) {
-            return null;
-        }
-
-        @Override
-        public BlockState getBlockState(BlockPos pos) {
-            return Blocks.AIR.defaultBlockState();
-        }
-
-        @Override
-        public FluidState getFluidState(BlockPos pos) {
-            return Fluids.EMPTY.defaultFluidState();
-        }
-
     }
 
     public static int onNoteChange(World world, BlockPos pos, BlockState state, int old, int _new) {


### PR DESCRIPTION
Backported version of #8128.

> When breaking a block within ForgeHooks#onBlockBreakEvent, Forge tells the client the block is gone for non-block entities. However, this just sets the block to air through the use of a dummy world. This would be fine normally; however, the addition of waterlogged blocks means that the FluidState of the block must also be taken into consideration.