### PR TITLE
Add Environment Tick Event

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -8,7 +8,7 @@
              Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure> either = chunkholder.m_140080_(ChunkStatus.f_62326_).getNow((Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>)null);
              if (either == null) {
                 return null;
-@@ -348,7 +_,7 @@
+@@ -348,14 +_,16 @@
           for(ServerChunkCache.ChunkAndHolder serverchunkcache$chunkandholder : list) {
              LevelChunk levelchunk1 = serverchunkcache$chunkandholder.f_184028_;
              ChunkPos chunkpos = levelchunk1.m_7697_();
@@ -17,6 +17,15 @@
                 levelchunk1.m_187632_(j);
                 if (flag2 && (this.f_8335_ || this.f_8336_) && this.f_8329_.m_6857_().m_61927_(chunkpos)) {
                    NaturalSpawner.m_47029_(this.f_8329_, levelchunk1, naturalspawner$spawnstate, this.f_8336_, this.f_8335_, flag1);
+                }
+ 
+                if (this.f_8329_.m_183438_(chunkpos.m_45588_())) {
++                   net.minecraftforge.event.ForgeEventFactory.onPreEnvironmentTick(f_8329_, levelchunk1, k);
+                   this.f_8329_.m_8714_(levelchunk1, k);
++                   net.minecraftforge.event.ForgeEventFactory.onPostEnvironmentTick(f_8329_, levelchunk1, k);
+                }
+             }
+          }
 @@ -426,6 +_,14 @@
  
     public <T> void m_8438_(TicketType<T> p_8439_, ChunkPos p_8440_, int p_8441_, T p_8442_) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -887,13 +887,13 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
     }
 
-    public static void onPreEnvironmentTick(Level level, LevelChunk chunk, int randomTickSpeed)
+    public static void onPreEnvironmentTick(ServerLevel level, LevelChunk chunk, int randomTickSpeed)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.START, level, chunk, randomTickSpeed));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(TickEvent.Phase.START, level, chunk, randomTickSpeed));
     }
 
-    public static void onPostEnvironmentTick(Level level, LevelChunk chunk, int randomTickSpeed)
+    public static void onPostEnvironmentTick(ServerLevel level, LevelChunk chunk, int randomTickSpeed)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.END, level, chunk, randomTickSpeed));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(TickEvent.Phase.END, level, chunk, randomTickSpeed));
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -35,6 +35,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
@@ -884,5 +885,15 @@ public class ForgeEventFactory
     public static void onPostServerTick()
     {
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END));
+    }
+
+    public static void onPreEnvironmentTick(Level level, LevelChunk chunk, int randomTickSpeed)
+    {
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.START, level, chunk, randomTickSpeed));
+    }
+
+    public static void onPostEnvironmentTick(Level level, LevelChunk chunk, int randomTickSpeed)
+    {
+        MinecraftForge.EVENT_BUS.post(new TickEvent.EnvironmentTickEvent(LogicalSide.SERVER, TickEvent.Phase.END, level, chunk, randomTickSpeed));
     }
 }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -22,13 +22,14 @@ package net.minecraftforge.event;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
 public class TickEvent extends Event
 {
     public enum Type {
-        WORLD, PLAYER, CLIENT, SERVER, RENDER;
+        WORLD, PLAYER, CLIENT, SERVER, RENDER, ENVIRONMENT;
     }
 
     public enum Phase {
@@ -66,6 +67,22 @@ public class TickEvent extends Event
             this.world = world;
         }
     }
