### PR TITLE
[1.18.x] Make `MinecraftLocator` respect non-`MOD` FML Mod Types

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
@@ -43,10 +43,8 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public abstract class AbstractJarFileLocator implements IModLocator {
+public abstract class AbstractJarFileLocator extends AbstractModLocator {
     private static final Logger LOGGER = LogManager.getLogger();
-    protected static final String MODS_TOML = "META-INF/mods.toml";
-    protected static final String MANIFEST = "META-INF/MANIFEST.MF";
 
     @Override
     public void scanFile(final IModFile file, final Consumer<Path> pathConsumer) {
@@ -70,69 +68,4 @@ public abstract class AbstractJarFileLocator implements IModLocator {
     }
 
     public abstract Stream<Path> scanCandidates();
-
-    @Override
-    public boolean isValid(final IModFile modFile) {
-        return true;
-    }
-
-    private Optional<IModFile> createMod(Path path) {
-        var mjm = new ModJarMetadata();
-        var sj = SecureJar.from(
-            Manifest::new,
-            jar -> jar.findFile(MODS_TOML).isPresent() ? mjm : JarMetadata.from(jar, path),
-            (root, p) -> true,
-            path
-        );
-
-        IModFile mod = null;
-        var type = sj.getManifest().getMainAttributes().getValue(ModFile.TYPE);
-        if (sj.findFile(MODS_TOML).isPresent()) {
-            LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);
-            mod = new ModFile(sj, this, ModFileParser::modsTomlParser);
-        } else if (type != null) {
-            LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MANIFEST, type, path);
-            mod = new ModFile(sj, this, this::manifestParser);
-        } else {
-            return Optional.empty();
-        }
-
-        mjm.setModFile(mod);
-        return Optional.ofNullable(mod);
-    }
-
-    private IModFileInfo manifestParser(final IModFile mod) {
-        Function<String, Optional<String>> cfg = name -> Optional.ofNullable(mod.getSecureJar().getManifest().getMainAttributes().getValue(name));
-        var license = cfg.apply("LICENSE").orElse("");
-        var dummy = new IConfigurable() {
-            @Override
-            public <T> Optional<T> getConfigElement(String... key) {
-                return Optional.empty();
-            }
-            @Override
-            public List<? extends IConfigurable> getConfigList(String... key) {
-                return Collections.emptyList();
-            }
-        };
-
-        return new IModFileInfo() {
-            @Override public List<IModInfo> getMods() { return Collections.emptyList(); }
-            @Override public List<LanguageSpec> requiredLanguageLoaders() { return Collections.emptyList(); }
-            @Override public boolean showAsResourcePack() { return false; }
-            @Override public Map<String, Object> getFileProperties() { return Collections.emptyMap(); }
-            @Override public String getLicense() { return license; }
-            @Override public IModFile getFile() { return mod; }
-            @Override public IConfigurable getConfig() { return dummy; }
-
-            // These Should never be called as it's only called from ModJarMetadata.version and we bypass that
-            @Override public String moduleName() { return mod.getSecureJar().name(); }
-            @Override public String versionString() { return null; }
-            @Override public List<String> usesServices() { return null; }
-
-            @Override
-            public String toString() {
-                return "IModFileInfo(" + mod.getFilePath() + ")";
-            }
-        };
-    }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import cpw.mods.jarhandling.JarMetadata;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
@@ -1,0 +1,91 @@
+package net.minecraftforge.fml.loading.moddiscovery;
+
+import cpw.mods.jarhandling.JarMetadata;
+import cpw.mods.jarhandling.SecureJar;
+import net.minecraftforge.fml.loading.LogMarkers;
+import net.minecraftforge.forgespi.language.IConfigurable;
+import net.minecraftforge.forgespi.language.IModFileInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
+import net.minecraftforge.forgespi.locating.IModFile;
+import net.minecraftforge.forgespi.locating.IModLocator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.jar.Manifest;
+
+public abstract class AbstractModLocator implements IModLocator {
+    private static final Logger LOGGER = LogManager.getLogger();
+    protected static final String MODS_TOML = "META-INF/mods.toml";
+    protected static final String MANIFEST = "META-INF/MANIFEST.MF";
+
+    protected Optional<IModFile> createMod(Path... path) {
+        var mjm = new ModJarMetadata();
+        var sj = SecureJar.from(
+                Manifest::new,
+                jar -> jar.findFile(MODS_TOML).isPresent() ? mjm : JarMetadata.from(jar, path),
+                (root, p) -> true,
+                path
+        );
+
+        IModFile mod;
+        var type = sj.getManifest().getMainAttributes().getValue(ModFile.TYPE);
+        if (sj.findFile(MODS_TOML).isPresent()) {
+            LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);
+            mod = new ModFile(sj, this, ModFileParser::modsTomlParser);
+        } else if (type != null) {
+            LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MANIFEST, type, path);
+            mod = new ModFile(sj, this, this::manifestParser);
+        } else {
+            return Optional.empty();
+        }
+
+        mjm.setModFile(mod);
+        return Optional.of(mod);
+    }
+
+    protected IModFileInfo manifestParser(final IModFile mod) {
+        Function<String, Optional<String>> cfg = name -> Optional.ofNullable(mod.getSecureJar().getManifest().getMainAttributes().getValue(name));
+        var license = cfg.apply("LICENSE").orElse("");
+        var dummy = new IConfigurable() {
+            @Override
+            public <T> Optional<T> getConfigElement(String... key) {
+                return Optional.empty();
+            }
+            @Override
+            public List<? extends IConfigurable> getConfigList(String... key) {
+                return Collections.emptyList();
+            }
+        };
+
+        return new IModFileInfo() {
+            @Override public List<IModInfo> getMods() { return Collections.emptyList(); }
+            @Override public List<LanguageSpec> requiredLanguageLoaders() { return Collections.emptyList(); }
+            @Override public boolean showAsResourcePack() { return false; }
+            @Override public Map<String, Object> getFileProperties() { return Collections.emptyMap(); }
+            @Override public String getLicense() { return license; }
+            @Override public IModFile getFile() { return mod; }
+            @Override public IConfigurable getConfig() { return dummy; }
+
+            // These Should never be called as it's only called from ModJarMetadata.version and we bypass that
+            @Override public String moduleName() { return mod.getSecureJar().name(); }
+            @Override public String versionString() { return null; }
+            @Override public List<String> usesServices() { return null; }
+
+            @Override
+            public String toString() {
+                return "IModFileInfo(" + mod.getFilePath() + ")";
+            }
+        };
+    }
+
+    @Override
+    public boolean isValid(final IModFile modFile) {
+        return true;
+    }
+}

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class MinecraftLocator implements IModLocator {
+public class MinecraftLocator extends AbstractModLocator {
     private static final Logger LOGGER = LogManager.getLogger();
 
     @Override
@@ -31,7 +31,8 @@ public class MinecraftLocator implements IModLocator {
                 .map(sj -> new ModFile(sj, this, ModFileParser::modsTomlParser))
                 .collect(Collectors.<IModFile>toList());
         var othermods = baseMC.otherModPaths().stream()
-                .map(p->ModJarMetadata.buildFile(this, p.toArray(Path[]::new)))
+                .map(p -> createMod(p.toArray(Path[]::new)).orElse(null))
+                .filter(Objects::nonNull)
                 .toList();
         artifacts.add(mcjar);
         artifacts.addAll(othermods);
@@ -111,10 +112,5 @@ public class MinecraftLocator implements IModLocator {
     @Override
     public void initArguments(final Map<String, ?> arguments) {
         // no op
-    }
-
-    @Override
-    public boolean isValid(final IModFile modFile) {
-        return true;
     }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import com.electronwill.nightconfig.core.Config;


### PR DESCRIPTION
This fixes #8344; you can see a more detailed analysis of the problem there.

`MOD_CLASSES` now respects loading non-`MOD` FML Mod Types.
I tested the functionality of `GAMELIBRARY` and `LANGPROVIDER` in their own userdev environments and was able to load the game properly using this PR.

In my testing, I found that in the manifest, `Automatic-Module-Name` is required to be set for non-MOD types in dev, otherwise a crash will be thrown from the empty module name, along with setting `FMLModType` of course.