### PR TITLE
[1.16.x] Ensure that all render targets in a PostChain use the same format

### DIFF
--- a/patches/minecraft/net/minecraft/client/shader/ShaderGroup.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/ShaderGroup.java.patch
@@ -10,3 +10,11 @@
                       IResource iresource = null;
  
                       try {
+@@ -273,6 +_,7 @@
+    public void func_148020_a(String p_148020_1_, int p_148020_2_, int p_148020_3_) {
+       Framebuffer framebuffer = new Framebuffer(p_148020_2_, p_148020_3_, true, Minecraft.field_142025_a);
+       framebuffer.func_147604_a(0.0F, 0.0F, 0.0F, 0.0F);
++      if (field_148035_a.isStencilEnabled()) framebuffer.enableStencil();
+       this.field_148032_e.put(p_148020_1_, framebuffer);
+       if (p_148020_2_ == this.field_148038_h && p_148020_3_ == this.field_148039_i) {
+          this.field_148029_f.add(framebuffer);


### PR DESCRIPTION
This is a backport of #7978 or its merged https://github.com/MinecraftForge/MinecraftForge/commit/9746db5129124f70835b501cad691a84943b6f41. This fixes #6995 by making sure all render targets within a `ShaderGroup` or `Postchain` use the same format. Credits to @malte0811.

This can be verified using the same process mentioned in the issue:
> Make sure the stencil buffer test mod is enabled (this is the default).
> Launch MC with test mods (forge_test_client gradle task).
> Create a superflat world (any world will most likely work).
> Enable "Fabulous" graphics
> Observe log spam (or don't in this case since this would fix the issue)