### PR TITLE
Re-add missing default spawn lists in features and use of insideOnly

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
@@ -35,6 +35,15 @@
                                return;
                             }
  
+@@ -263,7 +_,7 @@
+    }
+ 
+    private static WeightedRandomList<MobSpawnSettings.SpawnerData> m_151591_(ServerLevel p_151592_, StructureFeatureManager p_151593_, ChunkGenerator p_151594_, MobCategory p_151595_, BlockPos p_151596_, @Nullable Biome p_151597_) {
+-      return m_186529_(p_151596_, p_151592_, p_151595_, p_151593_) ? NetherFortressFeature.f_66381_ : p_151594_.m_142184_(p_151597_ != null ? p_151597_ : p_151592_.m_46857_(p_151596_), p_151593_, p_151595_, p_151596_);
++      return m_186529_(p_151596_, p_151592_, p_151595_, p_151593_) ? StructureFeature.f_67025_.getSpawnList(MobCategory.MONSTER) : p_151594_.m_142184_(p_151597_ != null ? p_151597_ : p_151592_.m_46857_(p_151596_), p_151593_, p_151595_, p_151596_);
+    }
+ 
+    public static boolean m_186529_(BlockPos p_186530_, ServerLevel p_186531_, MobCategory p_186532_, StructureFeatureManager p_186533_) {
 @@ -297,6 +_,13 @@
        if (p_47052_ == SpawnPlacements.Type.NO_RESTRICTIONS) {
           return true;

--- a/patches/minecraft/net/minecraft/world/level/levelgen/feature/NetherFortressFeature.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/feature/NetherFortressFeature.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/levelgen/feature/NetherFortressFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/NetherFortressFeature.java
+@@ -42,4 +_,11 @@
+ 
+       p_197129_.m_192792_(p_197130_.f_192708_(), 48, 70);
+    }
++
++   @Override
++   public List<MobSpawnSettings.SpawnerData> getDefaultSpawnList(net.minecraft.world.entity.MobCategory category) {
++      if (category == net.minecraft.world.entity.MobCategory.MONSTER)
++         return f_66381_.m_146338_();
++      return java.util.Collections.emptyList();
++   }
+ }

--- a/patches/minecraft/net/minecraft/world/level/levelgen/feature/PillagerOutpostFeature.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/feature/PillagerOutpostFeature.java.patch
@@ -1,14 +1,14 @@
---- a/net/minecraft/world/level/levelgen/feature/OceanMonumentFeature.java
-+++ b/net/minecraft/world/level/levelgen/feature/OceanMonumentFeature.java
-@@ -74,4 +_,11 @@
-          return structurepiecesbuilder.m_192780_();
+--- a/net/minecraft/world/level/levelgen/feature/PillagerOutpostFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/PillagerOutpostFeature.java
+@@ -52,4 +_,11 @@
+          return false;
        }
     }
 +
 +   @Override
 +   public java.util.List<MobSpawnSettings.SpawnerData> getDefaultSpawnList(net.minecraft.world.entity.MobCategory category) {
 +      if (category == net.minecraft.world.entity.MobCategory.MONSTER)
-+         return f_66469_.m_146338_();
++         return f_66559_.m_146338_();
 +      return java.util.Collections.emptyList();
 +   }
  }

--- a/patches/minecraft/net/minecraft/world/level/levelgen/feature/SwamplandHutFeature.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/feature/SwamplandHutFeature.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/level/levelgen/feature/SwamplandHutFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/SwamplandHutFeature.java
+@@ -22,4 +_,13 @@
+    private static void m_197181_(StructurePiecesBuilder p_197182_, PieceGenerator.Context<NoneFeatureConfiguration> p_197183_) {
+       p_197182_.m_142679_(new SwamplandHutPiece(p_197183_.f_192708_(), p_197183_.f_192705_().m_45604_(), p_197183_.f_192705_().m_45605_()));
+    }
++
++   @Override
++   public java.util.List<MobSpawnSettings.SpawnerData> getDefaultSpawnList(net.minecraft.world.entity.MobCategory category) {
++      if (category == net.minecraft.world.entity.MobCategory.MONSTER)
++         return f_67169_.m_146338_();
++      else if (category == net.minecraft.world.entity.MobCategory.CREATURE)
++         return f_67170_.m_146338_();
++      return java.util.Collections.emptyList();
++   }
+ }

