### PR TITLE
[1.12.x] Remove log4j-slf4j18-impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,7 +306,6 @@ project(':forge') {
         installer 'net.sf.jopt-simple:jopt-simple:5.0.3'
         installer 'org.apache.logging.log4j:log4j-api:2.15.0' //TODO: Unpin in 1.18.1 or when Mojang bumps the Log4J version
         installer 'org.apache.logging.log4j:log4j-core:2.15.0' //TODO: Unpin in 1.18.1 or when Mojang bumps the Log4J version
-        installer 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0' //TODO: Unpin in 1.18.1 or when Mojang bumps the Log4J version
 
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.0'
         testImplementation 'org.junit.vintage:junit-vintage-engine:5.+'


### PR DESCRIPTION
In the recent update to log4j, the author of the patch included `log4j-slf4j18-impl` in the installer configuration. However, Forge doesn't use slf4j, and as the installer doesn't download transitive dependecies, this library is useless on its own. I don't think it should have been included (and don't think slf4j was ever part of Forge for 1.12 in the first place), so I'm PRing its removal.

We noticed this because the inclusion of this library broke plugin logging in SpongeForge - we use slf4j 1.7.25 and this dep is for the not yet released version 2.

See https://github.com/SpongePowered/SpongeForge/issues/3275