### PR TITLE
Prevent release of custom payload packet buffer

### DIFF
--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -37,7 +37,7 @@
  
     public void m_5797_(ClientGamePacketListener p_132041_) {
        p_132041_.m_7413_(this);
-+      if (this.shouldRelease) this.f_132030_.release();
++      if (this.shouldRelease) this.f_132030_.release(); // FORGE: Fix impl buffer leaks (MC-121884), can only be fixed partially, because else you get problems in LAN-Worlds
     }
  
     public ResourceLocation m_132042_() {

--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -9,11 +9,3 @@
     private static final int f_178834_ = 1048576;
     public static final ResourceLocation f_132012_ = new ResourceLocation("brand");
     public static final ResourceLocation f_132013_ = new ResourceLocation("debug/path");
-@@ -52,6 +_,7 @@
- 
-    public void m_5797_(ClientGamePacketListener p_132041_) {
-       p_132041_.m_7413_(this);
-+      this.f_132030_.release(); // FORGE: Fix impl buffer leaks (MC-121884)
-    }
- 
-    public ResourceLocation m_132042_() {

--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -9,3 +9,35 @@
     private static final int f_178834_ = 1048576;
     public static final ResourceLocation f_132012_ = new ResourceLocation("brand");
     public static final ResourceLocation f_132013_ = new ResourceLocation("debug/path");
+@@ -26,6 +_,7 @@
+    public static final ResourceLocation f_178833_ = new ResourceLocation("debug/game_event_listeners");
+    private final ResourceLocation f_132029_;
+    private final FriendlyByteBuf f_132030_;
++   private final boolean shouldRelease;
+ 
+    public ClientboundCustomPayloadPacket(ResourceLocation p_132034_, FriendlyByteBuf p_132035_) {
+       this.f_132029_ = p_132034_;
+@@ -33,6 +_,7 @@
+       if (p_132035_.writerIndex() > 1048576) {
+          throw new IllegalArgumentException("Payload may not be larger than 1048576 bytes");
+       }
++      this.shouldRelease = false; //We are not the owner of the buffer, don't release it, it might be reused.
+    }
+ 
+    public ClientboundCustomPayloadPacket(FriendlyByteBuf p_178836_) {
+@@ -43,6 +_,7 @@
+       } else {
+          throw new IllegalArgumentException("Payload may not be larger than 1048576 bytes");
+       }
++      this.shouldRelease = true; //We are the owner of the buffer, release it when we are done.
+    }
+ 
+    public void m_5779_(FriendlyByteBuf p_132044_) {
+@@ -52,6 +_,7 @@
+ 
+    public void m_5797_(ClientGamePacketListener p_132041_) {
+       p_132041_.m_7413_(this);
++      if (this.shouldRelease) this.f_132030_.release();
+    }
+ 
+    public ResourceLocation m_132042_() {


### PR DESCRIPTION
Discussed internally.

The merged PR prevents LAN worlds from being joinable when a packet to multiple players is send and the player that is hosting the LAN world is not the last.
This is caused by the fact that the hosting player shares an in-memory netty channel and upon receiving the packet immediately frees the internal buffer preventing other player targeted transmissions from reading from it and transmitting to their respective none hosting-clients causing a crash of the netty sending thread and a kick of the player.

To reproduce:
Send any packet using a simple channel on player join to all players in a LAN opened world.

Discord links:
- Public: <https://discord.com/channels/313125603924639766/725850371834118214/904340137285156864>
- Triage: <https://discord.com/channels/313125603924639766/887479168168775761/904356052227735582>