### PR TITLE
Add missing call to Entity#onAddedToWorld for non-player entities server-side

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -156,6 +156,20 @@
     }
  
     private boolean m_8872_(Entity p_8873_) {
+@@ -754,7 +_,12 @@
+          f_8566_.warn("Tried to add entity {} but it was marked as removed already", (Object)EntityType.m_20613_(p_8873_.m_6095_()));
+          return false;
+       } else {
+-         return this.f_143244_.m_157533_(p_8873_);
++         if (this.f_143244_.m_157533_(p_8873_)) {
++            p_8873_.onAddedToWorld();
++            return true;
++         } else {
++            return false;
++         }
+       }
+    }
+ 
 @@ -790,10 +_,20 @@
     }
  


### PR DESCRIPTION
Currently `IForgeEntity#onAddedToWorld` is not called on server side (`ServerLevel`) for non-player entities. As far as I can tell this is unintentional and differs from 1.16.

The vanilla `ServerLevel` now handles `addEntity` and `addPlayer` completely separately. Previously `addPlayer` also called `addEntity` (which included the `onAddedToWorld` patch). In 1.17 two separate patches are needed and currently only `addPlayer` is patched.

On client-side (`ClientLevel`) nothing has changed. Same for 'onRemovedFromWorld`.