### PR TITLE
Hotfix: Prevent a crash on a getCapabilities() call when the ItemStack is EMPTY

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -57,6 +57,11 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
     {
         this.baseClass = baseClass;
         this.isLazy = SUPPORTS_LAZY_CAPABILITIES && isLazy;
+
+        if (this.isLazy)
+        {
+            this.lazyParentSupplier = () -> null; //Items have a null delegate so this needs to be set to prevent a crash
+        }
     }
 
     protected final void gatherCapabilities()


### PR DESCRIPTION
If a `getCapabilities()` call is made on the `EMPTY` ItemStack (so the actual object, as in the ones used in none populated slots in Nonnullists like in inventories) then a crash occurs.

This is due to the fact that this particular object does not have a delegate associated and and as such is the only object for which `gatherCapabilities(...)` is not called in the `forgeInit()` method of the itemstack.

In general this now prevents a crash from occurring on lazily initialized capability providers which don't call the `gatherCapabilities(...)` method to initialize the provider.

