### PR TITLE
Apply window resizing to all gui layers

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -185,7 +185,13 @@
        }
  
        if (this.f_91056_ != null) {
-@@ -1136,6 +_,7 @@
+@@ -1131,11 +_,12 @@
+       int i = this.f_90990_.m_85385_(this.f_91066_.f_92072_, this.m_91390_());
+       this.f_90990_.m_85378_((double)i);
+       if (this.f_91080_ != null) {
+-         this.f_91080_.m_6574_(this, this.f_90990_.m_85445_(), this.f_90990_.m_85446_());
++         net.minecraftforge.client.ForgeHooksClient.resizeGuiLayers(this, this.f_90990_.m_85445_(), this.f_90990_.m_85446_());
+       }
  
        RenderTarget rendertarget = this.m_91385_();
        rendertarget.m_83941_(this.f_90990_.m_85441_(), this.f_90990_.m_85442_(), f_91002_);

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -185,11 +185,10 @@
        }
  
        if (this.f_91056_ != null) {
-@@ -1131,11 +_,12 @@
-       int i = this.f_90990_.m_85385_(this.f_91066_.f_92072_, this.m_91390_());
+@@ -1132,10 +_,12 @@
        this.f_90990_.m_85378_((double)i);
        if (this.f_91080_ != null) {
--         this.f_91080_.m_6574_(this, this.f_90990_.m_85445_(), this.f_90990_.m_85446_());
+          this.f_91080_.m_6574_(this, this.f_90990_.m_85445_(), this.f_90990_.m_85446_());
 +         net.minecraftforge.client.ForgeHooksClient.resizeGuiLayers(this, this.f_90990_.m_85445_(), this.f_90990_.m_85446_());
        }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -172,6 +172,10 @@ public class ForgeHooksClient
      */
     private static final Stack<Screen> guiLayers = new Stack<>();
 
+    public static void resizeGuiLayers(Minecraft minecraft, int width, int height) {
+        guiLayers.forEach(screen -> screen.resize(minecraft, width, height));
+    }
+
     public static void clearGuiLayers(Minecraft minecraft)
     {
         while(guiLayers.size() > 0)


### PR DESCRIPTION
This will cause *all* screens in the guiLayers Stack to re-init. 
Fixes widgets being dislocated on bottom layers when re-sizing the window.