### PR TITLE
Add IExtensibleEnum to Biome.TemperatureModifier

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/biome/Biome.java.patch
@@ -20,3 +20,41 @@
     });
     public static final Codec<Biome> f_47430_ = RecordCodecBuilder.create((p_47504_) -> {
        return p_47504_.group(Biome.ClimateSettings.f_47679_.forGetter((p_151703_) -> {
+@@ -607,7 +_,7 @@
+       }
+    }
+ 
+-   public static enum TemperatureModifier implements StringRepresentable {
++   public static enum TemperatureModifier implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
+       NONE("none") {
+          public float m_8117_(BlockPos p_47767_, float p_47768_) {
+             return p_47768_;
+@@ -635,10 +_,27 @@
+          return p_47753_;
+       }));
+ 
+-      public abstract float m_8117_(BlockPos p_47754_, float p_47755_);
++      public float m_8117_(BlockPos p_47754_, float p_47755_) { return this.temperatureModifier.modifyTemperature(p_47754_, p_47755_); }
+ 
+       TemperatureModifier(String p_47745_) {
+          this.f_47738_ = p_47745_;
++      }
++
++      private BiomeTemperatureModifier temperatureModifier;
++      private TemperatureModifier(String modifierName, BiomeTemperatureModifier temperatureModifier) {
++         this(modifierName);
++         this.temperatureModifier = temperatureModifier;
++      }
++      public static TemperatureModifier create(String name, String modifierName, BiomeTemperatureModifier temperatureModifier) {
++    	  throw new IllegalStateException("Enum not extended");
++      }
++      @java.lang.Override
++      public void init() {
++         f_47739_.put(this.m_47758_(), this);
++      }
++      @java.lang.FunctionalInterface
++      public interface BiomeTemperatureModifier {
++         float modifyTemperature(BlockPos pos, float noise);
+       }
+ 
+       public String m_47758_() {

--- a/patches/minecraft/net/minecraft/world/level/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/biome/Biome.java.patch
@@ -29,7 +29,7 @@
        NONE("none") {
           public float m_8117_(BlockPos p_47767_, float p_47768_) {
              return p_47768_;
-@@ -635,10 +_,27 @@
+@@ -635,11 +_,30 @@
           return p_47753_;
        }));
  
@@ -38,23 +38,26 @@
  
        TemperatureModifier(String p_47745_) {
           this.f_47738_ = p_47745_;
-+      }
+       }
 +
++      /* ***** FORGE START ***** */
 +      private BiomeTemperatureModifier temperatureModifier;
 +      private TemperatureModifier(String modifierName, BiomeTemperatureModifier temperatureModifier) {
 +         this(modifierName);
 +         this.temperatureModifier = temperatureModifier;
 +      }
 +      public static TemperatureModifier create(String name, String modifierName, BiomeTemperatureModifier temperatureModifier) {
-+    	  throw new IllegalStateException("Enum not extended");
++          throw new IllegalStateException("Enum not extended");
 +      }
-+      @java.lang.Override
++      @Override
 +      public void init() {
 +         f_47739_.put(this.m_47758_(), this);
 +      }
-+      @java.lang.FunctionalInterface
++      @FunctionalInterface
 +      public interface BiomeTemperatureModifier {
 +         float modifyTemperature(BlockPos pos, float noise);
-       }
++      }
++      /* ***** FORGE END ***** */
  
        public String m_47758_() {
+          return this.f_47738_;

--- a/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
@@ -40,34 +40,51 @@ import net.minecraftforge.fmllegacy.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
-@Mod("biome_temperature_modifier_test")
+@Mod(BiomeTemperatureModifierTest.MOD_ID)
 public class BiomeTemperatureModifierTest 
 {
+	static final String MOD_ID = "biome_temperature_modifier_test";
     private static final boolean ENABLED = false;
-    public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, "biome_temperature_modifier_test");
-    public static final ResourceKey<Biome> TEST_BIOME_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation("biome_temperature_modifier_test", "test_biome"));
-    public static final RegistryObject<Biome> TEST_BIOME = BIOMES.register("test_biome", BiomeTemperatureModifierTest::makeTestBiome);
+    public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, MOD_ID);
+    public static final ResourceKey<Biome> TEST_BIOME_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MOD_ID, "test_biome"));
+    public static final RegistryObject<Biome> TEST_BIOME = BIOMES.register("test_biome", () -> BiomeTemperatureModifierTest.TEST_BIOME_BIOME);
 
     public BiomeTemperatureModifierTest() 
     {
+    	if (!ENABLED) return;
         BIOMES.register(FMLJavaModLoadingContext.get().getModEventBus());
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
     }
 
     private void commonSetup(FMLCommonSetupEvent event) 
     {
-        if (!ENABLED) return;
         event.enqueueWork(() -> {
             BiomeDictionary.addTypes(TEST_BIOME_KEY, BiomeDictionary.Type.MODIFIED);
             BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeEntry(TEST_BIOME_KEY, 100));
         });
     }
 
