### PR TITLE
[1.16.x] Add world and location data to PlaySoundAtEntityEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/player/ClientPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/player/ClientPlayerEntity.java.patch
@@ -12,7 +12,7 @@
     }
  
     public void func_184185_a(SoundEvent p_184185_1_, float p_184185_2_, float p_184185_3_) {
-+      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(this, p_184185_1_, this.func_184176_by(), p_184185_2_, p_184185_3_);
++      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(this, p_184185_1_, this.func_184176_by(), p_184185_2_, p_184185_3_, this.field_70170_p, this.func_226277_ct_(), this.func_226278_cu_(), this.func_226281_cx_());
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_184185_1_ = event.getSound();
 +      p_184185_2_ = event.getVolume();

--- a/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/world/ClientWorld.java.patch
@@ -42,7 +42,7 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
-+      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_10_, p_184148_11_);
++      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_10_, p_184148_11_, this, p_184148_2_, p_184148_4_, p_184148_6_);
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_184148_8_ = event.getSound();
 +      p_184148_9_ = event.getCategory();
@@ -54,7 +54,7 @@
     }
  
     public void func_217384_a(@Nullable PlayerEntity p_217384_1_, Entity p_217384_2_, SoundEvent p_217384_3_, SoundCategory p_217384_4_, float p_217384_5_, float p_217384_6_) {
-+      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_217384_1_, p_217384_3_, p_217384_4_, p_217384_5_, p_217384_6_);
++      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_217384_1_, p_217384_3_, p_217384_4_, p_217384_5_, p_217384_6_, this, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_());
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_217384_3_ = event.getSound();
 +      p_217384_4_ = event.getCategory();

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -218,7 +218,7 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
-+      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_10_, p_184148_11_);
++      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_10_, p_184148_11_, this, p_184148_2_, p_184148_4_, p_184148_6_);
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_184148_8_ = event.getSound();
 +      p_184148_9_ = event.getCategory();
@@ -227,7 +227,7 @@
     }
  
     public void func_217384_a(@Nullable PlayerEntity p_217384_1_, Entity p_217384_2_, SoundEvent p_217384_3_, SoundCategory p_217384_4_, float p_217384_5_, float p_217384_6_) {
-+      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_217384_1_, p_217384_3_, p_217384_4_, p_217384_5_, p_217384_6_);
++      net.minecraftforge.event.entity.PlaySoundAtEntityEvent event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_217384_1_, p_217384_3_, p_217384_4_, p_217384_5_, p_217384_6_, this, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_());
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_217384_3_ = event.getSound();
 +      p_217384_4_ = event.getCategory();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -429,9 +429,9 @@ public class ForgeEventFactory
         return event.getCanUpdate();
     }
 
