### PR TITLE
Add `BiomeDictionary#hasType(String)`

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -157,6 +157,19 @@ public class BiomeDictionary
         }
 
         /**
+         * Checks if a type instance exists for a given name. Does not have any side effects if a type does not already exist.
+         * This can be used for checking if a user-defined type is valid, for example, in a codec which accepts biome dictionary names.
+         * @param name The name.
+         * @return {@code true} if a type exists with this name.
+         *
+         * @see #getType(String, Type...) for type naming conventions.
+         */
+        public static boolean hasType(String name)
+        {
+            return byName.containsKey(name.toUpperCase());
+        }
+
+        /**
          * @return An unmodifiable collection of all current biome types.
          */
         public static Collection<Type> getAll()

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -162,7 +162,7 @@ public class BiomeDictionary
          * @param name The name.
          * @return {@code true} if a type exists with this name.
          *
-         * @see #getType(String, Type...) for type naming conventions.
+         * @see #getType(String, Type...) #getType for type naming conventions.
          */
         public static boolean hasType(String name)
         {

--- a/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;


### PR DESCRIPTION
Add a way of checking if a type exists by name. This is useful in terms of error reporting when provided by biome dictionary names from untrusted sources (e.g. a config or codec). As an example, currently all that's possible is the following code:

```java
Codec<BiomeDictionary.Type> CODEC = Codec.STRING.xmap(
    BiomeDictionary.Type::getType,
    BiomeDictionary.Type::getName
);
```

Whereas, adding `hasType` allows us to report errors and typos in the user's configuration:

```java
Codec<BiomeDictionary.Type> CODEC = Codec.STRING.comapFlatMap(
    t -> BiomeDictionary.Type.hasType(t) ?
        DataResult.success(BiomeDictionary.Type.getType(t)) :
        DataResult.error("No biome dictionary type with name: " + t),
    BiomeDictionary.Type::getName
);
```