### PR TITLE
Fix Signs breaking with custom `WoodType`s

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -6,7 +6,7 @@
     public static ModelLayerLocation m_171291_(WoodType p_171292_) {
 -      return m_171300_("sign/" + p_171292_.m_61846_(), "main");
 +      ResourceLocation location = new ResourceLocation(p_171292_.m_61846_());
-+      return new ModelLayerLocation(new ResourceLocation(location.m_135827_(), "signs/" + location.m_135815_()), "main");
++      return new ModelLayerLocation(new ResourceLocation(location.m_135827_(), "sign/" + location.m_135815_()), "main");
     }
  
     public static Stream<ModelLayerLocation> m_171288_() {

--- a/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -6,7 +6,7 @@
     public static ModelLayerLocation m_171291_(WoodType p_171292_) {
 -      return m_171300_("sign/" + p_171292_.m_61846_(), "main");
 +      ResourceLocation location = new ResourceLocation(p_171292_.m_61846_());
-+      return new ModelLayerLocation(new ResourceLocation(location.m_135827_(), "entity/signs/" + location.m_135815_()), "main");
++      return new ModelLayerLocation(new ResourceLocation(location.m_135827_(), "signs/" + location.m_135815_()), "main");
     }
  
     public static Stream<ModelLayerLocation> m_171288_() {

--- a/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/client/model/geom/ModelLayers.java
++++ b/net/minecraft/client/model/geom/ModelLayers.java
+@@ -199,7 +_,8 @@
+    }
+ 
+    public static ModelLayerLocation m_171291_(WoodType p_171292_) {
+-      return m_171300_("sign/" + p_171292_.m_61846_(), "main");
++      ResourceLocation location = new ResourceLocation(p_171292_.m_61846_());
++      return new ModelLayerLocation(new ResourceLocation(location.m_135827_(), "entity/signs/" + location.m_135815_()), "main");
+    }
+ 
+    public static Stream<ModelLayerLocation> m_171288_() {


### PR DESCRIPTION
This PR Fixes #8131 by implementing the solution that @SmellyModder suggested. This has been tested using the [CustomSignsTest](https://github.com/MinecraftForge/MinecraftForge/blob/166feefc023c7e153072a18e6b49982d7246fb0a/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java)

And the game loads just fine.
![3iGlKbR](https://user-images.githubusercontent.com/4164263/135552126-819214af-9e95-4dc2-92a4-6fe7fa002ae6.png)

This was the only mod I was able to test, because BiomesOPlenty doesn't add custom signs, Biomes You'll Go doesn't have a Forge version for 1.17.x, and TwilightForest uses their own sign renderer.