### PR TITLE
Reintroduce modded biome variants

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java
 +++ b/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java
-@@ -19,7 +_,11 @@
-                   return 23;
+@@ -20,6 +_,11 @@
                 }
              }
--
-+            net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES;
+ 
++            net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>) net.minecraftforge.registries.ForgeRegistries.BIOMES;
 +            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> edge = net.minecraftforge.common.BiomeManager.getEdgeBiome(registry.getKey(p_76669_), registry.getKey(p_76665_), registry.getKey(p_76666_), registry.getKey(p_76667_), registry.getKey(p_76668_));
 +            if(edge.isPresent()) {
 +               return net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(edge.get()));

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java
++++ b/net/minecraft/world/level/newbiome/layer/BiomeEdgeLayer.java
+@@ -19,7 +_,11 @@
+                   return 23;
+                }
+             }
+-
++            net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES;
++            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> edge = net.minecraftforge.common.BiomeManager.getEdgeBiome(registry.getKey(p_76669_), registry.getKey(p_76665_), registry.getKey(p_76666_), registry.getKey(p_76667_), registry.getKey(p_76668_));
++            if(edge.isPresent()) {
++               return net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(edge.get()));
++            }
+             return p_76669_;
+          } else {
+             return 34;

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java.patch
@@ -1,15 +1,13 @@
 --- a/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java
 +++ b/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java
-@@ -51,7 +_,11 @@
+@@ -51,6 +_,10 @@
        } else {
           if (p_76838_.m_5826_(3) == 0 || k == 0) {
              int l = i;
--            if (i == 2) {
 +            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> hills = net.minecraftforge.common.BiomeManager.getHillsBiome(((net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES).getKey(i));
 +            if(hills.isPresent()) {
 +               l = net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(hills.get()));
-+            }
-+            else if (i == 2) {
++            } else
+             if (i == 2) {
                 l = 17;
              } else if (i == 4) {
-                l = 18;

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java
++++ b/net/minecraft/world/level/newbiome/layer/RegionHillsLayer.java
+@@ -51,7 +_,11 @@
+       } else {
+          if (p_76838_.m_5826_(3) == 0 || k == 0) {
+             int l = i;
+-            if (i == 2) {
++            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> hills = net.minecraftforge.common.BiomeManager.getHillsBiome(((net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES).getKey(i));
++            if(hills.isPresent()) {
++               l = net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(hills.get()));
++            }
++            else if (i == 2) {
+                l = 17;
+             } else if (i == 4) {
+                l = 18;

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/RiverMixerLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/RiverMixerLayer.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/newbiome/layer/RiverMixerLayer.java
++++ b/net/minecraft/world/level/newbiome/layer/RiverMixerLayer.java
+@@ -14,6 +_,10 @@
+       if (Layers.m_76721_(i)) {
+          return i;
+       } else if (j == 7) {
++         java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> river = net.minecraftforge.common.BiomeManager.getRiverBiome(((net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES).getKey(i));
++         if(river.isPresent()) {
++            return net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(river.get()));
++         }
+          if (i == 12) {
+             return 11;
+          } else {

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/ShoreLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/ShoreLayer.java.patch
@@ -4,7 +4,7 @@
     private static final IntSet f_76911_ = new IntOpenHashSet(new int[]{168, 169, 21, 22, 23, 149, 151});
  
     public int m_6949_(Context p_76918_, int p_76919_, int p_76920_, int p_76921_, int p_76922_, int p_76923_) {
-+      net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES;
++      net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>) net.minecraftforge.registries.ForgeRegistries.BIOMES;
 +      java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> shore = net.minecraftforge.common.BiomeManager.getShoreBiome(registry.getKey(p_76923_), registry.getKey(p_76919_), registry.getKey(p_76920_), registry.getKey(p_76921_), registry.getKey(p_76922_));
 +      if(shore.isPresent()) {
 +         return net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(shore.get()));

--- a/patches/minecraft/net/minecraft/world/level/newbiome/layer/ShoreLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/newbiome/layer/ShoreLayer.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/newbiome/layer/ShoreLayer.java
++++ b/net/minecraft/world/level/newbiome/layer/ShoreLayer.java
+@@ -12,6 +_,11 @@
+    private static final IntSet f_76911_ = new IntOpenHashSet(new int[]{168, 169, 21, 22, 23, 149, 151});
+ 
+    public int m_6949_(Context p_76918_, int p_76919_, int p_76920_, int p_76921_, int p_76922_, int p_76923_) {
++      net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.level.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES;
++      java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.biome.Biome>> shore = net.minecraftforge.common.BiomeManager.getShoreBiome(registry.getKey(p_76923_), registry.getKey(p_76919_), registry.getKey(p_76920_), registry.getKey(p_76921_), registry.getKey(p_76922_));
++      if(shore.isPresent()) {
++         return net.minecraft.data.BuiltinRegistries.f_123865_.m_7447_(net.minecraft.data.BuiltinRegistries.f_123865_.m_6246_(shore.get()));
++      }
+       if (p_76923_ == 14) {
+          if (Layers.m_76751_(p_76919_) || Layers.m_76751_(p_76920_) || Layers.m_76751_(p_76921_) || Layers.m_76751_(p_76922_)) {
+             return 15;

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 
@@ -257,6 +258,56 @@ public class BiomeManager
         public boolean isModded()
         {
             return isModded;
+        }
+    }
+
+    private static final List<IBiomeLayerModifier> biomeLayerModifiers = new ArrayList<>();
+
+    public static void addBiomeLayerModifier(IBiomeLayerModifier modifier)
+    {
+        biomeLayerModifiers.add(modifier);
+    }
+
+    public static Optional<ResourceKey<Biome>> getHillsBiome(ResourceKey<Biome> biome)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getHillsBiome(biome)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<ResourceKey<Biome>> getRiverBiome(ResourceKey<Biome> biome)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getRiverBiome(biome)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<ResourceKey<Biome>> getEdgeBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getEdgeBiome(biome, north, west, south, east)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<ResourceKey<Biome>> getShoreBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getShoreBiome(biome, north, west, south, east)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public interface IBiomeLayerModifier
+    {
+        default Optional<ResourceKey<Biome>> getHillsBiome(ResourceKey<Biome> biome)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<ResourceKey<Biome>> getRiverBiome(ResourceKey<Biome> biome)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<ResourceKey<Biome>> getShoreBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<ResourceKey<Biome>> getEdgeBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+        {
+            return Optional.empty();
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
@@ -1,0 +1,150 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.core.Registry;
+import net.minecraft.data.worldgen.BiomeDefaultFeatures;
+import net.minecraft.data.worldgen.SurfaceBuilders;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.biome.*;
+import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.common.BiomeManager;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import java.util.Optional;
+
+/**
+ * Must be enabled.
+ *
+ * When generated the "biome_variant_test:main" biome should generate in the overworld.
+ * Within the "biome area" there should be hills ("biome_variant_test:hills") and potentially rivers ("biome_variant_test:river") flowing to/from other biomes.
+ * At the edge of the "biome area" there should be an edge biome ("biome_variant_test:edge").
+ * If the "biome area" is next to an ocean there should be a shore ("biome_variant_test:shore").
+ */
+@Mod(BiomeVariantTest.MODID)
+public class BiomeVariantTest {
+
+    static final String MODID = "biome_variant_test";
+    private static final boolean ENABLED = false;
+
+    private static final ResourceKey<Biome> MAIN_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "main"));
+    private static final ResourceKey<Biome> HILLS_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "hills"));
+    private static final ResourceKey<Biome> EDGE_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "edge"));
+    private static final ResourceKey<Biome> RIVER_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "river"));
+    private static final ResourceKey<Biome> SHORE_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "shore"));
+
+    public BiomeVariantTest()
+    {
+        if(ENABLED)
+        {
+            FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(Biome.class, this::onRegisterBiome);
+            FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
+        }
+    }
+
+    private void onRegisterBiome(RegistryEvent.Register<Biome> event)
+    {
+        //Core biome
+        BiomeGenerationSettings.Builder main_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(SurfaceBuilders.END);
+        BiomeDefaultFeatures.addDefaultCarvers(main_generation);
+        BiomeDefaultFeatures.addDefaultLakes(main_generation);
+
+        Biome main = (new Biome.BiomeBuilder()).precipitation(Biome.Precipitation.RAIN).biomeCategory(Biome.BiomeCategory.PLAINS).depth(0.1F).scale(0.1F).temperature(0.4F).downfall(0.4F).specialEffects((new BiomeSpecialEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnSettings.Builder().build()).generationSettings(main_generation.build()).build();
+        event.getRegistry().register(main.setRegistryName(MODID, "main"));
+
+        //Hills variant
+        BiomeGenerationSettings.Builder hills_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(SurfaceBuilders.END);
+        BiomeDefaultFeatures.addDefaultCarvers(hills_generation);
+        BiomeDefaultFeatures.addDefaultLakes(hills_generation);
+
+        Biome hills = (new Biome.BiomeBuilder()).precipitation(Biome.Precipitation.RAIN).biomeCategory(Biome.BiomeCategory.PLAINS).depth(0.4F).scale(0.3F).temperature(0.8F).downfall(0.4F).specialEffects((new BiomeSpecialEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnSettings.Builder().build()).generationSettings(hills_generation.build()).build();
+        event.getRegistry().register(hills.setRegistryName(MODID, "hills"));
+
+        //Edge variant
+        BiomeGenerationSettings.Builder edge_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(SurfaceBuilders.END);
+        BiomeDefaultFeatures.addDefaultCarvers(edge_generation);
+        BiomeDefaultFeatures.addDefaultLakes(edge_generation);
+
+        Biome edge = (new Biome.BiomeBuilder()).precipitation(Biome.Precipitation.RAIN).biomeCategory(Biome.BiomeCategory.PLAINS).depth(0F).scale(0F).temperature(0.8F).downfall(0F).specialEffects((new BiomeSpecialEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnSettings.Builder().build()).generationSettings(edge_generation.build()).build();
+        event.getRegistry().register(edge.setRegistryName(MODID, "edge"));
+
+        //River variant
+        BiomeGenerationSettings.Builder river_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(SurfaceBuilders.END);
+        BiomeDefaultFeatures.addDefaultCarvers(river_generation);
+        BiomeDefaultFeatures.addDefaultLakes(river_generation);
+        BiomeDefaultFeatures.addDefaultSprings(river_generation);
+
+        Biome river = (new Biome.BiomeBuilder()).precipitation(Biome.Precipitation.RAIN).biomeCategory(Biome.BiomeCategory.PLAINS).depth(-0.5F).scale(0F).temperature(0.8F).downfall(0F).specialEffects((new BiomeSpecialEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnSettings.Builder().build()).generationSettings(river_generation.build()).build();
+        event.getRegistry().register(river.setRegistryName(MODID, "river"));
+
+
+        //Shore variant
+        BiomeGenerationSettings.Builder shore_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(SurfaceBuilders.SOUL_SAND_VALLEY);
+        BiomeDefaultFeatures.addDefaultCarvers(shore_generation);
+        BiomeDefaultFeatures.addDefaultLakes(shore_generation);
+
+        Biome shore = (new Biome.BiomeBuilder()).precipitation(Biome.Precipitation.RAIN).biomeCategory(Biome.BiomeCategory.PLAINS).depth(0f).scale(0F).temperature(0.5F).downfall(0F).specialEffects((new BiomeSpecialEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnSettings.Builder().build()).generationSettings(shore_generation.build()).build();
+        event.getRegistry().register(shore.setRegistryName(MODID, "shore"));
+
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event)
+    {
+        event.enqueueWork(this::addBiomesToGenerator);
+    }
+
+    private void addBiomesToGenerator()
+    {
+        //Add only the main biome entry
+        BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeManager.BiomeEntry(MAIN_KEY, 10));
+        //Tell the BiomeManager all biomes that might spawn
+        BiomeManager.addAdditionalOverworldBiomes(MAIN_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(HILLS_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(EDGE_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(RIVER_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(SHORE_KEY);
+
+        //Register our biome layer modifier
+        BiomeManager.addBiomeLayerModifier(new BiomeManager.IBiomeLayerModifier() {
+
+            @Override
+            public Optional<ResourceKey<Biome>> getHillsBiome(ResourceKey<Biome> biome)
+            {
+                return biome.equals(MAIN_KEY) ? Optional.of(HILLS_KEY) : Optional.empty();
+            }
+
+            @Override
+            public Optional<ResourceKey<Biome>> getEdgeBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+            {
+                if(biome.equals(MAIN_KEY))
+                {
+                    if(!north.equals(MAIN_KEY) || !west.equals(MAIN_KEY) || !south.equals(MAIN_KEY) || !east.equals(MAIN_KEY))
+                    {
+                        //If any of the adjacent biomes is not the core biome, we are at the biome edge
+                        return Optional.of(EDGE_KEY);
+                    }
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<ResourceKey<Biome>> getRiverBiome(ResourceKey<Biome> biome)
+            {
+                return biome.equals(MAIN_KEY) ? Optional.of(RIVER_KEY) : Optional.empty();
+            }
+
+            @Override
+            public Optional<ResourceKey<Biome>> getShoreBiome(ResourceKey<Biome> biome, ResourceKey<Biome> north, ResourceKey<Biome> west, ResourceKey<Biome> south, ResourceKey<Biome> east)
+            {
+                if(biome == MAIN_KEY && (BiomeDictionary.hasType(north, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(west, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(south, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(east, BiomeDictionary.Type.OCEAN)))
+                {
+                    //If any adjacent biome is of ocean type, we want a shore
+                    return Optional.of(SHORE_KEY);
+                }
+                return Optional.empty();
+            }
+        });
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -170,5 +170,7 @@ license="LGPL v2.1"
     modId="full_pots_accessor_demo"
 [[mods]]
     modId="part_entity_test"
+[[mods]]
+    modId="biome_variant_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR reintroduces a way to register/provide certain biome variants for your own biomes (or for vanilla or other modded biomes).
This e.g. allows having a hills variant of your biome seamlessly integrate into the world.

## Biome layer and variants in vanilla
MC first generates a "biome layer" based on the biomes with a biome entry/weight which specifies the biome for each chunk. Then it applies several "layers" that can modify the biome layer. For example the `RegionHillsLayer` can replace some biome chunks within a larger biome with a hills variant of that biome (`desert` -> `desert_hills`).
These modifications work on hardcoded biome ids in the respective layer class.

## Previous work
In 1.15 three of these layers were patched to allow mods to introduce their own biome variants
Hills: https://github.com/MinecraftForge/MinecraftForge/pull/6571
River: https://github.com/MinecraftForge/MinecraftForge/pull/5969
Shore: https://github.com/MinecraftForge/MinecraftForge/pull/7001

They all rely on new methods in the `Biome` class which can be overridden to return the respective variant for the modded biome.
Since with 1.16.2 modded biomes do not use a subclass of `Biome`, a new method is needed.

## How this works
The patches to the biome modification layers remain functionally unchanged as nothing has changed here. Only analog patch to `BiomeEdgeLayer` is added.
Instead of querying the respective Biome, Forge's `BiomeManager` class is now used to get the biome variants.
If a modder wants to provide biome variants to their own (or other biomes), they can register a `IBiomeLayerModifier` and override the respective method to provide the desired variant.
The integer biome ids that are used in the layer classes are translated to the `ResourceKey` id of the biome.

## Test
This PR brings a (disabled-by-default) test mod, that introduces a new biome (added with a `BiomeEntry` to be generated) and hills, edge, shore and river variant.

## Discussion
Things to think about:
- Use `null` instead of `Optional` in `IBiomeLayerModifier` return
- Instead of registering a single `IBiomeLayerModifier` that is queryied for any biome, register biome specific `IBiomeLayerModifier`


