### PR TITLE
Deprecate for removal the durability bar methods in Item extension

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
@@ -57,25 +57,6 @@
              crashreportcategory.m_128165_("Item Damage", () -> {
                 return String.valueOf(p_174237_.m_41773_());
              });
-@@ -332,14 +_,15 @@
-             multibuffersource$buffersource.m_109911_();
-          }
- 
--         if (p_115176_.m_150947_()) {
-+         if (p_115176_.m_41720_().showDurabilityBar(p_115176_)) {
-             RenderSystem.m_69465_();
-             RenderSystem.m_69472_();
-             RenderSystem.m_69461_();
-             Tesselator tesselator = Tesselator.m_85913_();
-             BufferBuilder bufferbuilder = tesselator.m_85915_();
--            int i = p_115176_.m_150948_();
--            int j = p_115176_.m_150949_();
-+            double health = p_115176_.m_41720_().getDurabilityForDisplay(p_115176_);
-+            int i = Math.round(13.0F - (float)health * 13.0F);
-+            int j = p_115176_.m_41720_().getRGBDurabilityForDisplay(p_115176_);
-             this.m_115152_(bufferbuilder, p_115177_ + 2, p_115178_ + 13, 13, 2, 0, 0, 0, 255);
-             this.m_115152_(bufferbuilder, p_115177_ + 2, p_115178_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
-             RenderSystem.m_69478_();
 @@ -377,5 +_,9 @@
  
     public void m_6213_(ResourceManager p_115105_) {

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -35,6 +35,26 @@
     public final int m_41462_() {
        return this.f_41371_;
     }
+@@ -151,16 +_,15 @@
+    }
+ 
+    public boolean m_142522_(ItemStack p_150899_) {
+-      return p_150899_.m_41768_();
++      return p_150899_.m_41720_().showDurabilityBar(p_150899_);
+    }
+ 
+    public int m_142158_(ItemStack p_150900_) {
+-      return Math.round(13.0F - (float)p_150900_.m_41773_() * 13.0F / (float)this.f_41371_);
++      return Math.round(13.0F - ((float) p_150900_.m_41720_().getDurabilityForDisplay(p_150900_) * 13.0F));
+    }
+ 
+    public int m_142159_(ItemStack p_150901_) {
+-      float f = Math.max(0.0F, ((float)this.f_41371_ - (float)p_150901_.m_41773_()) / (float)this.f_41371_);
+-      return Mth.m_14169_(f / 3.0F, 1.0F, 1.0F);
++      return p_150901_.m_41720_().getRGBDurabilityForDisplay(p_150901_);
+    }
+ 
+    public boolean m_142207_(ItemStack p_150888_, Slot p_150889_, ClickAction p_150890_, Player p_150891_) {
 @@ -216,10 +_,12 @@
     }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -448,7 +448,9 @@ public interface IForgeItem
      *
      * @param stack The current Item Stack
      * @return True if it should render the 'durability' bar.
+     * @deprecated To be removed in 1.18. Override {@link Item#isBarVisible(ItemStack)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.17.1")
     default boolean showDurabilityBar(ItemStack stack)
     {
         return stack.isDamaged();
@@ -460,7 +462,10 @@ public interface IForgeItem
      * @param stack The current ItemStack
      * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged /
      *         empty bar)
+     * @deprecated To be removed in 1.18. Override {@link Item#getBarWidth(ItemStack)} instead, with the notable difference
+     *             that the new method returns the width of the colored bar in pixels (where a full bar is 13px wide).
      */
+    @Deprecated(forRemoval = true, since = "1.17.1")
     default double getDurabilityForDisplay(ItemStack stack)
     {
         return (double) stack.getDamageValue() / (double) stack.getMaxDamage();
@@ -473,7 +478,9 @@ public interface IForgeItem
      *
      * @param stack Stack to get durability from
      * @return A packed RGB value for the durability colour (0x00RRGGBB)
+     * @deprecated To be removed in 1.18. Override {@link Item#getBarColor(ItemStack)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.17.1")
     default int getRGBDurabilityForDisplay(ItemStack stack)
     {
         return Mth.hsvToRgb(Math.max(0.0F, (float) (1.0F - getDurabilityForDisplay(stack))) / 3.0F, 1.0F, 1.0F);


### PR DESCRIPTION
This PR fixes #8201 by deprecating for removal in 1.18 the three durability bar methods in the `IForgeItem` extension interface:
- `showDurabilityBar`, whose vanilla replacement is `Item#isBarVisible`;
- `getDurabilityForDisplay`, whose nearest vanilla replacement is `Item#getBarWidth`; and
- `getRGBDurabilityForDisplay`, whose vanilla replacement is `Item#getBarColor`.

To retain compatibility with existing mods which override the extension methods, the vanilla methods redirect to the extension methods for now. These redirects will be removed alongside the above three extension methods in the future.

It should be noted that `getBarWidth` is not a one-to-one replacement for `getDurabilityForDisplay`, as the vanilla method returns the actual width of the colored bar in pixels while the extension method returns a percentage (`0.0F` to `1.0F`) representing how much of the colored bar is rendered. For compatibility, that particular vanilla method's redirect performs the necessary conversion from the percentage to the width in pixels, using the original assumption of a 13-pixel bar.

This PR also partially addresses #8212, by fixing the bundle 'fill' bar. Also see #8213 which fixes the second part of that issue (the wrongly positioned image tooltip component).