### PR TITLE
[1.17.x] make ScrollPanel better usable by modders

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -22,7 +22,11 @@ package net.minecraftforge.client.gui;
 import java.util.Collections;
 import java.util.List;
 
-import com.mojang.blaze3d.vertex.*;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.renderer.GameRenderer;
 

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -54,13 +54,16 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     private final int barLeft;
     private final int bgColorFrom;
     private final int bgColorTo;
+    private final int barBgColor;
+    private final int barColor;
+    private final int barBorderColor;
 
     public ScrollPanel(Minecraft client, int width, int height, int top, int left)
     {
-        this(client, width, height, top, left, 4, 0xC0101010, 0xD0101010);
+        this(client, width, height, top, left, 4, 0xC0101010, 0xD0101010, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
     }
 
-    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int bgColorFrom, int bgColorTo)
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int bgColorFrom, int bgColorTo, int barBgColor, int barColor, int barBorderColor)
     {
         this.client = client;
         this.width = width;
@@ -73,6 +76,9 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         this.border = border;
         this.bgColorFrom = bgColorFrom;
         this.bgColorTo = bgColorTo;
+        this.barBgColor = barBgColor;
+        this.barColor = barColor;
+        this.barBorderColor = barBorderColor;
     }
 
     protected abstract int getContentHeight();
@@ -244,25 +250,42 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
                 barTop = this.top;
             }
 
+            float barBgAlpha     = (float)(this.barBgColor >> 24 & 255) / 255.0F;
+            float barBgRed       = (float)(this.barBgColor >> 16 & 255) / 255.0F;
+            float barBgGreen     = (float)(this.barBgColor >>  8 & 255) / 255.0F;
+            float barBgBlue      = (float)(this.barBgColor       & 255) / 255.0F;
+
             RenderSystem.setShader(GameRenderer::getPositionColorShader);
             RenderSystem.disableTexture();
             worldr.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            worldr.vertex(barLeft,            this.bottom, 0.0D).color(0x00, 0x00, 0x00, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth, this.bottom, 0.0D).color(0x00, 0x00, 0x00, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth, this.top,    0.0D).color(0x00, 0x00, 0x00, 0xFF).endVertex();
-            worldr.vertex(barLeft,            this.top,    0.0D).color(0x00, 0x00, 0x00, 0xFF).endVertex();
+            worldr.vertex(barLeft,            this.bottom, 0.0D).color(barBgRed, barBgGreen, barBgBlue, barBgAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth, this.bottom, 0.0D).color(barBgRed, barBgGreen, barBgBlue, barBgAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth, this.top,    0.0D).color(barBgRed, barBgGreen, barBgBlue, barBgAlpha).endVertex();
+            worldr.vertex(barLeft,            this.top,    0.0D).color(barBgRed, barBgGreen, barBgBlue, barBgAlpha).endVertex();
             tess.end();
+
+            float barAlpha       = (float)(this.barColor >> 24 & 255) / 255.0F;
+            float barRed         = (float)(this.barColor >> 16 & 255) / 255.0F;
+            float barGreen       = (float)(this.barColor >>  8 & 255) / 255.0F;
+            float barBlue        = (float)(this.barColor       & 255) / 255.0F;
+
             worldr.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            worldr.vertex(barLeft,            barTop + barHeight, 0.0D).color(0x80, 0x80, 0x80, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth, barTop + barHeight, 0.0D).color(0x80, 0x80, 0x80, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth, barTop,             0.0D).color(0x80, 0x80, 0x80, 0xFF).endVertex();
