### PR TITLE
Fix TileFluidHandler implementing the incorrect save method and not invalidating the LazyOptional

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -52,11 +52,10 @@ public class TileFluidHandler extends BlockEntity
     }
 
     @Override
-    public CompoundTag save(CompoundTag tag)
+    public void saveAdditional(CompoundTag tag)
     {
         super.save(tag);
         tank.writeToNBT(tag);
-        return tag;
     }
 
     @Override
@@ -66,5 +65,12 @@ public class TileFluidHandler extends BlockEntity
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
             return holder.cast();
         return super.getCapability(capability, facing);
+    }
+
+    @Override
+    public void invalidateCaps()
+    {
+        super.invalidateCaps();
+        holder.invalidate();
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -54,7 +54,7 @@ public class TileFluidHandler extends BlockEntity
     @Override
     public void saveAdditional(CompoundTag tag)
     {
-        super.save(tag);
+        super.saveAdditional(tag);
         tank.writeToNBT(tag);
     }
 

--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -37,7 +37,7 @@ public class TileFluidHandler extends BlockEntity
 {
     protected FluidTank tank = new FluidTank(FluidAttributes.BUCKET_VOLUME);
     
-    private final LazyOptional<IFluidHandler> holder = LazyOptional.of(() -> tank);
+    private LazyOptional<IFluidHandler> holder = LazyOptional.of(() -> tank);
 
     public TileFluidHandler(@Nonnull BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state)
     {
@@ -72,5 +72,12 @@ public class TileFluidHandler extends BlockEntity
     {
         super.invalidateCaps();
         holder.invalidate();
+    }
+
+    @Override
+    public void reviveCaps()
+    {
+        super.reviveCaps();
+        holder = LazyOptional.of(() -> tank);
     }
 }


### PR DESCRIPTION
Corrects TileFluidHandler by replacing ```BlockEntity#save``` with ```BlockEntity#saveAdditional``` and invalidating the LazyOptional.

Fixes #8332 