### PR TITLE
Add a RenderArmEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
@@ -10,3 +10,16 @@
     }
  
     public Vec3 m_7860_(AbstractClientPlayer p_117785_, float p_117786_) {
+@@ -158,10 +_,12 @@
+    }
+ 
+    public void m_117770_(PoseStack p_117771_, MultiBufferSource p_117772_, int p_117773_, AbstractClientPlayer p_117774_) {
++      if(!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonArm(p_117771_, p_117772_, p_117773_, p_117774_, HumanoidArm.RIGHT))
+       this.m_117775_(p_117771_, p_117772_, p_117773_, p_117774_, (this.f_115290_).f_102811_, (this.f_115290_).f_103375_);
+    }
+ 
+    public void m_117813_(PoseStack p_117814_, MultiBufferSource p_117815_, int p_117816_, AbstractClientPlayer p_117817_) {
++      if(!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonArm(p_117814_, p_117815_, p_117816_, p_117817_, HumanoidArm.LEFT))
+       this.m_117775_(p_117814_, p_117815_, p_117816_, p_117817_, (this.f_115290_).f_102812_, (this.f_115290_).f_103374_);
+    }
+ 

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -31,6 +31,7 @@ import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.locale.Language;
 import net.minecraft.network.Connection;
@@ -38,6 +39,7 @@ import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.level.block.state.BlockState;
 import com.mojang.blaze3d.platform.Window;
@@ -236,6 +238,11 @@ public class ForgeHooksClient
     public static boolean renderSpecificFirstPersonHand(InteractionHand hand, PoseStack mat, MultiBufferSource buffers, int light, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)
     {
         return MinecraftForge.EVENT_BUS.post(new RenderHandEvent(hand, mat, buffers, light, partialTicks, interpPitch, swingProgress, equipProgress, stack));
+    }
+
+    public static boolean renderSpecificFirstPersonArm(PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight, AbstractClientPlayer player, HumanoidArm arm)
+    {
+        return MinecraftForge.EVENT_BUS.post(new RenderArmEvent(poseStack, multiBufferSource, packedLight, player, arm));
     }
 
     public static void onTextureStitchedPre(TextureAtlas map, Set<ResourceLocation> resourceLocations)

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * This is a more targeted version of {@link RenderHandEvent} event that is fired specifically when
  * a player's arm is being rendered in first person, and should be used instead if the desired
- * outcome is just to replace the rendering of the arm, such as to add make armor render on it or
+ * outcome is just to replace the rendering of the arm, such as to make armor render on it or
  * instead of it.
  *
  * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
@@ -77,7 +77,7 @@ public class RenderArmEvent extends Event
     }
 
     /**
-     * @return the Client player that is having their arm rendered. In general this will be the same as {@link net.minecraft.client.Minecraft#getInstance()#getPlayer()}.
+     * @return the client player that is having their arm rendered. In general this will be the same as {@link net.minecraft.client.Minecraft#player}.
      */
     public AbstractClientPlayer getPlayer()
     {

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * This is a more targeted version of {@link RenderHandEvent} event that is fired specifically when
+ * a player's arm is being rendered in first person, and should be used instead if the desired
+ * outcome is just to replace the rendering of the arm, such as to add make armor render on it or
+ * instead of it.
+ *
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ * Canceling the event causes the arm to not render.
+ */
+@Cancelable
+public class RenderArmEvent extends Event
+{
+    private final PoseStack poseStack;
+    private final MultiBufferSource multiBufferSource;
+    private final int packedLight;
+    private final AbstractClientPlayer player;
+    private final HumanoidArm arm;
+
+    public RenderArmEvent(PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight, AbstractClientPlayer player, HumanoidArm arm)
+    {
+        this.poseStack = poseStack;
+        this.multiBufferSource = multiBufferSource;
+        this.packedLight = packedLight;
+        this.player = player;
+        this.arm = arm;
+    }
+
+    /**
+     * @return The arm being rendered.
+     */
+    public HumanoidArm getArm()
+    {
+        return arm;
+    }
+
+    public PoseStack getPoseStack()
+    {
+        return poseStack;
+    }
+
+    public MultiBufferSource getMultiBufferSource()
+    {
+        return multiBufferSource;
+    }
+
+    public int getPackedLight()
+    {
+        return packedLight;
+    }
+
+    /**
+     * @return the Client player that is having their arm rendered. In general this will be the same as {@link net.minecraft.client.Minecraft#getInstance()#getPlayer()}.
+     */
+    public AbstractClientPlayer getPlayer()
+    {
+        return player;
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to add a more targeted version of `RenderHandEvent` for mods that specifically want to be adjusting the rendering of a player's arm, such as to make "long sleeve" armor be able to render on the arm. While this is possible via `RenderHandEvent`, it requires copy pasting large portions of vanilla code for purposes of:
- Performing all the transformations to the `PoseStack` to get it rendering in the correct place
- Rendering maps (as vanilla renders arm(s) when holding maps)

Additionally this more targeted PR will allow mods making changes to hands to natively then support any mods that say make the offhand always render to have it render properly with the adjustments desired.