### PR TITLE
Fix crash with PermissionsAPI

### DIFF
--- a/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
@@ -111,7 +111,6 @@ public class ServerLifecycleHooks
     public static void handleServerStopping(final MinecraftServer server)
     {
         allowLogins.set(false);
-        PermissionAPI.resetPermissionAPI();
         MinecraftForge.EVENT_BUS.post(new ServerStoppingEvent(server));
     }
 

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -109,9 +109,10 @@ public final class PermissionAPI
      */
     public static void initializePermissionAPI()
     {
-        if(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() != ServerLifecycleHooks.class)
+        Class callerClass = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
+        if (callerClass != ServerLifecycleHooks.class)
         {
-            LOGGER.warn("Another mod tried to initialize the PermissionAPI, this is not allowed!");
+            LOGGER.warn("{} tried to initialize the PermissionAPI, this call will be ignored.", callerClass.getName());
             return;
         }
 

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -19,14 +19,12 @@
 
 package net.minecraftforge.server.permission;
 
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.util.StringRepresentable;
 import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import net.minecraftforge.server.permission.exceptions.UnregisteredPermissionException;
 import net.minecraftforge.server.permission.handler.DefaultPermissionHandler;
@@ -38,7 +36,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
 
 public final class PermissionAPI
 {
@@ -108,7 +109,13 @@ public final class PermissionAPI
      */
     public static void initializePermissionAPI()
     {
-        if (PermissionAPI.activeHandler != null) throw new IllegalStateException("Tried to initialize PermissionAPI multiple times!");
+        if(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() != ServerLifecycleHooks.class)
+        {
+            LOGGER.warn("Another mod tried to initialize the PermissionAPI, this is not allowed!");
+            return;
+        }
+
+        PermissionAPI.activeHandler = null;
 
         PermissionGatherEvent.Handler handlerEvent = new PermissionGatherEvent.Handler();
         MinecraftForge.EVENT_BUS.post(handlerEvent);
@@ -139,15 +146,5 @@ public final class PermissionAPI
         {
             LOGGER.error("Error parsing config value 'permissionHandler'", e);
         }
-    }
-
-    /**
-     * <p>Helper method for internal use only!</p>
-     * <p>Resets the active permission handler.</p>
-     */
-    public static void resetPermissionAPI()
-    {
-        PermissionAPI.activeHandler = null;
-        LOGGER.debug("Reset PermissionAPI");
     }
 }


### PR DESCRIPTION
Fixes a seemingly rare crash that was reported in the Forge Discord server today.
<https://discord.com/channels/313125603924639766/313125603924639766/925064802932502579>

That is done by replacing the security measures, which prevent other mods from reseting the PermissionAPI.