### PR TITLE
Reorder image tooltip component to match vanilla

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1123,7 +1123,7 @@ public class ForgeHooksClient
         List<Either<FormattedText, TooltipComponent>> elements = textElements.stream()
                 .map((Function<FormattedText, Either<FormattedText, TooltipComponent>>) Either::left)
                 .collect(Collectors.toCollection(ArrayList::new));
-        itemComponent.ifPresent(c -> elements.add(Either.right(c)));
+        itemComponent.ifPresent(c -> elements.add(1, Either.right(c)));
 
         var event = new RenderTooltipEvent.GatherComponents(stack, screenWidth, screenHeight, elements, -1);
         MinecraftForge.EVENT_BUS.post(event);


### PR DESCRIPTION
This PR fixes #8212 by moving the image tooltip component (used most prominently by the bundle item) to index `1`, after the component for the item name and before the rest of the components, matching vanilla rendering. 

This seems to have been an oversight by the tooltip rewrite PR #8038. The PR patched `Screen` to remove the code which adds the image component to the second position within the list (the index argument of `1`):

https://github.com/MinecraftForge/MinecraftForge/blob/cdd38270e9080a4579003c5138afbe300e00693e/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch#L39-L41

That piece of code was translocated to the Forge hook in `ForgeHooksClient` instead, but the index argument was forgotten, which leads the image component to be added to the end of the list and causes the linked issue:

https://github.com/MinecraftForge/MinecraftForge/blob/cdd38270e9080a4579003c5138afbe300e00693e/src/main/java/net/minecraftforge/client/ForgeHooksClient.java#L1126

This PR simply re-adds the index argument of `1` to the `List#add` call, mimicing the original vanilla code to insert the image component to the second position within the list rather than at the end.

**In-game screenshot of the PR in action:**
![image](https://user-images.githubusercontent.com/21304337/143380402-4cb1c849-9250-4a37-b2c1-2996d0b1d2dc.png)

