### PR TITLE
[1.18.x] Ensure ScreenEvent doesn't accept null screens

### DIFF
--- a/patches/minecraft/net/minecraft/client/KeyboardHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/KeyboardHandler.java.patch
@@ -25,20 +25,20 @@
                 if (p_90897_ != 1 && (p_90897_ != 2 || !this.f_90868_)) {
                    if (p_90897_ == 0) {
 -                     aboolean[0] = screen.m_7920_(p_90895_, p_90896_, p_90898_);
-+                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyReleasedPre(this.f_90867_.f_91080_, p_90895_, p_90896_, p_90898_);
++                     aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyReleasedPre(screen, p_90895_, p_90896_, p_90898_);
 +                     if (!aboolean[0]) aboolean[0] = screen.m_7920_(p_90895_, p_90896_, p_90898_);
-+                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyReleasedPost(this.f_90867_.f_91080_, p_90895_, p_90896_, p_90898_);
++                     if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyReleasedPost(screen, p_90895_, p_90896_, p_90898_);
                    }
                 } else {
                    screen.m_169416_();
 -                  aboolean[0] = screen.m_7933_(p_90895_, p_90896_, p_90898_);
-+                  aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyPressedPre(this.f_90867_.f_91080_, p_90895_, p_90896_, p_90898_);
++                  aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyPressedPre(screen, p_90895_, p_90896_, p_90898_);
 +                  if (!aboolean[0]) aboolean[0] = screen.m_7933_(p_90895_, p_90896_, p_90898_);
-+                  if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyPressedPost(this.f_90867_.f_91080_, p_90895_, p_90896_, p_90898_);
++                  if (!aboolean[0]) aboolean[0] = net.minecraftforge.client.ForgeHooksClient.onScreenKeyPressedPost(screen, p_90895_, p_90896_, p_90898_);
                 }
  
              }, "keyPressed event handler", screen.getClass().getCanonicalName());
-@@ -406,7 +_,7 @@
+@@ -406,22 +_,26 @@
                 }
              }
           }
@@ -47,22 +47,25 @@
        }
     }
  
-@@ -416,12 +_,16 @@
+    private void m_90889_(long p_90890_, int p_90891_, int p_90892_) {
+       if (p_90890_ == this.f_90867_.m_91268_().m_85439_()) {
+-         GuiEventListener guieventlistener = this.f_90867_.f_91080_;
++         Screen guieventlistener = this.f_90867_.f_91080_;
           if (guieventlistener != null && this.f_90867_.m_91265_() == null) {
              if (Character.charCount(p_90891_) == 1) {
                 Screen.m_96579_(() -> {
 -                  guieventlistener.m_5534_((char)p_90891_, p_90892_);
-+                  if (net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPre(this.f_90867_.f_91080_, (char)p_90891_, p_90892_)) return;
++                  if (net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPre(guieventlistener, (char)p_90891_, p_90892_)) return;
 +                  if (guieventlistener.m_5534_((char)p_90891_, p_90892_)) return;
-+                  net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPost(this.f_90867_.f_91080_, (char)p_90891_, p_90892_);
++                  net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPost(guieventlistener, (char)p_90891_, p_90892_);
                 }, "charTyped event handler", guieventlistener.getClass().getCanonicalName());
              } else {
                 for(char c0 : Character.toChars(p_90891_)) {
                    Screen.m_96579_(() -> {
 -                     guieventlistener.m_5534_(c0, p_90892_);
-+                     if (net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPre(this.f_90867_.f_91080_, c0, p_90892_)) return;
++                     if (net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPre(guieventlistener, c0, p_90892_)) return;
 +                     if (guieventlistener.m_5534_(c0, p_90892_)) return;
-+                     net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPost(this.f_90867_.f_91080_, c0, p_90892_);
++                     net.minecraftforge.client.ForgeHooksClient.onScreenCharTypedPost(guieventlistener, c0, p_90892_);
                    }, "charTyped event handler", guieventlistener.getClass().getCanonicalName());
                 }
              }

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.client.event;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -47,7 +48,7 @@ public class ScreenEvent extends Event
 
     public ScreenEvent(Screen screen)
     {
-        this.screen = screen;
+        this.screen = Objects.requireNonNull(screen);
     }
 
     /**


### PR DESCRIPTION
I encountered a crash where a mod uses its key event handler to set `minecraft.screen` to `null`, and doesn't cancel the event.
https://github.com/mezz/JustEnoughItems/issues/2597
This results in a crash in the consumers of the event that assume the `screen` field will not be `null`.

This PR hardens some places where these events are fired, and asserts the event's `screen` field isn't `null` in order to crash earlier, closer to the cause of the issue.