### PR TITLE
Clear local variable table on RuntimeEnumExtender transformation

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -150,6 +150,19 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
 
             mtd.access |= Opcodes.ACC_SYNCHRONIZED;
             mtd.instructions.clear();
+            mtd.localVariables.clear();
+            if (mtd.tryCatchBlocks != null)
+            {
+                mtd.tryCatchBlocks.clear();
+            }
+            if (mtd.visibleLocalVariableAnnotations != null)
+            {
+                mtd.visibleLocalVariableAnnotations.clear();
+            }
+            if (mtd.invisibleLocalVariableAnnotations != null)
+            {
+                mtd.invisibleLocalVariableAnnotations.clear();
+            }
             InstructionAdapter ins = new InstructionAdapter(mtd);
 
             int vars = 0;


### PR DESCRIPTION
[1.18.x PR](https://github.com/MinecraftForge/MinecraftForge/pull/8502) | **1.16.x backport**

This is a "proper" fix for clearing the state of the LVT in the `create` functions due to an exposure of debugging with Mixins. 

## The Crash

Traditionally, I am always writing mixins for SpongeForge, and lately I discovered a crash that was invariably caused by Mixin's debugging tool (`-Dmixin.debug.export=true`) when a Mixin targeted `net.minecraft.entity.EntityClassification`, it'd cause the export to trigger `ClassNode.accept()` to dump the class, and the LVT for the method modified by `RuntimeEnumExtender` doesn't match the expected LVT (the LVT still had the original LVT for the thrown exception).

The various logs and exports that were related to Mixin troubleshooting: https://gist.github.com/gabizou/beef7061791cdf3fdebb46b810362300

## The reproduction

1. Add a Mixin:
```java
@Mixin(EntityClassification)
public abstract class EntityClassificationMixin {
}
```
2. Run Minecraft with `-Dmixin.debug.export=true`
3. Crash occurs as above, and the exported Mixin code appears as above (but this isn't the final class loaded by ModLauncher)

## The Resulting class
The javap output of the loaded class in both with the mixing above and without the mixing: https://gist.github.com/gabizou/9d4926c4d4eaddac128db73ae770759d

Tagging @Mumfrey to help get any further details that I might've missed.