-            worldr.vertex(barLeft,            barTop,             0.0D).color(0x80, 0x80, 0x80, 0xFF).endVertex();
+            worldr.vertex(barLeft,            barTop + barHeight, 0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth, barTop + barHeight, 0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth, barTop,             0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
+            worldr.vertex(barLeft,            barTop,             0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
             tess.end();
+
+            float barBorderAlpha = (float)(this.barBorderColor >> 24 & 255) / 255.0F;
+            float barBorderRed   = (float)(this.barBorderColor >> 16 & 255) / 255.0F;
+            float barBorderGreen = (float)(this.barBorderColor >>  8 & 255) / 255.0F;
+            float barBorderBlue  = (float)(this.barBorderColor       & 255) / 255.0F;
+
             worldr.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            worldr.vertex(barLeft,                barTop + barHeight - 1, 0.0D).color(0xC0, 0xC0, 0xC0, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth - 1, barTop + barHeight - 1, 0.0D).color(0xC0, 0xC0, 0xC0, 0xFF).endVertex();
-            worldr.vertex(barLeft + barWidth - 1, barTop,                 0.0D).color(0xC0, 0xC0, 0xC0, 0xFF).endVertex();
-            worldr.vertex(barLeft,                barTop,                 0.0D).color(0xC0, 0xC0, 0xC0, 0xFF).endVertex();
+            worldr.vertex(barLeft,                barTop + barHeight - 1, 0.0D).color(barBorderRed, barBorderGreen, barBorderBlue, barBorderAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth - 1, barTop + barHeight - 1, 0.0D).color(barBorderRed, barBorderGreen, barBorderBlue, barBorderAlpha).endVertex();
+            worldr.vertex(barLeft + barWidth - 1, barTop,                 0.0D).color(barBorderRed, barBorderGreen, barBorderBlue, barBorderAlpha).endVertex();
+            worldr.vertex(barLeft,                barTop,                 0.0D).color(barBorderRed, barBorderGreen, barBorderBlue, barBorderAlpha).endVertex();
             tess.end();
         }
 

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -174,6 +174,9 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     // TODO: 1.18 rename and add PoseStack parameter
     protected void drawBackground() {}
 
+    /**
+     * Draws the background of the scroll panel. This runs AFTER Scissors are enabled.
+     */
     protected void drawBackground(PoseStack matrix, Tesselator tess, float partialTicks)
     {
         BufferBuilder worldr = tess.getBuilder();

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -273,9 +273,9 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     }
 
     @Override
-    public boolean mouseReleased(double p_mouseReleased_1_, double p_mouseReleased_3_, int p_mouseReleased_5_)
+    public boolean mouseReleased(double mouseX, double mouseY, int button)
     {
-        if (super.mouseReleased(p_mouseReleased_1_, p_mouseReleased_3_, p_mouseReleased_5_))
+        if (super.mouseReleased(mouseX, mouseY, button))
             return true;
         boolean ret = this.scrolling;
         this.scrolling = false;

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -59,7 +59,27 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
 
     public ScrollPanel(Minecraft client, int width, int height, int top, int left)
     {
-        this(client, width, height, top, left, 4, 6, 0xC0101010, 0xD0101010, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
+        this(client, width, height, top, left, 4);
+    }
+
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border)
+    {
+        this(client, width, height, top, left, border, 6);
+    }
+
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth)
+    {
+        this(client, width, height, top, left, border, barWidth, 0xC0101010, 0xD0101010);
+    }
+
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColor)
+    {
+        this(client, width, height, top, left, border, barWidth, bgColor, bgColor);
+    }
+
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColorFrom, int bgColorTo)
+    {
+        this(client, width, height, top, left, border, barWidth, bgColorFrom, bgColorTo, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
     }
 
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColorFrom, int bgColorTo, int barBgColor, int barColor, int barBorderColor)

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -167,7 +167,8 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+    public boolean mouseClicked(double mouseX, double mouseY, int button)
+    {
         if (super.mouseClicked(mouseX, mouseY, button))
             return true;
 
@@ -185,7 +186,8 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     }
 
     @Override
