### PR TITLE
Add BonusDamage event. Closes #6564

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -204,7 +204,7 @@
                 f1 = EnchantmentHelper.m_44833_(this.m_21205_(), MobType.f_21640_);
              }
  
-+            f1 = net.minecraftforge.common.ForgeHooks.getDamageBonus(this, this.m_21205_(), p_36347_, f1);
++            f1 = net.minecraftforge.common.ForgeHooks.getDamageBonus(this, p_36347_, f1);
              float f2 = this.m_36403_(0.5F);
              f *= 0.2F + f2 * f2 * 0.8F;
              f1 *= f2;

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -200,6 +200,14 @@
        if (p_36347_.m_6097_()) {
           if (!p_36347_.m_7313_(this)) {
              float f = (float)this.m_21133_(Attributes.f_22281_);
+@@ -1038,6 +_,7 @@
+                f1 = EnchantmentHelper.m_44833_(this.m_21205_(), MobType.f_21640_);
+             }
+ 
++            f1 = net.minecraftforge.common.ForgeHooks.getDamageBonus(this, this.m_21205_(), p_36347_, f1);
+             float f2 = this.m_36403_(0.5F);
+             f *= 0.2F + f2 * f2 * 0.8F;
+             f1 *= f2;
 @@ -1045,7 +_,7 @@
              if (f > 0.0F || f1 > 0.0F) {
                 boolean flag = f2 > 0.9F;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1242,9 +1242,9 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new EntityEvent.EnteringSection(entity, packedOldPos, packedNewPos));
     }
 