+
+    public static class EnvironmentTickEvent extends TickEvent
+    {
+        public final Level level;
+        public final LevelChunk chunk;
+        public final int randomTickSpeed;
+
+        public EnvironmentTickEvent(LogicalSide side, Phase phase, Level level, LevelChunk chunk, int randomTickSpeed)
+        {
+            super(Type.ENVIRONMENT, side, phase);
+            this.level = level;
+            this.chunk = chunk;
+            this.randomTickSpeed = randomTickSpeed;
+        }
+    }
+
     public static class PlayerTickEvent extends TickEvent {
         public final Player player;
 

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
@@ -73,16 +74,31 @@ public class TickEvent extends Event
      */
     public static class EnvironmentTickEvent extends TickEvent
     {
-        public final Level level;
-        public final LevelChunk chunk;
-        public final int randomTickSpeed;
+        private final ServerLevel level;
+        private final LevelChunk chunk;
+        private final int randomTickSpeed;
 
-        public EnvironmentTickEvent(LogicalSide side, Phase phase, Level level, LevelChunk chunk, int randomTickSpeed)
+        public EnvironmentTickEvent(Phase phase, ServerLevel level, LevelChunk chunk, int randomTickSpeed)
         {
-            super(Type.ENVIRONMENT, side, phase);
+            super(Type.ENVIRONMENT, LogicalSide.SERVER, phase);
             this.level = level;
             this.chunk = chunk;
             this.randomTickSpeed = randomTickSpeed;
+        }
+
+        public ServerLevel getLevel()
+        {
+            return level;
+        }
+
+        public LevelChunk getChunk()
+        {
+            return chunk;
+        }
+
+        public int getRandomTickSpeed()
+        {
+            return randomTickSpeed;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -68,6 +68,9 @@ public class TickEvent extends Event
         }
     }
 
+    /**
+     * Called before and after a chunk is ticked for things like random ticks and weather. Useful for random-tick and weather based actions.
+     */
     public static class EnvironmentTickEvent extends TickEvent
     {
         public final Level level;

--- a/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
@@ -34,7 +34,7 @@ import net.minecraftforge.fml.common.Mod;
 public class EnvironmentTickEventTest
 {
     public static final String MODID = "environment_tick_event_test";
-    public static final boolean ENABLED = true;
+    public static final boolean ENABLED = false;
 
     public EnvironmentTickEventTest()
     {
@@ -46,10 +46,10 @@ public class EnvironmentTickEventTest
     {
         if (ENABLED && event.phase == TickEvent.Phase.END) // recreate snowing logic
         {
-            Level level = event.level;
+            Level level = event.getLevel();
             if (level.isRaining() && level.random.nextInt(16) == 0)
             {
-                ChunkPos chunkPos = event.chunk.getPos();
+                ChunkPos chunkPos = event.getChunk().getPos();
                 BlockPos pos = level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, level.getBlockRandomPos(chunkPos.getMinBlockX(), 0, chunkPos.getMinBlockZ(), 15));
                 BlockPos belowPos = pos.below();
                 Biome biome = level.getBiome(pos);

--- a/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/EnvironmentTickEventTest.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(EnvironmentTickEventTest.MODID)
+public class EnvironmentTickEventTest
+{
+    public static final String MODID = "environment_tick_event_test";
+    public static final boolean ENABLED = true;
+
+    public EnvironmentTickEventTest()
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onEnvironmentTick(final TickEvent.EnvironmentTickEvent event)
+    {
+        if (ENABLED && event.phase == TickEvent.Phase.END) // recreate snowing logic
+        {
+            Level level = event.level;
+            if (level.isRaining() && level.random.nextInt(16) == 0)
+            {
+                ChunkPos chunkPos = event.chunk.getPos();
+                BlockPos pos = level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, level.getBlockRandomPos(chunkPos.getMinBlockX(), 0, chunkPos.getMinBlockZ(), 15));
+                BlockPos belowPos = pos.below();
+                Biome biome = level.getBiome(pos);
+                if (biome.shouldSnow(level, pos)) // snow obsidian
+                {
+                    level.setBlockAndUpdate(belowPos, Blocks.CRYING_OBSIDIAN.defaultBlockState());
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -45,6 +45,8 @@ license="LGPL v2.1"
 [[mods]]
     modId="chunkwatchworldtest"
 [[mods]]
+    modId="environment_tick_event_test"
+[[mods]]
     modId="trsr_transformer_test"
 [[mods]]
     modId="nameplate_render_test"


### PR DESCRIPTION
This is a 1.18 port of #7235. I made a test mod with some functionality since the old test mod was just massive log spam.

I put the hook inside the `canTick` check because I can't think of a use case for intentionally attempting to tick chunks that aren't accessible, and it's a guard modders will have to add themselves each time otherwise.

To restate some applications for this event: modifying snowy weather so that the snow builds up in layers, as well as giving better control for mods that want to give blocks extra random ticks in certain conditions.