### PR TITLE
Added instructions for VSCode setup in README.txt

### DIFF
--- a/mdk/README.txt
+++ b/mdk/README.txt
@@ -15,6 +15,7 @@ Setup Process:
 Step 1: Open your command-line and browse to the folder where you extracted the zip file.
 
 Step 2: You're left with a choice.
+
 If you prefer to use Eclipse:
 1. Run the following command: `gradlew genEclipseRuns` (`./gradlew genEclipseRuns` if you are on Mac/Linux)
 2. Open Eclipse, Import > Existing Gradle Project > Select Folder 
@@ -25,6 +26,12 @@ If you prefer to use IntelliJ:
 2. Select your build.gradle file and have it import.
 3. Run the following command: `gradlew genIntellijRuns` (`./gradlew genIntellijRuns` if you are on Mac/Linux)
 4. Refresh the Gradle Project in IDEA if required.
+
+If you prefer to use Visual Studio Code:
+1. Install the following 3 extensions from the VSCode marketplace:
+   Gradle for Java, Language Support for Java(TM) by Red Hat, Debugger for Java
+2. Open the folder in VSCode and have it import.
+3. Run the following command: `.\gradlew genVSCodeRuns` to generate the launch settings
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can 
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 

--- a/mdk/gitignore.txt
+++ b/mdk/gitignore.txt
@@ -13,6 +13,9 @@ out
 *.iml
 .idea
 
+# vscode
+.vscode
+
 # gradle
 build
 .gradle


### PR DESCRIPTION
For a long time I thought Forge did not support Visual Studio Code as a development environment, I only recently found out the forge mdk provides a `genVSCodeRuns` command, which is however not mentioned in README.txt