-    public static PlaySoundAtEntityEvent onPlaySoundAtEntity(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch)
+    public static PlaySoundAtEntityEvent onPlaySoundAtEntity(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch, World level, double x, double y, double z)
     {
-        PlaySoundAtEntityEvent event = new PlaySoundAtEntityEvent(entity, name, category, volume, pitch);
+        PlaySoundAtEntityEvent event = new PlaySoundAtEntityEvent(entity, name, category, volume, pitch, level, x, y, z);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -91,7 +91,7 @@ public class PlaySoundAtEntityEvent extends EntityEvent
     public double getY() { return this.y; }
     public double getZ() { return this.z; }
     public void setSound(SoundEvent value) { this.name = value; }
-    public void setVolume(float value) { this.newVolume = value; }
     public void setCategory(SoundCategory category) { this.category = category; }
+    public void setVolume(float value) { this.newVolume = value; }
     public void setPitch(float value) { this.newPitch = value; }
 }

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -38,6 +38,10 @@ import net.minecraft.util.SoundEvent;
  * {@link #pitch} contains the pitch at which the sound is to be played originally.<br>
  * {@link #newVolume} contains the volume at which the sound is actually played.<br>
  * {@link #newPitch} contains the pitch at which the sound is actually played.<br>
+ * {@link #level} contains the world in which the sound is to be played.<br>
+ * {@link #x} contains the x coordinate at which the sound is to be played.<br>
+ * {@link #y} contains the y coordinate at which the sound is to be played.<br>
+ * {@link #z} contains the x coordinate at which the sound is to be played.<br>
  * Changing the {@link #name} field will cause the sound of this name to be played instead of the originally intended sound.<br>
  * <br>
  * This event is {@link Cancelable}.<br>
@@ -56,8 +60,12 @@ public class PlaySoundAtEntityEvent extends EntityEvent
     private final float pitch;
     private float newVolume;
     private float newPitch;
+    private final World level;
+    private final double x;
+    private final double y;
+    private final double z;
 
-    public PlaySoundAtEntityEvent(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch)
+    public PlaySoundAtEntityEvent(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch, World level, double x, double y, double z)
     {
         super(entity);
         this.name = name;
@@ -66,6 +74,10 @@ public class PlaySoundAtEntityEvent extends EntityEvent
         this.pitch = pitch;
         this.newVolume = volume;
         this.newPitch = pitch;
+        this.level = level;
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     public SoundEvent getSound() { return this.name; }
@@ -74,8 +86,12 @@ public class PlaySoundAtEntityEvent extends EntityEvent
     public float getDefaultPitch() { return this.pitch; }
     public float getVolume() { return this.newVolume; }
     public float getPitch() { return this.newPitch; }
+    public World getLevel() { return this.level; }
+    public double getX() { return this.x; }
+    public double getY() { return this.y; }
+    public double getZ() { return this.z; }
+    public void setVolume(float value) { this.newVolume = value; }
     public void setSound(SoundEvent value) { this.name = value; }
     public void setCategory(SoundCategory category) { this.category = category; }
-    public void setVolume(float value) { this.newVolume = value; }
     public void setPitch(float value) { this.newPitch = value; }
 }

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -90,8 +90,8 @@ public class PlaySoundAtEntityEvent extends EntityEvent
     public double getX() { return this.x; }
     public double getY() { return this.y; }
     public double getZ() { return this.z; }
-    public void setVolume(float value) { this.newVolume = value; }
     public void setSound(SoundEvent value) { this.name = value; }
+    public void setVolume(float value) { this.newVolume = value; }
     public void setCategory(SoundCategory category) { this.category = category; }
     public void setPitch(float value) { this.newPitch = value; }
 }

--- a/src/test/java/net/minecraftforge/debug/misc/PlaySoundAtEntityEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/PlaySoundAtEntityEventTest.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 @Mod("play_sound_at_entity_test")
 public class PlaySoundAtEntityEventTest {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     private static final Logger LOGGER = LogManager.getLogger("Sound Event Test Test");
     public PlaySoundAtEntityEventTest() {
         if (ENABLED) {

--- a/src/test/java/net/minecraftforge/debug/misc/PlaySoundAtEntityEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/PlaySoundAtEntityEventTest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.debug.misc;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("play_sound_at_entity_test")
+public class PlaySoundAtEntityEventTest {
+    private static final boolean ENABLED = true;
+    private static final Logger LOGGER = LogManager.getLogger("Sound Event Test Test");
+    public PlaySoundAtEntityEventTest() {
+        if (ENABLED) {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void onSoundEvent(PlaySoundAtEntityEvent soundEvent) {
+        LOGGER.info(String.format("GOT %S SOUND EVENT at {%f, %f, %f} in %s",
+                soundEvent.getSound().getRegistryName().getPath(),
+                soundEvent.getX(),
+                soundEvent.getY(),
+                soundEvent.getZ(),
+                soundEvent.getLevel().dimension().location().getPath()
+        ));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -148,5 +148,7 @@ license="LGPL v2.1"
     modId="full_pots_accessor_demo"
 [[mods]]
     modId="forge_spawnegg_test"
+[[mods]]
+    modId="play_sound_at_entity_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Expose `World` and x/y/z coordinates in `PlaySoundAtEntityEvent`. This is necessary because the player entity attached to the event is often null and thus the location and world corresponding to the event cannot always be determined. These changes expose those values as separate fields so that they can be accessed by mods that subscribe to the event. This is useful, for instance, if a mod wants to hook into sound events to provide a sense of hearing to a mob (as I was trying to do before writing this PR).

An example mod is provided in `PlaySoundAtEntityEventTest.java`. Set the `ENABLED` flag to `true` to enable the event subscription. When the mod is enabled, there should be lots of log spam showing the coordinates and dimension name of each sound event. An easy way to confirm the coordinates are correct is to tp to an entity making sound.