-    public boolean mouseReleased(double p_mouseReleased_1_, double p_mouseReleased_3_, int p_mouseReleased_5_) {
+    public boolean mouseReleased(double p_mouseReleased_1_, double p_mouseReleased_3_, int p_mouseReleased_5_)
+    {
         if (super.mouseReleased(p_mouseReleased_1_, p_mouseReleased_3_, p_mouseReleased_5_))
             return true;
         boolean ret = this.scrolling;
@@ -219,7 +221,6 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         return false;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void render(PoseStack matrix, int mouseX, int mouseY, float partialTicks)
     {
@@ -250,10 +251,10 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
                 barTop = this.top;
             }
 
-            float barBgAlpha     = (float)(this.barBgColor >> 24 & 255) / 255.0F;
-            float barBgRed       = (float)(this.barBgColor >> 16 & 255) / 255.0F;
-            float barBgGreen     = (float)(this.barBgColor >>  8 & 255) / 255.0F;
-            float barBgBlue      = (float)(this.barBgColor       & 255) / 255.0F;
+            int barBgAlpha = this.barBgColor >> 24 & 0xff;
+            int barBgRed   = this.barBgColor >> 16 & 0xff;
+            int barBgGreen = this.barBgColor >>  8 & 0xff;
+            int barBgBlue  = this.barBgColor       & 0xff;
 
             RenderSystem.setShader(GameRenderer::getPositionColorShader);
             RenderSystem.disableTexture();
@@ -264,10 +265,10 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
             worldr.vertex(barLeft,            this.top,    0.0D).color(barBgRed, barBgGreen, barBgBlue, barBgAlpha).endVertex();
             tess.end();
 
-            float barAlpha       = (float)(this.barColor >> 24 & 255) / 255.0F;
-            float barRed         = (float)(this.barColor >> 16 & 255) / 255.0F;
-            float barGreen       = (float)(this.barColor >>  8 & 255) / 255.0F;
-            float barBlue        = (float)(this.barColor       & 255) / 255.0F;
+            int barAlpha = this.barColor >> 24 & 0xff;
+            int barRed   = this.barColor >> 16 & 0xff;
+            int barGreen = this.barColor >>  8 & 0xff;
+            int barBlue  = this.barColor       & 0xff;
 
             worldr.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
             worldr.vertex(barLeft,            barTop + barHeight, 0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
@@ -276,10 +277,10 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
             worldr.vertex(barLeft,            barTop,             0.0D).color(barRed, barGreen, barBlue, barAlpha).endVertex();
             tess.end();
 
-            float barBorderAlpha = (float)(this.barBorderColor >> 24 & 255) / 255.0F;
-            float barBorderRed   = (float)(this.barBorderColor >> 16 & 255) / 255.0F;
-            float barBorderGreen = (float)(this.barBorderColor >>  8 & 255) / 255.0F;
-            float barBorderBlue  = (float)(this.barBorderColor       & 255) / 255.0F;
+            int barBorderAlpha = this.barBorderColor >> 24 & 0xff;
+            int barBorderRed   = this.barBorderColor >> 16 & 0xff;
+            int barBorderGreen = this.barBorderColor >>  8 & 0xff;
+            int barBorderBlue  = this.barBorderColor       & 0xff;
 
             worldr.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
             worldr.vertex(barLeft,                barTop + barHeight - 1, 0.0D).color(barBorderRed, barBorderGreen, barBorderBlue, barBorderAlpha).endVertex();

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -197,10 +197,8 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     }
 
     /**
-     * Draw anything special on the screen. GL_SCISSOR is enabled for anything that
-     * is rendered outside of the view box. Do not mess with SCISSOR unless you support this.
-     * @param mouseY
-     * @param mouseX
+     * Draw anything special on the screen. Scissor (RenderSystem.enableScissor) is enabled
+     * for anything that is rendered outside the view box. Do not mess with Scissor unless you support this.
      */
     protected abstract void drawPanel(PoseStack mStack, int entryRight, int relativeY, Tesselator tess, int mouseX, int mouseY);
 

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -53,6 +53,11 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     private final int barWidth = 6;
     private final int barLeft;
 
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left)
+    {
+        this(client, width, height, top, left, 4);
+    }
+
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border)
     {
         this.client = client;

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -171,6 +171,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
 
     protected abstract int getContentHeight();
 
+    // TODO: 1.18 rename and add PoseStack parameter
     protected void drawBackground() {}
 
     protected void drawBackground(PoseStack matrix, Tesselator tess, float partialTicks)

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -39,6 +39,9 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraftforge.fmlclient.gui.GuiUtils;
 
+/**
+ * Abstract scroll panel class.
+ */
 public abstract class ScrollPanel extends AbstractContainerEventHandler implements Widget, NarratableEntry
 {
     private final Minecraft client;
@@ -61,31 +64,92 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     private final int barColor;
     private final int barBorderColor;
 
+    /**
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left)
     {
         this(client, width, height, top, left, 4);
     }
 
+    /**
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     * @param border the size of the border
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border)
     {
         this(client, width, height, top, left, border, 6);
     }
 
+    /**
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     * @param border the size of the border
+     * @param barWidth the width of the scroll bar
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth)
     {
         this(client, width, height, top, left, border, barWidth, 0xC0101010, 0xD0101010);
     }
 
+    /**
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     * @param border the size of the border
+     * @param barWidth the width of the scroll bar
+     * @param bgColor the color for the background
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColor)
     {
         this(client, width, height, top, left, border, barWidth, bgColor, bgColor);
     }
 
+    /**
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     * @param border the size of the border
+     * @param barWidth the width of the scroll bar
+     * @param bgColorFrom the start color for the background gradient
+     * @param bgColorTo the end color for the background gradient
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColorFrom, int bgColorTo)
     {
         this(client, width, height, top, left, border, barWidth, bgColorFrom, bgColorTo, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
     }
 
+    /**
+     * Base constructor
+     *
+     * @param client the minecraft instance this ScrollPanel should use
+     * @param width the width
+     * @param height the height
+     * @param top the offset from the top (y coord)
+     * @param left the offset from the left (x coord)
+     * @param border the size of the border
+     * @param barWidth the width of the scroll bar
+     * @param bgColorFrom the start color for the background gradient
+     * @param bgColorTo the end color for the background gradient
+     * @param barBgColor the color for the scroll bar background
+     * @param barColor the color for the scroll bar handle
+     * @param barBorderColor the border color for the scroll bar handle
+     */
     public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColorFrom, int bgColorTo, int barBgColor, int barColor, int barBorderColor)
     {
         this.client = client;

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -25,7 +25,6 @@ import java.util.List;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.renderer.GameRenderer;
-import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
@@ -50,7 +49,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     protected boolean captureMouse = true;
     protected final int border;
 
-    private final int barWidth = 6;
+    private final int barWidth;
     private final int barLeft;
     private final int bgColorFrom;
     private final int bgColorTo;
@@ -60,10 +59,10 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
 
     public ScrollPanel(Minecraft client, int width, int height, int top, int left)
     {
-        this(client, width, height, top, left, 4, 0xC0101010, 0xD0101010, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
+        this(client, width, height, top, left, 4, 6, 0xC0101010, 0xD0101010, 0xFF000000, 0xFF808080, 0xFFC0C0C0);
     }
 
-    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int bgColorFrom, int bgColorTo, int barBgColor, int barColor, int barBorderColor)
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border, int barWidth, int bgColorFrom, int bgColorTo, int barBgColor, int barColor, int barBorderColor)
     {
         this.client = client;
         this.width = width;
@@ -74,6 +73,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         this.right = width + this.left;
         this.barLeft = this.left + this.width - barWidth;
         this.border = border;
+        this.barWidth = barWidth;
         this.bgColorFrom = bgColorFrom;
         this.bgColorTo = bgColorTo;
         this.barBgColor = barBgColor;

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -48,12 +48,12 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     private boolean scrolling;
     protected float scrollDistance;
     protected boolean captureMouse = true;
-    protected final int border = 4;
+    protected final int border;
 
     private final int barWidth = 6;
     private final int barLeft;
 
-    public ScrollPanel(Minecraft client, int width, int height, int top, int left)
+    public ScrollPanel(Minecraft client, int width, int height, int top, int left, int border)
     {
         this.client = client;
         this.width = width;
@@ -63,6 +63,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         this.bottom = height + this.top;
         this.right = width + this.left;
         this.barLeft = this.left + this.width - barWidth;
+        this.border = border;
     }
 
     protected abstract int getContentHeight();

--- a/src/main/java/net/minecraftforge/fmlclient/gui/screen/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/fmlclient/gui/screen/ModListScreen.java
@@ -100,7 +100,6 @@ public class ModListScreen extends Screen
     }
 
     private static final int PADDING = 6;
-    private static final int BORDER = 4;
 
     private Screen parentScreen;
 
@@ -139,7 +138,7 @@ public class ModListScreen extends Screen
 
         InfoPanel(Minecraft mcIn, int widthIn, int heightIn, int topIn)
         {
-            super(mcIn, widthIn, heightIn, topIn, modList.getRight() + PADDING, BORDER);
+            super(mcIn, widthIn, heightIn, topIn, modList.getRight() + PADDING);
         }
 
         void setInfo(List<String> lines, ResourceLocation logoPath, Size2i logoDims)

--- a/src/main/java/net/minecraftforge/fmlclient/gui/screen/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/fmlclient/gui/screen/ModListScreen.java
@@ -100,6 +100,7 @@ public class ModListScreen extends Screen
     }
 
     private static final int PADDING = 6;
+    private static final int BORDER = 4;
 
     private Screen parentScreen;
 
@@ -138,7 +139,7 @@ public class ModListScreen extends Screen
 
         InfoPanel(Minecraft mcIn, int widthIn, int heightIn, int topIn)
         {
-            super(mcIn, widthIn, heightIn, topIn, modList.getRight() + PADDING);
+            super(mcIn, widthIn, heightIn, topIn, modList.getRight() + PADDING, BORDER);
         }
 
         void setInfo(List<String> lines, ResourceLocation logoPath, Size2i logoDims)

--- a/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
+++ b/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import com.google.gson.JsonDeserializationContext;


### PR DESCRIPTION
This PR adds:
- Parameters to the constructor of ScrollPanel for 
  - border
  - bar width
  - background color (from, to)
  - bar color (background, handle, handle border)
- A drawBackground method that takes the PoseStack, the Tesselator and the partialTicks and by default renders the background with the colors set in the constructor or the dirt background if the gui is outside of a world context (i.e. the main menu)

It also moves from the GL11 calls to calls to the methods provided by RenderSystem.

For any requested changes/additions please ping `@Minecraftschurli` in `#issues-and-prs` on the Forge Discord