### PR TITLE
[1.16.5]Fixes client side PartEntity id doesn't matches with server side

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
@@ -36,7 +36,7 @@
     }
  
     public void func_147279_a(SAnimateHandPacket p_147279_1_) {
-@@ -854,8 +_,8 @@
+@@ -854,11 +_,11 @@
           livingentity.func_213312_b(d0, d1, d2);
           livingentity.field_70761_aq = (float)(p_147281_1_.func_149032_n() * 360) / 256.0F;
           livingentity.field_70759_as = (float)(p_147281_1_.func_149032_n() * 360) / 256.0F;
@@ -46,7 +46,11 @@
 +            net.minecraftforge.entity.PartEntity<?>[] aenderdragonpartentity = livingentity.getParts();
  
              for(int i = 0; i < aenderdragonpartentity.length; ++i) {
-                aenderdragonpartentity[i].func_145769_d(i + p_147281_1_.func_149024_d());
+-               aenderdragonpartentity[i].func_145769_d(i + p_147281_1_.func_149024_d());
++               aenderdragonpartentity[i].func_145769_d((i + 1) + p_147281_1_.func_149024_d()); //Forge: Fixes MC-158205
+             }
+          }
+ 
 @@ -1004,8 +_,10 @@
           clientplayerentity1.func_233645_dx_().func_233784_a_(clientplayerentity.func_233645_dx_());
        }


### PR DESCRIPTION
#8188 
Fix shifting first despite other issue causing id mismatch that still exists.