### PR TITLE
[1.18.X] Add support for user-defined render types in static geometry

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -49,6 +49,15 @@
        this.f_91038_.m_10506_();
        this.f_91066_.m_92145_(this.f_91038_);
        this.f_91039_ = new LanguageManager(this.f_91066_.f_92075_);
+@@ -493,6 +_,8 @@
+       this.f_91036_.m_7217_(this.f_90994_);
+       this.f_90996_ = new ItemInHandRenderer(this);
+       this.f_91036_.m_7217_(this.f_90995_);
++      net.minecraftforge.client.ForgeHooksClient.fireRegisterRenderTypes();
++      net.minecraftforge.client.renderer.LevelRenderPhaseManager.getInstance().init();
+       this.f_90993_ = new RenderBuffers();
+       this.f_91063_ = new GameRenderer(this, this.f_91036_, this.f_90993_);
+       this.f_91036_.m_7217_(this.f_91063_);
 @@ -504,6 +_,7 @@
        this.m_91271_();
        this.f_91036_.m_7217_(this.f_90997_);

--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -43,7 +43,7 @@
        profilerfiller.m_6182_("compilechunks");
        this.m_194370_(p_109604_);
        profilerfiller.m_6182_("terrain");
-+      if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderSolids(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
++      if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderSolids(this, p_109600_, p_109604_, p_109607_)) {
        this.m_172993_(RenderType.m_110451_(), p_109600_, d0, d1, d2, p_109607_);
        this.m_172993_(RenderType.m_110457_(), p_109600_, d0, d1, d2, p_109607_);
        this.m_172993_(RenderType.m_110463_(), p_109600_, d0, d1, d2, p_109607_);
@@ -94,11 +94,11 @@
           this.f_109413_.m_83954_(Minecraft.f_91002_);
           this.f_109413_.m_83945_(this.f_109461_.m_91385_());
           profilerfiller.m_6182_("translucent");
-+         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_)) {
           this.m_172993_(RenderType.m_110466_(), p_109600_, d0, d1, d2, p_109607_);
 +         }
           profilerfiller.m_6182_("string");
-+         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_)) {
           this.m_172993_(RenderType.m_110503_(), p_109600_, d0, d1, d2, p_109607_);
 +         }
           this.f_109415_.m_83954_(Minecraft.f_91002_);
@@ -114,13 +114,13 @@
              this.f_109413_.m_83954_(Minecraft.f_91002_);
           }
  
-+         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_)) {
           this.m_172993_(RenderType.m_110466_(), p_109600_, d0, d1, d2, p_109607_);
 +         }
           multibuffersource$buffersource.m_109912_(RenderType.m_110504_());
           multibuffersource$buffersource.m_109911_();
           profilerfiller.m_6182_("string");
-+         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_)) {
           this.m_172993_(RenderType.m_110503_(), p_109600_, d0, d1, d2, p_109607_);
 +         }
           profilerfiller.m_6182_("particles");

--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -24,7 +24,7 @@
        float f = this.f_109461_.f_91073_.m_46722_(1.0F) / (Minecraft.m_91405_() ? 1.0F : 2.0F);
        if (!(f <= 0.0F)) {
           Random random = new Random((long)this.f_109477_ * 312987231L);
-@@ -1148,20 +_,23 @@
+@@ -1148,21 +_,24 @@
        RenderSystem.m_69421_(16640, Minecraft.f_91002_);
        float f = p_109605_.m_109152_();
        boolean flag2 = this.f_109461_.f_91073_.m_104583_().m_5781_(Mth.m_14107_(d0), Mth.m_14107_(d1)) || this.f_109461_.f_91065_.m_93090_().m_93715_();
@@ -43,13 +43,14 @@
        profilerfiller.m_6182_("compilechunks");
        this.m_194370_(p_109604_);
        profilerfiller.m_6182_("terrain");
++      if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderSolids(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
        this.m_172993_(RenderType.m_110451_(), p_109600_, d0, d1, d2, p_109607_);
-+      this.f_109461_.m_91304_().m_119428_(TextureAtlas.f_118259_).setBlurMipmap(false, this.f_109461_.f_91066_.f_92027_ > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
        this.m_172993_(RenderType.m_110457_(), p_109600_, d0, d1, d2, p_109607_);
-+      this.f_109461_.m_91304_().m_119428_(TextureAtlas.f_118259_).restoreLastBlurMipmap();
        this.m_172993_(RenderType.m_110463_(), p_109600_, d0, d1, d2, p_109607_);
++      }
        if (this.f_109465_.m_104583_().m_108885_()) {
           Lighting.m_84925_(p_109600_.m_85850_().m_85861_());
+       } else {
 @@ -1191,7 +_,7 @@
        MultiBufferSource.BufferSource multibuffersource$buffersource = this.f_109464_.m_110104_();
  
@@ -89,7 +90,18 @@
        }
  
        PoseStack posestack = RenderSystem.m_157191_();
-@@ -1344,7 +_,7 @@
+@@ -1337,14 +_,18 @@
+          this.f_109413_.m_83954_(Minecraft.f_91002_);
+          this.f_109413_.m_83945_(this.f_109461_.m_91385_());
+          profilerfiller.m_6182_("translucent");
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
+          this.m_172993_(RenderType.m_110466_(), p_109600_, d0, d1, d2, p_109607_);
++         }
+          profilerfiller.m_6182_("string");
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
+          this.m_172993_(RenderType.m_110503_(), p_109600_, d0, d1, d2, p_109607_);
++         }
+          this.f_109415_.m_83954_(Minecraft.f_91002_);
           this.f_109415_.m_83945_(this.f_109461_.m_91385_());
           RenderStateShard.f_110126_.m_110185_();
           profilerfiller.m_6182_("particles");
@@ -98,15 +110,33 @@
           RenderStateShard.f_110126_.m_110188_();
        } else {
           profilerfiller.m_6182_("translucent");
-@@ -1358,7 +_,7 @@
+@@ -1352,13 +_,17 @@
+             this.f_109413_.m_83954_(Minecraft.f_91002_);
+          }
+ 
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTranslucent(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
+          this.m_172993_(RenderType.m_110466_(), p_109600_, d0, d1, d2, p_109607_);
++         }
+          multibuffersource$buffersource.m_109912_(RenderType.m_110504_());
+          multibuffersource$buffersource.m_109911_();
           profilerfiller.m_6182_("string");
++         if (!net.minecraftforge.client.renderer.LevelRendererAdapter.getInstance().onRenderTripwire(this, p_109600_, p_109604_, p_109607_, profilerfiller)) {
           this.m_172993_(RenderType.m_110503_(), p_109600_, d0, d1, d2, p_109607_);
++         }
           profilerfiller.m_6182_("particles");
 -         this.f_109461_.f_91061_.m_107336_(p_109600_, multibuffersource$buffersource, p_109606_, p_109604_, p_109601_);
 +         this.f_109461_.f_91061_.render(p_109600_, multibuffersource$buffersource, p_109606_, p_109604_, p_109601_, frustum);
        }
  
        posestack.m_85836_();
