### PR TITLE
Changed control flow of post mouse events

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
@@ -8,21 +8,25 @@
           boolean[] aboolean = new boolean[]{false};
           if (this.f_91503_.m_91265_() == null) {
              if (this.f_91503_.f_91080_ == null) {
-@@ -82,11 +_,15 @@
+@@ -82,11 +_,19 @@
                 if (flag) {
                    screen.m_169415_();
                    Screen.m_96579_(() -> {
 -                     aboolean[0] = screen.m_6375_(d0, d1, i);
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPre(this.f_91503_.f_91080_, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.f_91503_.f_91080_.m_6375_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i);
++                     if (!aboolean[0]) {
++                        aboolean[0] = this.f_91503_.f_91080_.m_6375_(d0, d1, i);
++                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                     }
                    }, "mouseClicked event handler", screen.getClass().getCanonicalName());
                 } else {
                    Screen.m_96579_(() -> {
 -                     aboolean[0] = screen.m_6348_(d0, d1, i);
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPre(this.f_91503_.f_91080_, d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = this.f_91503_.f_91080_.m_6348_(d0, d1, i);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i);
++                     if (!aboolean[0]) {
++                        aboolean[0] = this.f_91503_.f_91080_.m_6348_(d0, d1, i);
++                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                     }
                    }, "mouseReleased event handler", screen.getClass().getCanonicalName());
                 }
              }

--- a/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
@@ -16,7 +16,7 @@
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPre(this.f_91503_.f_91080_, d0, d1, i);
 +                     if (!aboolean[0]) {
 +                        aboolean[0] = this.f_91503_.f_91080_.m_6375_(d0, d1, i);
-+                        aboolean[0] |= net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
 +                     }
                    }, "mouseClicked event handler", screen.getClass().getCanonicalName());
                 } else {
@@ -25,7 +25,7 @@
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPre(this.f_91503_.f_91080_, d0, d1, i);
 +                     if (!aboolean[0]) {
 +                        aboolean[0] = this.f_91503_.f_91080_.m_6348_(d0, d1, i);
-+                        aboolean[0] |= net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
 +                     }
                    }, "mouseReleased event handler", screen.getClass().getCanonicalName());
                 }

--- a/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHandler.java.patch
@@ -16,7 +16,7 @@
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPre(this.f_91503_.f_91080_, d0, d1, i);
 +                     if (!aboolean[0]) {
 +                        aboolean[0] = this.f_91503_.f_91080_.m_6375_(d0, d1, i);
-+                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                        aboolean[0] |= net.minecraftforge.client.ForgeHooksClient.onGuiMouseClickedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
 +                     }
                    }, "mouseClicked event handler", screen.getClass().getCanonicalName());
                 } else {
@@ -25,7 +25,7 @@
 +                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPre(this.f_91503_.f_91080_, d0, d1, i);
 +                     if (!aboolean[0]) {
 +                        aboolean[0] = this.f_91503_.f_91080_.m_6348_(d0, d1, i);
-+                        aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
++                        aboolean[0] |= net.minecraftforge.client.ForgeHooksClient.onGuiMouseReleasedPost(this.f_91503_.f_91080_, d0, d1, i, aboolean[0]);
 +                     }
                    }, "mouseReleased event handler", screen.getClass().getCanonicalName());
                 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -621,9 +621,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(event);
     }
 
-    public static boolean onGuiMouseClickedPost(Screen guiScreen, double mouseX, double mouseY, int button)
+    public static boolean onGuiMouseClickedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
-        Event event = new GuiScreenEvent.MouseClickedEvent.Post(guiScreen, mouseX, mouseY, button);
+        Event event = new GuiScreenEvent.MouseClickedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
         return MinecraftForge.EVENT_BUS.post(event);
     }
 
@@ -633,9 +633,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(event);
     }
 
-    public static boolean onGuiMouseReleasedPost(Screen guiScreen, double mouseX, double mouseY, int button)
+    public static boolean onGuiMouseReleasedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
-        Event event = new GuiScreenEvent.MouseReleasedEvent.Post(guiScreen, mouseX, mouseY, button);
+        Event event = new GuiScreenEvent.MouseReleasedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
         return MinecraftForge.EVENT_BUS.post(event);
     }
 

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -624,6 +624,7 @@ public class ForgeHooksClient
     public static boolean onGuiMouseClickedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
         Event event = new GuiScreenEvent.MouseClickedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
