### PR TITLE
Create worldgen.json

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/worldgen.json
+++ b/src/generated/resources/data/forge/tags/blocks/worldgen.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "forge:worldgen/overworld",
+    "forge:worldgen/the_nether",
+    "forge:worldgen/the_end"
+  ]
+}


### PR DESCRIPTION
I propose a tag that can be used to query for "raw" resources. This tag would contain only resources/blocks in the world, not derivative ones (so bamboo yes, but sticks no). There will be a set of sub-tags that specify which dimension the resources are generated in. Mods that add dimensions can add their own sub-tags.

This will primarily be used to get a list of "all resources generated in the world" which will help with mod integration.