-    public static float getDamageBonus(Player player, ItemStack weapon, Entity target, float enchantmentBonus)
+    public static float getDamageBonus(Player player, Entity target, float enchantmentBonus)
     {
-        DamageBonusEvent event = new DamageBonusEvent(player, weapon, target, enchantmentBonus);
+        DamageBonusEvent event = new DamageBonusEvent(player, target, enchantmentBonus);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getBonus();
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -144,6 +144,7 @@ import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import net.minecraftforge.event.entity.player.DamageBonusEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
@@ -1239,6 +1240,13 @@ public class ForgeHooks
     public static void onEntityEnterSection(Entity entity, long packedOldPos, long packedNewPos)
     {
         MinecraftForge.EVENT_BUS.post(new EntityEvent.EnteringSection(entity, packedOldPos, packedNewPos));
+    }
+
+    public static float getDamageBonus(Player player, ItemStack weapon, Entity target, float enchantmentBonus)
+    {
+        DamageBonusEvent event = new DamageBonusEvent(player, weapon, target, enchantmentBonus);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getBonus();
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/DamageBonusEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/DamageBonusEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * This event is fired whenever a player attacks an Entity in
+ * Player#attack(Entity).<p>
+ *
+ * This event is not {@link Cancelable}.<p>
+ *
+ * This allows adding to the base damage like DamageEnchantments do,
+ * but also considering the attacked Entity object including capabilities,
+ * not just the Entity's MobType<p>
+ *
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+public class DamageBonusEvent extends PlayerEvent
+{
+    private final ItemStack weapon;
+    private final Entity target;
+    private float bonus;
+
+    public DamageBonusEvent(Player player, ItemStack weapon, Entity target, float enchantmentBonus)
+    {
+        super(player);
+        this.weapon = weapon;
+        this.target = target;
+        this.bonus = enchantmentBonus;
+    }
+
+    /**
+     * @return The attacked entity
+     */
+    public Entity getTarget()
+    {
+        return target;
+    }
+
+    /**
+     * @return The item used for the attack
+     */
+    public ItemStack getWeapon()
+    {
+        return weapon;
+    }
+
+    /**
+     * @param additionalDamage Added to the existing bonus damage
+     */
+    public void addBonus(float additionalDamage)
+    {
+        this.bonus += additionalDamage;
+    }
+
+    /**
+     * Set the absolute bonus damage, overwriting any damage added by enchantments or other event handlers.
+     */
+    public void setBonus(float damage)
+    {
+        this.bonus = damage;
+    }
+
+    /**
+     * @return The total bonus damage (enchantments + damage already added to this event)
+     */
+    public float getBonus()
+    {
+        return this.bonus;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/DamageBonusEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/DamageBonusEvent.java
@@ -37,14 +37,12 @@ import net.minecraft.world.item.ItemStack;
  **/
 public class DamageBonusEvent extends PlayerEvent
 {
-    private final ItemStack weapon;
     private final Entity target;
     private float bonus;
 
-    public DamageBonusEvent(Player player, ItemStack weapon, Entity target, float enchantmentBonus)
+    public DamageBonusEvent(Player player, Entity target, float enchantmentBonus)
     {
         super(player);
-        this.weapon = weapon;
         this.target = target;
         this.bonus = enchantmentBonus;
     }
@@ -55,14 +53,6 @@ public class DamageBonusEvent extends PlayerEvent
     public Entity getTarget()
     {
         return target;
-    }
-
-    /**
-     * @return The item used for the attack
-     */
-    public ItemStack getWeapon()
-    {
-        return weapon;
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerBonusDamageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerBonusDamageEventTest.java
@@ -1,0 +1,59 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.world.entity.animal.Pig;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraftforge.event.entity.player.DamageBonusEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * When enabled, any weapon enchanted with smite should instantly kill a saddled pig, unless the player attack is on cooldown.
+ * Verify:
+ * 1. Get iron sword with smite
+ * 2. Spawn 3 pigs, saddle two of them
+ * 3. Attack the pig without a saddle: It should take several hits
+ * 4. Attack a saddled pig: It should die with a single hit
+ * 5. Swing your sword in the air, then immediately hit the last pig (so your attack cooldown is active): The pig should not die immediately
+ */
+@Mod("player_bonus_damage_event_test")
+@Mod.EventBusSubscriber()
+public class PlayerBonusDamageEventTest
+{
+    private static final boolean ENABLE = false;
+
+    @SubscribeEvent
+    public static void onDamageBonusEvent(DamageBonusEvent event)
+    {
+        if (!ENABLE) return;
+        if(EnchantmentHelper.getEnchantments(event.getWeapon()).containsKey(Enchantments.SMITE))
+        {
+            if(event.getTarget() instanceof Pig pig)
+            {
+                if(pig.isSaddled())
+                {
+                    event.addBonus(10);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerBonusDamageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerBonusDamageEventTest.java
@@ -45,7 +45,7 @@ public class PlayerBonusDamageEventTest
     public static void onDamageBonusEvent(DamageBonusEvent event)
     {
         if (!ENABLE) return;
-        if(EnchantmentHelper.getEnchantments(event.getWeapon()).containsKey(Enchantments.SMITE))
+        if(EnchantmentHelper.getEnchantments(event.getPlayer().getMainHandItem()).containsKey(Enchantments.SMITE))
         {
             if(event.getTarget() instanceof Pig pig)
             {

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -172,5 +172,7 @@ license="LGPL v2.1"
     modId="part_entity_test"
 [[mods]]
     modId="capabilities_test"
+[[mods]]
+    modId="player_bonus_damage_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
1.18 version of #8205

Enchantments can only modify the dealt damage based on the entity's CreatureAttribute, not on the entity object itself. Therefore it's not possible to e.g. change the damage based a capability of an attacked player/entity.

## Details
When a player attacks an entity, the dealt damage is calculated in `Player#attack` as follows:
`Total = (0.8*Att * Scale^2 + 0.2 * Att) * Critical + Ench * Scale`
Where
`Att` AttackDamage attribute
`Scale` multiplier from the attack cooldown
`Critical` multiplier based on critical hit
`Ench` Additional damage caused by enchantment

During `LivingAttackEvent` only `Total` is available. The attack cooldown has been reset already, so there is no way to accurately calculate the damage caused by a potential enchantment during that event. Only workaround I can see is to cache the attack cooldown during `AttackEntityEvent` event. But that will get messy, because two different entities (attacker and victim) are involved and the event (or the firing method) is called from many different places.



## Solution
As suggested by @ChampionAsh5357, this PR introduces a new event. This allows modifying the base damage before the scale is applied.
`Total = (0.8*Att * Scale^2 + 0.2 * Att) * Critical + (Ench + Bonus) * Scale`


For Mobs attacking with enchanted weapons `LivingAttackEvent` is sufficient, because they do not have the attack cooldown functionality.