### PR TITLE
Fix missing toolTip methods in Screen

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -43,7 +43,7 @@
        this.m_169383_(p_169389_, list, p_169392_, p_169393_);
     }
  
-@@ -183,20 +_,42 @@
+@@ -183,20 +_,48 @@
     }
  
     public void m_96597_(PoseStack p_96598_, List<Component> p_96599_, int p_96600_, int p_96601_) {
@@ -52,12 +52,15 @@
 +      this.m_169383_(p_96598_, components, p_96600_, p_96601_);
 +   }
 +   public void renderComponentTooltip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, ItemStack stack) {
-+      this.renderComponentToolTip(poseStack, tooltips, mouseX, mouseY, null, stack);
++      this.renderComponentTooltip(poseStack, tooltips, mouseX, mouseY, null, stack);
 +   }
 +   public void renderComponentTooltip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font) {
-+      this.renderComponentToolTip(poseStack, tooltips, mouseX, mouseY, font, ItemStack.f_41583_);
++      this.renderComponentTooltip(poseStack, tooltips, mouseX, mouseY, font, ItemStack.f_41583_);
 +   }
-+   public void renderComponentToolTip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font, ItemStack stack) {
++   @Deprecated(forRemoval = true, since = "1.18") public void renderComponentToolTip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font) {
++      renderComponentTooltip(poseStack, tooltips, mouseX, mouseY, font);
++   }
++   public void renderComponentTooltip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font, ItemStack stack) {
 +      this.tooltipFont = font;
 +      this.tooltipStack = stack;
 +      List<ClientTooltipComponent> components = net.minecraftforge.client.ForgeHooksClient.gatherTooltipComponents(stack, tooltips, mouseX, f_96543_, f_96544_, this.tooltipFont, this.f_96547_);
@@ -69,6 +72,9 @@
     public void m_96617_(PoseStack p_96618_, List<? extends FormattedCharSequence> p_96619_, int p_96620_, int p_96621_) {
        this.m_169383_(p_96618_, p_96619_.stream().map(ClientTooltipComponent::m_169948_).collect(Collectors.toList()), p_96620_, p_96621_);
     }
++   @Deprecated(forRemoval = true, since = "1.18") public void renderToolTip(PoseStack p_96618_, List<? extends FormattedCharSequence> p_96619_, int p_96620_, int p_96621_, Font font) {
++      renderTooltip(p_96618_, p_96619_, p_96620_, p_96621_, font);
++   }
 +   public void renderTooltip(PoseStack poseStack, List<? extends FormattedCharSequence> lines, int x, int y, Font font) {
 +      this.tooltipFont = font;
 +      this.m_96617_(poseStack, lines, x, y);

--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -57,7 +57,7 @@
 +   public void renderComponentTooltip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font) {
 +      this.renderComponentTooltip(poseStack, tooltips, mouseX, mouseY, font, ItemStack.f_41583_);
 +   }
-+   @Deprecated(forRemoval = true, since = "1.18") public void renderComponentToolTip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font) {
++   @Deprecated(forRemoval = true, since = "1.17.1") public void renderComponentToolTip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font) {
 +      renderComponentTooltip(poseStack, tooltips, mouseX, mouseY, font);
 +   }
 +   public void renderComponentTooltip(PoseStack poseStack, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, @Nullable Font font, ItemStack stack) {
@@ -72,7 +72,7 @@
     public void m_96617_(PoseStack p_96618_, List<? extends FormattedCharSequence> p_96619_, int p_96620_, int p_96621_) {
        this.m_169383_(p_96618_, p_96619_.stream().map(ClientTooltipComponent::m_169948_).collect(Collectors.toList()), p_96620_, p_96621_);
     }
-+   @Deprecated(forRemoval = true, since = "1.18") public void renderToolTip(PoseStack p_96618_, List<? extends FormattedCharSequence> p_96619_, int p_96620_, int p_96621_, Font font) {
++   @Deprecated(forRemoval = true, since = "1.17.1") public void renderToolTip(PoseStack p_96618_, List<? extends FormattedCharSequence> p_96619_, int p_96620_, int p_96621_, Font font) {
 +      renderTooltip(p_96618_, p_96619_, p_96620_, p_96621_, font);
 +   }
 +   public void renderTooltip(PoseStack poseStack, List<? extends FormattedCharSequence> lines, int x, int y, Font font) {


### PR DESCRIPTION
Restores binary compatibility for "ToolTip" methods in `Screen` caused by #8038.
Third time's a charm, right? Sorry, I thought I looked at these methods.