### PR TITLE
[1.18] Log missing mandatory dependencies

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -38,6 +38,7 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.*;
@@ -233,6 +234,13 @@ public class ModSorter
         LOGGER.debug(LOADING, "Found {} mod requirements missing ({} mandatory, {} optional)", missingVersions.size(), mandatoryMissing, missingVersions.size() - mandatoryMissing);
 
         if (!missingVersions.isEmpty()) {
+            if (mandatoryMissing > 0) {
+                LOGGER.error(LOADING, "Missing mandatory dependencies: {}", missingVersions.stream().filter(IModInfo.ModVersion::isMandatory).map(IModInfo.ModVersion::getModId).collect(Collectors.joining(", ")));
+            }
+            if (missingVersions.size() - mandatoryMissing > 0) {
+                LOGGER.error(LOADING, "Unsupported installed optional dependencies: {}", missingVersions.stream().filter(ver -> !ver.isMandatory()).map(IModInfo.ModVersion::getModId).collect(Collectors.joining(", ")));
+            }
+
             return missingVersions.stream()
                     .map(mv -> new ExceptionData(mv.isMandatory() ? "fml.modloading.missingdependency" : "fml.modloading.missingdependency.optional",
                             mv.getOwner(), mv.getModId(), mv.getOwner().getModId(), mv.getVersionRange(),


### PR DESCRIPTION
This PR adds logging of the mod IDs of all missing mandatory dependencies to allow debugging game crashes related to a missing dependency in rare cases where the game doesn't get to the screen that shows detailed info. See an example of that on [Discord](https://discord.com/channels/313125603924639766/437001959950778368/913856816587354134).
While it doesn't show as much info as the screen, it is still much more helpful then only knowing the amount of missing dependencies.

The dependency logging looks like this now (the last line is omitted when there are no missing mandatory dependencies):
```
[26Nov.2021 20:51:39.807] [main/DEBUG] [net.minecraftforge.fml.loading.ModSorter/LOADING]: Found 2 mod requirements (2 mandatory, 0 optional)
[26Nov.2021 20:51:39.809] [main/DEBUG] [net.minecraftforge.fml.loading.ModSorter/LOADING]: Found 1 mod requirements missing (1 mandatory, 0 optional)
[26Nov.2021 20:51:39.810] [main/DEBUG] [net.minecraftforge.fml.loading.ModSorter/LOADING]: Missing mandatory dependencies: test_mod_doesnt_exist
```

I will re-target this to the 1.18 branch when that is ready.