### PR TITLE
[1.17.x] add support for number formatting codes to TranslatableComponent

### DIFF
--- a/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
+++ b/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
@@ -9,7 +9,7 @@
  
     public TranslatableComponent(String p_131305_) {
        this.f_131298_ = p_131305_;
-@@ -70,23 +_,33 @@
+@@ -70,23 +_,30 @@
                 this.f_131301_.add(FormattedText.m_130775_(s));
              }
  
@@ -19,11 +19,9 @@
              if ("%".equals(s4) && "%%".equals(s1)) {
                 this.f_131301_.add(f_131296_);
              } else {
-+               /*
                 if (!"s".equals(s4)) {
-                   throw new TranslatableFormatException(this, "Unsupported format: '" + s1 + "'");
+-                  throw new TranslatableFormatException(this, "Unsupported format: '" + s1 + "'");
                 }
-+               */
  
                 String s2 = matcher.group(1);
                 int i1 = s2 != null ? Integer.parseInt(s2) - 1 : i++;

--- a/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
+++ b/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
@@ -5,32 +5,34 @@
     private Language f_131300_;
     private final List<FormattedText> f_131301_ = Lists.newArrayList();
 -   private static final Pattern f_131302_ = Pattern.compile("%(?:(\\d+)\\$)?([A-Za-z%]|$)");
-+   private static final Pattern f_131302_ = Pattern.compile("%(?:(\\d+)\\$)?([+-]?,?\\d*\\.?\\d*)?([A-Za-z%]|$)");
++   private static final Pattern f_131302_ = Pattern.compile("%(?:(\\d+)\\$)?([-#+ 0,(<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])");
  
     public TranslatableComponent(String p_131305_) {
        this.f_131298_ = p_131305_;
-@@ -70,11 +_,12 @@
+@@ -70,23 +_,33 @@
                 this.f_131301_.add(FormattedText.m_130775_(s));
              }
  
 -            String s4 = matcher.group(2);
-+            String s4 = matcher.group(3);
++            String s4 = matcher.group(6);
              String s1 = p_131322_.substring(k, l);
              if ("%".equals(s4) && "%%".equals(s1)) {
                 this.f_131301_.add(f_131296_);
              } else {
-+               if (!"f".equals(s4) && !"d".equals(s4))
++               /*
                 if (!"s".equals(s4)) {
                    throw new TranslatableFormatException(this, "Unsupported format: '" + s1 + "'");
                 }
-@@ -82,11 +_,18 @@
++               */
+ 
                 String s2 = matcher.group(1);
                 int i1 = s2 != null ? Integer.parseInt(s2) - 1 : i++;
                 if (i1 < this.f_131299_.length) {
-+                  if (!(this.f_131299_[i1] instanceof Component) && this.f_131299_[i1] != null)
-+                     this.f_131301_.add(FormattedText.m_130775_(("%"+matcher.group(2)+s4).formatted(this.f_131299_[i1])));
-+                  else
++                  if ("s".equals(s4) && net.minecraft.util.StringUtil.m_14408_(matcher.group(2)) && net.minecraft.util.StringUtil.m_14408_(matcher.group(4)) && net.minecraft.util.StringUtil.m_14408_(matcher.group(5))) {
                    this.f_131301_.add(this.m_131313_(i1));
++                  } else {
++                     this.f_131301_.add(FormattedText.m_130775_(matcher.group(0).formatted(f_131299_)));
++                  }
                 }
              }
           }

--- a/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
+++ b/patches/minecraft/net/minecraft/network/chat/TranslatableComponent.java.patch
@@ -1,6 +1,37 @@
 --- a/net/minecraft/network/chat/TranslatableComponent.java
 +++ b/net/minecraft/network/chat/TranslatableComponent.java
