### PR TITLE
[1.17.x] Add three new AT entries to make adding structures easier for mods

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -418,3 +418,6 @@ protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
+public-f net.minecraft.world.level.levelgen.feature.StructureFeature f_67031_ # NOISE_AFFECTING_FEATURES
+public-f net.minecraft.world.level.levelgen.StructureSettings f_64582_ # structureConfig
+public-f net.minecraft.world.level.levelgen.StructureSettings f_64580_ # DEFAULTS


### PR DESCRIPTION
This PR adds three access transformers to allow mods to add structures properly without needing to add an access transformer. Currently, in order for a mod to add a structure, it must use an access transformer, usually with these three AT entries that get copied throughout a lot of the mods that add overworld structures:

This access transformer is needed to make the ImmutableMap non-final to add the structure's default spawning settings:
```cfg
public-f net.minecraft.world.level.levelgen.StructureSettings f_64580_ # DEFAULTS
```
This access transformer is needed to make the ImmutableList non-final to add ground around the base of the structure in Beardifier
```cfg
public-f net.minecraft.world.level.levelgen.feature.StructureFeature f_67031_ # NOISE_AFFECTING_FEATURES
```
This access transformer is used by some mods ([here](https://github.com/TelepathicGrunt/StructureTutorialMod/blob/b550b51f3046846c2dc396dde3a23183cebdea9c/src/main/java/com/telepathicgrunt/structuretutorial/STStructures.java#L128), [here](https://github.com/ValhelsiaTeam/Valhelsia-Structures/blob/cb3f4ab4741ad51ee8045587609220439602c2d2/src/main/java/com/stal111/valhelsia_structures/core/init/ModStructures.java#L68), [here](https://github.com/xyroc/DungeonCrawl/blob/72915495bd563d419ec7e70e799f9c80fa879799/src/main/java/xiroc/dungeoncrawl/init/ModStructures.java#L96)) to re-add their structure's placement settings to `BuiltinRegistries.NOISE_GENERATOR_SETTINGS`:
```cfg
public-f net.minecraft.world.level.levelgen.StructureSettings f_64582_ # structureConfig
```
