### PR TITLE
[1.17] Forward Port MinecraftForge#7971 to 1.17 & update deprecation info

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -36,19 +36,16 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.ParsedCommandNode;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
-import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.Collection;
 
-/** @deprecated For removal in 1.17, superseded by {@code /execute in <dim> run tp <targets>} */
-@Deprecated
+/** @deprecated For removal in 1.18, superseded by {@code /execute in <dim> run tp <targets>} */
+@Deprecated(forRemoval = true, since = "1.17.1")
 public class CommandSetDimension
 {
     private static final SimpleCommandExceptionType NO_ENTITIES = new SimpleCommandExceptionType(new TranslatableComponent("commands.forge.setdim.invalid.entity"));
-    private static final DynamicCommandExceptionType INVALID_DIMENSION = new DynamicCommandExceptionType(dim -> new TranslatableComponent("commands.forge.setdim.invalid.dim", dim));
     static ArgumentBuilder<CommandSourceStack, ?> register()
     {
         return Commands.literal("setdimension")
@@ -70,27 +67,26 @@ public class CommandSetDimension
             throw NO_ENTITIES.create();
 
         String cmdTarget = "@s";
-        String posTarget = "";
+        String posTarget = "~ ~ ~";
         for (ParsedCommandNode<CommandSourceStack> parsed : ctx.getNodes())
         {
-            final CommandNode<CommandSourceStack> node = parsed.getNode();
             if (parsed.getNode() instanceof ArgumentCommandNode)
             {
-                if ("target".equals(parsed.getNode().getName()))
+                if ("targets".equals(parsed.getNode().getName()))
                 {
                     cmdTarget = parsed.getRange().get(ctx.getInput());
                 }
                 else if ("pos".equals(parsed.getNode().getName()))
                 {
-                    posTarget = " " + parsed.getRange().get(ctx.getInput());
+                    posTarget = parsed.getRange().get(ctx.getInput());
                 }
             }
         }
         final String dimName = dim.dimension().location().toString();
         final String finalCmdTarget = cmdTarget;
         final String finalPosTarget = posTarget;
-        Component suggestion = new TranslatableComponent("/execute in %s run tp %s%s", dimName, cmdTarget, finalPosTarget)
-                .withStyle((style) -> style.withColor(ChatFormatting.GREEN).withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget + finalPosTarget)));
+        Component suggestion = new TranslatableComponent("/execute in %s run tp %s %s", dimName, cmdTarget, finalPosTarget)
+                .withStyle((style) -> style.withColor(ChatFormatting.GREEN).withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/execute in " + dimName + " run tp " + finalCmdTarget + " " + finalPosTarget)));
         ctx.getSource().sendSuccess(new TranslatableComponent("commands.forge.setdim.deprecated", suggestion), true);
 
         return 0;


### PR DESCRIPTION
As requested by @gigaherz on [Discord](https://discord.com/channels/313125603924639766/852298000042164244/913374570944286751).

This PR updates <https://github.com/MinecraftForge/MinecraftForge/pull/7971>to target 1.17 and additional corrects the deprecation info on the class to bring it inline with the new style.