-@@ -87,6 +_,10 @@
+@@ -21,7 +_,7 @@
+    @Nullable
+    private Language f_131300_;
+    private final List<FormattedText> f_131301_ = Lists.newArrayList();
+-   private static final Pattern f_131302_ = Pattern.compile("%(?:(\\d+)\\$)?([A-Za-z%]|$)");
++   private static final Pattern f_131302_ = Pattern.compile("%(?:(\\d+)\\$)?([+-]?,?\\d*\\.?\\d*)?([A-Za-z%]|$)");
+ 
+    public TranslatableComponent(String p_131305_) {
+       this.f_131298_ = p_131305_;
+@@ -70,11 +_,12 @@
+                this.f_131301_.add(FormattedText.m_130775_(s));
+             }
+ 
+-            String s4 = matcher.group(2);
++            String s4 = matcher.group(3);
+             String s1 = p_131322_.substring(k, l);
+             if ("%".equals(s4) && "%%".equals(s1)) {
+                this.f_131301_.add(f_131296_);
+             } else {
++               if (!"f".equals(s4) && !"d".equals(s4))
+                if (!"s".equals(s4)) {
+                   throw new TranslatableFormatException(this, "Unsupported format: '" + s1 + "'");
+                }
+@@ -82,11 +_,18 @@
+                String s2 = matcher.group(1);
+                int i1 = s2 != null ? Integer.parseInt(s2) - 1 : i++;
+                if (i1 < this.f_131299_.length) {
++                  if (!(this.f_131299_[i1] instanceof Component) && this.f_131299_[i1] != null)
++                     this.f_131301_.add(FormattedText.m_130775_(("%"+matcher.group(2)+s4).formatted(this.f_131299_[i1])));
++                  else
+                   this.f_131301_.add(this.m_131313_(i1));
+                }
              }
           }
  

--- a/src/test/java/net/minecraftforge/debug/chat/TranslatableComponentFormattingTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/TranslatableComponentFormattingTest.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.debug.chat;
+
+import com.mojang.brigadier.Command;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import static java.util.Calendar.MAY;
+
+@Mod("translatable_component_formatting_test")
+public class TranslatableComponentFormattingTest
+{
+    public TranslatableComponentFormattingTest()
+    {
+        MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
+    }
+
+    private void registerCommands(RegisterCommandsEvent evt)
+    {
+        evt.getDispatcher().register(Commands.literal("test_component_formatting").executes(context -> {
+            // tests copied from java.util.Formatter javadoc
+            context.getSource().sendSuccess(new TranslatableComponent("translatable.formatting.test1", "a", new TextComponent("b"), "c", "d"), false);
+            context.getSource().sendSuccess(new TranslatableComponent("translatable.formatting.test2", Math.E), false);
+            context.getSource().sendSuccess(new TranslatableComponent("translatable.formatting.test3", -6217.585657), false);
+            context.getSource().sendSuccess(new TranslatableComponent("translatable.formatting.test4", Calendar.getInstance()), false);
+            Calendar c = new GregorianCalendar(1995, MAY, 23);
+            context.getSource().sendSuccess(new TranslatableComponent("translatable.formatting.test5", c), false);
+            return Command.SINGLE_SUCCESS;
+        }));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -170,5 +170,7 @@ license="LGPL v2.1"
     modId="full_pots_accessor_demo"
 [[mods]]
     modId="part_entity_test"
+[[mods]]
+    modId="translatable_component_formatting_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/assets/translatable_component_formatting_test/lang/en_us.json
+++ b/src/test/resources/assets/translatable_component_formatting_test/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "translatable.formatting.test1": "%4$2s %3$2s %2$2s %1$2s",
+  "translatable.formatting.test2": "e = %+10.4f",
+  "translatable.formatting.test3": "Amount gained or lost since last statement: $ %(,.2f",
+  "translatable.formatting.test4": "Local time: %tT",
+  "translatable.formatting.test5": "Duke's Birthday: %1$tb %1$te, %1$tY"
+}


### PR DESCRIPTION
Adds support for the default string formatting codes `f` and `d` from java to the TranslatableComponent.

Examples:

for parameter: `461012`
`%d` --> `461012`
`%08d` --> `00461012`
`%+8d` --> `+461012`
`%,8d` -->  ` 461,012`
`%+,8d`  -->  `+461,012`

for parameter: `Math.PI`
`%f` -->  `3.141593`
`%.3f` -->  `3.142`
`%10.3f` -->  `     3.142`
`%-10.3f` -->  `3.142`

Feedback on how to make it easier/better is appreciated.