### PR TITLE
[1.17.x] Change expected type of LootTable fields to arrays

### DIFF
--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -98,8 +98,8 @@ public final class ForgeLootTableProvider extends LootTableProvider {
     }
 
     private boolean findAndReplaceInLootPool(LootPool lootPool, Item from, ToolAction toolAction) {
-        List<LootPoolEntryContainer> lootEntries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "f_7902" +"3_");
-        List<LootItemCondition> lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "f_7902" + "4_");
+        LootPoolEntryContainer[] lootEntries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "f_7902" +"3_");
+        LootItemCondition[] lootConditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, lootPool, "f_7902" + "4_");
         boolean found = false;
 
         if (lootEntries == null) {
@@ -118,16 +118,16 @@ public final class ForgeLootTableProvider extends LootTableProvider {
             throw new IllegalStateException(LootPool.class.getName() + " is missing field f_7902" + "4_");
         }
 
-        for (int i = 0; i < lootConditions.size(); i++) {
-            LootItemCondition lootCondition = lootConditions.get(i);
+        for (int i = 0; i < lootConditions.length; i++) {
+            LootItemCondition lootCondition = lootConditions[i];
             if (lootCondition instanceof MatchTool && checkMatchTool((MatchTool) lootCondition, from)) {
-                lootConditions.set(i, CanToolPerformAction.canToolPerformAction(toolAction).build());
+                lootConditions[i] = CanToolPerformAction.canToolPerformAction(toolAction).build();
                 found = true;
             } else if (lootCondition instanceof InvertedLootItemCondition) {
                 LootItemCondition invLootCondition = ObfuscationReflectionHelper.getPrivateValue(InvertedLootItemCondition.class, (InvertedLootItemCondition) lootCondition, "f_8168" + "1_");
 
                 if (invLootCondition instanceof MatchTool && checkMatchTool((MatchTool) invLootCondition, from)) {
-                    lootConditions.set(i, InvertedLootItemCondition.invert(CanToolPerformAction.canToolPerformAction(toolAction)).build());
+                    lootConditions[i] = InvertedLootItemCondition.invert(CanToolPerformAction.canToolPerformAction(toolAction)).build();
                     found = true;
                 } else if (invLootCondition instanceof AlternativeLootItemCondition && findAndReplaceInAlternative((AlternativeLootItemCondition) invLootCondition, from, toolAction)) {
                     found = true;


### PR DESCRIPTION
#8184 reverted some LootTable patches, including the types of fields `f_79023_` and `f_79024_`. However, `ForgeLootTableProvider` expects a list for these fields, however the type of the fields is now an array.
This PR changes the expected type in `ForgeLootTableProvider` to an array as well.