-    private static Biome makeTestBiome() 
-    {
-        Biome.TemperatureModifier temperatureModifier = Biome.TemperatureModifier.create("TEST_MODIFIER", "test_modifier", (pos, noise) -> 2.0F);
-        return new Biome.BiomeBuilder().biomeCategory(BiomeCategory.NONE).depth(0.1F).scale(0.1F).downfall(0.0F).generationSettings(new BiomeGenerationSettings.Builder().surfaceBuilder(SurfaceBuilders.GRASS).build())
-        .mobSpawnSettings(MobSpawnSettings.EMPTY).specialEffects(new BiomeSpecialEffects.Builder().waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(128)
-        .ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).precipitation(Precipitation.NONE).temperature(2.0F).temperatureAdjustment(temperatureModifier).build();
-    }
+    /*
+     * the Biome is only made for testing, the parameters which are used are test parameters
+     */
+	private static final Biome TEST_BIOME_BIOME = new Biome.BiomeBuilder()
+            .biomeCategory(BiomeCategory.NONE)
+            .depth(0.1F)
+            .scale(0.1F)
+            .downfall(0.0F)
+            .precipitation(Precipitation.NONE)
+            .temperature(2.0F)
+            .generationSettings(new BiomeGenerationSettings.Builder()
+                    .surfaceBuilder(SurfaceBuilders.GRASS)
+                    .build())
+            .mobSpawnSettings(MobSpawnSettings.EMPTY)
+            .specialEffects(new BiomeSpecialEffects.Builder()
+                    .waterColor(255)
+                    .waterFogColor(80)
+                    .fogColor(16777215)
+                    .skyColor(65535)
+                    .ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS)
+                    .build())
+            .temperatureAdjustment(Biome.TemperatureModifier.create("TEST_MODIFIER", "test_modifier", (pos, noise) -> 2.0F))
+            .build();
 }

--- a/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
@@ -1,0 +1,73 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import net.minecraft.core.Registry;
+import net.minecraft.data.worldgen.SurfaceBuilders;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.biome.AmbientMoodSettings;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biome.BiomeCategory;
+import net.minecraft.world.level.biome.Biome.Precipitation;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.common.BiomeManager;
+import net.minecraftforge.common.BiomeManager.BiomeEntry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fmllegacy.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mod("biome_temperature_modifier_test")
+public class BiomeTemperatureModifierTest 
+{
+    private static final boolean ENABLED = false;
+    public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, "biome_temperature_modifier_test");
+    public static final ResourceKey<Biome> TEST_BIOME_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation("biome_temperature_modifier_test", "test_biome"));
+    public static final RegistryObject<Biome> TEST_BIOME = BIOMES.register("test_biome", BiomeTemperatureModifierTest::makeTestBiome);
+
+    public BiomeTemperatureModifierTest() 
+    {
+        BIOMES.register(FMLJavaModLoadingContext.get().getModEventBus());
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event) 
+    {
+        if (!ENABLED) return;
+        event.enqueueWork(() -> {
+            BiomeDictionary.addTypes(TEST_BIOME_KEY, BiomeDictionary.Type.MODIFIED);
+            BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeEntry(TEST_BIOME_KEY, 100));
+        });
+    }
+
+    private static Biome makeTestBiome() 
+    {
+        Biome.TemperatureModifier temperatureModifier = Biome.TemperatureModifier.create("TEST_MODIFIER", "test_modifier", (pos, noise) -> 2.0F);
+        return new Biome.BiomeBuilder().biomeCategory(BiomeCategory.NONE).depth(0.1F).scale(0.1F).downfall(0.0F).generationSettings(new BiomeGenerationSettings.Builder().surfaceBuilder(SurfaceBuilders.GRASS).build())
+        .mobSpawnSettings(MobSpawnSettings.EMPTY).specialEffects(new BiomeSpecialEffects.Builder().waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(128)
+        .ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS).build()).precipitation(Precipitation.NONE).temperature(2.0F).temperatureAdjustment(temperatureModifier).build();
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
@@ -51,7 +51,7 @@ public class BiomeTemperatureModifierTest
 
     public BiomeTemperatureModifierTest() 
     {
-    	if (!ENABLED) return;
+        if (!ENABLED) return;
         BIOMES.register(FMLJavaModLoadingContext.get().getModEventBus());
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
     }

