### PR TITLE
[1.16.x] Add ForgeSpawnEggItem to lazily handle EntityTypes

### DIFF
--- a/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/dispenser/IDispenseItemBehavior.java.patch
@@ -1,5 +1,27 @@
 --- a/net/minecraft/dispenser/IDispenseItemBehavior.java
 +++ b/net/minecraft/dispenser/IDispenseItemBehavior.java
+@@ -69,6 +_,7 @@
+ import net.minecraft.world.server.ServerWorld;
+ 
+ public interface IDispenseItemBehavior {
++   org.apache.logging.log4j.Logger LOGGER = org.apache.logging.log4j.LogManager.getLogger();
+    IDispenseItemBehavior field_223216_a_ = (p_210297_0_, p_210297_1_) -> {
+       return p_210297_1_;
+    };
+@@ -169,7 +_,12 @@
+          public ItemStack func_82487_b(IBlockSource p_82487_1_, ItemStack p_82487_2_) {
+             Direction direction = p_82487_1_.func_189992_e().func_177229_b(DispenserBlock.field_176441_a);
+             EntityType<?> entitytype = ((SpawnEggItem)p_82487_2_.func_77973_b()).func_208076_b(p_82487_2_.func_77978_p());
+-            entitytype.func_220331_a(p_82487_1_.func_197524_h(), p_82487_2_, (PlayerEntity)null, p_82487_1_.func_180699_d().func_177972_a(direction), SpawnReason.DISPENSER, direction != Direction.UP, false);
++            try { // FORGE: fix potential crash
++               entitytype.func_220331_a(p_82487_1_.func_197524_h(), p_82487_2_, (PlayerEntity) null, p_82487_1_.func_180699_d().func_177972_a(direction), SpawnReason.DISPENSER, direction != Direction.UP, false);
++            } catch (Exception e) {
++               LOGGER.error("Error while dispensing spawn egg from dispenser at {}", p_82487_1_.func_180699_d(), e);
++               return ItemStack.field_190927_a;
++            }
+             p_82487_2_.func_190918_g(1);
+             return p_82487_2_;
+          }
 @@ -373,8 +_,9 @@
                 world.func_175656_a(blockpos, AbstractFireBlock.func_235326_a_(world, blockpos));
              } else if (CampfireBlock.func_241470_h_(blockstate)) {

--- a/patches/minecraft/net/minecraft/item/SpawnEggItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/SpawnEggItem.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/item/SpawnEggItem.java
++++ b/net/minecraft/item/SpawnEggItem.java
+@@ -39,11 +_,14 @@
+    private final int field_195989_d;
+    private final EntityType<?> field_200890_d;
+ 
++   /** @deprecated Forge: Use {@link net.minecraftforge.common.ForgeSpawnEggItem} instead for suppliers */
++   @Deprecated
+    public SpawnEggItem(EntityType<?> p_i48465_1_, int p_i48465_2_, int p_i48465_3_, Item.Properties p_i48465_4_) {
+       super(p_i48465_4_);
+       this.field_200890_d = p_i48465_1_;
+       this.field_195988_c = p_i48465_2_;
+       this.field_195989_d = p_i48465_3_;
++      if (p_i48465_1_ != null)
+       field_195987_b.put(p_i48465_1_, this);
+    }
+ 
+@@ -124,6 +_,8 @@
+       return p_195983_1_ == 0 ? this.field_195988_c : this.field_195989_d;
+    }
+ 
++   /** @deprecated Forge: call {@link net.minecraftforge.common.ForgeSpawnEggItem#fromEntityType(EntityType)} instead */
++   @Deprecated
+    @Nullable
+    public static SpawnEggItem func_200889_b(@Nullable EntityType<?> p_200889_0_) {
+       return field_195987_b.get(p_200889_0_);

--- a/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
+++ b/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
@@ -36,7 +36,10 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ForgeSpawnEggItem extends SpawnEggItem
@@ -82,7 +85,16 @@ public class ForgeSpawnEggItem extends SpawnEggItem
             Direction face = source.getBlockState().getValue(DispenserBlock.FACING);
             EntityType<?> type = ((SpawnEggItem) stack.getItem()).getType(stack.getTag());
 
-            type.spawn(source.getLevel(), stack, null, source.getPos().relative(face), SpawnReason.DISPENSER, face != Direction.UP, false);
+            // FORGE: fix potential crash
+            try
+            {
+                type.spawn(source.getLevel(), stack, null, source.getPos().relative(face), SpawnReason.DISPENSER, face != Direction.UP, false);
+            }
+            catch (Exception exception)
+            {
+                DefaultDispenseItemBehavior.LOGGER.error("Error while dispensing spawn egg from dispenser at {}", source.getPos(), exception);
+                return ItemStack.EMPTY;
+            }
 
             stack.shrink(1);
             return stack;

--- a/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
+++ b/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
@@ -1,0 +1,125 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+import net.minecraft.block.DispenserBlock;
+import net.minecraft.dispenser.DefaultDispenseItemBehavior;
+import net.minecraft.dispenser.IBlockSource;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.Direction;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.function.Supplier;
+
+public class ForgeSpawnEggItem extends SpawnEggItem
+{
+    private static final List<ForgeSpawnEggItem> MOD_EGGS = new ArrayList<>();
+    private static final Map<EntityType<?>, ForgeSpawnEggItem> TYPE_MAP = new IdentityHashMap<>();
+    private final Supplier<? extends EntityType<?>> typeSupplier;
+
+    public ForgeSpawnEggItem(Supplier<? extends EntityType<?>> type, int backgroundColor, int highlightColor, Properties props)
+    {
+        super((EntityType<?>) null, backgroundColor, highlightColor, props);
+        this.typeSupplier = type;
+
+        MOD_EGGS.add(this);
+    }
+
+    @Override
+    public EntityType<?> getType(@Nullable CompoundNBT tag)
+    {
+        EntityType<?> type = super.getType(tag);
+        return type != null ? type : typeSupplier.get();
+    }
+
+    @Nullable
+    protected DefaultDispenseItemBehavior createDispenseBehavior()
+    {
+        return DEFAULT_DISPENSE_BEHAVIOR;
+    }
+
+    @Nullable
+    @OnlyIn(Dist.CLIENT)
+    public static SpawnEggItem fromEntityType(@Nullable EntityType<?> type)
+    {
+        SpawnEggItem ret = TYPE_MAP.get(type);
+        return ret != null ? ret : SpawnEggItem.byId(type);
+    }
+
+
+
+    private static final DefaultDispenseItemBehavior DEFAULT_DISPENSE_BEHAVIOR = new DefaultDispenseItemBehavior()
+    {
+        protected ItemStack execute(IBlockSource source, ItemStack stack)
+        {
+            Direction face = source.getBlockState().getValue(DispenserBlock.FACING);
+            EntityType<?> type = ((SpawnEggItem) stack.getItem()).getType(stack.getTag());
+
+            type.spawn(source.getLevel(), stack, null, source.getPos().relative(face), SpawnReason.DISPENSER, face != Direction.UP, false);
+
+            stack.shrink(1);
+            return stack;
+        }
+    };
+
+    @Mod.EventBusSubscriber(modid = "forge", bus = Mod.EventBusSubscriber.Bus.MOD)
+    private static class CommonHandler
+    {
+        @SubscribeEvent
+        public static void onCommonSetup(FMLCommonSetupEvent event)
+        {
+            MOD_EGGS.forEach(egg ->
+            {
+                DefaultDispenseItemBehavior dispenseBehavior = egg.createDispenseBehavior();
+                if (dispenseBehavior != null)
+                {
+                    DispenserBlock.registerBehavior(egg, dispenseBehavior);
+                }
+
+                TYPE_MAP.put(egg.typeSupplier.get(), egg);
+            });
+        }
+    }
+
+    @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = "forge", bus = Mod.EventBusSubscriber.Bus.MOD)
+    private static class ColorRegisterHandler
+    {
+        @SubscribeEvent(priority = EventPriority.HIGHEST)
+        public static void registerSpawnEggColors(ColorHandlerEvent.Item event)
+        {
+            MOD_EGGS.forEach(egg ->
+                    event.getItemColors().register((stack, layer) -> egg.getColor(layer), egg)
+            );
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
+++ b/src/main/java/net/minecraftforge/common/ForgeSpawnEggItem.java
@@ -24,13 +24,11 @@ import net.minecraft.dispenser.DefaultDispenseItemBehavior;
 import net.minecraft.dispenser.IBlockSource;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -69,7 +67,6 @@ public class ForgeSpawnEggItem extends SpawnEggItem
     }
 
     @Nullable
-    @OnlyIn(Dist.CLIENT)
     public static SpawnEggItem fromEntityType(@Nullable EntityType<?> type)
     {
         SpawnEggItem ret = TYPE_MAP.get(type);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -40,6 +40,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.entity.PartEntity;
 
@@ -117,7 +118,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundNBT>
             return new ItemStack(Items.END_CRYSTAL);
         else
         {
-            SpawnEggItem egg = SpawnEggItem.byId(getEntity().getType());
+            SpawnEggItem egg = ForgeSpawnEggItem.fromEntityType(getEntity().getType());
             if (egg != null) return new ItemStack(egg);
         }
         return ItemStack.EMPTY;

--- a/src/main/resources/forge.sas
+++ b/src/main/resources/forge.sas
@@ -41,6 +41,7 @@ net/minecraft/block/WoodType func_227046_a_()Ljava/util/stream/Stream; # getValu
 net/minecraft/block/WoodType func_227048_b_()Ljava/lang/String; # getName
 net/minecraft/item/DyeColor func_218388_g()I # getTextColor
 net/minecraft/item/DyeColor func_196058_b(I)Lnet/minecraft/item/DyeColor; # byFireworkColor
+net/minecraft/item/SpawnEggItem func_200889_b(Lnet/minecraft/entity/EntityType;)Lnet/minecraft/item/SpawnEggItem; # byId
 net/minecraft/item/crafting/Ingredient func_193365_a()[Lnet/minecraft/item/ItemStack; # getMatchingStacks
 net/minecraft/item/crafting/Ingredient func_193369_a([Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/crafting/Ingredient; # fromStacks
 net/minecraft/item/crafting/IRecipe func_222128_h()Lnet/minecraft/item/ItemStack; # getIcon

--- a/src/test/java/net/minecraftforge/debug/item/ForgeSpawnEggItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ForgeSpawnEggItemTest.java
@@ -1,0 +1,89 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.item;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
+import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.PigEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod(value = ForgeSpawnEggItemTest.MODID)
+public class ForgeSpawnEggItemTest
+{
+    static final String MODID = "forge_spawnegg_test";
+    static final boolean ENABLED = true;
+
+    private static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(ForgeRegistries.ENTITIES, MODID);
+    private static final RegistryObject<EntityType<PigEntity>> ENTITY = ENTITIES.register("test_entity", () ->
+            EntityType.Builder.of(PigEntity::new, EntityClassification.CREATURE).sized(1, 1).build("test_entity")
+    );
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final RegistryObject<ForgeSpawnEggItem> EGG = ITEMS.register("test_spawn_egg", () ->
+            new ForgeSpawnEggItem(ENTITY, 0x0000FF, 0xFF0000, new Item.Properties().tab(ItemGroup.TAB_MISC))
+    );
+
+    public ForgeSpawnEggItemTest()
+    {
+        if (ENABLED)
+        {
+            ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+            ENTITIES.register(FMLJavaModLoadingContext.get().getModEventBus());
+
+            FMLJavaModLoadingContext.get().getModEventBus().register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void onRegisterAttributes(final EntityAttributeCreationEvent event)
+    {
+        event.put(ENTITY.get(), PigEntity.createAttributes().build());
+    }
+
+    @Mod.EventBusSubscriber(modid = MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+    private static class ClientEvents
+    {
+        @SubscribeEvent
+        public static void onClientSetup(final FMLClientSetupEvent event)
+        {
+            if (!ENABLED) { return; }
+
+            event.enqueueWork(() ->
+            {
+                EntityRendererManager manager = Minecraft.getInstance().getEntityRenderDispatcher();
+                manager.register(ENTITY.get(), new PigRenderer(manager));
+            });
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -140,5 +140,7 @@ license="LGPL v2.1"
     modId="player_attack_knockback_test"
 [[mods]]
     modId="send_datapacks_to_client"
+[[mods]]
+    modId="forge_spawnegg_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/assets/forge_spawnegg_test/models/item/test_spawn_egg.json
+++ b/src/test/resources/assets/forge_spawnegg_test/models/item/test_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+    "parent": "minecraft:item/template_spawn_egg"
+}


### PR DESCRIPTION
This is the LTS backport of #8044.

This PR proposes a solution to the problem of SpawnEggItems requiring you to either pass in an EntityType that was initialized too early and therefore breaks registry contracts or pass in null and pollute the map with a useless null key which indirectly leads to problems later on, for example in the `ItemColors` registration where only the last modded egg registered this way would get tinting.

### Proposed Solution

The proposed solution is to store all ForgeSpawnEggItems added by mods in a list and transfer them over to the EntityType->SpawnEggItem map after EntityTypes have been registered. The original `SpawnEggItem` is patched to deprecate the constructor and guard against adding a null key to the `BY_ID` map.
The `BY_ID` map in question is used in four places:

1. **`IForgeEntity#getPickedResult(HitResult target)` via `SpawnEggItem.byId(EntityType type)`**
The call to `SpawnEggItem.byId(EntityType type)` is replaced with a call to `ForgeSpawnEggItem#fromEntityType(EntityType type)` which checks both `SpawnEggItem.byId(EntityType type)` and the `ForgeSpawnEggItem#TYPE_MAP`.

2. **`ItemColors.createDefault()` via `SpawnEggItem.eggs()`**
Even though this happens before EntityTypes are registered, it doesn't create any problems related to them because the EntityType is not used there. An event handler on `HIGHEST` priority registers the color handlers for mod eggs. A mod can easily override the `ItemColors` in `ColorHandlerEvent.Item` with standard priority if they wish to do so.
    
3. **`BlockModelProvider#run()` via `SpawnEggItem.eggs()`**
Doesn't matter to us because modders should not be using the vanilla `BlockModelGenerators` in datagen

4. **`IDispenseItemBehaviour.bootStrap()` via `SpawnEggItems.eggs()`**
This can be ignored for this purpose because I have found in my testing with breakpoints that the call to DispenseItemBehaviour.bootStrap() happens before `RegistryEvent<Item>` has fired which means that mod eggs are not included anyway. To make sure mod eggs get `DispenseItemBehaviour`s, they are registered in `FMLCommonSetup` at the same time the mod eggs are transferred to the type->egg map. If the modder wishes they can provide their own `DispenseItemBehaviour` or none via `ForgeSpawnEggItem#createDispenseBehavior()`.

Not adding any more ways to deviate from the default behaviour of the vanilla `SpawnEggItem` is very much intentional.
If you want your spawn eggs to behave differently to the vanilla spawn eggs, then you should IMO implement them yourself.

### Test

To test this I have included a test mod that adds a test entity and a spawn egg for that entity. In my testing spawning by hand, the coloring of the item, the dispense behaviour and "picking" the entity to get the egg for it worked flawlessly.