+        event.setCanceled(handled);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getResult() == Event.Result.DEFAULT ? handled : event.getResult() == Event.Result.ALLOW;
     }
@@ -637,6 +638,7 @@ public class ForgeHooksClient
     public static boolean onGuiMouseReleasedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
         Event event = new GuiScreenEvent.MouseReleasedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
+        event.setCanceled(handled);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getResult() == Event.Result.DEFAULT ? handled : event.getResult() == Event.Result.ALLOW;
     }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -624,7 +624,8 @@ public class ForgeHooksClient
     public static boolean onGuiMouseClickedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
         Event event = new GuiScreenEvent.MouseClickedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
-        return MinecraftForge.EVENT_BUS.post(event);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult() == Event.Result.DEFAULT ? handled : event.getResult() == Event.Result.ALLOW;
     }
 
     public static boolean onGuiMouseReleasedPre(Screen guiScreen, double mouseX, double mouseY, int button)
@@ -636,7 +637,8 @@ public class ForgeHooksClient
     public static boolean onGuiMouseReleasedPost(Screen guiScreen, double mouseX, double mouseY, int button, boolean handled)
     {
         Event event = new GuiScreenEvent.MouseReleasedEvent.Post(guiScreen, mouseX, mouseY, button, handled);
-        return MinecraftForge.EVENT_BUS.post(event);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult() == Event.Result.DEFAULT ? handled : event.getResult() == Event.Result.ALLOW;
     }
 
     public static boolean onGuiMouseDragPre(Screen guiScreen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY)

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -292,6 +292,9 @@ public class GuiScreenEvent extends Event
          *   <li><b>{@link Result#DENY}</b> - to force set the mouse click as not handled</li>
          * </ul>
          * </p>
+         *
+         * <p>Note that this event is currently pre-cancelled if {@link Screen#mouseClicked} returns {@code true}
+         * to retain old behavior. This will be changed in 1.18 when the event is made non-cancellable.</p>
          */
         @Cancelable // TODO: Make non-cancellable in 1.18.
         @HasResult
@@ -363,6 +366,9 @@ public class GuiScreenEvent extends Event
          *   <li><b>{@link Result#DENY}</b> - to force set the mouse release as not handled</li>
          * </ul>
          * </p>
+         *
+         * <p>Note that this event is currently pre-cancelled if {@link Screen#mouseReleased} returns {@code true}
+         * to retain old behavior. This will be changed in 1.18 when the event is made non-cancellable.</p>
          */
         @Cancelable // TODO: Make non-cancellable in 1.18.
         @HasResult

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -300,7 +300,8 @@ public class GuiScreenEvent extends Event
             /**
              * @return {@code true} if the mouse click was already handled by its screen
              */
-            public boolean wasHandled() {
+            public boolean wasHandled()
+            {
                 return handled;
             }
         }
@@ -352,7 +353,8 @@ public class GuiScreenEvent extends Event
             /**
              * @return {@code true} if the mouse release was already handled by its screen
              */
-            public boolean wasHandled() {
+            public boolean wasHandled()
+            {
                 return handled;
             }
         }

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -284,9 +284,17 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires after {@link GuiEventListener#mouseClicked(double, double, int)}.
-         * Cancel this event when you successfully use the mouse click, to prevent other handlers from using the same input.
+         *
+         * <p>This event {@linkplain HasResult has a result}.<br>
+         * <ul>
+         *   <li><b>{@link Result#ALLOW}</b> - to force set the mouse click as handled</li>
+         *   <li><b>{@link Result#DEFAULT}</b> - to use the default value of {@link #handled}</li>
+         *   <li><b>{@link Result#DENY}</b> - to force set the mouse click as not handled</li>
+         * </ul>
+         * </p>
          */
-        @Cancelable
+        @Cancelable // TODO: Make non-cancellable in 1.18.
+        @HasResult
         public static class Post extends MouseClickedEvent
         {
             private final boolean handled;
@@ -295,6 +303,16 @@ public class GuiScreenEvent extends Event
             {
                 super(gui, mouseX, mouseY, button);
                 this.handled = handled;
+            }
+
+            /**
+             * @deprecated event now has a result instead and will no longer be cancellable in 1.18; use {@link #setResult(Result)}
+             */
+            @Override
+            @Deprecated
+            public void setCanceled(boolean cancel)
+            {
+                this.setResult(cancel ? Result.ALLOW : Result.DEFAULT);
             }
 
             /**
@@ -337,9 +355,17 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires after {@link GuiEventListener#mouseReleased(double, double, int)}.
-         * Cancel this event when you successfully use the mouse release, to prevent other handlers from using the same input.
+         *
+         * <p>This event {@linkplain HasResult has a result}.<br>
+         * <ul>
+         *   <li><b>{@link Result#ALLOW}</b> - to force set the mouse release as handled</li>
+         *   <li><b>{@link Result#DEFAULT}</b> - to use the default value of {@link #handled}</li>
+         *   <li><b>{@link Result#DENY}</b> - to force set the mouse release as not handled</li>
+         * </ul>
+         * </p>
          */
-        @Cancelable
+        @Cancelable // TODO: Make non-cancellable in 1.18.
+        @HasResult
         public static class Post extends MouseReleasedEvent
         {
             private final boolean handled;
@@ -348,6 +374,16 @@ public class GuiScreenEvent extends Event
             {
                 super(gui, mouseX, mouseY, button);
                 this.handled = handled;
+            }
+
+            /**
+             * @deprecated event now has a result instead and will no longer be cancellable in 1.18; use {@link #setResult(Result)}
+             */
+            @Override
+            @Deprecated
+            public void setCanceled(boolean cancel)
+            {
+                this.setResult(cancel ? Result.ALLOW : Result.DEFAULT);
             }
 
             /**

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -283,15 +283,25 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseClicked(double, double, int)} if the click was not already handled.
+         * This event fires after {@link GuiEventListener#mouseClicked(double, double, int)}.
          * Cancel this event when you successfully use the mouse click, to prevent other handlers from using the same input.
          */
         @Cancelable
         public static class Post extends MouseClickedEvent
         {
-            public Post(Screen gui, double mouseX, double mouseY, int button)
+            private final boolean handled;
+
+            public Post(Screen gui, double mouseX, double mouseY, int button, boolean handled)
             {
                 super(gui, mouseX, mouseY, button);
+                this.handled = handled;
+            }
+
+            /**
+             * @return {@code true} if the mouse click was already handled by its screen
+             */
+            public boolean wasHandled() {
+                return handled;
             }
         }
     }
@@ -325,15 +335,25 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseReleased(double, double, int)} if the release was not already handled.
+         * This event fires after {@link GuiEventListener#mouseReleased(double, double, int)}.
          * Cancel this event when you successfully use the mouse release, to prevent other handlers from using the same input.
          */
         @Cancelable
         public static class Post extends MouseReleasedEvent
         {
-            public Post(Screen gui, double mouseX, double mouseY, int button)
+            private final boolean handled;
+
+            public Post(Screen gui, double mouseX, double mouseY, int button, boolean handled)
             {
                 super(gui, mouseX, mouseY, button);
+                this.handled = handled;
+            }
+
+            /**
+             * @return {@code true} if the mouse release was already handled by its screen
+             */
+            public boolean wasHandled() {
+                return handled;
             }
         }
     }


### PR DESCRIPTION
Changes control flow of `GuiScreenEvent$MouseClickedEvent$Post` and `GuiScreenEvent$MouseReleasedEvent$Post` as suggested by @Shadows-of-Fire to fix #6060. Overview is this:

- Fire pre event, set `aboolean[0]` (`handled`) to return value.
- If pre event was not cancelled (`!aboolean[0]`): 
  - Call regular `mouseClicked` method, set `aboolean[0]` to return value.
  - Fire post event (now sending `aboolean[0]` as a new `handled` field for the event). 
  - If post event result was default: 
    - Set `aboolean[0]` to use handled from `mouseClicked` return. 
  - Else if event result was allow:
    - Force `aboolean[0]` to `true`. 
  - Else if event result was deny:
    - Force `aboolean[0]` to `false`. 

The reason for this change is that it gives the post event a wider variety of use cases, such as that described by the OP of #6060, rather than only firing if the mouse event wasn't handled by vanilla. 

This PR does not attempt to fully clean up the events since there is already a PR for this which would need to be merged at some point on either end anyway. Only necessary Javadoc changes for accuracy of how the event now works are included.  