### PR TITLE
[1.16.x] Fix blocks with flammable material catching fire from lava when they are marked as non-flammable

### DIFF
--- a/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
@@ -29,17 +29,22 @@
              return true;
           }
        }
-@@ -104,8 +_,8 @@
+@@ -104,10 +_,15 @@
        return false;
     }
  
--   private boolean func_176368_m(IWorldReader p_176368_1_, BlockPos p_176368_2_) {
--      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).func_185904_a().func_76217_h();
-+   private boolean isFlammable(IWorldReader p_176368_1_, BlockPos p_176368_2_, Direction face) {
-+      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).isFlammable(p_176368_1_, p_176368_2_, face);
++   /** @deprecated Forge: use {@link LavaFluid#isFlammable(IWorldReader,BlockPos,Direction)} instead */
+    private boolean func_176368_m(IWorldReader p_176368_1_, BlockPos p_176368_2_) {
+       return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).func_185904_a().func_76217_h();
     }
  
++   private boolean isFlammable(IWorldReader p_176368_1_, BlockPos p_176368_2_, Direction face) {
++      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).isFlammable(p_176368_1_, p_176368_2_, face);
++   }
++
     @Nullable
+    @OnlyIn(Dist.CLIENT)
+    public IParticleData func_204521_c() {
 @@ -164,7 +_,7 @@
           FluidState fluidstate = p_205574_1_.func_204610_c(p_205574_2_);
           if (this.func_207185_a(FluidTags.field_206960_b) && fluidstate.func_206884_a(FluidTags.field_206959_a)) {

--- a/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
@@ -29,11 +29,12 @@
              return true;
           }
        }
-@@ -104,10 +_,15 @@
+@@ -104,10 +_,16 @@
        return false;
     }
  
 +   /** @deprecated Forge: use {@link LavaFluid#isFlammable(IWorldReader,BlockPos,Direction)} instead */
++   @Deprecated
     private boolean func_176368_m(IWorldReader p_176368_1_, BlockPos p_176368_2_) {
        return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).func_185904_a().func_76217_h();
     }

--- a/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
@@ -9,15 +9,37 @@
                       return;
                    }
                 } else if (blockstate.func_185904_a().func_76230_c()) {
-@@ -86,7 +_,7 @@
+@@ -85,8 +_,8 @@
+                   return;
                 }
  
-                if (p_207186_1_.func_175623_d(blockpos1.func_177984_a()) && this.func_176368_m(p_207186_1_, blockpos1)) {
+-               if (p_207186_1_.func_175623_d(blockpos1.func_177984_a()) && this.func_176368_m(p_207186_1_, blockpos1)) {
 -                  p_207186_1_.func_175656_a(blockpos1.func_177984_a(), AbstractFireBlock.func_235326_a_(p_207186_1_, blockpos1));
++               if (p_207186_1_.func_175623_d(blockpos1.func_177984_a()) && this.isFlammable(p_207186_1_, blockpos1, Direction.UP)) {
 +                  p_207186_1_.func_175656_a(blockpos1.func_177984_a(), net.minecraftforge.event.ForgeEventFactory.fireFluidPlaceBlockEvent(p_207186_1_, blockpos1.func_177984_a(), p_207186_2_, Blocks.field_150480_ab.func_176223_P()));
                 }
              }
           }
+@@ -96,7 +_,7 @@
+ 
+    private boolean func_176369_e(IWorldReader p_176369_1_, BlockPos p_176369_2_) {
+       for(Direction direction : Direction.values()) {
+-         if (this.func_176368_m(p_176369_1_, p_176369_2_.func_177972_a(direction))) {
++         if (this.isFlammable(p_176369_1_, p_176369_2_.func_177972_a(direction), direction)) {
+             return true;
+          }
+       }
+@@ -104,8 +_,8 @@
+       return false;
+    }
+ 
+-   private boolean func_176368_m(IWorldReader p_176368_1_, BlockPos p_176368_2_) {
+-      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).func_185904_a().func_76217_h();
++   private boolean isFlammable(IWorldReader p_176368_1_, BlockPos p_176368_2_, Direction face) {
++      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).isFlammable(p_176368_1_, p_176368_2_, face);
+    }
+ 
+    @Nullable
 @@ -164,7 +_,7 @@
           FluidState fluidstate = p_205574_1_.func_204610_c(p_205574_2_);
           if (this.func_207185_a(FluidTags.field_206960_b) && fluidstate.func_206884_a(FluidTags.field_206959_a)) {

--- a/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
@@ -38,8 +38,8 @@
        return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).func_185904_a().func_76217_h();
     }
  
