### PR TITLE
Deprecate net.minecraftforge.common.util.Constants and inner classes to encourage usage of vanilla constants

### DIFF
--- a/patches/minecraft/net/minecraft/world/effect/MobEffectInstance.java.patch
+++ b/patches/minecraft/net/minecraft/world/effect/MobEffectInstance.java.patch
@@ -72,9 +72,9 @@
 +      this.curativeItems = curativeItems;
 +   }
 +   private static MobEffectInstance readCurativeItems(MobEffectInstance effect, CompoundTag nbt) {
-+      if (nbt.m_128425_("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_LIST)) {
++      if (nbt.m_128425_("CurativeItems", net.minecraft.nbt.Tag.f_178202_)) {
 +         java.util.List<net.minecraft.world.item.ItemStack> items = new java.util.ArrayList<net.minecraft.world.item.ItemStack>();
-+         net.minecraft.nbt.ListTag list = nbt.m_128437_("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
++         net.minecraft.nbt.ListTag list = nbt.m_128437_("CurativeItems", net.minecraft.nbt.Tag.f_178203_);
 +         for (int i = 0; i < list.size(); i++) {
 +            items.add(net.minecraft.world.item.ItemStack.m_41712_(list.m_128728_(i)));
 +         }

--- a/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.util;
 import java.lang.ref.WeakReference;
 import java.util.Objects;
 
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.nbt.CompoundTag;
@@ -135,7 +136,7 @@ public class BlockSnapshot
         BlockState current = getCurrentBlock();
         BlockState replaced = getReplacedBlock();
 
-        int flags = notifyNeighbors ? Constants.BlockFlags.DEFAULT : Constants.BlockFlags.BLOCK_UPDATE;
+        int flags = notifyNeighbors ? Block.UPDATE_ALL : Block.UPDATE_CLIENTS;
 
         if (current != replaced)
         {

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -26,7 +26,10 @@ import net.minecraft.world.level.block.LevelEvent;
 /**
  * A class containing constants for magic numbers used in the minecraft codebase.
  * Everything here should be checked each update, and have a comment relating to where to check it.
+ *
+ * @deprecated No longer needed. See inner classes for replacements
  */
+@Deprecated(since = "1.18", forRemoval = true)
 public class Constants
 {
     /**
@@ -35,7 +38,9 @@ public class Constants
      *
      * Main use is checking tag type in {@link net.minecraft.nbt.CompoundNBT#contains(String, int)}
      *
+     * @deprecated Replaced by the constants in {@link net.minecraft.nbt.Tag}
      */
+    @Deprecated(since = "1.18", forRemoval = true)
     public static class NBT
     {
         public static final int TAG_END         = Tag.TAG_END;
@@ -58,7 +63,10 @@ public class Constants
      * The world event IDS, used when calling {@link IWorld#playEvent(int, BlockPos, int)}. <br>
      * Can be found from {@link net.minecraft.client.renderer.WorldRenderer#playEvent}<br>
      * Some of the events use the {@code data} parameter. If this is the case, an explanation of what {@code data} does is also provided
+     *
+     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.LevelEvent}
      */
+    @Deprecated(since = "1.18", forRemoval = true)
     public static class WorldEvents {
         public static final int DISPENSER_DISPENSE_SOUND        = LevelEvent.SOUND_DISPENSER_DISPENSE;
         public static final int DISPENSER_FAIL_SOUND            = LevelEvent.SOUND_DISPENSER_FAIL;
@@ -155,7 +163,10 @@ public class Constants
      * {@link World#markAndNotifyBlock}, and
      * {@link WorldRenderer#notifyBlockUpdate}<br>
      * Flags can be combined with bitwise OR
+     *
+     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.Block}
      */
+    @Deprecated(since = "1.18", forRemoval = true)
     public static class BlockFlags {
         /**
          * Calls

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -27,9 +27,10 @@ import net.minecraft.world.level.block.LevelEvent;
  * A class containing constants for magic numbers used in the minecraft codebase.
  * Everything here should be checked each update, and have a comment relating to where to check it.
  *
- * @deprecated No longer needed. See inner classes for replacements
+ * @deprecated No longer needed. See inner classes for replacements.
+ * TODO Remove in 1.18
  */
-@Deprecated(since = "1.18", forRemoval = true)
+@Deprecated(since = "1.17", forRemoval = true)
 public class Constants
 {
     /**
@@ -38,9 +39,10 @@ public class Constants
      *
      * Main use is checking tag type in {@link net.minecraft.nbt.CompoundNBT#contains(String, int)}
      *
-     * @deprecated Replaced by the constants in {@link net.minecraft.nbt.Tag}
+     * @deprecated Replaced by the constants in {@link net.minecraft.nbt.Tag}.
+     * TODO Remove in 1.18
      */
-    @Deprecated(since = "1.18", forRemoval = true)
+    @Deprecated(since = "1.17", forRemoval = true)
     public static class NBT
     {
         public static final int TAG_END         = Tag.TAG_END;
@@ -64,9 +66,10 @@ public class Constants
      * Can be found from {@link net.minecraft.client.renderer.WorldRenderer#playEvent}<br>
      * Some of the events use the {@code data} parameter. If this is the case, an explanation of what {@code data} does is also provided
      *
-     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.LevelEvent}
+     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.LevelEvent}.
+     * TODO Remove in 1.18
      */
-    @Deprecated(since = "1.18", forRemoval = true)
+    @Deprecated(since = "1.17", forRemoval = true)
     public static class WorldEvents {
         public static final int DISPENSER_DISPENSE_SOUND        = LevelEvent.SOUND_DISPENSER_DISPENSE;
         public static final int DISPENSER_FAIL_SOUND            = LevelEvent.SOUND_DISPENSER_FAIL;
@@ -164,9 +167,10 @@ public class Constants
      * {@link WorldRenderer#notifyBlockUpdate}<br>
      * Flags can be combined with bitwise OR
      *
-     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.Block}
+     * @deprecated Replaced by the constants in {@link net.minecraft.world.level.block.Block}.
+     * TODO Remove in 1.18
      */
-    @Deprecated(since = "1.18", forRemoval = true)
+    @Deprecated(since = "1.17", forRemoval = true)
     public static class BlockFlags {
         /**
          * Calls

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -19,6 +19,10 @@
 
 package net.minecraftforge.common.util;
 
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LevelEvent;
+
 /**
  * A class containing constants for magic numbers used in the minecraft codebase.
  * Everything here should be checked each update, and have a comment relating to where to check it.
@@ -34,20 +38,20 @@ public class Constants
      */
     public static class NBT
     {
-        public static final int TAG_END         = 0;
-        public static final int TAG_BYTE        = 1;
-        public static final int TAG_SHORT       = 2;
-        public static final int TAG_INT         = 3;
-        public static final int TAG_LONG        = 4;
-        public static final int TAG_FLOAT       = 5;
-        public static final int TAG_DOUBLE      = 6;
-        public static final int TAG_BYTE_ARRAY  = 7;
-        public static final int TAG_STRING      = 8;
-        public static final int TAG_LIST        = 9;
-        public static final int TAG_COMPOUND    = 10;
-        public static final int TAG_INT_ARRAY   = 11;
-        public static final int TAG_LONG_ARRAY  = 12;
-        public static final int TAG_ANY_NUMERIC = 99;
+        public static final int TAG_END         = Tag.TAG_END;
+        public static final int TAG_BYTE        = Tag.TAG_BYTE;
+        public static final int TAG_SHORT       = Tag.TAG_SHORT;
+        public static final int TAG_INT         = Tag.TAG_INT;
+        public static final int TAG_LONG        = Tag.TAG_LONG;
+        public static final int TAG_FLOAT       = Tag.TAG_FLOAT;
+        public static final int TAG_DOUBLE      = Tag.TAG_DOUBLE;
+        public static final int TAG_BYTE_ARRAY  = Tag.TAG_BYTE_ARRAY;
+        public static final int TAG_STRING      = Tag.TAG_STRING;
+        public static final int TAG_LIST        = Tag.TAG_LIST;
+        public static final int TAG_COMPOUND    = Tag.TAG_COMPOUND;
+        public static final int TAG_INT_ARRAY   = Tag.TAG_INT_ARRAY;
+        public static final int TAG_LONG_ARRAY  = Tag.TAG_LONG_ARRAY;
+        public static final int TAG_ANY_NUMERIC = Tag.TAG_ANY_NUMERIC;
     }
 
     /**
@@ -56,91 +60,91 @@ public class Constants
      * Some of the events use the {@code data} parameter. If this is the case, an explanation of what {@code data} does is also provided
      */
     public static class WorldEvents {
-        public static final int DISPENSER_DISPENSE_SOUND        = 1000;
-        public static final int DISPENSER_FAIL_SOUND            = 1001;
+        public static final int DISPENSER_DISPENSE_SOUND        = LevelEvent.SOUND_DISPENSER_DISPENSE;
+        public static final int DISPENSER_FAIL_SOUND            = LevelEvent.SOUND_DISPENSER_FAIL;
         /**
          * Like DISPENSER_DISPENSE_SOUND, but for items that are fired (arrows, eggs, snowballs)
          */
-        public static final int DISPENSER_LAUNCH_SOUND          = 1002;
-        public static final int ENDEREYE_LAUNCH_SOUND           = 1003;
-        public static final int FIREWORK_SHOOT_SOUND            = 1004;
-        public static final int IRON_DOOR_OPEN_SOUND            = 1005;
-        public static final int WOODEN_DOOR_OPEN_SOUND          = 1006;
-        public static final int WOODEN_TRAPDOOR_OPEN_SOUND      = 1007;
-        public static final int FENCE_GATE_OPEN_SOUND           = 1008;
-        public static final int FIRE_EXTINGUISH_SOUND           = 1009;
+        public static final int DISPENSER_LAUNCH_SOUND          = LevelEvent.SOUND_DISPENSER_PROJECTILE_LAUNCH;
+        public static final int ENDEREYE_LAUNCH_SOUND           = LevelEvent.SOUND_ENDER_EYE_LAUNCH;
+        public static final int FIREWORK_SHOOT_SOUND            = LevelEvent.SOUND_FIREWORK_SHOOT;
+        public static final int IRON_DOOR_OPEN_SOUND            = LevelEvent.SOUND_OPEN_IRON_DOOR;
+        public static final int WOODEN_DOOR_OPEN_SOUND          = LevelEvent.SOUND_OPEN_WOODEN_DOOR;
+        public static final int WOODEN_TRAPDOOR_OPEN_SOUND      = LevelEvent.SOUND_OPEN_WOODEN_TRAP_DOOR;
+        public static final int FENCE_GATE_OPEN_SOUND           = LevelEvent.SOUND_OPEN_FENCE_GATE;
+        public static final int FIRE_EXTINGUISH_SOUND           = LevelEvent.SOUND_EXTINGUISH_FIRE;
         /**
          * {@code data} is the item ID of the record you want to play
          */
-        public static final int PLAY_RECORD_SOUND               = 1010;
-        public static final int IRON_DOOR_CLOSE_SOUND           = 1011;
-        public static final int WOODEN_DOOR_CLOSE_SOUND         = 1012;
-        public static final int WOODEN_TRAPDOOR_CLOSE_SOUND     = 1013;
-        public static final int FENCE_GATE_CLOSE_SOUND          = 1014;
-        public static final int GHAST_WARN_SOUND                = 1015;
-        public static final int GHAST_SHOOT_SOUND               = 1016;
-        public static final int ENDERDRAGON_SHOOT_SOUND         = 1017;
-        public static final int BLAZE_SHOOT_SOUND               = 1018;
-        public static final int ZOMBIE_ATTACK_DOOR_WOOD_SOUND   = 1019;
-        public static final int ZOMBIE_ATTACK_DOOR_IRON_SOUND   = 1020;
-        public static final int ZOMBIE_BREAK_DOOR_WOOD_SOUND    = 1021;
-        public static final int WITHER_BREAK_BLOCK_SOUND        = 1022;
-        public static final int WITHER_BREAK_BLOCK              = 1023;
-        public static final int WITHER_SHOOT_SOUND              = 1024;
-        public static final int BAT_TAKEOFF_SOUND               = 1025;
-        public static final int ZOMBIE_INFECT_SOUND             = 1026;
-        public static final int ZOMBIE_VILLAGER_CONVERTED_SOUND = 1027;
-        public static final int ANVIL_DESTROYED_SOUND           = 1029;
-        public static final int ANVIL_USE_SOUND                 = 1030;
-        public static final int ANVIL_LAND_SOUND                = 1031;
-        public static final int PORTAL_TRAVEL_SOUND             = 1032;
-        public static final int CHORUS_FLOWER_GROW_SOUND        = 1033;
-        public static final int CHORUS_FLOWER_DEATH_SOUND       = 1034;
-        public static final int BREWING_STAND_BREW_SOUND        = 1035;
-        public static final int IRON_TRAPDOOR_CLOSE_SOUND       = 1036;
-        public static final int IRON_TRAPDOOR_OPEN_SOUND        = 1037;
-        public static final int PHANTOM_BITE_SOUND              = 1039;
-        public static final int ZOMBIE_CONVERT_TO_DROWNED_SOUND = 1040;
-        public static final int HUSK_CONVERT_TO_ZOMBIE_SOUND    = 1041;
-        public static final int GRINDSTONE_USE_SOUND            = 1042;
-        public static final int ITEM_BOOK_TURN_PAGE_SOUND       = 1043;
+        public static final int PLAY_RECORD_SOUND               = LevelEvent.SOUND_PLAY_RECORDING;
+        public static final int IRON_DOOR_CLOSE_SOUND           = LevelEvent.SOUND_CLOSE_IRON_DOOR;
+        public static final int WOODEN_DOOR_CLOSE_SOUND         = LevelEvent.SOUND_CLOSE_WOODEN_DOOR;
+        public static final int WOODEN_TRAPDOOR_CLOSE_SOUND     = LevelEvent.SOUND_CLOSE_WOODEN_TRAP_DOOR;
+        public static final int FENCE_GATE_CLOSE_SOUND          = LevelEvent.SOUND_CLOSE_FENCE_GATE;
+        public static final int GHAST_WARN_SOUND                = LevelEvent.SOUND_GHAST_WARNING;
+        public static final int GHAST_SHOOT_SOUND               = LevelEvent.SOUND_GHAST_FIREBALL;
+        public static final int ENDERDRAGON_SHOOT_SOUND         = LevelEvent.SOUND_DRAGON_FIREBALL;
+        public static final int BLAZE_SHOOT_SOUND               = LevelEvent.SOUND_BLAZE_FIREBALL;
+        public static final int ZOMBIE_ATTACK_DOOR_WOOD_SOUND   = LevelEvent.SOUND_ZOMBIE_WOODEN_DOOR;
+        public static final int ZOMBIE_ATTACK_DOOR_IRON_SOUND   = LevelEvent.SOUND_ZOMBIE_IRON_DOOR;
+        public static final int ZOMBIE_BREAK_DOOR_WOOD_SOUND    = LevelEvent.SOUND_ZOMBIE_DOOR_CRASH;
+        public static final int WITHER_BREAK_BLOCK_SOUND        = LevelEvent.SOUND_WITHER_BLOCK_BREAK;
+        public static final int WITHER_BREAK_BLOCK              = LevelEvent.SOUND_WITHER_BOSS_SPAWN;
+        public static final int WITHER_SHOOT_SOUND              = LevelEvent.SOUND_WITHER_BOSS_SHOOT;
+        public static final int BAT_TAKEOFF_SOUND               = LevelEvent.SOUND_BAT_LIFTOFF;
+        public static final int ZOMBIE_INFECT_SOUND             = LevelEvent.SOUND_ZOMBIE_INFECTED;
+        public static final int ZOMBIE_VILLAGER_CONVERTED_SOUND = LevelEvent.SOUND_ZOMBIE_CONVERTED;
+        public static final int ANVIL_DESTROYED_SOUND           = LevelEvent.SOUND_ANVIL_BROKEN;
+        public static final int ANVIL_USE_SOUND                 = LevelEvent.SOUND_ANVIL_USED;
+        public static final int ANVIL_LAND_SOUND                = LevelEvent.SOUND_ANVIL_LAND;
+        public static final int PORTAL_TRAVEL_SOUND             = LevelEvent.SOUND_PORTAL_TRAVEL;
+        public static final int CHORUS_FLOWER_GROW_SOUND        = LevelEvent.SOUND_CHORUS_GROW;
+        public static final int CHORUS_FLOWER_DEATH_SOUND       = LevelEvent.SOUND_CHORUS_DEATH;
+        public static final int BREWING_STAND_BREW_SOUND        = LevelEvent.SOUND_BREWING_STAND_BREW;
+        public static final int IRON_TRAPDOOR_CLOSE_SOUND       = LevelEvent.SOUND_CLOSE_IRON_TRAP_DOOR;
+        public static final int IRON_TRAPDOOR_OPEN_SOUND        = LevelEvent.SOUND_OPEN_IRON_TRAP_DOOR;
+        public static final int PHANTOM_BITE_SOUND              = LevelEvent.SOUND_PHANTOM_BITE;
+        public static final int ZOMBIE_CONVERT_TO_DROWNED_SOUND = LevelEvent.SOUND_ZOMBIE_TO_DROWNED;
+        public static final int HUSK_CONVERT_TO_ZOMBIE_SOUND    = LevelEvent.SOUND_HUSK_TO_ZOMBIE;
+        public static final int GRINDSTONE_USE_SOUND            = LevelEvent.SOUND_GRINDSTONE_USED;
+        public static final int ITEM_BOOK_TURN_PAGE_SOUND       = LevelEvent.SOUND_PAGE_TURN;
         /**
          * Spawns the composter particles and plays the sound event sound event<br>
          * {@code data} is bigger than 0 when the composter can still be filled up, and is smaller or equal to 0 when the composter is full. (This only effects the sound event)
          */
-        public static final int COMPOSTER_FILLED_UP             = 1500;
-        public static final int LAVA_EXTINGUISH                 = 1501;
-        public static final int REDSTONE_TORCH_BURNOUT          = 1502;
-        public static final int END_PORTAL_FRAME_FILL           = 1503;
+        public static final int COMPOSTER_FILLED_UP             = LevelEvent.COMPOSTER_FILL;
+        public static final int LAVA_EXTINGUISH                 = LevelEvent.LAVA_FIZZ;
+        public static final int REDSTONE_TORCH_BURNOUT          = LevelEvent.REDSTONE_TORCH_BURNOUT;
+        public static final int END_PORTAL_FRAME_FILL           = LevelEvent.END_PORTAL_FRAME_FILL;
         /**
          * {@code data} is the {@link Direction#getIndex()} of the direction the smoke is to come out of.
          */
-        public static final int DISPENSER_SMOKE                 = 2000;
+        public static final int DISPENSER_SMOKE                 = LevelEvent.PARTICLES_SHOOT;
 
         /**
          * {@code data} is the {@link net.minecraft.block.Block#getStateId state id} of the block broken
          */
-        public static final int BREAK_BLOCK_EFFECTS             = 2001;
+        public static final int BREAK_BLOCK_EFFECTS             = LevelEvent.PARTICLES_DESTROY_BLOCK;
         /**
          * {@code data} is the rgb color int that should be used for the potion particles<br>
          * This is the same as {@link Constants.WorldEvents#POTION_IMPACT} but uses the particle type {@link ParticleTypes#EFFECT}
          */
-        public static final int POTION_IMPACT_INSTANT           = 2002;
-        public static final int ENDER_EYE_SHATTER               = 2003;
-        public static final int MOB_SPAWNER_PARTICLES           = 2004;
+        public static final int POTION_IMPACT_INSTANT           = LevelEvent.PARTICLES_SPELL_POTION_SPLASH;
+        public static final int ENDER_EYE_SHATTER               = LevelEvent.PARTICLES_EYE_OF_ENDER_DEATH;
+        public static final int MOB_SPAWNER_PARTICLES           = LevelEvent.PARTICLES_MOBBLOCK_SPAWN;
         /**
          * {@code data} is the amount of particles to spawn. If {@code data} is 0 then there will be 15 particles spawned
          */
-        public static final int BONEMEAL_PARTICLES              = 2005;
-        public static final int DRAGON_FIREBALL_HIT             = 2006;
+        public static final int BONEMEAL_PARTICLES              = LevelEvent.PARTICLES_PLANT_GROWTH;
+        public static final int DRAGON_FIREBALL_HIT             = LevelEvent.PARTICLES_DRAGON_FIREBALL_SPLASH;
         /**
          * {@code data} is the rgb color int that should be used for the potion particles<br>
          * This is the same as {@link Constants.WorldEvents#POTION_IMPACT_INSTANT} but uses the particle type {@link ParticleTypes#INSTANT_EFFECT}
          */
-        public static final int POTION_IMPACT                   = 2007;
-        public static final int SPAWN_EXPLOSION_PARTICLE        = 2008;
-        public static final int GATEWAY_SPAWN_EFFECTS           = 3000;
-        public static final int ENDERMAN_GROWL_SOUND            = 3001;
+        public static final int POTION_IMPACT                   = LevelEvent.PARTICLES_INSTANT_POTION_SPLASH;
+        public static final int SPAWN_EXPLOSION_PARTICLE        = LevelEvent.PARTICLES_DRAGON_BLOCK_BREAK;
+        public static final int GATEWAY_SPAWN_EFFECTS           = LevelEvent.ANIMATION_END_GATEWAY_SPAWN;
+        public static final int ENDERMAN_GROWL_SOUND            = LevelEvent.ANIMATION_DRAGON_SUMMON_ROAR;
     }
 
 
@@ -158,21 +162,21 @@ public class Constants
          * {@link Block#neighborChanged(BlockState, World, BlockPos, Block, BlockPos, boolean)
          * neighborChanged} on surrounding blocks (with isMoving as false). Also updates comparator output state.
          */
-        public static final int NOTIFY_NEIGHBORS     = (1 << 0);
+        public static final int NOTIFY_NEIGHBORS     = Block.UPDATE_NEIGHBORS;
         /**
          * Calls {@link World#notifyBlockUpdate(BlockPos, BlockState, BlockState, int)}.<br>
          * Server-side, this updates all the path-finding navigators.
          */
-        public static final int BLOCK_UPDATE         = (1 << 1);
+        public static final int BLOCK_UPDATE         = Block.UPDATE_CLIENTS;
         /**
          * Stops the blocks from being marked for a render update
          */
-        public static final int NO_RERENDER          = (1 << 2);
+        public static final int NO_RERENDER          = Block.UPDATE_INVISIBLE;
         /**
          * Makes the block be re-rendered immediately, on the main thread.
          * If NO_RERENDER is set, then this will be ignored
          */
-        public static final int RERENDER_MAIN_THREAD = (1 << 3);
+        public static final int RERENDER_MAIN_THREAD = Block.UPDATE_IMMEDIATE;
         /**
          * Causes neighbor updates to be sent to all surrounding blocks (including
          * diagonals). This in turn will call
@@ -181,13 +185,13 @@ public class Constants
          * {@link Block#updateNeighbors(BlockState, IWorld, BlockPos, int)
          * updateNeighbors} on the new state.
          */
-        public static final int UPDATE_NEIGHBORS     = (1 << 4);
+        public static final int UPDATE_NEIGHBORS     = Block.UPDATE_KNOWN_SHAPE;
 
         /**
          * Prevents neighbor changes from spawning item drops, used by
          * {@link Block#replaceBlock(BlockState, BlockState, IWorld, BlockPos, int)}.
          */
-        public static final int NO_NEIGHBOR_DROPS    = (1 << 5);
+        public static final int NO_NEIGHBOR_DROPS    = Block.UPDATE_SUPPRESS_DROPS;
 
         /**
          * Tell the block being changed that it was moved, rather than removed/replaced,
@@ -195,9 +199,9 @@ public class Constants
          * {@link Block#onReplaced(BlockState, World, BlockPos, BlockState, boolean)}
          * as the last parameter.
          */
-        public static final int IS_MOVING            = (1 << 6);
+        public static final int IS_MOVING            = Block.UPDATE_MOVE_BY_PISTON;
 
-        public static final int DEFAULT = NOTIFY_NEIGHBORS | BLOCK_UPDATE;
-        public static final int DEFAULT_AND_RERENDER = DEFAULT | RERENDER_MAIN_THREAD;
+        public static final int DEFAULT = Block.UPDATE_ALL;
+        public static final int DEFAULT_AND_RERENDER = Block.UPDATE_ALL_IMMEDIATE;
     }
 }

--- a/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeChunkManager.java
@@ -43,7 +43,6 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ForcedChunksSavedData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fml.ModList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -263,8 +262,8 @@ public class ForgeChunkManager
         if (!blockForcedChunks.isEmpty() || !entityForcedChunks.isEmpty())
         {
             Map<String, Long2ObjectMap<CompoundTag>> forcedEntries = new HashMap<>();
-            writeForcedChunkOwners(forcedEntries, blockForcedChunks, "Blocks", Constants.NBT.TAG_COMPOUND, (pos, forcedBlocks) -> forcedBlocks.add(NbtUtils.writeBlockPos(pos)));
-            writeForcedChunkOwners(forcedEntries, entityForcedChunks, "Entities", Constants.NBT.TAG_INT_ARRAY, (uuid, forcedEntities) -> forcedEntities.add(NbtUtils.createUUID(uuid)));
+            writeForcedChunkOwners(forcedEntries, blockForcedChunks, "Blocks", Tag.TAG_COMPOUND, (pos, forcedBlocks) -> forcedBlocks.add(NbtUtils.writeBlockPos(pos)));
+            writeForcedChunkOwners(forcedEntries, entityForcedChunks, "Entities", Tag.TAG_INT_ARRAY, (uuid, forcedEntities) -> forcedEntities.add(NbtUtils.createUUID(uuid)));
             ListTag forcedChunks = new ListTag();
             for (Map.Entry<String, Long2ObjectMap<CompoundTag>> entry : forcedEntries.entrySet())
             {
@@ -316,14 +315,14 @@ public class ForgeChunkManager
      */
     public static void readForgeForcedChunks(CompoundTag nbt, TicketTracker<BlockPos> blockForcedChunks, TicketTracker<UUID> entityForcedChunks)
     {
-        ListTag forcedChunks = nbt.getList("ForgeForced", Constants.NBT.TAG_COMPOUND);
+        ListTag forcedChunks = nbt.getList("ForgeForced", Tag.TAG_COMPOUND);
         for (int i = 0; i < forcedChunks.size(); i++)
         {
             CompoundTag forcedEntry = forcedChunks.getCompound(i);
             String modId = forcedEntry.getString("Mod");
             if (ModList.get().isLoaded(modId))
             {
-                ListTag modForced = forcedEntry.getList("ModForced", Constants.NBT.TAG_COMPOUND);
+                ListTag modForced = forcedEntry.getList("ModForced", Tag.TAG_COMPOUND);
                 for (int j = 0; j < modForced.size(); j++)
                 {
                     CompoundTag modEntry = modForced.getCompound(j);
@@ -346,7 +345,7 @@ public class ForgeChunkManager
      */
     private static void readBlockForcedChunks(String modId, long chunkPos, CompoundTag modEntry, String key, Map<TicketOwner<BlockPos>, LongSet> blockForcedChunks)
     {
-        ListTag forcedBlocks = modEntry.getList(key, Constants.NBT.TAG_COMPOUND);
+        ListTag forcedBlocks = modEntry.getList(key, Tag.TAG_COMPOUND);
         for (int k = 0; k < forcedBlocks.size(); k++)
         {
             blockForcedChunks.computeIfAbsent(new TicketOwner<>(modId, NbtUtils.readBlockPos(forcedBlocks.getCompound(k))), owner -> new LongOpenHashSet()).add(chunkPos);
@@ -358,7 +357,7 @@ public class ForgeChunkManager
      */
     private static void readEntityForcedChunks(String modId, long chunkPos, CompoundTag modEntry, String key, Map<TicketOwner<UUID>, LongSet> entityForcedChunks)
     {
-        ListTag forcedEntities = modEntry.getList(key, Constants.NBT.TAG_INT_ARRAY);
+        ListTag forcedEntities = modEntry.getList(key, Tag.TAG_INT_ARRAY);
         for (Tag uuid : forcedEntities)
         {
             entityForcedChunks.computeIfAbsent(new TicketOwner<>(modId, NbtUtils.loadUUID(uuid)), owner -> new LongOpenHashSet()).add(chunkPos);

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fluids;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.item.ItemStack;
@@ -29,7 +30,6 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.IRegistryDelegate;
 
@@ -114,7 +114,7 @@ public class FluidStack
         {
             return EMPTY;
         }
-        if (!nbt.contains("FluidName", Constants.NBT.TAG_STRING))
+        if (!nbt.contains("FluidName", Tag.TAG_STRING))
         {
             return EMPTY;
         }
@@ -127,7 +127,7 @@ public class FluidStack
         }
         FluidStack stack = new FluidStack(fluid, nbt.getInt("Amount"));
 
-        if (nbt.contains("Tag", Constants.NBT.TAG_COMPOUND))
+        if (nbt.contains("Tag", Tag.TAG_COMPOUND))
         {
             stack.tag = nbt.getCompound("Tag");
         }
@@ -234,7 +234,7 @@ public class FluidStack
     {
         getOrCreateTag();
         CompoundTag child = tag.getCompound(childName);
-        if (!tag.contains(childName, Constants.NBT.TAG_COMPOUND))
+        if (!tag.contains(childName, Tag.TAG_COMPOUND))
         {
             tag.put(childName, child);
         }

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
@@ -19,11 +19,11 @@
 
 package net.minecraftforge.fluids.capability.wrappers;
 
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.LiquidBlockContainer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
@@ -60,7 +60,7 @@ public class BlockWrapper extends VoidFluidHandler
         if (action.execute())
         {
             FluidUtil.destroyBlockOnFluidPlacement(world, blockPos);
-            world.setBlock(blockPos, state, Constants.BlockFlags.DEFAULT_AND_RERENDER);
+            world.setBlock(blockPos, state, Block.UPDATE_ALL_IMMEDIATE);
         }
         return FluidAttributes.BUCKET_VOLUME;
     }

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -19,11 +19,11 @@
 
 package net.minecraftforge.items;
 
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.core.NonNullList;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 
 import javax.annotation.Nonnull;
@@ -200,8 +200,8 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
     @Override
     public void deserializeNBT(CompoundTag nbt)
     {
-        setSize(nbt.contains("Size", Constants.NBT.TAG_INT) ? nbt.getInt("Size") : stacks.size());
-        ListTag tagList = nbt.getList("Items", Constants.NBT.TAG_COMPOUND);
+        setSize(nbt.contains("Size", Tag.TAG_INT) ? nbt.getInt("Size") : stacks.size());
+        ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
         for (int i = 0; i < tagList.size(); i++)
         {
             CompoundTag itemTags = tagList.getCompound(i);


### PR DESCRIPTION
Because in 1.17 constants are no longer stripped from the vanilla source code the Constant class provided by Forge is no longer necessary.
This PR deprecates said classes, replaces the existing initializations with references to the vanilla equivalents and replaces existing references in forge code/patches with the vanilla equivalents.