--- a/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
+++ b/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
@@ -98,8 +98,14 @@ public class StructureSpawnManager
             StructureFeature<?> structure = entry.getKey();
             StructureSpawnInfo spawnInfo = entry.getValue();
             //Note: We check if the structure has spawns for a type first before looking at the world as it should be a cheaper check
-            if (spawnInfo.spawns.containsKey(classification) && structureManager.getStructureAt(pos, structure).isValid())
-                return spawnInfo.spawns.get(classification);
+            if (spawnInfo.spawns.containsKey(classification))
+            {
+                boolean valid = spawnInfo.insideOnly
+                        ? structureManager.getStructureWithPieceAt(pos, structure).isValid()
+                        : structureManager.getStructureAt(pos, structure).isValid();
+                if (valid)
+                    return spawnInfo.spawns.get(classification);
+            }
         }
         return null;
     }


### PR DESCRIPTION
This PR fixes #8265 by re-adding the missing default spawn lists (returned via `IForgeStructureFeature#getDefaultSpawnList`) to the four vanilla features of nether fortresses, ocean monuments, pillager outposts, and swampland huts.

The patches to the features for [nether fortresses][nether-fortress-1.18-deletion], [pillager outposts][pillager-outputs-1.18-deletion], and [swampland huts][swampland-hut-1.18-deletion] were removed in the 1.18 patch and update cycle.[^1] 

The patch for the [ocean monument][ocean-monument-1.18-change] remained, but it was slightly errorneous in that it removed an existing method in the `OceanMonumentFeature` class -- the `linearSeparation` method -- and replacing it with the `getDefaultSpawnList` method, rather than merely adding the new method.

Testing this PR with the steps in the linked issue (visting a pillager outpost and watching for pillager spawns) shows this fixes the issue.

---

This PR also fixes #8301 by modifying `StructureSpawnManager` to respect `insideOnly`, which controls whether the structure spawns occur within the structure's overall bounds or only within the 'inside' space of the structure (the bounds of each piece within the structure). 

This seems to have been introduced in the 1.18 patch and update cycle. The `StructureFeatureManager#getStructureAt(BlockPos, boolean, StructureFeature<?>)` method with the `insideOnly` boolean parameter was split into two: `getStructureAt` for the overall bounds of the structure feature, and `getStructureWithPieceAt` for the 'inside' space of the structure (the bounds of each piece). During patching, the second parameter was likely removed to fix the compilation error but was not revisited later to check the correctness of the code. <sup>#BlameCurle</sup>

[swampland-hut-1.18-deletion]: https://github.com/MinecraftForge/MinecraftForge/commit/40a174310d9eaf31e089f18b66a26d45c96d5587#diff-8c3a104cde9267723d45c08ddb2afe5fd1ac47dda3c48b008d7da44ba13903a9
[pillager-outputs-1.18-deletion]: https://github.com/MinecraftForge/MinecraftForge/commit/40a174310d9eaf31e089f18b66a26d45c96d5587#diff-37267cec0c0e9d464e54413c218521ac8da2bf733e1ecefc979c8d70e261e8e6
[nether-fortress-1.18-deletion]: https://github.com/MinecraftForge/MinecraftForge/commit/40a174310d9eaf31e089f18b66a26d45c96d5587#diff-f8480fb199973b9d8605133fca1201edaf4768fbba13150545c9ca69c68f7962
[ocean-monument-1.18-change]: https://github.com/MinecraftForge/MinecraftForge/commit/40a174310d9eaf31e089f18b66a26d45c96d5587#diff-f84183102ec66011846e5dac2404cd95cdee733fa2f7250893a7c7b9d01a3be1

[^1]: I presume these patches were removed because the method they used to remove as part of the patch was removed, and it was assumed that the patch was therefore unnecessary.<sup>#BlameCurle</sup>