-+   private boolean isFlammable(IWorldReader p_176368_1_, BlockPos p_176368_2_, Direction face) {
-+      return p_176368_2_.func_177956_o() >= 0 && p_176368_2_.func_177956_o() < 256 && !p_176368_1_.func_175667_e(p_176368_2_) ? false : p_176368_1_.func_180495_p(p_176368_2_).isFlammable(p_176368_1_, p_176368_2_, face);
++   private boolean isFlammable(IWorldReader world, BlockPos pos, Direction face) {
++      return pos.func_177956_o() >= 0 && pos.func_177956_o() < 256 && !world.func_175667_e(pos) ? false : world.func_180495_p(pos).isFlammable(world, pos, face);
 +   }
 +
     @Nullable

--- a/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/LavaFluid.java.patch
@@ -25,7 +25,7 @@
     private boolean func_176369_e(IWorldReader p_176369_1_, BlockPos p_176369_2_) {
        for(Direction direction : Direction.values()) {
 -         if (this.func_176368_m(p_176369_1_, p_176369_2_.func_177972_a(direction))) {
-+         if (this.isFlammable(p_176369_1_, p_176369_2_.func_177972_a(direction), direction)) {
++         if (this.isFlammable(p_176369_1_, p_176369_2_.func_177972_a(direction), direction.func_176734_d())) {
              return true;
           }
        }

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -39,6 +39,7 @@ net/minecraft/entity/item/minecart/ContainerMinecartEntity.changeDimension(Lnet/
 net/minecraft/entity/merchant/villager/AbstractVillagerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 net/minecraft/entity/player/PlayerEntity.getDigSpeed(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)F=|p_184813_1_,pos
 net/minecraft/entity/player/ServerPlayerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
+net/minecraft/fluid/LavaFluid.isFlammable(Lnet/minecraft/world/IWorldReader;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/Direction;)Z=|p_176368_1_,p_176368_2_,face
 net/minecraft/item/BoneMealItem.applyBonemeal(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)Z=|p_195966_0_,p_195966_1_,p_195966_2_,player
 net/minecraft/item/DyeableHorseArmorItem.<init>(ILnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/Item$Properties;)V=|p_i50047_1_,texture,p_i50047_3_
 net/minecraft/item/FilledMapItem.getCustomMapData(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;)Lnet/minecraft/world/storage/MapData;=|p_195950_0_,p_195950_1_

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -39,7 +39,6 @@ net/minecraft/entity/item/minecart/ContainerMinecartEntity.changeDimension(Lnet/
 net/minecraft/entity/merchant/villager/AbstractVillagerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
 net/minecraft/entity/player/PlayerEntity.getDigSpeed(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)F=|p_184813_1_,pos
 net/minecraft/entity/player/ServerPlayerEntity.changeDimension(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_241206_1_,teleporter
-net/minecraft/fluid/LavaFluid.isFlammable(Lnet/minecraft/world/IWorldReader;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/Direction;)Z=|p_176368_1_,p_176368_2_,face
 net/minecraft/item/BoneMealItem.applyBonemeal(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)Z=|p_195966_0_,p_195966_1_,p_195966_2_,player
 net/minecraft/item/DyeableHorseArmorItem.<init>(ILnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/Item$Properties;)V=|p_i50047_1_,texture,p_i50047_3_
 net/minecraft/item/FilledMapItem.getCustomMapData(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;)Lnet/minecraft/world/storage/MapData;=|p_195950_0_,p_195950_1_


### PR DESCRIPTION
This is the LTS backport of #8160

Currently only the `FireBlock` asks the block itself wether it is flammable through the use of Forge extensions. This leads to issues like this: https://github.com/XFactHD/FramedBlocks/issues/31 where a block that uses `Material.WOOD` but returns `false` from `IForgeBlock#isFlammable()` catches fire from the lava but is never destroyed by the `FireBlock` because it thinks the block is not flammable.

This PR patches the `LavaFluid` to use the Forge extensions for flammability instead of checking the material for flammability. This way the behaviour of the `LavaFluid` is equivalent to the `FireBlock` which is already using these Forge extensions.

I can add a test mod for the flammability hooks if that is desired.