### PR TITLE
Make WorldEvent.Load run for Overworld before chunk creation like other dimensions

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -9,14 +9,22 @@
           atomicreference.get().m_130011_();
        }, "Server thread");
        thread.setUncaughtExceptionHandler((p_177909_, p_177910_) -> {
-@@ -402,6 +_,7 @@
+@@ -365,6 +_,7 @@
+       this.f_129732_ = new CommandStorage(dimensiondatastorage);
+       WorldBorder worldborder = serverlevel.m_6857_();
+       worldborder.m_61931_(serverleveldata.m_5813_());
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Load(f_129762_.get(Level.f_46428_)));
+       if (!serverleveldata.m_6535_()) {
+          try {
+             m_177896_(serverlevel, serverleveldata, worldgensettings.m_64660_(), flag);
+@@ -401,6 +_,7 @@
+             ServerLevel serverlevel1 = new ServerLevel(this, this.f_129738_, this.f_129744_, derivedleveldata, resourcekey1, dimensiontype1, p_129816_, chunkgenerator1, flag, j, ImmutableList.of(), false);
              worldborder.m_61929_(new BorderChangeListener.DelegateBorderChangeListener(serverlevel1.m_6857_()));
              this.f_129762_.put(resourcekey1, serverlevel1);
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Load(f_129762_.get(resourcekey)));
           }
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Load(f_129762_.get(resourcekey)));
        }
  
-    }
 @@ -411,6 +_,7 @@
           p_177898_.m_7250_(BlockPos.f_121853_.m_6630_(80), 0.0F);
        } else {

--- a/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
+++ b/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import com.google.gson.JsonDeserializationContext;


### PR DESCRIPTION
I was doing some testing by removing structures from a dimension by removing them from the world's chunk generate in WorldEvent.Load. What I noticed is while doing that worked perfectly for any dimension, Overworld was an exception where the structure still spawned around the world origin but my change seemed to apply past origin area (200 block radius around origin).

Looking at the patch for WorldEvent.Load, I noticed the event is added to a for loop that deliberately skips over the overworld inside but the hook is after the check. Meaning the Overworld's stuff was defined further above and when looking higher, I saw setInitialSpawn method being called after the Overworld is setup.

I believe setInitialSpawn is creating chunks around the spawn of the Overworld which causes WorldEvent.Load to fire when the overworld has already genned some chunks as it is in a different state now than the rest of the dimensions.

So this pr is to move the old WorldEvent.Load event into the loop's if statement to exclude the overworld there. Then make a second hook for the WorldEvent.Load event that is placed before setInitialSpawn method. That way when the event fires, modders know the overworld is not at a different stage or loading than other dimensions. Just something for better consistency.

Testing quickly with a temporary datapack and some small code seems like this PR works and now modders can be certain that the dimension is consistent each time the event fires now.

Also, someone forgot to put a license header on their file so that's slipped into this pr to help. but I can remove this extra license file thing if preferred.

Once this is merged, I'll make pr for 1.16.5