+@@ -1511,6 +_,7 @@
+                uniform.m_85633_();
+             }
+ 
++            if (p_172994_ instanceof net.minecraftforge.client.renderer.IComplexRenderType complexRenderType) { complexRenderType.beforeChunkRender(this, chunkrenderdispatcher$renderchunk, p_172995_, p_172996_, p_172997_, p_172998_, p_172999_); }
+             vertexbuffer.m_166887_();
+             flag1 = true;
+          }
 @@ -1790,6 +_,11 @@
  
     public void m_181409_(PoseStack p_181410_, Matrix4f p_181411_, float p_181412_, Runnable p_181413_) {

--- a/patches/minecraft/net/minecraft/client/renderer/RenderStateShard.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderStateShard.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/RenderStateShard.java
++++ b/net/minecraft/client/renderer/RenderStateShard.java
+@@ -115,7 +_,7 @@
+    protected static final RenderStateShard.ShaderStateShard f_173093_ = new RenderStateShard.ShaderStateShard(GameRenderer::m_172755_);
+    protected static final RenderStateShard.ShaderStateShard f_173094_ = new RenderStateShard.ShaderStateShard(GameRenderer::m_172756_);
+    protected static final RenderStateShard.ShaderStateShard f_173095_ = new RenderStateShard.ShaderStateShard(GameRenderer::m_172757_);
+-   protected static final RenderStateShard.TextureStateShard f_110145_ = new RenderStateShard.TextureStateShard(TextureAtlas.f_118259_, false, true);
++   protected static final RenderStateShard.TextureStateShard f_110145_ = new net.minecraftforge.client.ForgeRenderTypes.MipmapFixTextureShard(TextureAtlas.f_118259_, false, true); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
+    protected static final RenderStateShard.TextureStateShard f_110146_ = new RenderStateShard.TextureStateShard(TextureAtlas.f_118259_, false, false);
+    protected static final RenderStateShard.EmptyTextureStateShard f_110147_ = new RenderStateShard.EmptyTextureStateShard();
+    protected static final RenderStateShard.TexturingStateShard f_110148_ = new RenderStateShard.TexturingStateShard("default_texturing", () -> {

--- a/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
@@ -34,3 +34,12 @@
     }
  
     public static RenderType m_110502_() {
+@@ -375,7 +_,7 @@
+    }
+ 
+    public static List<RenderType> m_110506_() {
+-      return ImmutableList.of(m_110451_(), m_110457_(), m_110463_(), m_110466_(), m_110503_());
++      return net.minecraftforge.client.renderer.LevelRenderPhaseManager.getInstance().getKnownTypes();
+    }
+ 
+    public int m_110507_() {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1045,4 +1045,8 @@ public class ForgeHooksClient
                 .toList();
     }
 
+    public static void fireRegisterRenderTypes() {
+        ModLoader.get().postEvent(new RenderTypeRegisterEvent());
+    }
+
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1045,7 +1045,8 @@ public class ForgeHooksClient
                 .toList();
     }
 
-    public static void fireRegisterRenderTypes() {
+    public static void fireRegisterRenderTypes()
+    {
         ModLoader.get().postEvent(new RenderTypeRegisterEvent());
     }
 

--- a/src/main/java/net/minecraftforge/client/event/LayerRenderTypeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/LayerRenderTypeRegisterEvent.java
@@ -1,0 +1,85 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.renderer.RenderType;
+import net.minecraftforge.common.util.SortedRegistry;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
+
+/**
+ * Fired during setup on {@link net.minecraftforge.api.distmarker.Dist#CLIENT}
+ * to register custom render types for static block rendering.
+ *
+ * @see Solid
+ * @see Translucent
+ * @see Tripwire
+ */
+public abstract class LayerRenderTypeRegisterEvent extends Event implements IModBusEvent
+{
+    private final SortedRegistry.Builder<RenderType> builder;
+
+    protected LayerRenderTypeRegisterEvent(SortedRegistry.Builder<RenderType> builder)
+    {
+        this.builder = builder;
+    }
+
+    public SortedRegistry.Builder<RenderType> getBuilder()
+    {
+        return builder;
+    }
+
+    /**
+     * Variant of {@link LayerRenderTypeRegisterEvent} for solid render types.
+     * Vanilla includes {@link RenderType#solid()}, {@link RenderType#cutoutMipped()}
+     * and {@link RenderType#cutout()} in that order.
+     */
+    public static class Solid extends LayerRenderTypeRegisterEvent
+    {
+        public Solid(SortedRegistry.Builder<RenderType> builder)
+        {
+            super(builder);
+        }
+    }
+
+    /**
+     * Variant of {@link LayerRenderTypeRegisterEvent} for translucent render types.
+     * Vanilla includes {@link RenderType#translucent()} only.
+     */
+    public static class Translucent extends LayerRenderTypeRegisterEvent
+    {
+        public Translucent(SortedRegistry.Builder<RenderType> builder)
+        {
+            super(builder);
+        }
+    }
+
+    /**
+     * Variant of {@link LayerRenderTypeRegisterEvent} for tripwire like render types.
+     * Vanilla includes {@link RenderType#tripwire()} only.
+     */
+    public static class Tripwire extends LayerRenderTypeRegisterEvent
+    {
+        public Tripwire(SortedRegistry.Builder<RenderType> builder)
+        {
+            super(builder);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderTypeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTypeRegisterEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
+
+/**
+ * Fired during setup on {@link net.minecraftforge.api.distmarker.Dist#CLIENT}
+ * to create custom render types.
+ */
+public class RenderTypeRegisterEvent extends Event implements IModBusEvent
+{
+}

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
@@ -49,9 +49,10 @@ public class MultiLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoa
     public MultiLayerModelBuilder<T> submodel(RenderType layer, T modelBuilder)
     {
         Preconditions.checkNotNull(layer, "layer must not be null");
-        Preconditions.checkArgument(LevelRenderPhaseManager.getInstance().getAllKnownTypes().containsValue(layer), "layer must be supported by MultiLayerModel");
+        var name = LevelRenderPhaseManager.getInstance().getAllKnownTypes().inverse().get(layer);
+        Preconditions.checkArgument(name != null, "layer must be supported by MultiLayerModel");
         Preconditions.checkNotNull(modelBuilder, "modelBuilder must not be null");
-        childModels.put(LevelRenderPhaseManager.getInstance().getAllKnownTypes().inverse().get(layer), modelBuilder);
+        childModels.put(name, modelBuilder);
         return this;
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
@@ -23,9 +23,10 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.client.model.MultiLayerModel;
+import net.minecraftforge.client.event.LayerRenderTypeRegisterEvent;
 import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
 import net.minecraftforge.client.model.generators.ModelBuilder;
+import net.minecraftforge.client.renderer.LevelRenderPhaseManager;
 import net.minecraftforge.common.data.ExistingFileHelper;
 
 import java.util.LinkedHashMap;
@@ -38,7 +39,7 @@ public class MultiLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoa
         return new MultiLayerModelBuilder<>(parent, existingFileHelper);
     }
 
-    private final Map<String, T> childModels = new LinkedHashMap<>();
+    private final Map<ResourceLocation, T> childModels = new LinkedHashMap<>();
 
     protected MultiLayerModelBuilder(T parent, ExistingFileHelper existingFileHelper)
     {
@@ -48,9 +49,9 @@ public class MultiLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoa
     public MultiLayerModelBuilder<T> submodel(RenderType layer, T modelBuilder)
     {
         Preconditions.checkNotNull(layer, "layer must not be null");
-        Preconditions.checkArgument(MultiLayerModel.Loader.BLOCK_LAYERS.containsValue(layer), "layer must be supported by MultiLayerModel");
+        Preconditions.checkArgument(LevelRenderPhaseManager.getInstance().getAllKnownTypes().containsValue(layer), "layer must be supported by MultiLayerModel");
         Preconditions.checkNotNull(modelBuilder, "modelBuilder must not be null");
-        childModels.put(MultiLayerModel.Loader.BLOCK_LAYERS.inverse().get(layer), modelBuilder);
+        childModels.put(LevelRenderPhaseManager.getInstance().getAllKnownTypes().inverse().get(layer), modelBuilder);
         return this;
     }
 
@@ -60,9 +61,9 @@ public class MultiLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoa
         json = super.toJson(json);
 
         JsonObject parts = new JsonObject();
-        for(Map.Entry<String, T> entry : childModels.entrySet())
+        for(Map.Entry<ResourceLocation, T> entry : childModels.entrySet())
         {
-            parts.add(entry.getKey(), entry.getValue().toJson());
+            parts.add(entry.getKey().toString(), entry.getValue().toJson());
         }
         json.add("layers", parts);
 

--- a/src/main/java/net/minecraftforge/client/renderer/ComplexRenderType.java
+++ b/src/main/java/net/minecraftforge/client/renderer/ComplexRenderType.java
@@ -7,11 +7,19 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 
+/**
+ * An implementation of {@link net.minecraft.client.renderer.RenderType.CompositeRenderType} with
+ * the {@link IComplexRenderType} interface.
+ * Create using {@link ComplexRenderTypeBuilder}.
+ *
+ * @see ComplexRenderTypeBuilder
+ */
 public final class ComplexRenderType extends RenderType.CompositeRenderType implements IComplexRenderType
 {
     private final IBeforeChunkRenderCallback beforeChunkRenderCallback;
 
-    public static ComplexRenderTypeBuilder builder() {
+    public static ComplexRenderTypeBuilder builder()
+    {
         return new ComplexRenderTypeBuilder();
     }
 
@@ -23,7 +31,8 @@ public final class ComplexRenderType extends RenderType.CompositeRenderType impl
       final boolean affectsCrumbling,
       final boolean sortOnUpload,
       final CompositeState compositeState,
-      final IBeforeChunkRenderCallback beforeChunkRenderCallback) {
+      final IBeforeChunkRenderCallback beforeChunkRenderCallback
+    ) {
         super(name, vertexFormat, mode, bufferSize, affectsCrumbling, sortOnUpload, compositeState);
         this.beforeChunkRenderCallback = beforeChunkRenderCallback;
     }
@@ -36,8 +45,8 @@ public final class ComplexRenderType extends RenderType.CompositeRenderType impl
       final double cameraX,
       final double cameraY,
       final double cameraZ,
-      final Matrix4f projectionMatrix)
-    {
+      final Matrix4f projectionMatrix
+    ) {
         this.beforeChunkRenderCallback.beforeChunkRender(
           levelRenderer, renderChunk, poseStack, cameraX, cameraY, cameraZ, projectionMatrix
         );

--- a/src/main/java/net/minecraftforge/client/renderer/ComplexRenderType.java
+++ b/src/main/java/net/minecraftforge/client/renderer/ComplexRenderType.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.math.Matrix4f;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+
+public final class ComplexRenderType extends RenderType.CompositeRenderType implements IComplexRenderType
+{
+    private final IBeforeChunkRenderCallback beforeChunkRenderCallback;
+
+    public static ComplexRenderTypeBuilder builder() {
+        return new ComplexRenderTypeBuilder();
+    }
+
+    ComplexRenderType(
+      final String name,
+      final VertexFormat vertexFormat,
+      final VertexFormat.Mode mode,
+      final int bufferSize,
+      final boolean affectsCrumbling,
+      final boolean sortOnUpload,
+      final CompositeState compositeState,
+      final IBeforeChunkRenderCallback beforeChunkRenderCallback) {
+        super(name, vertexFormat, mode, bufferSize, affectsCrumbling, sortOnUpload, compositeState);
+        this.beforeChunkRenderCallback = beforeChunkRenderCallback;
+    }
+
+    @Override
+    public void beforeChunkRender(
+      final LevelRenderer levelRenderer,
+      final ChunkRenderDispatcher.RenderChunk renderChunk,
+      final PoseStack poseStack,
+      final double cameraX,
+      final double cameraY,
+      final double cameraZ,
+      final Matrix4f projectionMatrix)
+    {
+        this.beforeChunkRenderCallback.beforeChunkRender(
+          levelRenderer, renderChunk, poseStack, cameraX, cameraY, cameraZ, projectionMatrix
+        );
+    }
+}

--- a/src/main/java/net/minecraftforge/client/renderer/ComplexRenderTypeBuilder.java
+++ b/src/main/java/net/minecraftforge/client/renderer/ComplexRenderTypeBuilder.java
@@ -29,8 +29,7 @@ public final class ComplexRenderTypeBuilder
       final boolean affectsCrumbling,
       final boolean sortOnUpload,
       final RenderType.CompositeState compositeState
-    )
-    {
+    ) {
         return new ComplexRenderType(
             name, vertexFormat, mode, bufferSize, affectsCrumbling, sortOnUpload, compositeState, beforeChunkRenderCallback
         );

--- a/src/main/java/net/minecraftforge/client/renderer/ComplexRenderTypeBuilder.java
+++ b/src/main/java/net/minecraftforge/client/renderer/ComplexRenderTypeBuilder.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.client.renderer;
+
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.renderer.RenderType;
+
+public final class ComplexRenderTypeBuilder
+{
+    private static final IBeforeChunkRenderCallback DEFAULT_BEFORE_CHUNK_CALLBACK = (levelRenderer, renderChunk, poseStack, cameraX, cameraY, cameraZ, projectionMatrix) -> {
+        //Noop
+    };
+
+    private IBeforeChunkRenderCallback beforeChunkRenderCallback = DEFAULT_BEFORE_CHUNK_CALLBACK;
+
+    ComplexRenderTypeBuilder()
+    {
+    }
+
+    public ComplexRenderTypeBuilder beforeChunkRenderCallback(IBeforeChunkRenderCallback beforeChunkRenderCallback)
+    {
+        this.beforeChunkRenderCallback = beforeChunkRenderCallback;
+        return this;
+    }
+
+    public ComplexRenderType build(
+      final String name,
+      final VertexFormat vertexFormat,
+      final VertexFormat.Mode mode,
+      final int bufferSize,
+      final boolean affectsCrumbling,
+      final boolean sortOnUpload,
+      final RenderType.CompositeState compositeState
+    )
+    {
+        return new ComplexRenderType(
+            name, vertexFormat, mode, bufferSize, affectsCrumbling, sortOnUpload, compositeState, beforeChunkRenderCallback
+        );
+    }
+}

--- a/src/main/java/net/minecraftforge/client/renderer/IBeforeChunkRenderCallback.java
+++ b/src/main/java/net/minecraftforge/client/renderer/IBeforeChunkRenderCallback.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+
+/**
+ * Interface which describes a callback that is invoked by the {@link LevelRenderer} before
+ * a none empty chunk is rendered. This is useful for uploading additional uniforms to the GPU,
+ * or modifying the current GPU state based on what chunk is being rendered.
+ *
+ * Has to be passed to a {@link ComplexRenderType} during creation of said render type so that it is picked up.
+ * The render type then needs to be registered via a {@link net.minecraftforge.client.event.LayerRenderTypeRegisterEvent} of
+ * the appropriate phase, and a set of blocks need to use the render type before the callback is invoked.
+ */
+@FunctionalInterface
+public interface IBeforeChunkRenderCallback
+{
+    /**
+     * Invoked by the level renderer to indicate that a chunk is about to be rendered.
+     *
+     * @param levelRenderer The renderer.
+     * @param renderChunk The chunk that is about to be rendered.
+     * @param poseStack The current pose stack.
+     * @param cameraX The camera x position.
+     * @param cameraY The camera y position.
+     * @param cameraZ The camera z position.
+     * @param projectionMatrix The projection matrix.
+     */
+    void beforeChunkRender(
+      LevelRenderer levelRenderer,
+      ChunkRenderDispatcher.RenderChunk renderChunk,
+      PoseStack poseStack,
+      double cameraX,
+      double cameraY,
+      double cameraZ,
+      Matrix4f projectionMatrix
+    );
+}

--- a/src/main/java/net/minecraftforge/client/renderer/IBeforeChunkRenderCallback.java
+++ b/src/main/java/net/minecraftforge/client/renderer/IBeforeChunkRenderCallback.java
@@ -6,13 +6,13 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 
 /**
- * Interface which describes a callback that is invoked by the {@link LevelRenderer} before
- * a none empty chunk is rendered. This is useful for uploading additional uniforms to the GPU,
+ * Interface which represents a callback that is invoked by the {@link LevelRenderer} before
+ * a non-empty chunk is rendered. This is useful for uploading additional uniforms to the GPU,
  * or modifying the current GPU state based on what chunk is being rendered.
  *
- * Has to be passed to a {@link ComplexRenderType} during creation of said render type so that it is picked up.
- * The render type then needs to be registered via a {@link net.minecraftforge.client.event.LayerRenderTypeRegisterEvent} of
- * the appropriate phase, and a set of blocks need to use the render type before the callback is invoked.
+ * For use with render types, must be passed to a {@link ComplexRenderTypeBuilder}.
+ * This render type must be registered via a {@link net.minecraftforge.client.event.LayerRenderTypeRegisterEvent}
+ * of the appropriate phase.
  */
 @FunctionalInterface
 public interface IBeforeChunkRenderCallback

--- a/src/main/java/net/minecraftforge/client/renderer/IComplexRenderType.java
+++ b/src/main/java/net/minecraftforge/client/renderer/IComplexRenderType.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.client.renderer;
+
+/**
+ * Interface which needs to be implemented by custom render types
+ * which are used inside the {@link LevelRendererAdapter} when it
+ * performs the rendering of chunk sections.
+ */
+public interface IComplexRenderType extends IBeforeChunkRenderCallback
+{
+}

--- a/src/main/java/net/minecraftforge/client/renderer/IComplexRenderType.java
+++ b/src/main/java/net/minecraftforge/client/renderer/IComplexRenderType.java
@@ -1,9 +1,10 @@
 package net.minecraftforge.client.renderer;
 
 /**
- * Interface which needs to be implemented by custom render types
- * which are used inside the {@link LevelRendererAdapter} when it
- * performs the rendering of chunk sections.
+ * Interface which implemented by custom render types which are to be
+ * notified when a chunk section is rendered using them.
+ *
+ * @see ComplexRenderType
  */
 public interface IComplexRenderType extends IBeforeChunkRenderCallback
 {

--- a/src/main/java/net/minecraftforge/client/renderer/LevelRenderPhaseManager.java
+++ b/src/main/java/net/minecraftforge/client/renderer/LevelRenderPhaseManager.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Manager which deals with rendering phases used during level rendering.
+ * Manager for the different phases of static geometry rendering in a level.
  * This class is only in use when the {@link LevelRendererAdapter} is used.
  */
 public final class LevelRenderPhaseManager
@@ -63,15 +63,9 @@ public final class LevelRenderPhaseManager
         tripwirePhases = tripwireBuilder.build();
 
         allKnownTypes.clear();
-        allKnownTypes.putAll(
-          solidPhases.getUnorderedEntries()
-        );
-        allKnownTypes.putAll(
-          translucentPhases.getUnorderedEntries()
-        );
-        allKnownTypes.putAll(
-          tripwirePhases.getUnorderedEntries()
-        );
+        allKnownTypes.putAll(solidPhases.getUnorderedEntries());
+        allKnownTypes.putAll(translucentPhases.getUnorderedEntries());
+        allKnownTypes.putAll(tripwirePhases.getUnorderedEntries());
 
         knownTypes.clear();
         knownTypes.addAll(allKnownTypes.values());

--- a/src/main/java/net/minecraftforge/client/renderer/LevelRenderPhaseManager.java
+++ b/src/main/java/net/minecraftforge/client/renderer/LevelRenderPhaseManager.java
@@ -1,0 +1,126 @@
+package net.minecraftforge.client.renderer;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.client.event.LayerRenderTypeRegisterEvent;
+import net.minecraftforge.common.util.SortedRegistry;
+import net.minecraftforge.fml.ModLoader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Manager which deals with rendering phases used during level rendering.
+ * This class is only in use when the {@link LevelRendererAdapter} is used.
+ */
+public final class LevelRenderPhaseManager
+{
+    private static final LevelRenderPhaseManager INSTANCE = new LevelRenderPhaseManager();
+
+    public static LevelRenderPhaseManager getInstance()
+    {
+        return INSTANCE;
+    }
+
+    private SortedRegistry<RenderType> solidPhases       = null;
+    private SortedRegistry<RenderType> translucentPhases = null;
+    private SortedRegistry<RenderType> tripwirePhases    = null;
+
+    private final BiMap<ResourceLocation, RenderType> allKnownTypes = HashBiMap.create();
+    private final BiMap<ResourceLocation, RenderType> allKnownTypesView = Maps.unmodifiableBiMap(allKnownTypes);
+
+    private final List<RenderType> knownTypes = Lists.newArrayList();
+    private final List<RenderType> knownTypesView = Collections.unmodifiableList(knownTypes);
+
+    private LevelRenderPhaseManager()
+    {
+    }
+
+    public void init()
+    {
+        if (solidPhases != null)
+            throw new IllegalStateException("Attempted to set up static render types twice.");
+
+        var solidBuilder = new SortedRegistry.Builder<>(RenderType.class);
+        var translucentBuilder = new SortedRegistry.Builder<>(RenderType.class);
+        var tripwireBuilder = new SortedRegistry.Builder<>(RenderType.class);
+
+        addSolidVanillaTypes(solidBuilder);
+        addTranslucentVanillaTypes(translucentBuilder);
+        addTripwireVanillaTypes(tripwireBuilder);
+
+        ModLoader.get().postEvent(new LayerRenderTypeRegisterEvent.Solid(solidBuilder));
+        ModLoader.get().postEvent(new LayerRenderTypeRegisterEvent.Translucent(translucentBuilder));
+        ModLoader.get().postEvent(new LayerRenderTypeRegisterEvent.Tripwire(tripwireBuilder));
+
+        solidPhases = solidBuilder.build();
+        translucentPhases = translucentBuilder.build();
+        tripwirePhases = tripwireBuilder.build();
+
+        allKnownTypes.clear();
+        allKnownTypes.putAll(
+          solidPhases.getUnorderedEntries()
+        );
+        allKnownTypes.putAll(
+          translucentPhases.getUnorderedEntries()
+        );
+        allKnownTypes.putAll(
+          tripwirePhases.getUnorderedEntries()
+        );
+
+        knownTypes.clear();
+        knownTypes.addAll(allKnownTypes.values());
+    }
+
+    public Collection<RenderType> getSolidPhases()
+    {
+        return solidPhases.getElements();
+    }
+
+    public Collection<RenderType> getTranslucentPhases()
+    {
+        return translucentPhases.getElements();
+    }
+
+    public Collection<RenderType> getTripwirePhases()
+    {
+        return tripwirePhases.getElements();
+    }
+
+    public BiMap<ResourceLocation, RenderType> getAllKnownTypes()
+    {
+        return allKnownTypesView;
+    }
+
+    public List<RenderType> getKnownTypes()
+    {
+        return knownTypesView;
+    }
+
+    private static void addSolidVanillaTypes(SortedRegistry.Builder<RenderType> solidBuilder)
+    {
+        var solid = new ResourceLocation("solid");
+        var cutoutMipped = new ResourceLocation("cutout_mipped");
+        var cutout = new ResourceLocation("cutout");
+        solidBuilder.add(RenderType.solid(), solid, List.of(), List.of(cutoutMipped));
+        solidBuilder.add(RenderType.cutoutMipped(), cutoutMipped, List.of(solid), List.of(cutout));
+        solidBuilder.add(RenderType.cutout(), cutout, List.of(cutoutMipped), List.of());
+    }
+
+    private static void addTranslucentVanillaTypes(SortedRegistry.Builder<RenderType> translucentBuilder)
+    {
+        var translucent = new ResourceLocation("translucent");
+        translucentBuilder.add(RenderType.translucent(), translucent, List.of(), List.of());
+    }
+
+    private static void addTripwireVanillaTypes(SortedRegistry.Builder<RenderType> tripwireBuilder)
+    {
+        var tripwire = new ResourceLocation("tripwire");
+        tripwireBuilder.add(RenderType.tripwire(), tripwire, List.of(), List.of());
+    }
+}

--- a/src/main/java/net/minecraftforge/client/renderer/LevelRendererAdapter.java
+++ b/src/main/java/net/minecraftforge/client/renderer/LevelRendererAdapter.java
@@ -12,7 +12,8 @@ import net.minecraftforge.common.ForgeConfig;
 import java.util.Collection;
 
 /**
- * Adapter class which is used to manage the custom render types when they are rendered in the world.
+ * Adapter class used to dispatch draw calls for vanilla and user-provided static
+ * render types during level rendering.
  */
 public final class LevelRendererAdapter
 {
@@ -36,13 +37,12 @@ public final class LevelRendererAdapter
       final LevelRenderer levelRenderer,
       final PoseStack poseStack,
       final Camera camera,
-      final Matrix4f projectionMatrix,
-      final ProfilerFiller profilerFiller
+      final Matrix4f projectionMatrix
     ) {
         if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
             return false;
 
-        doRenderPhases(LevelRenderPhaseManager.getInstance().getSolidPhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getSolidPhases(), camera, levelRenderer, poseStack, projectionMatrix);
 
         return true;
     }
@@ -56,13 +56,12 @@ public final class LevelRendererAdapter
       final LevelRenderer levelRenderer,
       final PoseStack poseStack,
       final Camera camera,
-      final Matrix4f projectionMatrix,
-      final ProfilerFiller profilerFiller
+      final Matrix4f projectionMatrix
     ) {
         if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
             return false;
 
-        doRenderPhases(LevelRenderPhaseManager.getInstance().getTranslucentPhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getTranslucentPhases(), camera, levelRenderer, poseStack, projectionMatrix);
 
         return true;
     }
@@ -76,13 +75,12 @@ public final class LevelRendererAdapter
       final LevelRenderer levelRenderer,
       final PoseStack poseStack,
       final Camera camera,
-      final Matrix4f projectionMatrix,
-      final ProfilerFiller profilerFiller
+      final Matrix4f projectionMatrix
     ) {
         if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
             return false;
 
-        doRenderPhases(LevelRenderPhaseManager.getInstance().getTripwirePhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getTripwirePhases(), camera, levelRenderer, poseStack, projectionMatrix);
 
         return true;
     }
@@ -92,26 +90,11 @@ public final class LevelRendererAdapter
       final Camera camera,
       final LevelRenderer levelRenderer,
       final PoseStack poseStack,
-      final Matrix4f projectionMatrix,
-      final ProfilerFiller profilerFiller
+      final Matrix4f projectionMatrix
     ) {
         final Vec3 cameraPos = camera.getPosition();
-        final double cameraX = cameraPos.x;
-        final double cameraY = cameraPos.y;
-        final double cameraZ = cameraPos.z;
-
+        final double cameraX = cameraPos.x, cameraY = cameraPos.y, cameraZ = cameraPos.z;
         for (final RenderType renderType : phases)
-        {
-            profilerFiller.push(renderType.name);
-            levelRenderer.renderChunkLayer(
-              renderType,
-              poseStack,
-              cameraX,
-              cameraY,
-              cameraZ,
-              projectionMatrix
-            );
-            profilerFiller.pop();
-        }
+            levelRenderer.renderChunkLayer(renderType, poseStack, cameraX, cameraY, cameraZ, projectionMatrix);
     }
 }

--- a/src/main/java/net/minecraftforge/client/renderer/LevelRendererAdapter.java
+++ b/src/main/java/net/minecraftforge/client/renderer/LevelRendererAdapter.java
@@ -1,0 +1,117 @@
+package net.minecraftforge.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
+import net.minecraft.client.Camera;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ForgeConfig;
+
+import java.util.Collection;
+
+/**
+ * Adapter class which is used to manage the custom render types when they are rendered in the world.
+ */
+public final class LevelRendererAdapter
+{
+    private static final LevelRendererAdapter INSTANCE = new LevelRendererAdapter();
+
+    public static LevelRendererAdapter getInstance()
+    {
+        return INSTANCE;
+    }
+
+    private LevelRendererAdapter()
+    {
+    }
+
+    /**
+     * Invoked by the renderer when it is time to render the blocks which are solid.
+     *
+     * @return {@code true} when the renderer should not render the blocks, {@code false} otherwise.
+     */
+    public boolean onRenderSolids(
+      final LevelRenderer levelRenderer,
+      final PoseStack poseStack,
+      final Camera camera,
+      final Matrix4f projectionMatrix,
+      final ProfilerFiller profilerFiller
+    ) {
+        if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
+            return false;
+
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getSolidPhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+
+        return true;
+    }
+
+    /**
+     * Invoked by the renderer when it is time to render the blocks which are translucent.
+     *
+     * @return {@code true} when the renderer should not render the blocks, {@code false} otherwise.
+     */
+    public boolean onRenderTranslucent(
+      final LevelRenderer levelRenderer,
+      final PoseStack poseStack,
+      final Camera camera,
+      final Matrix4f projectionMatrix,
+      final ProfilerFiller profilerFiller
+    ) {
+        if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
+            return false;
+
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getTranslucentPhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+
+        return true;
+    }
+
+    /**
+     * Invoked by the renderer when it is time to render the blocks which are tripwire.
+     *
+     * @return {@code true} when the renderer should not render the blocks, {@code false} otherwise.
+     */
+    public boolean onRenderTripwire(
+      final LevelRenderer levelRenderer,
+      final PoseStack poseStack,
+      final Camera camera,
+      final Matrix4f projectionMatrix,
+      final ProfilerFiller profilerFiller
+    ) {
+        if (!ForgeConfig.CLIENT.useLevelRendererAdapter.get())
+            return false;
+
+        doRenderPhases(LevelRenderPhaseManager.getInstance().getTripwirePhases(), camera, levelRenderer, poseStack, projectionMatrix, profilerFiller);
+
+        return true;
+    }
+
+    private void doRenderPhases(
+      final Collection<RenderType> phases,
+      final Camera camera,
+      final LevelRenderer levelRenderer,
+      final PoseStack poseStack,
+      final Matrix4f projectionMatrix,
+      final ProfilerFiller profilerFiller
+    ) {
+        final Vec3 cameraPos = camera.getPosition();
+        final double cameraX = cameraPos.x;
+        final double cameraY = cameraPos.y;
+        final double cameraZ = cameraPos.z;
+
+        for (final RenderType renderType : phases)
+        {
+            profilerFiller.push(renderType.name);
+            levelRenderer.renderChunkLayer(
+              renderType,
+              poseStack,
+              cameraX,
+              cameraY,
+              cameraZ,
+              projectionMatrix
+            );
+            profilerFiller.pop();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -128,6 +128,8 @@ public class ForgeConfig {
 
         public final BooleanValue forceSystemNanoTime;
 
+        public final BooleanValue useLevelRendererAdapter;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -158,6 +160,11 @@ public class ForgeConfig {
                     .comment("Forces the use of System.nanoTime instead of glfwGetTime, as the main Util time provider")
                     .translation("forge.configgui.forceSystemNanoTime")
                     .define("forceSystemNanoTime", false);
+
+            useLevelRendererAdapter = builder
+                    .comment("Set to true to use the Forge LevelRendererAdapter instead of the default one.")
+                    .translation("forge.configgui.useLevelRendererAdapter")
+                    .define("useLevelRendererAdapter", true);
 
             builder.pop();
         }

--- a/src/main/java/net/minecraftforge/common/util/SortedRegistry.java
+++ b/src/main/java/net/minecraftforge/common/util/SortedRegistry.java
@@ -37,7 +37,8 @@ public class SortedRegistry<T>
     private final ImmutableList<T> elements;
     private final ImmutableBiMap<ResourceLocation, T> names;
 
-    private SortedRegistry(ImmutableList<T> elements, ImmutableBiMap<ResourceLocation, T> names) {
+    private SortedRegistry(ImmutableList<T> elements, ImmutableBiMap<ResourceLocation, T> names)
+    {
         this.elements = elements;
         this.names = names;
     }
@@ -55,7 +56,8 @@ public class SortedRegistry<T>
      * Returns the unordered collection of entries.
      * @return An immutable bimap of unordered entries
      */
-    public ImmutableBiMap<ResourceLocation, T> getUnorderedEntries() {
+    public ImmutableBiMap<ResourceLocation, T> getUnorderedEntries()
+    {
         return names;
     }
 
@@ -149,7 +151,8 @@ public class SortedRegistry<T>
         private final BiMap<ResourceLocation, T> entries = HashBiMap.create();
         private final Multimap<ResourceLocation, ResourceLocation> edges = HashMultimap.create();
 
-        public Builder(Class<T> type) {
+        public Builder(Class<T> type)
+        {
             this.type = type;
         }
 

--- a/src/main/java/net/minecraftforge/common/util/SortedRegistry.java
+++ b/src/main/java/net/minecraftforge/common/util/SortedRegistry.java
@@ -1,0 +1,216 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.util;
+
+import com.google.common.collect.*;
+import com.google.common.graph.ElementOrder;
+import com.google.common.graph.GraphBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fml.loading.toposort.TopologicalSort;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * A {@link ResourceLocation} to T registry where elements may define arbitrary ordering rules.
+ * @param <T> The type of elements in the registry
+ */
+public class SortedRegistry<T>
+{
+    private final ImmutableList<T> elements;
+    private final ImmutableBiMap<ResourceLocation, T> names;
+
+    private SortedRegistry(ImmutableList<T> elements, ImmutableBiMap<ResourceLocation, T> names) {
+        this.elements = elements;
+        this.names = names;
+    }
+
+    /**
+     * Returns the list of elements in ascending order as defined by the dependencies.
+     * @return An immutable list of sorted elements
+     */
+    public ImmutableList<T> getElements()
+    {
+        return elements;
+    }
+
+    /**
+     * Returns the unordered collection of entries.
+     * @return An immutable bimap of unordered entries
+     */
+    public ImmutableBiMap<ResourceLocation, T> getUnorderedEntries() {
+        return names;
+    }
+
+    /**
+     * Returns the element associated with the given name.
+     * @param name The name to look up
+     * @return The element, or null if not registered
+     */
+    @Nullable
+    public T get(ResourceLocation name)
+    {
+        return names.get(name);
+    }
+
+    /**
+     * Returns the name with which the given element was registered.
+     * @param element The element to look up
+     * @return The name of the element, or null if not registered
+     */
+    @Nullable
+    public ResourceLocation getName(T element)
+    {
+        return names.inverse().get(element);
+    }
+
+    /**
+     * Checks whether the given name is contained in the registry.
+     * @param name The name to look up
+     * @return True if registered, false otherwise
+     */
+    public boolean contains(ResourceLocation name)
+    {
+        return names.containsKey(name);
+    }
+
+    /**
+     * Checks whether the given element is contained in the registry.
+     * @param element The element to look up
+     * @return True if registered, false otherwise
+     */
+    public boolean contains(T element)
+    {
+        return names.containsValue(element);
+    }
+
+    /**
+     * Returns the ordered list of elements that appear before the specified one.
+     * If the element is not found, an empty list is returned.
+     * @param element The element to look up
+     * @return An immutable list of predecessors in ascending order
+     */
+    public ImmutableList<T> getAllBefore(T element)
+    {
+        var index = elements.indexOf(element);
+        if (index == -1) return ImmutableList.of();
+        return elements.subList(0, index);
+    }
+
+    /**
+     * Returns the ordered list of elements that appear after the specified one.
+     * If the element is not found, an empty list is returned.
+     * @param element The element to look up
+     * @return An immutable list of successors in ascending order
+     */
+    public ImmutableList<T> getAllAfter(T element)
+    {
+        var index = elements.indexOf(element);
+        if (index == -1) return ImmutableList.of();
+        return elements.subList(index + 1, elements.size());
+    }
+
+    /**
+     * Returns the ordered list of elements that appear between the specified ones.
+     * If the first element is null or not found, the registry is indexed from the start.
+     * If the last element is null or not found, the registry is indexed until the end.
+     * @param first The lower bound
+     * @param last The upper bound
+     * @return An immutable list of elements between the arguments in ascending order
+     */
+    public ImmutableList<T> getAllBetween(@Nullable T first, @Nullable T last)
+    {
+        var firstIndex = first != null ? elements.indexOf(first) : -1;
+        var lastIndex = last != null ? elements.indexOf(last) : elements.size();
+        if (firstIndex >= lastIndex) return ImmutableList.of();
+        return elements.subList(firstIndex + 1, lastIndex);
+    }
+
+    public static class Builder<T>
+    {
+        private final Class<T> type;
+        private final BiMap<ResourceLocation, T> entries = HashBiMap.create();
+        private final Multimap<ResourceLocation, ResourceLocation> edges = HashMultimap.create();
+
+        public Builder(Class<T> type) {
+            this.type = type;
+        }
+
+        /**
+         * Adds an element to the sorted registry.
+         * @param element The element
+         * @param name The name of the element
+         * @param predecessors A list of elements that must appear before this element (String, ResourceName, and T are allowed)
+         * @param successors A list of elements that must appear after this element (String, ResourceName, and T are allowed)
+         * @param <T2> The type of the element
+         * @return The element
+         */
+        public synchronized <T2 extends T> T2 add(T2 element, ResourceLocation name, List<Object> predecessors, List<Object> successors)
+        {
+            Objects.requireNonNull(predecessors, "Predecessor list may not be null.");
+            Objects.requireNonNull(successors, "Successor list may not be null.");
+            if (entries.containsKey(name))
+                throw new IllegalArgumentException("An entry has already been registered with this name: " + name);
+            entries.put(name, element);
+            for(var other : predecessors)
+                edges.put(getName(other), name);
+            for(var other : successors)
+                edges.put(name, getName(other));
+            return element;
+        }
+
+        private ResourceLocation getName(Object element)
+        {
+            Objects.requireNonNull(element, "Attempted to get name of a null object.");
+            if (element instanceof ResourceLocation rl)
+                return rl;
+            if (element instanceof String s)
+                return new ResourceLocation(s);
+            if (type.isAssignableFrom(element.getClass()))
+            {
+                var name = entries.inverse().get(type.cast(element));
+                return Objects.requireNonNull(name, "Cannot add a dependency on an element that is not registered.");
+            }
+            throw new IllegalStateException("Invalid object type passed into dependencies: " + element.getClass());
+        }
+
+        /**
+         * Creates a new {@link SortedRegistry} from the registered elements and dependencies.
+         * @return A new registry
+         */
+        @SuppressWarnings("UnstableApiUsage")
+        public SortedRegistry<T> build()
+        {
+            var graph = GraphBuilder.directed().nodeOrder(ElementOrder.<T>insertion()).build();
+            for(var element : entries.values())
+            {
+                graph.addNode(element);
+            }
+            edges.forEach((from, to) -> {
+                if (entries.containsKey(from) && entries.containsKey(to))
+                    graph.putEdge(entries.get(from), entries.get(to));
+            });
+            var sortedElements = TopologicalSort.topologicalSort(graph, null);
+            return new SortedRegistry<>(ImmutableList.copyOf(sortedElements), ImmutableBiMap.copyOf(entries));
+        }
+
+    }
+
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -76,6 +76,8 @@ public net.minecraft.client.particle.ParticleEngine m_107381_(Lnet/minecraft/cor
 public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration
 public net.minecraft.client.renderer.GameRenderer m_109128_(Lnet/minecraft/resources/ResourceLocation;)V # loadEffect
 protected-f net.minecraft.client.renderer.RenderStateShard f_110131_ # setupState
+protected-f net.minecraft.client.renderer.RenderStateShard f_110132_ # clearState
+public net.minecraft.client.renderer.RenderStateShard f_110133_ # name
 public net.minecraft.client.renderer.RenderStateShard$BooleanStateShard
 public net.minecraft.client.renderer.RenderStateShard$CullStateShard
 public net.minecraft.client.renderer.RenderStateShard$DepthTestStateShard
@@ -95,6 +97,8 @@ public net.minecraft.client.renderer.RenderStateShard$TransparencyStateShard
 public net.minecraft.client.renderer.RenderStateShard$WriteMaskStateShard
 public net.minecraft.client.renderer.RenderType m_173215_(Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType; # create
 public net.minecraft.client.renderer.RenderType$CompositeState
+public-f net.minecraft.client.renderer.RenderType$CompositeRenderType #Enable the complex render type to extend this custom type.
+protected net.minecraft.client.renderer.RenderType$CompositeRenderType <init>(Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)V
 public net.minecraft.client.renderer.block.model.BlockElement m_111320_(Lnet/minecraft/core/Direction;)[F # uvsByFace
 public net.minecraft.client.renderer.block.model.BlockElement$Deserializer
 public net.minecraft.client.renderer.block.model.BlockElement$Deserializer <init>()V # constructor
@@ -440,3 +444,4 @@ protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
+public net.minecraft.client.renderer.LevelRenderer m_172993_(Lnet/minecraft/client/renderer/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;DDDLcom/mojang/math/Matrix4f;)V

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -75,9 +75,9 @@ public net.minecraft.client.particle.ParticleEngine m_107378_(Lnet/minecraft/cor
 public net.minecraft.client.particle.ParticleEngine m_107381_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V # register
 public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration
 public net.minecraft.client.renderer.GameRenderer m_109128_(Lnet/minecraft/resources/ResourceLocation;)V # loadEffect
+public net.minecraft.client.renderer.LevelRenderer m_172993_(Lnet/minecraft/client/renderer/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;DDDLcom/mojang/math/Matrix4f;)V
 protected-f net.minecraft.client.renderer.RenderStateShard f_110131_ # setupState
 protected-f net.minecraft.client.renderer.RenderStateShard f_110132_ # clearState
-public net.minecraft.client.renderer.RenderStateShard f_110133_ # name
 public net.minecraft.client.renderer.RenderStateShard$BooleanStateShard
 public net.minecraft.client.renderer.RenderStateShard$CullStateShard
 public net.minecraft.client.renderer.RenderStateShard$DepthTestStateShard
@@ -444,4 +444,3 @@ protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
-public net.minecraft.client.renderer.LevelRenderer m_172993_(Lnet/minecraft/client/renderer/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;DDDLcom/mojang/math/Matrix4f;)V

--- a/src/test/java/net/minecraftforge/debug/client/LayerRenderTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/LayerRenderTypeTest.java
@@ -1,0 +1,147 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client;
+
+import com.mojang.blaze3d.shaders.Uniform;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.math.Matrix4f;
+import net.minecraft.Util;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.Material;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.LayerRenderTypeRegisterEvent;
+import net.minecraftforge.client.event.RegisterShadersEvent;
+import net.minecraftforge.client.event.RenderTypeRegisterEvent;
+import net.minecraftforge.client.renderer.ComplexRenderType;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+@Mod(LayerRenderTypeTest.MOD_ID)
+public class LayerRenderTypeTest
+{
+    private static final boolean ENABLED = true;
+    static final String MOD_ID = "layer_render_type_test";
+
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MOD_ID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+
+    private static final RegistryObject<Block> TEST_BLOCK = BLOCKS.register("test", () -> new Block(BlockBehaviour.Properties.of(Material.STONE)));
+    private static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new BlockItem(TEST_BLOCK.get(), new Item.Properties()));
+
+    public LayerRenderTypeTest()
+    {
+        if (ENABLED)
+        {
+            BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
+            ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+        }
+    }
+
+    @Mod.EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+    private static class ClientHandler
+    {
+        private static ShaderInstance CUSTOM_SHADER;
+
+        private static final ResourceLocation CUSTOM_RENDER_TYPE_NAME = new ResourceLocation(MOD_ID, "custom");
+        private static RenderType CUSTOM_RENDER_TYPE;
+
+        @SubscribeEvent
+        public static void onClientSetup(final FMLClientSetupEvent event)
+        {
+            if (!ENABLED) return;
+
+            ItemBlockRenderTypes.setRenderLayer(TEST_BLOCK.get(), CUSTOM_RENDER_TYPE);
+        }
+
+        @SubscribeEvent
+        public static void onRegisterRenderTypes(RenderTypeRegisterEvent event)
+        {
+            if (!ENABLED) return;
+
+            CUSTOM_RENDER_TYPE = ComplexRenderType.builder()
+                    .beforeChunkRenderCallback(ClientHandler::beforeChunkRender)
+                    .build(
+                            CUSTOM_RENDER_TYPE_NAME.toString(),
+                            DefaultVertexFormat.BLOCK, VertexFormat.Mode.QUADS,
+                            RenderType.SMALL_BUFFER_SIZE, true, false,
+                            RenderType.CompositeState.builder()
+                                    .setLightmapState(new RenderStateShard.LightmapStateShard(true))
+                                    .setShaderState(new RenderStateShard.ShaderStateShard(() -> CUSTOM_SHADER))
+                                    .setTextureState(new RenderStateShard.TextureStateShard(TextureAtlas.LOCATION_BLOCKS, false, false))
+                                    .createCompositeState(true)
+                    );
+        }
+
+        @SubscribeEvent
+        public static void onRegisterSolidStaticRenderTypes(LayerRenderTypeRegisterEvent.Solid event)
+        {
+            if (!ENABLED) return;
+
+            event.getBuilder().add(
+                    CUSTOM_RENDER_TYPE, CUSTOM_RENDER_TYPE_NAME,
+                    List.of(RenderType.cutout()), // After cutout
+                    List.of()
+            );
+        }
+
+        @SubscribeEvent
+        public static void onRegisterShaders(RegisterShadersEvent event) throws IOException
+        {
+            if (!ENABLED) return;
+
+            event.registerShader(
+                    new ShaderInstance(event.getResourceManager(), new ResourceLocation(MOD_ID, "rendertype_custom"), DefaultVertexFormat.BLOCK),
+                    shader -> CUSTOM_SHADER = shader
+            );
+        }
+
+        private static void beforeChunkRender(
+            LevelRenderer levelRenderer,
+            ChunkRenderDispatcher.RenderChunk renderChunk,
+            PoseStack poseStack,
+            double cameraX,
+            double cameraY,
+            double cameraZ,
+            Matrix4f projectionMatrix)
+        {
+            final Uniform TIME = CUSTOM_SHADER.getUniform("SysTime");
+            Objects.requireNonNull(TIME).set((Util.getMillis() % 1000) / 1000f);
+        }
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/client/LayerRenderTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/LayerRenderTypeTest.java
@@ -137,8 +137,8 @@ public class LayerRenderTypeTest
             double cameraX,
             double cameraY,
             double cameraZ,
-            Matrix4f projectionMatrix)
-        {
+            Matrix4f projectionMatrix
+        ) {
             final Uniform TIME = CUSTOM_SHADER.getUniform("SysTime");
             Objects.requireNonNull(TIME).set((Util.getMillis() % 1000) / 1000f);
         }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -174,5 +174,7 @@ license="LGPL v2.1"
     modId="part_entity_test"
 [[mods]]
     modId="capabilities_test"
+[[mods]]
+    modId="layer_render_type_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/assets/layer_render_type_test/blockstates/test.json
+++ b/src/test/resources/assets/layer_render_type_test/blockstates/test.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/white_wool"
+    }
+  }
+}

--- a/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.fsh
+++ b/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.fsh
@@ -1,0 +1,23 @@
+#version 150
+
+#moj_import <fog.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec2 texCoord0;
+in vec4 normal;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    color = color * vec4(abs(normal.xyz), 1);
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.json
+++ b/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.json
@@ -1,0 +1,30 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "srcalpha",
+        "dstrgb": "1-srcalpha"
+    },
+    "vertex": "layer_render_type_test:rendertype_custom",
+    "fragment": "layer_render_type_test:rendertype_custom",
+    "attributes": [
+        "Position",
+        "Color",
+        "UV0",
+        "UV2",
+        "Normal"
+    ],
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler2" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ChunkOffset", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
+        { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+        { "name": "SysTime", "type": "float", "count": 1, "values": [ 0 ] }
+    ]
+}

--- a/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.vsh
+++ b/src/test/resources/assets/layer_render_type_test/shaders/core/rendertype_custom.vsh
@@ -1,0 +1,30 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform vec3 ChunkOffset;
+uniform float SysTime;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position + ChunkOffset + sin(3.1415 * 2 * vec3(2 * SysTime + 0.69, 5 * SysTime, 3 * SysTime + 4.20)) * 0.1, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position + ChunkOffset, 1.0)).xyz);
+    vertexColor = Color * minecraft_sample_lightmap(Sampler2, UV2);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}


### PR DESCRIPTION
Minecraft's render engine supports the creation of custom render types, which allow the user to specify the vertex format and render state (face culling, depth sorting, shaders, etc) for certain parts of their geometry. However, natively these only work on dynamic geometry (entity/blockentity renderers), and not static elements like terrain.

This PR adds the necessary hooks to extend the default set of render types supported for static geometry rendering (solid, cutout_mipped, cutout, translucent, tripwire).

## Motivation

The `RenderType` system is incredibly powerful, but it's currently limited to just dynamic geometry, which requires a considerable amount of CPU time and GPU bandwidth to gather and upload every single frame. This means that any effect involving static geometry that requires a custom render state or shader (which is not all that uncommon) is creating an unnecessary load on both the CPU and GPU.

## Implementation

As suggested by @OrionDevelopment, the code from Forge's existing `TierSortingRegistry` was generified and repurposed to provide a method through which developers can register their own `RenderType` instances and customize their ordering relative to both Minecraft's built in render types as well as other mods'. The tier sorting registry has been migrated to this generified registry as well.

Due to the way Minecraft schedules its rendering, the render types have been split into three phases: solid, translucent and tripwire. Solid render types are rendered before entities, translucent render types are rendered after them, and tripwire render types are rendered after the dynamic buffers have been drawn. This is reflected in the events fired during client initialization to register custom render types: `StaticRenderTypeRegisterEvent.Solid`, `StaticRenderTypeRegisterEvent.Translucent` and `StaticRenderTypeRegisterEvent.Tripwire`. These events are fired on the mod bus as they are used to register mod-owned render types.

Along with these events, a `RenderTypeRegisterEvent` has been added for any mod that may need to register custom render types. This event provides a convenient and consistent place for this to take place, and ensures correct initialization of all required resources has taken place by the time it is fired. This event is also fired on the mod bus as it is used to register mod-owned render types.

The render calls for each phase are delegated from `LevelRenderer` to the `LevelRendererAdapter` class, which may decide (based on a Forge client config option) to run vanilla's default code path, or visit each of the vanilla + custom render types for that phase in the configured order. 

An additional set of interfaces and classes has been created to allow the creation of custom render types which receive a callback before rendering every chunk, allowing developers to compute and upload their own sets of uniforms to their shaders, or otherwise update the render state before the draw call is issued.

Forge's `MultiLayerModel` has been updated to support user-registered static render types, and the public field listing the old supported render types has been deprecated and marked for removal.

Lastly, a test mod is provided (mod id `layer_render_type_test`) which adds a block with a custom render type. This render type's shader makes the block's geometry shake, and its color changes depending on the camera's orientation relative to the faces.

## Demo

Here is a short demo gif of the block in the test mod as the camera moves around:

![gif](https://user-images.githubusercontent.com/2066666/147593837-70b9ec1c-ed39-4d5f-a16e-52025ce1fcff.gif)

## Performance and memory implications

The overhead of this system is minimal, with a baseline cost of 3 foreach loops iterating over a pre-computed empty list.

The cost of additional render layers is down to each layer's specific settings. The main factors will be:
 - Memory usage increase of at least `RenderType#bufferSize()` for every chunk (negligible under vanilla standards of <= 1MB)
 - Added CPU cost of capturing and rendering the additional geometry (may be considerably optimized by deviating from the current way Forge handles render types in baked models, but this would be another PR)
 - Minor CPU hit during startup while the render types are registered and sorted

In conclusion, the actual cost if unused is negligible, but as with everything, it must be used in moderation (at least until the aforementioned changes to baked models are discussed and implemented).

## Maintainability

This PR moves the maintenance tasks related to `MultiLayerModel` (keeping an updated list of vanilla-supported static render types) to the `LevelRenderPhaseManager` class. `MultiLayerModel` now relies on this, and as such it does not need to be kept updated anymore.

The mipmap fixes in `LevelRenderer` have been moved to `ForgeRenderTypes.MipmapFixTextureShard` and are now applied by replacing vanilla's default mipmap texture render state shard, which is a more idiomatic approach and ensures that the fix is applied to any render types using the mipmapped blocks texture.

Additional maintenance tasks may involve adding/re-ordering hooks in `LevelRenderer` in the case that vanilla adds new static render types. These changes are unlikely and should not result in any changes to the core API.

## Additional notes

During the testing of this pull request, I found that in a Forge dev environment with test mods enabled, reloading resources triggers an invalid GL state which changes the colors of everything in the game and prevents text from rendering. This has been tested with and without this PR's changes, and the effect is the same, so the problem is expected to be in one of the other tests. This has not been tested in an environment without tests because if it works in a mod dev environment (which it does), it should work in an empty Forge dev environment.

If you want, I can open an issue about this.

---

Special thanks to @OrionDevelopment for all the help, feedback and code provided throughout the development of this PR.  
They provided a significant amount of code, but the git authorship has been lost in refactoring and cleanup.