### PR TITLE
[1.18.X] Add events for collecting static and dynamic level geometry

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -59,7 +59,15 @@
              ++this.f_109439_;
              if (entity.f_19797_ == 0) {
                 entity.f_19790_ = entity.m_20185_();
-@@ -1230,6 +_,7 @@
+@@ -1224,12 +_,15 @@
+       multibuffersource$buffersource.m_109912_(RenderType.m_110452_(TextureAtlas.f_118259_));
+       multibuffersource$buffersource.m_109912_(RenderType.m_110458_(TextureAtlas.f_118259_));
+       multibuffersource$buffersource.m_109912_(RenderType.m_110476_(TextureAtlas.f_118259_));
++      profilerfiller.m_6182_("forge_dynamic_geometry");
++      net.minecraftforge.client.ForgeHooksClient.onGatherDynamicLevelGeometry(multibuffersource$buffersource, this, p_109600_, p_109601_, p_109604_);
+       profilerfiller.m_6182_("blockentities");
+ 
+       for(LevelRenderer.RenderChunkInfo levelrenderer$renderchunkinfo : this.f_194297_) {
           List<BlockEntity> list = levelrenderer$renderchunkinfo.f_109839_.m_112835_().m_112773_();
           if (!list.isEmpty()) {
              for(BlockEntity blockentity1 : list) {

--- a/patches/minecraft/net/minecraft/client/renderer/chunk/ChunkRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/ChunkRenderDispatcher.java.patch
@@ -82,6 +82,14 @@
              this.f_112858_ = p_194428_;
           }
  
+@@ -562,6 +_,7 @@
+             this.f_112858_ = null;
+             PoseStack posestack = new PoseStack();
+             if (renderchunkregion != null) {
++               net.minecraftforge.client.ForgeHooksClient.onGatherStaticChunkGeometry(p_112870_, renderchunkregion, RenderChunk.this.f_112793_, visgraph, p_112869_, RenderChunk.this::m_112805_);
+                ModelBlockRenderer.m_111000_();
+                Random random = new Random();
+                BlockRenderDispatcher blockrenderdispatcher = Minecraft.m_91087_().m_91289_();
 @@ -580,8 +_,10 @@
                    }
  

--- a/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
@@ -1,0 +1,108 @@
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Camera;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.chunk.RenderChunkRegion;
+import net.minecraft.client.renderer.chunk.VisGraph;
+import net.minecraft.core.BlockPos;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ * on {@link net.minecraftforge.api.distmarker.Dist#CLIENT} when geometry
+ * is being collected from its respective sources.
+ *
+ * @see ChunkSectionStatic
+ * @see LevelDynamic
+ */
+public abstract class GatherGeometryEvent extends Event
+{
+    private final MultiBufferSource bufferSource;
+
+    protected GatherGeometryEvent(MultiBufferSource bufferSource)
+    {
+        this.bufferSource = bufferSource;
+    }
+
+    public MultiBufferSource getBufferSource()
+    {
+        return bufferSource;
+    }
+
+    /**
+     * Fired when the client is gathering static geometry and
+     * occlusion data for a 16x16x16 section of a chunk.
+     */
+    public static class ChunkSectionStatic extends GatherGeometryEvent
+    {
+        private final RenderChunkRegion region;
+        private final BlockPos.MutableBlockPos origin;
+        private final VisGraph visibilityGraph;
+
+        public ChunkSectionStatic(MultiBufferSource bufferSource, RenderChunkRegion region, BlockPos.MutableBlockPos origin, VisGraph visibilityGraph)
+        {
+            super(bufferSource);
+            this.region = region;
+            this.origin = origin;
+            this.visibilityGraph = visibilityGraph;
+        }
+
+        public RenderChunkRegion getRegion()
+        {
+            return region;
+        }
+
+        public BlockPos.MutableBlockPos getOrigin()
+        {
+            return origin;
+        }
+
+        public VisGraph getVisibilityGraph()
+        {
+            return visibilityGraph;
+        }
+    }
+
+    /**
+     * Fired when the client is gathering dynamic level geometry.
+     */
+    public static class LevelDynamic extends GatherGeometryEvent
+    {
+        private final LevelRenderer levelRenderer;
+        private final PoseStack poseStack;
+        private final float partialTicks;
+        private final Camera camera;
+
+        public LevelDynamic(MultiBufferSource bufferSource, LevelRenderer levelRenderer, PoseStack poseStack,
+                            float partialTicks, Camera camera)
+        {
+            super(bufferSource);
+            this.levelRenderer = levelRenderer;
+            this.camera = camera;
+            this.partialTicks = partialTicks;
+            this.poseStack = poseStack;
+        }
+
+        public LevelRenderer getLevelRenderer()
+        {
+            return levelRenderer;
+        }
+
+        public PoseStack getPoseStack()
+        {
+            return poseStack;
+        }
+
+        public float getPartialTicks()
+        {
+            return partialTicks;
+        }
+
+        public Camera getCamera()
+        {
+            return camera;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.client.renderer.chunk.VisGraph;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.eventbus.api.Event;
 
+import javax.annotation.Nullable;
+
 /**
  * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
  * on {@link net.minecraftforge.api.distmarker.Dist#CLIENT} when geometry
@@ -37,11 +39,12 @@ public abstract class GatherGeometryEvent extends Event
      */
     public static class ChunkSectionStatic extends GatherGeometryEvent
     {
+        @Nullable
         private final RenderChunkRegion region;
         private final BlockPos.MutableBlockPos origin;
         private final VisGraph visibilityGraph;
 
-        public ChunkSectionStatic(MultiBufferSource bufferSource, RenderChunkRegion region, BlockPos.MutableBlockPos origin, VisGraph visibilityGraph)
+        public ChunkSectionStatic(MultiBufferSource bufferSource, @Nullable RenderChunkRegion region, BlockPos.MutableBlockPos origin, VisGraph visibilityGraph)
         {
             super(bufferSource);
             this.region = region;
@@ -49,6 +52,7 @@ public abstract class GatherGeometryEvent extends Event
             this.visibilityGraph = visibilityGraph;
         }
 
+        @Nullable
         public RenderChunkRegion getRegion()
         {
             return region;

--- a/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GatherGeometryEvent.java
@@ -63,6 +63,13 @@ public abstract class GatherGeometryEvent extends Event
             return origin;
         }
 
+        /**
+         * The visibility graph for this 16x16x16 section of a chunk.
+         *
+         * This is used to mark areas of a chunk as opaque, and is used by
+         * Minecraft to determine whether other chunks are being occluded
+         * by this one or not, and thus whether they need to be rendered.
+         */
         public VisGraph getVisibilityGraph()
         {
             return visibilityGraph;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,3 +1,4 @@
+public com.mojang.blaze3d.vertex.BufferBuilder$SortState f_166818_ # vertices
 public net.minecraft.advancements.CriteriaTriggers m_10595_(Lnet/minecraft/advancements/CriterionTrigger;)Lnet/minecraft/advancements/CriterionTrigger; # register
 default net.minecraft.client.KeyMapping f_90817_ # isDown
 public net.minecraft.client.Minecraft f_90987_ # textureManager
@@ -126,6 +127,9 @@ public net.minecraft.client.renderer.entity.ItemRenderer m_115162_(Lcom/mojang/b
 public net.minecraft.client.renderer.entity.ItemRenderer m_115189_(Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/item/ItemStack;IILcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V # renderModelLists
 public net.minecraft.client.renderer.entity.LivingEntityRenderer m_115326_(Lnet/minecraft/client/renderer/entity/layers/RenderLayer;)Z # addLayer
 public net.minecraft.client.renderer.texture.TextureAtlasSprite m_118415_()I # getFrameCount
+public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$CompiledChunk f_112749_ # hasBlocks
+public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$CompiledChunk f_112750_ # hasLayer
+public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$CompiledChunk f_112751_ # isCompletelyEmpty
 public net.minecraft.client.resources.ClientPackSource f_174791_ # BUILT_IN
 private-f net.minecraft.client.resources.model.ModelBakery f_119216_ # atlasPreparations - need to un-finalize so that we can delay initialization to after calling super() in ModelLoader
 protected net.minecraft.client.resources.model.ModelBakery f_119234_ # UNREFERENCED_TEXTURES

--- a/src/test/java/net/minecraftforge/debug/client/rendering/GeometryGatheringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/GeometryGatheringTest.java
@@ -1,0 +1,90 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import com.google.common.base.Suppliers;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.GatherGeometryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.function.Supplier;
+
+@Mod(GeometryGatheringTest.MOD_ID)
+public class GeometryGatheringTest
+{
+    private static final boolean ENABLED = true;
+    static final String MOD_ID = "geometry_gathering_test";
+
+    @Mod.EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+    private static class ClientHandler
+    {
+        private static final Supplier<BlockState> STATIC_STATE = Suppliers.memoize(() -> Blocks.OBSIDIAN.defaultBlockState());
+        private static final Supplier<BlockState> DYNAMIC_STATE = Suppliers.memoize(() -> Blocks.STONE.defaultBlockState());
+
+        @SubscribeEvent
+        public static void onGatherStaticChunkGeometry(final GatherGeometryEvent.ChunkSectionStatic event)
+        {
+            if (!ENABLED) return;
+            if (event.getOrigin().getY() >> 4 != 80 >> 4) return;
+
+            event.getVisibilityGraph().setOpaque(event.getOrigin().above(80 & 0xF));
+
+            var bufferSource = event.getBufferSource();
+            var poseStack = new PoseStack();
+            poseStack.translate(0, 80 & 0xF, 0);
+
+            var blockRenderer = Minecraft.getInstance().getBlockRenderer();
+            blockRenderer.getModelRenderer().renderModel(
+                    poseStack.last(), bufferSource.getBuffer(RenderType.solid()),
+                    STATIC_STATE.get(), blockRenderer.getBlockModel(STATIC_STATE.get()),
+                    1f, 1f, 1f, 0x0E00E0, OverlayTexture.NO_OVERLAY
+            );
+        }
+
+        @SubscribeEvent
+        public static void onGatherDynamicLevelGeometry(final GatherGeometryEvent.LevelDynamic event)
+        {
+            if (!ENABLED) return;
+
+            var bufferSource = event.getBufferSource();
+            var poseStack = event.getPoseStack();
+
+            poseStack.pushPose();
+            poseStack.translate(0, 5, 0);
+
+            var blockRenderer = Minecraft.getInstance().getBlockRenderer();
+            blockRenderer.getModelRenderer().renderModel(
+                    poseStack.last(), bufferSource.getBuffer(RenderType.solid()),
+                    DYNAMIC_STATE.get(), blockRenderer.getBlockModel(DYNAMIC_STATE.get()),
+                    1f, 1f, 1f, 0x0E00E0, OverlayTexture.NO_OVERLAY
+            );
+
+            poseStack.popPose();
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -174,5 +174,7 @@ license="LGPL v2.1"
     modId="part_entity_test"
 [[mods]]
     modId="capabilities_test"
+[[mods]]
+    modId="geometry_gathering_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
As things stand right now, the rendering hooks provided by Forge are quite minimal, which limits the options natively available. This pull request aims to provide the two most useful level-related geometry collection events.

## Implementation

Two events are provided: `GatherGeometryEvent.ChunkSectionStatic` and `GatherGeometryEvent.LevelDynamic`.

The former is fired every time a chunk section (16x16x16) is baked before any block geometry is added. This event provides a `MultiBufferSource`, a section origin position, a `RenderChunkRegion` which provides access to the blocks, and the visibility graph used to determine chunk section occlusion.

The latter is fired every frame after `Entity` rendering, but ahead of `BlockEntity` rendering. This event also provides a `MultiBufferSource`, as well as the active level renderer, pose stack, camera and partial tick time.

The static chunk geometry event requires a multi-buffer source to be provided by Forge, as the backing buffer container is a `ChunkBufferBuilderPack`. This buffer source ensures that the requested render type can be used for static rendering (see #8331) and initializes the layer's buffer. After firing the event, the layers containing geometry are marked as such so the chunk section knows whether to render or not.

Lastly, a test mod is provided (mod id `geometry_gathering_test`) which statically renders an obsidian block with full brightness at (0, 80, 0) in every chunk, and dynamically renders a stone block 5 meters above the player's head.

## Demo

Here are some images of the obsidian and stone blocks previously mentioned:

![obsidian blocks](https://user-images.githubusercontent.com/2066666/147836007-403b9b41-49f0-48fb-a10b-0851d9b87a59.jpg)

![stone block](https://user-images.githubusercontent.com/2066666/147836008-e069211c-fd0a-4192-8c7e-04ee8770aa22.png)

## Performance implications

The chunk section geometry-gathering event is fired for as many vertical sections as a chunk has (dependent on world height), for every chunk that needs to be re-rendered. Due to being fired before any blocks have been populated, the time iterating the visited render types should be minimal, and the overall performance impact should not be noticeable, even when re-rendering the entire level.

The level geometry-gathering event is fired once per frame for the current level, and has the same performance implications as the current `RenderLevelLastEvent` - that is, negligible.

## Maintainability

These events shouldn't require any ongoing maintenance.