### PR TITLE
Fix render pipeline lighting issue with small cubes

### DIFF
--- a/patches/minecraft/com/mojang/math/Vector3f.java.patch
+++ b/patches/minecraft/com/mojang/math/Vector3f.java.patch
@@ -1,16 +1,11 @@
 --- a/com/mojang/math/Vector3f.java
 +++ b/com/mojang/math/Vector3f.java
-@@ -137,8 +_,12 @@
-    }
+@@ -138,7 +_,7 @@
  
     public boolean m_122278_() {
-+      return normalize(false);
-+   }
-+
-+   public boolean normalize(boolean force) {
        float f = this.f_122228_ * this.f_122228_ + this.f_122229_ * this.f_122229_ + this.f_122230_ * this.f_122230_;
 -      if ((double)f < 1.0E-5D) {
-+      if (!force && (double)f < 1.0E-5D) {
++      if ((double)f == 0) {
           return false;
        } else {
           float f1 = Mth.m_14195_(f);

--- a/patches/minecraft/com/mojang/math/Vector3f.java.patch
+++ b/patches/minecraft/com/mojang/math/Vector3f.java.patch
@@ -1,5 +1,19 @@
 --- a/com/mojang/math/Vector3f.java
 +++ b/com/mojang/math/Vector3f.java
+@@ -137,8 +_,12 @@
+    }
+ 
+    public boolean m_122278_() {
++      return normalize(false);
++   }
++
++   public boolean normalize(boolean force) {
+       float f = this.f_122228_ * this.f_122228_ + this.f_122229_ * this.f_122229_ + this.f_122230_ * this.f_122230_;
+-      if ((double)f < 1.0E-5D) {
++      if (!force && (double)f < 1.0E-5D) {
+          return false;
+       } else {
+          float f1 = Mth.m_14195_(f);
 @@ -207,4 +_,16 @@
     public String toString() {
        return "[" + this.f_122228_ + ", " + this.f_122229_ + ", " + this.f_122230_ + "]";

--- a/patches/minecraft/com/mojang/math/Vector3f.java.patch
+++ b/patches/minecraft/com/mojang/math/Vector3f.java.patch
@@ -5,7 +5,7 @@
     public boolean m_122278_() {
        float f = this.f_122228_ * this.f_122228_ + this.f_122229_ * this.f_122229_ + this.f_122230_ * this.f_122230_;
 -      if ((double)f < 1.0E-5D) {
-+      if ((double)f == 0) {
++      if (f < Float.MIN_NORMAL) { //Forge: Fix MC-239212
           return false;
        } else {
           float f1 = Mth.m_14195_(f);

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -172,7 +172,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
             t.set(position[0]);
             v2.sub(t);
             v2.cross(v1);
-            v2.normalize();
+            v2.normalize(true);
             for(int v = 0; v < 4; v++)
             {
                 normal[v][0] = v2.x();

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -172,7 +172,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
             t.set(position[0]);
             v2.sub(t);
             v2.cross(v1);
-            v2.normalize(true);
+            v2.normalize();
             for(int v = 0; v < 4; v++)
             {
                 normal[v][0] = v2.x();


### PR DESCRIPTION
This will also allow other mods which need to calculate small normalised vectors to be able to use the default classes without needing to write their own, while not affecting any side effects created by how the base game uses this function.

![image](https://user-images.githubusercontent.com/3209834/137609776-a4dd39a8-ede6-49dd-847a-3d083df76d28.png)

It fixes the bug shown above and is useful for other mods where any problems with the resulting vector are probably not as bad as it not being calculated in the first place.


After changes
![image](https://user-images.githubusercontent.com/3209834/137609942-5b59b589-de5c-4817-bd6a-24b288b228b6.png)
