### PR TITLE
1.16.x Add option to ITeleporter to disable creation of an Obsidian Platform when travelling to the End dimension.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -43,7 +43,9 @@
                 this.field_193110_cw = this.func_213303_ch();
 -            } else if (p_241206_1_.func_234923_W_() == World.field_234920_i_) {
 +            } else if (spawnPortal && p_241206_1_.func_234923_W_() == World.field_234920_i_) {
-                this.func_242110_a(p_241206_1_, new BlockPos(portalinfo.field_222505_a));
+                if (teleporter.spawnPlatform()) {
+                    this.func_242110_a(p_241206_1_, new BlockPos(portalinfo.field_222505_a));
+                }
              }
  
 @@ -657,6 +_,9 @@

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -43,7 +43,7 @@
                 this.field_193110_cw = this.func_213303_ch();
 -            } else if (p_241206_1_.func_234923_W_() == World.field_234920_i_) {
 +            } else if (spawnPortal && p_241206_1_.func_234923_W_() == World.field_234920_i_) {
-                if (teleporter.spawnPlatform(this, serverworld, p_241206_1_)) {
+                if (teleporter.spawnEndPlatform(this, serverworld, p_241206_1_)) {
                     this.func_242110_a(p_241206_1_, new BlockPos(portalinfo.field_222505_a));
                 }
              }

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -43,7 +43,7 @@
                 this.field_193110_cw = this.func_213303_ch();
 -            } else if (p_241206_1_.func_234923_W_() == World.field_234920_i_) {
 +            } else if (spawnPortal && p_241206_1_.func_234923_W_() == World.field_234920_i_) {
-                if (teleporter.spawnPlatform()) {
+                if (teleporter.spawnPlatform(this, serverworld, p_241206_1_)) {
                     this.func_242110_a(p_241206_1_, new BlockPos(portalinfo.field_222505_a));
                 }
              }

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -104,4 +104,15 @@ public interface ITeleporter
         return true;
     }
 
+    /**
+     * Called when vanilla wants to spawn the obsidian platform in the End dimension. Return true to spawn the platform.
+     * @param player the player
+     * @param sourceWorld the source world
+     * @param destWorld the target world
+     * @return true to spawn the obsidian platform
+     */
+    default boolean spawnEndPlatform(ServerPlayerEntity player, ServerWorld sourceWorld, ServerWorld destWorld)
+    {
+        return true;   
+    }
 }

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -105,7 +105,7 @@ public interface ITeleporter
     }
 
     /**
-     * Called when vanilla wants to spawn the obsidian platform in the End dimension. Return true to spawn the platform.
+     * Called when vanilla wants to spawn the End platform when changing dimension to the End. Return true to spawn the platform.
      * @param player the player
      * @param sourceWorld the source world
      * @param destWorld the target world


### PR DESCRIPTION
Im running into an issue with my mod, where whenever I changeDimension the player to the End, it always spawns the End platform, no matter what BlockPos I teleport them to. I can't find a way to disable this with the current system.