### PR TITLE
Restore missing patch to LevelChunk

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -78,6 +78,15 @@
        } else {
           CompoundTag compoundtag = this.f_187609_.get(p_62932_);
           if (compoundtag != null) {
+@@ -433,7 +_,7 @@
+       p_187974_.accept((p_187968_, p_187969_, p_187970_) -> {
+          BlockEntity blockentity = this.m_5685_(p_187968_, LevelChunk.EntityCreationType.IMMEDIATE);
+          if (blockentity != null && p_187970_ != null && blockentity.m_58903_() == p_187969_) {
+-            blockentity.m_142466_(p_187970_);
++            blockentity.handleUpdateTag(p_187970_);
+          }
+ 
+       });
 @@ -453,7 +_,7 @@
  
     public Stream<BlockPos> m_6267_() {


### PR DESCRIPTION
In 1.17.x `ClientPacketListener` was patched to call `handleUpdateTag` instead of load. This logic was moved to `LevelChunk`, and the patch accidentally dropped in the migration.

I discussed this yesterday with Curle on Discord, but I'm not sure what the conclusion was so opening a PR for better visibility/tracking. I know there was some concern about the changed semantics of save/load - I don't think this is an issue here, as `handleUpdateTag` just calls `load` by default, so we're not changing vanilla behaviour at all.