### PR TITLE
[1.18.x] Fix some test worldgen data breaking datapack imports in forgedev test

### DIFF
--- a/src/test/resources/data/biome_loading_event_test/worldgen/biome/desert.json
+++ b/src/test/resources/data/biome_loading_event_test/worldgen/biome/desert.json
@@ -24,12 +24,17 @@
   "features": [
     [],
     [
-      "minecraft:lake_lava"
+      "minecraft:lake_lava_underground",
+      "minecraft:lake_lava_surface"
     ],
-    [],
     [
-      "minecraft:fossil",
-      "minecraft:monster_room"
+      "minecraft:amethyst_geode"
+    ],
+    [
+      "minecraft:fossil_upper",
+      "minecraft:fossil_lower",
+      "minecraft:monster_room",
+      "minecraft:monster_room_deep"
     ],
     [
       "minecraft:desert_well"
@@ -38,22 +43,40 @@
     [
       "minecraft:ore_dirt",
       "minecraft:ore_gravel",
-      "minecraft:ore_granite",
-      "minecraft:ore_diorite",
-      "minecraft:ore_andesite",
-      "minecraft:ore_coal",
-      "minecraft:ore_iron",
+      "minecraft:ore_granite_upper",
+      "minecraft:ore_granite_lower",
+      "minecraft:ore_diorite_upper",
+      "minecraft:ore_diorite_lower",
+      "minecraft:ore_andesite_upper",
+      "minecraft:ore_andesite_lower",
+      "minecraft:ore_tuff",
+      "minecraft:ore_coal_upper",
+      "minecraft:ore_coal_lower",
+      "minecraft:ore_iron_upper",
+      "minecraft:ore_iron_middle",
+      "minecraft:ore_iron_small",
       "minecraft:ore_gold",
+      "minecraft:ore_gold_lower",
       "minecraft:ore_redstone",
+      "minecraft:ore_redstone_lower",
       "minecraft:ore_diamond",
+      "minecraft:ore_diamond_large",
+      "minecraft:ore_diamond_buried",
       "minecraft:ore_lapis",
+      "minecraft:ore_lapis_buried",
+      "minecraft:ore_copper",
+      "minecraft:underwater_magma",
       "minecraft:disk_sand",
       "minecraft:disk_clay",
       "minecraft:disk_gravel"
-
     ],
     [],
     [
+      "minecraft:spring_water",
+      "minecraft:spring_lava"
+    ],
+    [
+      "minecraft:glow_lichen",
       "minecraft:flower_default",
       "minecraft:patch_grass_badlands",
       "minecraft:patch_dead_bush_2",
@@ -61,21 +84,11 @@
       "minecraft:red_mushroom_normal",
       "minecraft:patch_sugar_cane_desert",
       "minecraft:patch_pumpkin",
-      "minecraft:patch_cactus_desert",
-      "minecraft:spring_water",
-      "minecraft:spring_lava"
+      "minecraft:patch_cactus_desert"
     ],
     [
       "minecraft:freeze_top_layer"
     ]
-  ],
-  "starts": [
-    "minecraft:village_desert",
-    "minecraft:pillager_outpost",
-    "minecraft:desert_pyramid",
-    "minecraft:mineshaft",
-    "minecraft:stronghold",
-    "minecraft:ruined_portal_desert"
   ],
   "spawners": {
     "monster": [

--- a/src/test/resources/data/dimension_settings_test/dimension/test_overworld.json
+++ b/src/test/resources/data/dimension_settings_test/dimension/test_overworld.json
@@ -12,8 +12,8 @@
     "seed": 12345,
     "settings": "dimension_settings_test:test_overworld",
     "biome_source": {
-      "seed": 12345,
-      "type": "minecraft:vanilla_layered"
+      "preset": "minecraft:overworld",
+      "type": "minecraft:multi_noise"
     }
   }
 }


### PR DESCRIPTION
#8247

Some forgedev testing data files weren't updated to 1.18's new names and data formats, preventing *any* custom dimension json from loading in forgedev test due to the datapack import failing. This fixes them.