### PR TITLE
Fixed incorrect generic in PermissionAPI

### DIFF
--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -77,7 +77,7 @@ public final class PermissionAPI
      * PermissionNodes default handler.
      * @throws UnregisteredPermissionException when the PermissionNode wasn't registered properly
      */
-    public static <T> T getPermission(ServerPlayer player, PermissionNode<T> node, PermissionDynamicContext<? extends StringRepresentable>... context)
+    public static <T> T getPermission(ServerPlayer player, PermissionNode<T> node, PermissionDynamicContext<?>... context)
     {
         if (!activeHandler.getRegisteredNodes().contains(node)) throw new UnregisteredPermissionException(node);
         return activeHandler.getPermission(player, node, context);
@@ -95,7 +95,7 @@ public final class PermissionAPI
      * PermissionNodes default handler.
      * @throws UnregisteredPermissionException when the PermissionNode wasn't registered properly
      */
-    public static <T> T getOfflinePermission(UUID player, PermissionNode<T> node, PermissionDynamicContext<? extends StringRepresentable>... context)
+    public static <T> T getOfflinePermission(UUID player, PermissionNode<T> node, PermissionDynamicContext<?>... context)
     {
         if (!activeHandler.getRegisteredNodes().contains(node)) throw new UnregisteredPermissionException(node);
         return activeHandler.getOfflinePermission(player, node, context);

--- a/src/test/java/net/minecraftforge/debug/PermissionTest.java
+++ b/src/test/java/net/minecraftforge/debug/PermissionTest.java
@@ -94,7 +94,7 @@ public class PermissionTest
      * Without that, the expected UnregisteredPermissionNode exception, triggers further exceptions and therefore isn't visible anymore.
      * This is only required to handle the intended error in the permission API, and should not be necessary with correct use.
      */
-    private static boolean canUseCommand(CommandSourceStack src, PermissionNode<Boolean> booleanPermission, PermissionDynamicContext<? extends StringRepresentable>... context)
+    private static boolean canUseCommand(CommandSourceStack src, PermissionNode<Boolean> booleanPermission, PermissionDynamicContext<?>... context)
     {
         try
         {


### PR DESCRIPTION
A generic restriction for PermissionDynamicContext was missed.
This PR removes that restriction to match the intended one.