### PR TITLE
[1.18] Adds hook for entity EXP value, fixes mutable experience getter in Zombie, readds missing LivingExperienceDropEvent 

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -600,9 +600,9 @@
 +    * @return The amount of experience
 +    */
 +   public int getTotalExperienceValue(Player player){
-+      if(!this.m_6149_())
++      if(!m_6149_())
 +         return 0;
-+      int i = this.m_6552_(player);
++      int i = m_6552_(player);
 +      return net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, player, i);
     }
  }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -611,7 +611,7 @@
 +   }
 +
 +   @Override
-+   public int getTotalExperienceValue(Player player){
++   public int getTotalExperienceValue(Player player) {
 +      if(!m_6149_() && !m_6124_())
 +         return 0;
 +      int i = m_6552_(player);

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.world.scores.PlayerTeam;
  
 -public abstract class LivingEntity extends Entity {
-+public abstract class LivingEntity extends Entity implements net.minecraftforge.common.extensions.IForgeLivingEntity{
++public abstract class LivingEntity extends Entity implements net.minecraftforge.common.extensions.IForgeLivingEntity {
     private static final UUID f_20929_ = UUID.fromString("662A6B8D-DA3E-4C1C-8813-96EA6097278D");
     private static final UUID f_20959_ = UUID.fromString("87f46a96-686f-4796-b035-22e16ee9e038");
     private static final UUID f_147184_ = UUID.fromString("1eaf83ff-7207-4596-b37a-d7a07b3ec4ce");

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -588,3 +588,21 @@
           }
        } else {
           return EquipmentSlot.HEAD;
+@@ -3287,5 +_,17 @@
+    }
+ 
+    public static record Fallsounds(SoundEvent f_196626_, SoundEvent f_196627_) {
++   }
++
++   /**
++    * Exposes the experience value of the entity after the getExperienceDrop event.
++    * @param player The attacking player involved in obtaining this experience, typically lastHurtByPlayer.
++    * @return The amount of experience
++    */
++   public int getTotalExperienceValue(Player player){
++      if(!this.m_6149_())
++         return 0;
++      int i = this.m_6552_(player);
++      return net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, player, i);
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -118,7 +_,9 @@
+@@ -114,11 +_,13 @@
+ import net.minecraft.world.phys.Vec3;
+ import net.minecraft.world.scores.PlayerTeam;
+ 
+-public abstract class LivingEntity extends Entity {
++public abstract class LivingEntity extends Entity implements net.minecraftforge.common.extensions.IForgeLivingEntity{
     private static final UUID f_20929_ = UUID.fromString("662A6B8D-DA3E-4C1C-8813-96EA6097278D");
     private static final UUID f_20959_ = UUID.fromString("87f46a96-686f-4796-b035-22e16ee9e038");
     private static final UUID f_147184_ = UUID.fromString("1eaf83ff-7207-4596-b37a-d7a07b3ec4ce");
@@ -205,6 +210,17 @@
     }
  
     protected void m_5907_() {
+@@ -1306,7 +_,9 @@
+ 
+    protected void m_21226_() {
+       if (this.f_19853_ instanceof ServerLevel && (this.m_6124_() || this.f_20889_ > 0 && this.m_6149_() && this.f_19853_.m_46469_().m_46207_(GameRules.f_46135_))) {
+-         ExperienceOrb.m_147082_((ServerLevel)this.f_19853_, this.m_20182_(), this.m_6552_(this.f_20888_));
++         int i = this.m_6552_(this.f_20888_);
++         i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.f_20888_, i);
++         ExperienceOrb.m_147082_((ServerLevel)this.f_19853_, this.m_20182_(), i);
+       }
+ 
+    }
 @@ -1322,7 +_,8 @@
        ResourceLocation resourcelocation = this.m_5743_();
        LootTable loottable = this.f_19853_.m_142572_().m_129898_().m_79217_(resourcelocation);
@@ -588,19 +604,15 @@
           }
        } else {
           return EquipmentSlot.HEAD;
-@@ -3287,5 +_,17 @@
+@@ -3287,5 +_,13 @@
     }
  
     public static record Fallsounds(SoundEvent f_196626_, SoundEvent f_196627_) {
 +   }
 +
-+   /**
-+    * Exposes the experience value of the entity after the getExperienceDrop event.
-+    * @param player The attacking player involved in obtaining this experience, typically lastHurtByPlayer.
-+    * @return The amount of experience
-+    */
++   @Override
 +   public int getTotalExperienceValue(Player player){
-+      if(!m_6149_())
++      if(!m_6149_() && !m_6124_())
 +         return 0;
 +      int i = m_6552_(player);
 +      return net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, player, i);

--- a/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -1,18 +1,17 @@
 --- a/net/minecraft/world/entity/monster/Zombie.java
 +++ b/net/minecraft/world/entity/monster/Zombie.java
-@@ -156,11 +_,7 @@
-    }
+@@ -157,7 +_,11 @@
  
     protected int m_6552_(Player p_34322_) {
--      if (this.m_6162_()) {
--         this.f_21364_ = (int)((float)this.f_21364_ * 2.5F);
--      }
--
--      return super.m_6552_(p_34322_);
-+      return this.m_6162_() ? (int) (super.m_6552_(p_34322_) * 2.5F) : super.m_6552_(p_34322_);
-    }
+       if (this.m_6162_()) {
++         int oldReward = this.f_21364_;
+          this.f_21364_ = (int)((float)this.f_21364_ * 2.5F);
++         int reward = super.m_6552_(p_34322_);
++         this.f_21364_ = oldReward;
++         return reward;
+       }
  
-    public void m_6863_(boolean p_34309_) {
+       return super.m_6552_(p_34322_);
 @@ -191,7 +_,7 @@
        if (!this.f_19853_.f_46443_ && this.m_6084_() && !this.m_21525_()) {
           if (this.m_34329_()) {

--- a/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -1,5 +1,18 @@
 --- a/net/minecraft/world/entity/monster/Zombie.java
 +++ b/net/minecraft/world/entity/monster/Zombie.java
+@@ -156,11 +_,7 @@
+    }
+ 
+    protected int m_6552_(Player p_34322_) {
+-      if (this.m_6162_()) {
+-         this.f_21364_ = (int)((float)this.f_21364_ * 2.5F);
+-      }
+-
+-      return super.m_6552_(p_34322_);
++      return this.m_6162_() ? (int) (super.m_6552_(p_34322_) * 2.5F) : super.m_6552_(p_34322_);
+    }
+ 
+    public void m_6863_(boolean p_34309_) {
 @@ -191,7 +_,7 @@
        if (!this.f_19853_.f_46443_ && this.m_6084_() && !this.m_21525_()) {
           if (this.m_34329_()) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.common.extensions;
 
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+
+public interface IForgeLivingEntity
+{
+
+    private LivingEntity self() { return (LivingEntity) this; }
+
+    /**
+     * Returns the experience value of the entity after the LivingExperienceDropEvent is fired.
+     * Returns 0 if the entity should not drop experience.
+     *
+     * @param player The attacking player involved in obtaining this experience, typically lastHurtByPlayer.
+     * @return The amount of experience
+     */
+    int getTotalExperienceValue(Player player);
+}


### PR DESCRIPTION
This is a port of the previous 1.16 version of this PR: https://github.com/MinecraftForge/MinecraftForge/pull/7852

This PR exposes a way for modders to obtain the 'true' experience value of a mob. Currently, shouldDropExperience and getExperienceReward are protected methods. While these could be set to public, this method runs all of the expected logic modders would typically need to do themselves in order to conform to vanilla EXP rules, including a call to the getExperienceDrop forge event.

Additionally, a patch is made to Zombie#getExperienceReward as the existing method mutates and increases the xpReward each time the method is called.

**Adds getTotalExperienceValue to LivingEntity**
Exposes a way for modders to obtain the exp value of a mob.

**Patches Zombie#getExperienceReward**
Changes the method to safely return the exp value of the entity without increasing it each call.