### PR TITLE
Added RenderItemEvent and SetupLivingBipedAnimEvent 1.18

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/client/model/HumanoidModel.java
++++ b/net/minecraft/client/model/HumanoidModel.java
+@@ -79,6 +_,7 @@
+    }
+ 
+    public void m_6973_(T p_102866_, float p_102867_, float p_102868_, float p_102869_, float p_102870_, float p_102871_) {
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.SetupLivingBipedAnimEvent.Pre(p_102866_, this, p_102867_, p_102868_, p_102869_, p_102870_, p_102871_))) return;
+       boolean flag = p_102866_.m_21256_() > 4;
+       boolean flag1 = p_102866_.m_6067_();
+       this.f_102808_.f_104204_ = p_102870_ * ((float)Math.PI / 180F);
+@@ -224,6 +_,7 @@
+       }
+ 
+       this.f_102809_.m_104315_(this.f_102808_);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.SetupLivingBipedAnimEvent.Post(p_102866_, this, p_102867_, p_102868_, p_102869_, p_102870_, p_102871_));
+    }
+ 
+    private void m_102875_(T p_102876_) {

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/ItemInHandLayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/ItemInHandLayer.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/renderer/entity/layers/ItemInHandLayer.java
++++ b/net/minecraft/client/renderer/entity/layers/ItemInHandLayer.java
+@@ -39,7 +_,7 @@
+    }
+ 
+    protected void m_117184_(LivingEntity p_117185_, ItemStack p_117186_, ItemTransforms.TransformType p_117187_, HumanoidArm p_117188_, PoseStack p_117189_, MultiBufferSource p_117190_, int p_117191_) {
+-      if (!p_117186_.m_41619_()) {
++      if (!p_117186_.m_41619_() && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Pre(p_117185_, p_117186_, p_117187_, p_117188_, p_117189_, p_117190_, p_117191_))) {
+          p_117189_.m_85836_();
+          this.m_117386_().m_6002_(p_117188_, p_117189_);
+          p_117189_.m_85845_(Vector3f.f_122223_.m_122240_(-90.0F));
+@@ -48,6 +_,8 @@
+          p_117189_.m_85837_((double)((float)(flag ? -1 : 1) / 16.0F), 0.125D, -0.625D);
+          Minecraft.m_91087_().m_91292_().m_109322_(p_117185_, p_117186_, p_117187_, flag, p_117189_, p_117190_, p_117191_);
+          p_117189_.m_85849_();
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderItemEvent.Post(p_117185_, p_117186_, p_117187_, p_117188_, p_117189_, p_117190_, p_117191_));
++
+       }
+    }
+ }

