### PR TITLE
[1.17.x] Added missing copper ingot item tag.

### DIFF
--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -246,6 +246,7 @@ public class Tags
         public static final IOptionalNamedTag<Item> HEADS = tag("heads");
         public static final IOptionalNamedTag<Item> INGOTS = tag("ingots");
         public static final IOptionalNamedTag<Item> INGOTS_BRICK = tag("ingots/brick");
+        public static final IOptionalNamedTag<Item> INGOTS_COPPER = tag("ingots/copper");
         public static final IOptionalNamedTag<Item> INGOTS_GOLD = tag("ingots/gold");
         public static final IOptionalNamedTag<Item> INGOTS_IRON = tag("ingots/iron");
         public static final IOptionalNamedTag<Item> INGOTS_NETHERITE = tag("ingots/netherite");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -88,8 +88,9 @@ public final class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.GRAVEL, Tags.Items.GRAVEL);
         tag(Tags.Items.GUNPOWDER).add(Items.GUNPOWDER);
         tag(Tags.Items.HEADS).add(Items.CREEPER_HEAD, Items.DRAGON_HEAD, Items.PLAYER_HEAD, Items.SKELETON_SKULL, Items.WITHER_SKELETON_SKULL, Items.ZOMBIE_HEAD);
-        tag(Tags.Items.INGOTS).addTags(Tags.Items.INGOTS_IRON, Tags.Items.INGOTS_GOLD, Tags.Items.INGOTS_BRICK, Tags.Items.INGOTS_NETHER_BRICK, Tags.Items.INGOTS_NETHERITE);
+        tag(Tags.Items.INGOTS).addTags(Tags.Items.INGOTS_BRICK, Tags.Items.INGOTS_COPPER, Tags.Items.INGOTS_GOLD, Tags.Items.INGOTS_IRON, Tags.Items.INGOTS_NETHERITE, Tags.Items.INGOTS_NETHER_BRICK);
         tag(Tags.Items.INGOTS_BRICK).add(Items.BRICK);
+        tag(Tags.Items.INGOTS_COPPER).add(Items.COPPER_INGOT);
         tag(Tags.Items.INGOTS_GOLD).add(Items.GOLD_INGOT);
         tag(Tags.Items.INGOTS_IRON).add(Items.IRON_INGOT);
         tag(Tags.Items.INGOTS_NETHERITE).add(Items.NETHERITE_INGOT);

--- a/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
@@ -74,6 +74,7 @@ public final class ForgeRecipeProvider extends RecipeProvider
     protected void buildCraftingRecipes(Consumer<FinishedRecipe> consumer)
     {
         replace(Items.STICK,        Tags.Items.RODS_WOODEN);
+        replace(Items.COPPER_INGOT, Tags.Items.INGOTS_COPPER);
         replace(Items.GOLD_INGOT,   Tags.Items.INGOTS_GOLD);
         replace(Items.IRON_INGOT,   Tags.Items.INGOTS_IRON);
         replace(Items.NETHERITE_INGOT, Tags.Items.INGOTS_NETHERITE);


### PR DESCRIPTION
The copper ingot is currently missing in the item tags.
This PR adds the copper ingot to the item tags.

Run a test instance and confirmed that the copper ingot recipes works as expected:
![Screenshot 2021-11-28 160256](https://user-images.githubusercontent.com/12183293/143773657-df04638a-1c97-47ba-ba7c-24037ea74d22.jpg)

