### PR TITLE
Don't reload resources twice when creating worlds, Fix #8125 for 1.17

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -310,12 +310,13 @@
     }
  
     private boolean m_91278_() {
-@@ -1814,11 +_,11 @@
+@@ -1814,11 +_,12 @@
     }
  
     public void m_91200_(String p_91201_) {
 -      this.m_91219_(p_91201_, RegistryAccess.m_123086_(), Minecraft::m_91133_, Minecraft::m_91135_, false, Minecraft.ExperimentalDialogType.BACKUP);
-+      this.doLoadLevel(p_91201_, RegistryAccess.m_123086_(), Minecraft::m_91133_, Minecraft::m_91135_, false, Minecraft.ExperimentalDialogType.BACKUP, false);
++      // We need to delay the call to RegistryAccess.builtin() as long as possible, in order to allow our world persistence hooks to run. So we pass in null here, and fix it later, only in the case where creating = false
++      this.doLoadLevel(p_91201_, null, Minecraft::m_91133_, Minecraft::m_91135_, false, Minecraft.ExperimentalDialogType.BACKUP, false);
     }
  
     public void m_91202_(String p_91203_, LevelSettings p_91204_, RegistryAccess.RegistryHolder p_91205_, WorldGenSettings p_91206_) {
@@ -337,17 +338,16 @@
        LevelStorageSource.LevelStorageAccess levelstoragesource$levelstorageaccess;
        try {
           levelstoragesource$levelstorageaccess = this.f_91031_.m_78260_(p_91220_);
-@@ -1843,12 +_,17 @@
+@@ -1843,12 +_,16 @@
        }
  
        Minecraft.ServerStem minecraft$serverstem;
-+      final RegistryAccess.RegistryHolder dyn_f;
++      final RegistryAccess.RegistryHolder importedRegistries;
        try {
 -         minecraft$serverstem = this.m_91190_(p_91221_, p_91222_, p_91223_, p_91224_, levelstoragesource$levelstorageaccess);
-+         Minecraft.ServerStem mgr = this.m_91190_(p_91221_, p_91222_, p_91223_, p_91224_, levelstoragesource$levelstorageaccess);
-+         // We need to rebuild this if we're loading world, so that it gets all the information from AFTER we inject our mappings from the save.
-+         dyn_f = creating ? p_91221_ : RegistryAccess.m_123086_();
-+         minecraft$serverstem = creating ? mgr : this.m_91190_(dyn_f, p_91222_, p_91223_, p_91224_, levelstoragesource$levelstorageaccess); //Note this runs the injection again... which isn't good.. but hey.. we need a better spot to hook in.
++         if (!creating) levelstoragesource$levelstorageaccess.runWorldPersistenceHooks();
++         importedRegistries = creating ? p_91221_ : RegistryAccess.m_123086_();
++         minecraft$serverstem = this.m_91190_(importedRegistries, p_91222_, p_91223_, p_91224_, levelstoragesource$levelstorageaccess);
 +
        } catch (Exception exception) {
           f_90982_.warn("Failed to load datapacks, can't proceed with server load", (Throwable)exception);
@@ -362,7 +362,7 @@
  
           try {
 -            levelstoragesource$levelstorageaccess.m_78287_(p_91221_, worlddata);
-+            levelstoragesource$levelstorageaccess.m_78287_(dyn_f, worlddata);
++            levelstoragesource$levelstorageaccess.m_78287_(importedRegistries, worlddata);
              minecraft$serverstem.m_91433_().m_136179_();
              YggdrasilAuthenticationService yggdrasilauthenticationservice = new YggdrasilAuthenticationService(this.f_91030_);
              MinecraftSessionService minecraftsessionservice = yggdrasilauthenticationservice.createMinecraftSessionService();
@@ -371,7 +371,7 @@
              GameProfileCache.m_11004_(false);
              this.f_91007_ = MinecraftServer.m_129872_((p_167898_) -> {
 -               return new IntegratedServer(p_167898_, this, p_91221_, levelstoragesource$levelstorageaccess, minecraft$serverstem.m_91432_(), minecraft$serverstem.m_91433_(), worlddata, minecraftsessionservice, gameprofilerepository, gameprofilecache, (p_168000_) -> {
-+               return new IntegratedServer(p_167898_, this, dyn_f, levelstoragesource$levelstorageaccess, minecraft$serverstem.m_91432_(), minecraft$serverstem.m_91433_(), worlddata, minecraftsessionservice, gameprofilerepository, gameprofilecache, (p_168000_) -> {
++               return new IntegratedServer(p_167898_, this, importedRegistries, levelstoragesource$levelstorageaccess, minecraft$serverstem.m_91432_(), minecraft$serverstem.m_91433_(), worlddata, minecraftsessionservice, gameprofilerepository, gameprofilecache, (p_168000_) -> {
                    StoringChunkProgressListener storingchunkprogresslistener = new StoringChunkProgressListener(p_168000_ + 0);
                    this.f_90999_.set(storingchunkprogresslistener);
                    return ProcessorChunkProgressListener.m_143583_(storingchunkprogresslistener, this.f_91023_::add);
@@ -390,7 +390,7 @@
        } else {
           this.m_91143_(p_91225_, p_91220_, flag, () -> {
 -            this.m_91219_(p_91220_, p_91221_, p_91222_, p_91223_, p_91224_, Minecraft.ExperimentalDialogType.NONE);
-+            this.doLoadLevel(p_91220_, dyn_f, p_91222_, p_91223_, p_91224_, Minecraft.ExperimentalDialogType.NONE, creating);
++            this.doLoadLevel(p_91220_, importedRegistries, p_91222_, p_91223_, p_91224_, Minecraft.ExperimentalDialogType.NONE, creating);
           });
           minecraft$serverstem.close();
  

--- a/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -32,12 +32,25 @@
           } catch (Exception exception) {
              f_78191_.error("Exception reading {}", p_78214_, exception);
              return null;
-@@ -319,7 +_,7 @@
+@@ -319,7 +_,20 @@
        @Nullable
        public WorldData m_78280_(DynamicOps<Tag> p_78281_, DataPackConfig p_78282_) {
           this.m_78313_();
 -         return LevelStorageSource.this.m_78229_(this.f_78271_.toFile(), LevelStorageSource.m_78247_(p_78281_, p_78282_));
 +         return LevelStorageSource.this.m_78229_(this.f_78271_.toFile(), LevelStorageSource.getReader(p_78281_, p_78282_, this));
++      }
++
++      public void runWorldPersistenceHooks() {
++         this.m_78313_();
++         LevelStorageSource.this.m_78229_(this.f_78271_.toFile(), (file, dataFixer) -> {
++            try {
++               CompoundTag compoundTag = NbtIo.m_128937_(file);
++               net.minecraftforge.fmllegacy.WorldPersistenceHooks.handleWorldDataLoad(this, null, compoundTag);
++            } catch (Exception e) {
++               f_78191_.error("Exception reading {}", file, e);
++            }
++            return null;
++         });
        }
  
        @Nullable

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -101,6 +101,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * todo: 1.18, remove WorldPersistenceHooks.WorldPersistenceHook. It is unnecessary
+ */
 @Mod("forge")
 public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 {
@@ -149,7 +152,6 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         CrashReportCallables.registerCrashCallable("FML", ForgeVersion::getSpec);
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
-        WorldPersistenceHooks.addHook(this);
         WorldPersistenceHooks.addHook(new FMLWorldPersistenceHook());
         final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::registerCapabilities);
@@ -208,25 +210,20 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         WorldWorkerManager.clear();
     }
 
+    /**
+     * todo 1.18: remove
+     */
+    @Deprecated(since = "1.17.1", forRemoval = true)
     @Override
     public CompoundTag getDataForWriting(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo)
     {
-        CompoundTag forgeData = new CompoundTag();
-        CompoundTag dims = new CompoundTag();
-        //TODO Dimensions
-//        DimensionManager.writeRegistry(dims);
-        if (!dims.isEmpty())
-            forgeData.put("dims", dims);
-        return forgeData;
+        return new CompoundTag();
     }
 
     @Override
+    @Deprecated(since = "1.17.1", forRemoval = true)
     public void readData(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo, CompoundTag tag)
     {
-        //TODO Dimensions
-//        if (tag.contains("dims", 10))
-//            DimensionManager.readRegistry(tag.getCompound("dims"));
-//        DimensionManager.processScheduledDeletions(levelSave);
     }
 
     public void mappingChanged(FMLModIdMappingEvent evt)
@@ -235,6 +232,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
     }
 
     @Override
+    @Deprecated(since = "1.17.1", forRemoval = true)
     public String getModId()
     {
         return ForgeVersion.MOD_ID;

--- a/src/main/java/net/minecraftforge/fmllegacy/FMLWorldPersistenceHook.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/FMLWorldPersistenceHook.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Multimap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -84,7 +87,7 @@ public final class FMLWorldPersistenceHook implements WorldPersistenceHooks.Worl
     }
 
     @Override
-    public void readData(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo, CompoundTag tag)
+    public void readData(LevelStorageSource.LevelStorageAccess levelSave, @Nullable WorldData serverInfo, CompoundTag tag)
     {
         if (tag.contains("LoadingModList"))
         {

--- a/src/main/java/net/minecraftforge/fmllegacy/WorldPersistenceHooks.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/WorldPersistenceHooks.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public class WorldPersistenceHooks
 {
@@ -39,7 +40,7 @@ public class WorldPersistenceHooks
         worldPersistenceHooks.forEach(wac->tagCompound.put(wac.getModId(), wac.getDataForWriting(levelSave, serverInfo)));
     }
 
-    public static void handleWorldDataLoad(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo, CompoundTag tagCompound)
+    public static void handleWorldDataLoad(LevelStorageSource.LevelStorageAccess levelSave, @Nullable WorldData serverInfo, CompoundTag tagCompound)
     {
         worldPersistenceHooks.forEach(wac->wac.readData(levelSave, serverInfo, tagCompound.getCompound(wac.getModId())));
     }
@@ -47,7 +48,12 @@ public class WorldPersistenceHooks
     public interface WorldPersistenceHook
     {
         String getModId();
+
         CompoundTag getDataForWriting(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo);
-        void readData(LevelStorageSource.LevelStorageAccess levelSave, WorldData serverInfo, CompoundTag tag);
+
+        /**
+         * todo: 1.18: Either remove the WorldData parameter, as it has a dependency on doing an entire pointless resource reload, or refactor this into a better location.
+         */
+        void readData(LevelStorageSource.LevelStorageAccess levelSave, @Nullable WorldData serverInfo, CompoundTag tag);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;


### PR DESCRIPTION
Background is in https://github.com/MinecraftForge/MinecraftForge/issues/8125#issuecomment-946683773

The solution?

- Notice that `WorldPersistenceHook` takes a `WorldData` parameter which is unused in Forge's implementations.
- Notice that we have all the context available to call directly into the world persistence hooks, from where we create the registries if we just pass in a `null` for this `WorldData`, with a simple added method in `LevelStorageSource`
- Delay a call to `RegistryAccess#builtin` until after the world persistence hooks have been run, in the case where we load an existing world.

Additionally
- The `WorldPersistenceHook` used by `ForgeMod` is... totally useless. It's from pre 1.16 `DimensionManager` code and should be ripped out and removed at one's earliest convienience.
- This doesn't build because of missing license headers, so I took the liberty to include those as well.

Draft because I'd like feedback on this while I (figure out how to) test this.