### PR TITLE
Add bulk (stack size ignoring and slot ignoring) functions to IItemHandler

### DIFF
--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -28,6 +28,7 @@ package net.minecraftforge.energy;
  * Created with consent and permission of King Lemming and Team CoFH. Released with permission under LGPL 2.1 when bundled with Forge.
  *
  */
+// TODO: replace all the boolean parameters by FluidAction (renamed to also fit items and energy)
 public interface IEnergyStorage
 {
     /**

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -110,8 +110,7 @@ public interface IItemHandler
 
     /**
      * Extracts an ItemStack from the given slot.
-     * If there is more than the max stack size in the current slot and more than the max stack size is requested,
-     * then more than the max stack size may be returned.
+     * The returned stack's count may not exceed the max stack size of the item stack.
      * <p>
      * The returned value must be empty if nothing is extracted,
      * otherwise its stack size must be less than or equal to {@code amount} and {@link ItemStack#getMaxStackSize()}.
@@ -127,13 +126,18 @@ public interface IItemHandler
     ItemStack extractItem(int slot, int amount, boolean simulate);
 
     /**
-     * Extracts an ItemStack from the given slot, but limiting the amount extracted to {@link ItemStack#getMaxStackSize()}.
+     * Extracts an ItemStack from the given slot, completely ignoring the max stack size.
+     * If there is more than the max stack size in the current slot and more than the max stack size is requested,
+     * then more than the max stack size may be returned.
+     * <p>
+     * By default, this calls the usual extractItem that limits the amount to the max stack size.
+     * Handlers that can store more items in each slot should override both methods.
+     * </p>
      * @see #extractItem
      */
     @Nonnull
-    default ItemStack limitedExtractItem(int slot, int amount, boolean simulate) {
-        int limitedAmount = Math.min(amount, getStackInSlot(slot).getMaxStackSize());
-        return extractItem(slot, limitedAmount, simulate);
+    default ItemStack extractItemIgnoreStackSize(int slot, int amount, boolean simulate) {
+        return extractItem(slot, amount, simulate);
     }
 
     /**
@@ -159,7 +163,7 @@ public interface IItemHandler
         {
             if (ItemHandlerHelper.canItemStacksStack(getStackInSlot(i), template))
             {
-                extracted += extractItem(i, amount - extracted, simulate).getCount();
+                extracted += extractItemIgnoreStackSize(i, amount - extracted, simulate).getCount();
                 if (extracted >= amount) break;
             }
         }

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.items;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -26,7 +27,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
 
-
+// TODO: replace all the boolean parameters by FluidAction (renamed to also fit items and energy)
 public interface IItemHandler
 {
     /**
@@ -61,12 +62,13 @@ public interface IItemHandler
     /**
      * <p>
      * Inserts an ItemStack into the given slot and return the remainder.
-     * The ItemStack <em>should not</em> be modified in this function!
+     * The given stack's size may be greater than the itemstack's max size.
      * </p>
-     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, IFluidHandler.FluidAction)}
+     * Note: This function returns the REMAINDER - what was NOT inserted!
+     * This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, IFluidHandler.FluidAction)}, which returns what was inserted.
      *
      * @param slot     Slot to insert into.
-     * @param stack    ItemStack to insert. This must not be modified by the item handler.
+     * @param stack    ItemStack to insert. Its ownership is given to the item handler. It must never be used or modified by the caller afterwards!
      * @param simulate If true, the insertion is only simulated
      * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).
      *         May be the same as the input ItemStack if unchanged, otherwise a new ItemStack.
@@ -76,7 +78,38 @@ public interface IItemHandler
     ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate);
 
     /**
+     * Tries to insert as many of the given item as possible into this item handler, spreading it across slots as needed.
+     * This should be preferred over {@link #insertItem} if the caller doesn't care about the slot the item goes into,
+     * as it gives the handler the opportunity to optimize this operation.
+     *
+     * @param stack    The stack that should be inserted. {@link ItemStack#EMPTY} is not valid.
+     *                 Ownership of this stack is transferred to the item handler and may not be reused by the caller afterwards.
+     *                 This stack does not need to adhere to {@link ItemStack#getMaxStackSize()}.
+     * @param simulate If true, the insertion is only simulated
+     * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).
+     *         May be the same as the input ItemStack if unchanged, otherwise a new ItemStack.
+     *         The returned ItemStack can be safely modified after.
+     */
+    @Nonnull
+    default ItemStack bulkInsertItem(@Nonnull ItemStack stack, boolean simulate) {
+        Preconditions.checkArgument(!stack.isEmpty(), "stack may not be empty");
+
+        for (int i = 0; i < getSlots(); i++)
+        {
+            stack = insertItem(i, stack, simulate);
+            if (stack.isEmpty())
+            {
+                return ItemStack.EMPTY;
+            }
+        }
+
+        return stack;
+    }
+
+    /**
      * Extracts an ItemStack from the given slot.
+     * If there is more than the max stack size in the current slot and more than the max stack size is requested,
+     * then more than the max stack size may be returned.
      * <p>
      * The returned value must be empty if nothing is extracted,
      * otherwise its stack size must be less than or equal to {@code amount} and {@link ItemStack#getMaxStackSize()}.
@@ -90,6 +123,47 @@ public interface IItemHandler
      **/
     @Nonnull
     ItemStack extractItem(int slot, int amount, boolean simulate);
+
+    /**
+     * Extracts an ItemStack from the given slot, but limiting the amount extracted to {@link ItemStack#getMaxStackSize()}.
+     * @see #extractItem
+     */
+    @Nonnull
+    default ItemStack limitedExtractItem(int slot, int amount, boolean simulate) {
+        int limitedAmount = Math.min(amount, getStackInSlot(slot).getMaxStackSize());
+        return extractItem(slot, limitedAmount, simulate);
+    }
+
+    /**
+     * Tries to extract as many items that can be stacked with the given template item as requested from this
+     * item handler. Will extract regardless of slot and does not respect {@link ItemStack#getMaxStackSize()}.
+     *
+     * @param template The template item for the items that should be extracted.
+     *                 Only items matching this templates item, tags and caps will be extracted.
+     *                 {@link ItemStack#EMPTY} is not a valid template.
+     *                 The handler must not modify this template.
+     * @param amount   The maximum amount to extract. Must be 0 or greater.
+     * @param simulate If true, the extraction is only simulated
+     * @return The stack of items that could be extracted. This stack does not adhere to {@link ItemStack#getMaxStackSize()}
+     *         if the input amount doesn't.
+     */
+    @Nonnull
+    default ItemStack bulkExtractItem(ItemStack template, int amount, boolean simulate) {
+        Preconditions.checkArgument(!template.isEmpty(), "template may not be empty");
+        if (amount < 0) throw new IllegalArgumentException("amount may not be negative: " + amount);
+
+        int extracted = 0;
+        for (int i = 0; i < getSlots(); i++)
+        {
+            if (ItemHandlerHelper.canItemStacksStack(getStackInSlot(i), template))
+            {
+                extracted += extractItem(i, amount - extracted, simulate).getCount();
+                if (extracted >= amount) break;
+            }
+        }
+
+        return ItemHandlerHelper.copyStackWithSize(template, extracted);
+    }
 
     /**
      * Retrieves the maximum stack size allowed to exist in the given slot.

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -63,12 +63,13 @@ public interface IItemHandler
      * <p>
      * Inserts an ItemStack into the given slot and return the remainder.
      * The given stack's size may be greater than the itemstack's max size.
+     * The ItemStack <em>should not</em> be modified in this function!
      * </p>
      * Note: This function returns the REMAINDER - what was NOT inserted!
      * This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, IFluidHandler.FluidAction)}, which returns what was inserted.
      *
      * @param slot     Slot to insert into.
-     * @param stack    ItemStack to insert. Its ownership is given to the item handler. It must never be used or modified by the caller afterwards!
+     * @param stack    ItemStack to insert. This must not be modified by the item handler.
      * @param simulate If true, the insertion is only simulated
      * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).
      *         May be the same as the input ItemStack if unchanged, otherwise a new ItemStack.
@@ -81,9 +82,10 @@ public interface IItemHandler
      * Tries to insert as many of the given item as possible into this item handler, spreading it across slots as needed.
      * This should be preferred over {@link #insertItem} if the caller doesn't care about the slot the item goes into,
      * as it gives the handler the opportunity to optimize this operation.
+     * The ItemStack <em>should not</em> be modified in this function!
      *
      * @param stack    The stack that should be inserted. {@link ItemStack#EMPTY} is not valid.
-     *                 Ownership of this stack is transferred to the item handler and may not be reused by the caller afterwards.
+     *                 This must not be modified by the item handler.
      *                 This stack does not need to adhere to {@link ItemStack#getMaxStackSize()}.
      * @param simulate If true, the insertion is only simulated
      * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -33,22 +33,14 @@ import javax.annotation.Nullable;
 
 public class ItemHandlerHelper
 {
+    /**
+     * @deprecated Use {@link IItemHandler#bulkInsertItem} instead.
+     */
+    @Deprecated(since = "1.18")
     @Nonnull
-    public static ItemStack insertItem(IItemHandler dest, @Nonnull ItemStack stack, boolean simulate)
-    {
-        if (dest == null || stack.isEmpty())
-            return stack;
-
-        for (int i = 0; i < dest.getSlots(); i++)
-        {
-            stack = dest.insertItem(i, stack, simulate);
-            if (stack.isEmpty())
-            {
-                return ItemStack.EMPTY;
-            }
-        }
-
-        return stack;
+    public static ItemStack insertItem(IItemHandler dest, @Nonnull ItemStack stack, boolean simulate) {
+        if (dest == null || stack.isEmpty()) return stack;
+        return dest.bulkInsertItem(stack, simulate);
     }
 
     public static boolean canItemStacksStack(@Nonnull ItemStack a, @Nonnull ItemStack b)

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -107,7 +107,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         {
             if (existing.isEmpty())
             {
-                this.stacks.set(slot, reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, limit) : stack);
+                this.stacks.set(slot, reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, limit) : stack.copy());
             }
             else
             {

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -125,6 +125,16 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
     }
 
     @Override
+    @Nonnull
+    public ItemStack extractItemIgnoreStackSize(int slot, int amount, boolean simulate)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        slot = getSlotFromIndex(slot, index);
+        return handler.extractItemIgnoreStackSize(slot, amount, simulate);
+    }
+
+    @Override
     public int getSlotLimit(int slot)
     {
         int index = getIndexForSlot(slot);

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -86,6 +86,18 @@ public class RangedWrapper implements IItemHandlerModifiable {
     }
 
     @Override
+    @Nonnull
+    public ItemStack extractItemIgnoreStackSize(int slot, int amount, boolean simulate)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.extractItemIgnoreStackSize(slot + minSlot, amount, simulate);
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    @Override
     public void setStackInSlot(int slot, @Nonnull ItemStack stack)
     {
         if (checkSlot(slot))


### PR DESCRIPTION
Implements #8175.

This PR extends IItemHandler for two uses cases:
- handlers that can store more than max stack size per slot.
- handlers that can efficiently find a requested resource without iterating through all slots.

### More than max stack size
The javadoc of `insertItem` is clarified to mention that all of these should not limit themselves to max stack size.
The javadoc of `extractItem` is clarified to mention that it should limit itself to the max stack size.
`extractItemIgnoreStackSize` is added for handlers and callers that support amounts larger than the max stack size.

This is mostly a correctness/feature augmentation to allow mods that deal with large item quantities to work better (AE2, RS, drawers, deep storage units, etc).

### Slot ignoring
`bulkInsertItem` and `bulkExtractItem` are added to allow for faster insertion or extraction operations when the caller doesn't need explicit per-slot access (that should be the case most of the time).
They ignore the stack size limit because they are mostly meant for mods that can provide very large amounts of items, for example colossal chests, ender rift, or the aforementioned AE2, RS, etc.

Limitation: currently, there is no way to know if a handler supports these bulk functions, or if the default implementation is used. Should a `boolean supportsBulkTransfer()` function be added too, or is that too much?

This is a performance-oriented addition. But note that the default `bulkInsertItem` replaces the helper in `ItemStackHelper`, and can be quite convenient for modders.

### Other stuff
Fixed `ItemStackHandler` not always copying the passed stack. By the contract of `insertItem`, the passed stack should never be modified (or stored, obviously).