### PR TITLE
[1.17.x] crude fix for gamelibraries

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModList.java
@@ -70,7 +70,11 @@ public class ModList
 
     private ModList(final List<ModFile> modFiles, final List<ModInfo> sortedList)
     {
-        this.modFiles = modFiles.stream().map(ModFile::getModFileInfo).map(ModFileInfo.class::cast).collect(Collectors.toList());
+        this.modFiles = modFiles.stream().
+                filter(modFile -> modFile.getType() == IModFile.Type.MOD).
+                map(ModFile::getModFileInfo).
+                map(ModFileInfo.class::cast).
+                collect(Collectors.toList());
         this.sortedList = sortedList.stream().
                 map(ModInfo.class::cast).
                 collect(Collectors.toList());

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
@@ -146,7 +146,7 @@ public class LoadingModList
                     final ModFileInfo next = modFileIterator.next();
                     final Path resource = next.getFile().findResource(resourceName);
                     if (Files.exists(resource)) {
-                        return LamdbaExceptionUtils.uncheck(()->new URL("modjar://" + next.getMods().get(0).getModId() + "/" + resourceName));
+                        return LamdbaExceptionUtils.uncheck(()->new URL("modjar://" + next.moduleName() + "/" + resourceName));
                     }
                 }
                 return null;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -150,9 +150,9 @@ public class ModSorter
 
     private void buildUniqueList()
     {
-        // Collect mod files by first modid in the file. This will be used for deduping purposes
+        // Collect mod files by module name. This will be used for deduping purposes
         final Map<String, List<IModFile>> modFilesByFirstId = modFiles.stream()
-                .collect(groupingBy(mf -> mf.getModInfos().get(0).getModId()));
+                .collect(groupingBy(mf -> mf.getModFileInfo().moduleName()));
 
         // Capture forge and MC here, so we can keep them for later
         forgeAndMC = new ArrayList<>();

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
@@ -48,7 +48,10 @@ public class ModFileParser {
 
     public static IModFileInfo modsTomlParser(final IModFile imodFile) {
         ModFile modFile = (ModFile) imodFile;
-        LOGGER.debug(LOADING,"Considering mod file candidate {}", modFile.getFilePath());
+        LOGGER.debug(LOADING,"Considering mod file candidate {} of type {}", modFile.getFilePath(), modFile.getType());
+        if (modFile.getType() == IModFile.Type.GAMELIBRARY) {
+            return new ModFileInfo(modFile, modFile.getSecureJar().getManifest());
+        }
         final Path modsjson = modFile.findResource("META-INF", "mods.toml");
         if (!Files.exists(modsjson)) {
             LOGGER.warn(LOADING, "Mod file {} is missing mods.toml file", modFile.getFilePath());


### PR DESCRIPTION
Currently libraries with the FMLModType of GAMELIBRARY do not load from legacyClasspath and otherwise error because they don't have a mods.toml . This PR proposes a fix that creates a ModFileInfo from a manifest for gamelibraries. It also makes it so the fields FMLModLoader, FMLLoaderVersion and LICENSE are required to be set in the manifest for gamelibraries.

To test this I published to my mavenLocal and used it in a mod that depends on a gamelibrary (which loads without any problems with these changes).