--- a/src/main/java/net/minecraftforge/client/event/RenderItemEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * RenderItemEvent is fired if rendering a Item.
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If the event is canceled, the item render not anymore.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+
+public class RenderItemEvent extends Event
+{
+    private LivingEntity livingEntity;
+    private ItemStack itemStack;
+    private final ItemTransforms.TransformType transformType;
+    private HumanoidArm handSide;
+    private final PoseStack matrixStack;
+    private final MultiBufferSource renderTypeBuffer;
+    private final int light;
+
+    public RenderItemEvent(LivingEntity livingEntity, ItemStack itemStack, ItemTransforms.TransformType transformType, HumanoidArm handSide, PoseStack matrixStack, MultiBufferSource renderTypeBuffer, int light)
+    {
+        this.livingEntity = livingEntity;
+        this.itemStack = itemStack;
+        this.transformType = transformType;
+        this.handSide = handSide;
+        this.matrixStack = matrixStack;
+        this.renderTypeBuffer = renderTypeBuffer;
+        this.light = light;
+    }
+
+    public LivingEntity getLivingEntity()
+    {
+        return this.livingEntity;
+    }
+
+    public ItemStack getItemStack()
+    {
+        return this.itemStack;
+    }
+
+    public ItemTransforms.TransformType getTransformType()
+    {
+        return this.transformType;
+    }
+
+    public HumanoidArm getHandSide()
+    {
+        return this.handSide;
+    }
+
+    public PoseStack getMatrixStack()
+    {
+        return this.matrixStack;
+    }
+
+    public MultiBufferSource getRenderTypeBuffer()
+    {
+        return this.renderTypeBuffer;
+    }
+
+    public int getLight()
+    {
+        return this.light;
+    }
+
+    @Cancelable
+    public static class Pre extends RenderItemEvent
+    {
+        public Pre(LivingEntity livingEntity, ItemStack itemStack, ItemTransforms.TransformType transformType, HumanoidArm handSide, PoseStack matrixStack, MultiBufferSource renderTypeBuffer, int light)
+        {
+            super(livingEntity, itemStack, transformType, handSide, matrixStack, renderTypeBuffer, light);
+        }
+    }
+
+    public static class Post extends RenderItemEvent
+    {
+        public Post(LivingEntity livingEntity, ItemStack itemStack, ItemTransforms.TransformType transformType, HumanoidArm handSide, PoseStack matrixStack, MultiBufferSource renderTypeBuffer, int light)
+        {
+            super(livingEntity, itemStack, transformType, handSide, matrixStack, renderTypeBuffer, light);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/SetupLivingBipedAnimEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/SetupLivingBipedAnimEvent.java
@@ -1,0 +1,110 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * SetupLivingBipedAnimEvent is fired if rendering a PlayerModel.
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If the event is canceled, does all Vanilla animations stop.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+
+public class SetupLivingBipedAnimEvent extends Event
+{
+    private LivingEntity livingEntity;
+    private HumanoidModel model;
+    private float limbSwing;
+    private float limbSwingAmount;
+    private float ageInTicks;
+    private float netHeadYaw;
+    private float headPitch;
+
+    public SetupLivingBipedAnimEvent(LivingEntity livingEntity, HumanoidModel model, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch)
+    {
+        this.livingEntity = livingEntity;
+        this.model = model;
+        this.limbSwing = limbSwing;
+        this.limbSwingAmount = limbSwingAmount;
+        this.ageInTicks = ageInTicks;
+        this.netHeadYaw = netHeadYaw;
+        this.headPitch = headPitch;
+    }
+
+    public LivingEntity getLivingEntity()
+    {
+        return livingEntity;
+    }
+
+    public HumanoidModel getModel()
+    {
+        return model;
+    }
+
+    public float getLimbSwing()
+    {
+        return limbSwing;
+    }
+
+    public float getLimbSwingAmount()
+    {
+        return limbSwingAmount;
+    }
+
+    public float getAgeInTicks()
+    {
+        return ageInTicks;
+    }
+
+    public float getNetHeadYaw()
+    {
+        return netHeadYaw;
+    }
+
+    public float getHeadPitch() {
+        return headPitch;
+    }
+
+    @Cancelable
+    public static class Pre extends SetupLivingBipedAnimEvent
+    {
+        public Pre(LivingEntity livingEntity, HumanoidModel model, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch)
+        {
+            super(livingEntity, model, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+
+    public static class Post extends SetupLivingBipedAnimEvent
+    {
+        public Post(LivingEntity livingEntity, HumanoidModel model, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch)
+        {
+            super(livingEntity, model, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+}


### PR DESCRIPTION
Added RenderItemEvent and SetupLivingBipedAnimEvent 1.18

Its the 1.18 version of this PR: https://github.com/MinecraftForge/MinecraftForge/pull/8217

all full done and need just a merge :)

Disable Item Renderer (or change it to a new one):
![2021-11-30_19 54 24](https://user-images.githubusercontent.com/65916181/144111825-dde33eab-1353-4496-9ef0-1ad543ff6a3e.png)

Player Animations:
![2021-11-30_20 03 08](https://user-images.githubusercontent.com/65916181/144111861-2f9b264e-9ce9-4169-b0a0-a9b33aebf98a.png)

