### PR TITLE
Make tryEmptyContainer respect doDrain

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -190,7 +190,7 @@ public class FluidUtil
                 .map(containerFluidHandler -> {
 
                     // We are acting on a COPY of the stack, so performing changes is acceptable even if we are simulating.
-                    FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, true);
+                    FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, doDrain);
                     if (transfer.isEmpty())
                         return FluidActionResult.FAILURE;
 


### PR DESCRIPTION
`FluidUtil::tryEmptyContainer` doesn't respect the `doDrain` flag, it fills the specified `IFluidHandler` regardless. 

It broke in this commit: https://github.com/MinecraftForge/MinecraftForge/commit/b294f4d8944d342611e95616152b128e5a03d6b5#diff-a6aa3c7740f816ab284f190e9121980e804de26f228e10af0ef9c4172fb0ac53