### PR TITLE
Update PotionAddedEvent with Entity Source

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -84,7 +84,7 @@
           return false;
        } else {
           MobEffectInstance mobeffectinstance = this.f_20945_.get(p_147208_.m_19544_());
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionAddedEvent(this, mobeffectinstance, p_147208_));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionAddedEvent(this, mobeffectinstance, p_147208_, p_147209_));
           if (mobeffectinstance == null) {
              this.f_20945_.put(p_147208_.m_19544_(), p_147208_);
              this.m_142540_(p_147208_, p_147209_);

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.entity.living;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -127,11 +128,19 @@ public class PotionEvent extends LivingEvent
     public static class PotionAddedEvent extends PotionEvent
     {
         private final MobEffectInstance oldEffect;
-        
+        private final Entity source;
+
+        @Deprecated(forRemoval = true, since = "1.18")
         public PotionAddedEvent(LivingEntity living, MobEffectInstance oldEffect, MobEffectInstance newEffect)
+        {
+            this(living, oldEffect, newEffect, null);
+        }
+
+        public PotionAddedEvent(LivingEntity living, MobEffectInstance oldEffect, MobEffectInstance newEffect, Entity source)
         {
             super(living, newEffect);
             this.oldEffect = oldEffect;
+            this.source = source;
         }
         
         /**
@@ -151,6 +160,17 @@ public class PotionEvent extends LivingEvent
         public MobEffectInstance getOldPotionEffect()
         {
             return oldEffect;
+        }
+
+        /**
+         * Returns the entity source of the effect, or {@code null} if none exists.
+         *
+         * @return the entity source of the effect, or {@code null}
+         */
+        @Nullable
+        public Entity getPotionSource()
+        {
+            return source;
         }
     }
     

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -130,7 +130,7 @@ public class PotionEvent extends LivingEvent
         private final MobEffectInstance oldEffect;
         private final Entity source;
 
-        @Deprecated(forRemoval = true, since = "1.18")
+        @Deprecated(forRemoval = true, since = "1.17.1")
         public PotionAddedEvent(LivingEntity living, MobEffectInstance oldEffect, MobEffectInstance newEffect)
         {
             this(living, oldEffect, newEffect, null);

--- a/src/test/java/net/minecraftforge/debug/PotionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/PotionEventTest.java
@@ -53,7 +53,7 @@ public class PotionEventTest
     public static void onPotionAdded(PotionEvent.PotionAddedEvent event)
     {
         if (!event.getEntity().getCommandSenderWorld().isClientSide)
-            LOGGER.info("{} has a new PotionEffect {}, the old one was {}", event.getEntityLiving(), event.getPotionEffect(), event.getOldPotionEffect());
+            LOGGER.info("{} has a new PotionEffect {} from {}, the old one was {}", event.getEntityLiving(), event.getPotionEffect(), event.getPotionSource(), event.getOldPotionEffect());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Addresses #8141.

Adds the new entity source parameter to `PotionAddedEvent` and deprecates the old constructor for removal in 1.18. It also updates the `PotionEventTest` to display the new data in the logger.