--- a/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeTemperatureModifierTest.java
@@ -43,31 +43,15 @@ import net.minecraftforge.registries.ForgeRegistries;
 @Mod(BiomeTemperatureModifierTest.MOD_ID)
 public class BiomeTemperatureModifierTest 
 {
-	static final String MOD_ID = "biome_temperature_modifier_test";
+    static final String MOD_ID = "biome_temperature_modifier_test";
     private static final boolean ENABLED = false;
     public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, MOD_ID);
     public static final ResourceKey<Biome> TEST_BIOME_KEY = ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MOD_ID, "test_biome"));
-    public static final RegistryObject<Biome> TEST_BIOME = BIOMES.register("test_biome", () -> BiomeTemperatureModifierTest.TEST_BIOME_BIOME);
-
-    public BiomeTemperatureModifierTest() 
-    {
-        if (!ENABLED) return;
-        BIOMES.register(FMLJavaModLoadingContext.get().getModEventBus());
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
-    }
-
-    private void commonSetup(FMLCommonSetupEvent event) 
-    {
-        event.enqueueWork(() -> {
-            BiomeDictionary.addTypes(TEST_BIOME_KEY, BiomeDictionary.Type.MODIFIED);
-            BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeEntry(TEST_BIOME_KEY, 100));
-        });
-    }
-
+    
     /*
-     * the Biome is only made for testing, the parameters which are used are test parameters
+     * this is a dummy Biome it will be replace at runtime via a json Biome
      */
-	private static final Biome TEST_BIOME_BIOME = new Biome.BiomeBuilder()
+    public static final RegistryObject<Biome> TEST_BIOME = BIOMES.register("test_biome", () -> new Biome.BiomeBuilder()
             .biomeCategory(BiomeCategory.NONE)
             .depth(0.1F)
             .scale(0.1F)
@@ -86,5 +70,21 @@ public class BiomeTemperatureModifierTest
                     .ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS)
                     .build())
             .temperatureAdjustment(Biome.TemperatureModifier.create("TEST_MODIFIER", "test_modifier", (pos, noise) -> 2.0F))
-            .build();
+            .build());
+
+    public BiomeTemperatureModifierTest() 
+    {
+        if (!ENABLED) return;
+        BIOMES.register(FMLJavaModLoadingContext.get().getModEventBus());
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event) 
+    {
+        event.enqueueWork(() -> {
+            BiomeDictionary.addTypes(TEST_BIOME_KEY, BiomeDictionary.Type.MODIFIED);
+            BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeEntry(TEST_BIOME_KEY, 100));
+        });
+    }
+
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -168,5 +168,7 @@ license="LGPL v2.1"
     modId="custom_tooltip_test"
 [[mods]]
     modId="full_pots_accessor_demo"
+[[mods]]
+    modId="biome_temperature_modifier_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/data/biome_temperature_modifier_test/worldgen/biome/test_biome.json
+++ b/src/test/resources/data/biome_temperature_modifier_test/worldgen/biome/test_biome.json
@@ -1,0 +1,53 @@
+{
+  "effects": {
+    "mood_sound": {
+      "sound": "minecraft:ambient.cave",
+      "tick_delay": 6000,
+      "block_search_extent": 8,
+      "offset": 2.0
+    },
+    "sky_color": 16711680,
+    "fog_color": 16711935,
+    "water_color": 65535,
+    "water_fog_color": 0
+  },
+  "surface_builder": {
+    "config": {
+      "top_material": {
+        "Properties": {
+          "snowy": "false"
+        },
+        "Name": "minecraft:iron_block"
+      },
+      "under_material": {
+        "Name": "minecraft:stone"
+      },
+      "underwater_material": {
+        "Name": "minecraft:gravel"
+      }
+    },
+    "type": "minecraft:default"
+  },
+  "carvers": {},
+  "features": [],
+  "starts": [],
+  "spawners": {
+    "monster": [],
+    "creature": [],
+    "ambient": [],
+    "underground_water_creature": [],
+    "water_creature": [],
+    "water_ambient": [],
+    "misc": []
+  },
+  "spawn_costs": {},
+  "player_spawn_friendly": false,
+  "forge:registry_name": "biome_temperature_modifier_test:test_biome",
+  "precipitation": "none",
+  "temperature": -2.0,
+  "temperature_modifier": "test_modifier",
+  "downfall": 0.0,
+  "category": "none",
+  "depth": 0.4,
+  "scale": 1.0
+}


### PR DESCRIPTION
This PR add the `IExtensibleEnum` to the `Biome.TemperatureModifier`

Why is PR needed?
This PR allows Modders to create their own `TemperatureModifier`,
for example they can be used for:
if you are create a `Dimension` which looks similar to the `Overworld`, 
but the base height of the World is moved to the top/bottom (e.g. `SeaLevel` at 128), 
you can use the custom `TemperatureModifier` to rework the vanilla temperature-system,
since vanilla reduces the temperature the higher you go (it ensures that it snows in the mountains).
Than you can use the custom `TemperatureModifier` to make this logic working for your `Dimension`/the base height you use