### PR TITLE
[1.16] Reintroduce modded biome variants

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/layer/EdgeBiomeLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/EdgeBiomeLayer.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/gen/layer/EdgeBiomeLayer.java
++++ b/net/minecraft/world/gen/layer/EdgeBiomeLayer.java
+@@ -20,6 +_,11 @@
+                }
+             }
+ 
++            net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome>) net.minecraftforge.registries.ForgeRegistries.BIOMES;
++            java.util.Optional<net.minecraft.util.RegistryKey <net.minecraft.world.biome.Biome>> edge = net.minecraftforge.common.BiomeManager.getEdgeBiome(registry.getKey(p_202748_6_), registry.getKey(p_202748_2_), registry.getKey(p_202748_3_), registry.getKey(p_202748_4_), registry.getKey(p_202748_5_));
++            if(edge.isPresent()) {
++               return net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_148757_b(net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_230516_a_(edge.get()));
++            }
+             return p_202748_6_;
+          } else {
+             return 34;

--- a/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/HillsLayer.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/gen/layer/HillsLayer.java
++++ b/net/minecraft/world/gen/layer/HillsLayer.java
+@@ -51,6 +_,10 @@
+       } else {
+          if (p_215723_1_.func_202696_a(3) == 0 || k == 0) {
+             int l = i;
++            java.util.Optional<net.minecraft.util.RegistryKey<net.minecraft.world.biome.Biome>> hills = net.minecraftforge.common.BiomeManager.getHillsBiome(((net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES).getKey(i));
++            if(hills.isPresent()) {
++               l = net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_148757_b(net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_230516_a_(hills.get()));
++            } else
+             if (i == 2) {
+                l = 17;
+             } else if (i == 4) {

--- a/patches/minecraft/net/minecraft/world/gen/layer/MixRiverLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/MixRiverLayer.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/gen/layer/MixRiverLayer.java
++++ b/net/minecraft/world/gen/layer/MixRiverLayer.java
+@@ -14,6 +_,10 @@
+       if (LayerUtil.func_202827_a(i)) {
+          return i;
+       } else if (j == 7) {
++         java.util.Optional<net.minecraft.util.RegistryKey<net.minecraft.world.biome.Biome>> river = net.minecraftforge.common.BiomeManager.getRiverBiome(((net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome>)net.minecraftforge.registries.ForgeRegistries.BIOMES).getKey(i));
++         if(river.isPresent()) {
++            return net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_148757_b(net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_230516_a_(river.get()));
++         }
+          if (i == 12) {
+             return 11;
+          } else {

--- a/patches/minecraft/net/minecraft/world/gen/layer/ShoreLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/ShoreLayer.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/gen/layer/ShoreLayer.java
++++ b/net/minecraft/world/gen/layer/ShoreLayer.java
+@@ -12,6 +_,11 @@
+    private static final IntSet field_242943_c = new IntOpenHashSet(new int[]{168, 169, 21, 22, 23, 149, 151});
+ 
+    public int func_202748_a(INoiseRandom p_202748_1_, int p_202748_2_, int p_202748_3_, int p_202748_4_, int p_202748_5_, int p_202748_6_) {
++      net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome> registry = (net.minecraftforge.registries.ForgeRegistry<net.minecraft.world.biome.Biome>) net.minecraftforge.registries.ForgeRegistries.BIOMES;
++      java.util.Optional<net.minecraft.util.RegistryKey<net.minecraft.world.biome.Biome>> shore = net.minecraftforge.common.BiomeManager.getShoreBiome(registry.getKey(p_202748_6_), registry.getKey(p_202748_2_), registry.getKey(p_202748_3_), registry.getKey(p_202748_4_), registry.getKey(p_202748_5_));
++      if(shore.isPresent()) {
++         return net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_148757_b(net.minecraft.util.registry.WorldGenRegistries.field_243657_i.func_230516_a_(shore.get()));
++      }
+       if (p_202748_6_ == 14) {
+          if (LayerUtil.func_203631_b(p_202748_2_) || LayerUtil.func_203631_b(p_202748_3_) || LayerUtil.func_203631_b(p_202748_4_) || LayerUtil.func_203631_b(p_202748_5_)) {
+             return 15;

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 
@@ -257,6 +258,56 @@ public class BiomeManager
         public boolean isModded()
         {
             return isModded;
+        }
+    }
+
+    private static final List<IBiomeLayerModifier> biomeLayerModifiers = new ArrayList<>();
+
+    public static void addBiomeLayerModifier(IBiomeLayerModifier modifier)
+    {
+        biomeLayerModifiers.add(modifier);
+    }
+
+    public static Optional<RegistryKey<Biome>> getHillsBiome(RegistryKey<Biome> biome)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getHillsBiome(biome)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<RegistryKey<Biome>> getRiverBiome(RegistryKey<Biome> biome)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getRiverBiome(biome)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<RegistryKey<Biome>> getEdgeBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getEdgeBiome(biome, north, west, south, east)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public static Optional<RegistryKey<Biome>> getShoreBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+    {
+        return biomeLayerModifiers.stream().map( mod -> mod.getShoreBiome(biome, north, west, south, east)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public interface IBiomeLayerModifier
+    {
+        default Optional<RegistryKey<Biome>> getHillsBiome(RegistryKey<Biome> biome)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<RegistryKey<Biome>> getRiverBiome(RegistryKey<Biome> biome)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<RegistryKey<Biome>> getShoreBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+        {
+            return Optional.empty();
+        }
+
+        default Optional<RegistryKey<Biome>> getEdgeBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+        {
+            return Optional.empty();
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
@@ -1,0 +1,169 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.world;
+
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.*;
+import net.minecraft.world.gen.surfacebuilders.ConfiguredSurfaceBuilders;
+import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.common.BiomeManager;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import java.util.Optional;
+
+/**
+ * Manually enable to test.
+ *
+ * When generated the "biome_variant_test:main" biome should generate in the overworld.
+ * Within the "biome area" there should be hills ("biome_variant_test:hills") and potentially rivers ("biome_variant_test:river") flowing to/from other biomes.
+ * At the edge of the "biome area" there should be an edge biome ("biome_variant_test:edge").
+ * If the "biome area" is next to an ocean there should be a shore ("biome_variant_test:shore").
+ */
+@Mod(BiomeVariantTest.MODID)
+public class BiomeVariantTest
+{
+
+    static final String MODID = "biome_variant_test";
+    private static final boolean ENABLED = false;
+
+    private static final RegistryKey<Biome> MAIN_KEY = RegistryKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "main"));
+    private static final RegistryKey<Biome> HILLS_KEY = RegistryKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "hills"));
+    private static final RegistryKey<Biome> EDGE_KEY = RegistryKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "edge"));
+    private static final RegistryKey<Biome> RIVER_KEY = RegistryKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "river"));
+    private static final RegistryKey<Biome> SHORE_KEY = RegistryKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "shore"));
+
+    public BiomeVariantTest()
+    {
+        if(ENABLED)
+        {
+            FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(Biome.class, this::onRegisterBiome);
+            FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
+        }
+    }
+
+    private void onRegisterBiome(RegistryEvent.Register<Biome> event)
+    {
+        //Core biome
+        BiomeGenerationSettings.Builder main_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(ConfiguredSurfaceBuilders.END);
+        DefaultBiomeFeatures.addDefaultCarvers(main_generation);
+        DefaultBiomeFeatures.addDefaultLakes(main_generation);
+
+        Biome main = (new Biome.Builder()).precipitation(Biome.RainType.RAIN).biomeCategory(Biome.Category.PLAINS).depth(0.1F).scale(0.1F).temperature(0.4F).downfall(0.4F).specialEffects((new BiomeAmbience.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(MoodSoundAmbience.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnInfo.Builder().build()).generationSettings(main_generation.build()).build();
+        event.getRegistry().register(main.setRegistryName(MODID, "main"));
+
+        //Hills variant
+        BiomeGenerationSettings.Builder hills_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(ConfiguredSurfaceBuilders.END);
+        DefaultBiomeFeatures.addDefaultCarvers(hills_generation);
+        DefaultBiomeFeatures.addDefaultLakes(hills_generation);
+
+        Biome hills = (new Biome.Builder()).precipitation(Biome.RainType.RAIN).biomeCategory(Biome.Category.PLAINS).depth(0.4F).scale(0.3F).temperature(0.8F).downfall(0.4F).specialEffects((new BiomeAmbience.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(MoodSoundAmbience.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnInfo.Builder().build()).generationSettings(hills_generation.build()).build();
+        event.getRegistry().register(hills.setRegistryName(MODID, "hills"));
+
+        //Edge variant
+        BiomeGenerationSettings.Builder edge_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(ConfiguredSurfaceBuilders.END);
+        DefaultBiomeFeatures.addDefaultCarvers(edge_generation);
+        DefaultBiomeFeatures.addDefaultLakes(edge_generation);
+
+        Biome edge = (new Biome.Builder()).precipitation(Biome.RainType.RAIN).biomeCategory(Biome.Category.PLAINS).depth(0F).scale(0F).temperature(0.8F).downfall(0F).specialEffects((new BiomeAmbience.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(MoodSoundAmbience.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnInfo.Builder().build()).generationSettings(edge_generation.build()).build();
+        event.getRegistry().register(edge.setRegistryName(MODID, "edge"));
+
+        //River variant
+        BiomeGenerationSettings.Builder river_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(ConfiguredSurfaceBuilders.END);
+        DefaultBiomeFeatures.addDefaultCarvers(river_generation);
+        DefaultBiomeFeatures.addDefaultLakes(river_generation);
+        DefaultBiomeFeatures.addDefaultSprings(river_generation);
+
+        Biome river = (new Biome.Builder()).precipitation(Biome.RainType.RAIN).biomeCategory(Biome.Category.PLAINS).depth(-0.5F).scale(0F).temperature(0.8F).downfall(0F).specialEffects((new BiomeAmbience.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(MoodSoundAmbience.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnInfo.Builder().build()).generationSettings(river_generation.build()).build();
+        event.getRegistry().register(river.setRegistryName(MODID, "river"));
+
+
+        //Shore variant
+        BiomeGenerationSettings.Builder shore_generation = (new BiomeGenerationSettings.Builder()).surfaceBuilder(ConfiguredSurfaceBuilders.SOUL_SAND_VALLEY);
+        DefaultBiomeFeatures.addDefaultCarvers(shore_generation);
+        DefaultBiomeFeatures.addDefaultLakes(shore_generation);
+
+        Biome shore = (new Biome.Builder()).precipitation(Biome.RainType.RAIN).biomeCategory(Biome.Category.PLAINS).depth(0f).scale(0F).temperature(0.5F).downfall(0F).specialEffects((new BiomeAmbience.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(12638463).skyColor(0).ambientMoodSound(MoodSoundAmbience.LEGACY_CAVE_SETTINGS).build()).mobSpawnSettings(new MobSpawnInfo.Builder().build()).generationSettings(shore_generation.build()).build();
+        event.getRegistry().register(shore.setRegistryName(MODID, "shore"));
+
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event)
+    {
+        event.enqueueWork(this::addBiomesToGenerator);
+    }
+
+    private void addBiomesToGenerator()
+    {
+        //Add only the main biome entry
+        BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeManager.BiomeEntry(MAIN_KEY, 10));
+        //Tell the BiomeManager all biomes that might spawn
+        BiomeManager.addAdditionalOverworldBiomes(MAIN_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(HILLS_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(EDGE_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(RIVER_KEY);
+        BiomeManager.addAdditionalOverworldBiomes(SHORE_KEY);
+
+        //Register our biome layer modifier
+        BiomeManager.addBiomeLayerModifier(new BiomeManager.IBiomeLayerModifier() {
+
+            @Override
+            public Optional<RegistryKey<Biome>> getHillsBiome(RegistryKey<Biome> biome)
+            {
+                return biome.equals(MAIN_KEY) ? Optional.of(HILLS_KEY) : Optional.empty();
+            }
+
+            @Override
+            public Optional<RegistryKey<Biome>> getEdgeBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+            {
+                if(biome.equals(MAIN_KEY))
+                {
+                    if(!north.equals(MAIN_KEY) || !west.equals(MAIN_KEY) || !south.equals(MAIN_KEY) || !east.equals(MAIN_KEY))
+                    {
+                        //If any of the adjacent biomes is not the core biome, we are at the biome edge
+                        return Optional.of(EDGE_KEY);
+                    }
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<RegistryKey<Biome>> getRiverBiome(RegistryKey<Biome> biome)
+            {
+                return biome.equals(MAIN_KEY) ? Optional.of(RIVER_KEY) : Optional.empty();
+            }
+
+            @Override
+            public Optional<RegistryKey<Biome>> getShoreBiome(RegistryKey<Biome> biome, RegistryKey<Biome> north, RegistryKey<Biome> west, RegistryKey<Biome> south, RegistryKey<Biome> east)
+            {
+                if(biome == MAIN_KEY && (BiomeDictionary.hasType(north, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(west, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(south, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(east, BiomeDictionary.Type.OCEAN)))
+                {
+                    //If any adjacent biome is of ocean type, we want a shore
+                    return Optional.of(SHORE_KEY);
+                }
+                return Optional.empty();
+            }
+        });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeVariantTest.java
@@ -34,9 +34,10 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import java.util.Optional;
 
 /**
- * Manually enable to test.
+ * To test:
  *
- * When generated the "biome_variant_test:main" biome should generate in the overworld.
+ * Set ENABLED to true
+ * When enabled the "biome_variant_test:main" biome should generate in the overworld.
  * Within the "biome area" there should be hills ("biome_variant_test:hills") and potentially rivers ("biome_variant_test:river") flowing to/from other biomes.
  * At the edge of the "biome area" there should be an edge biome ("biome_variant_test:edge").
  * If the "biome area" is next to an ocean there should be a shore ("biome_variant_test:shore").

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -148,5 +148,7 @@ license="LGPL v2.1"
     modId="full_pots_accessor_demo"
 [[mods]]
     modId="forge_spawnegg_test"
+[[mods]]
+    modId="biome_variant_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
1.16 version of #8137 
In 1.18 the biome layer system is removed/overhauled, so this PR is only interesting for 1.16 LTS

This PR reintroduces a way to register/provide certain biome variants for your own biomes (or for vanilla or other modded biomes).
This e.g. allows having a hills variant of your biome seamlessly integrate into the world.

## Biome layer and variants in vanilla
MC first generates a "biome layer" based on the biomes with a biome entry/weight which specifies the biome for each chunk. Then it applies several "layers" that can modify the biome layer. For example the `HillsLayer` can replace some biome chunks within a larger biome with a hills variant of that biome (`desert` -> `desert_hills`).
These modifications work on hardcoded biome ids in the respective layer class.

## Previous work
In 1.15 three of these layers were patched to allow mods to introduce their own biome variants
Hills: https://github.com/MinecraftForge/MinecraftForge/pull/6571
River: https://github.com/MinecraftForge/MinecraftForge/pull/5969
Shore: https://github.com/MinecraftForge/MinecraftForge/pull/7001

They all rely on new methods in the `Biome` class which can be overridden to return the respective variant for the modded biome.
Since with 1.16.2 modded biomes do not use a subclass of `Biome`, a new method is needed.

## How this works
The patches to the biome modification layers remain functionally unchanged as nothing has changed here. Only analog patch to `EdgeBiomeLayer` is added.
Instead of querying the respective Biome, Forge's `BiomeManager` class is now used to get the biome variants.
If a modder wants to provide biome variants to their own (or other biomes), they can register a `IBiomeLayerModifier` and override the respective method to provide the desired variant.
The integer biome ids that are used in the layer classes are translated to the `RegistryKey` id of the biome.

## Test
This PR brings a (disabled-by-default) test mod, that introduces a new biome (added with a `BiomeEntry` to be generated) and hills, edge, shore and river variant.
Must be manually activated.

## Discussion
Things to think about:
- Use `null` instead of `Optional` in `IBiomeLayerModifier` return
- Instead of registering a single `IBiomeLayerModifier` that is queried for any biome, register biome specific `IBiomeLayerModifier`


