### PR TITLE
Provide access to the state in BucketPickup#getPickupSound

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -29,6 +29,15 @@
        if (blockhitresult.m_6662_() == HitResult.Type.MISS) {
           return InteractionResultHolder.m_19098_(itemstack);
        } else if (blockhitresult.m_6662_() != HitResult.Type.BLOCK) {
+@@ -56,7 +_,7 @@
+                   ItemStack itemstack1 = bucketpickup.m_142598_(p_40703_, blockpos, blockstate1);
+                   if (!itemstack1.m_41619_()) {
+                      p_40704_.m_36246_(Stats.f_12982_.m_12902_(this));
+-                     bucketpickup.m_142298_().ifPresent((p_150709_) -> {
++                     bucketpickup.getPickupSound(blockstate1).ifPresent((p_150709_) -> {
+                         p_40704_.m_5496_(p_150709_, 1.0F, 1.0F);
+                      });
+                      p_40703_.m_142346_(p_40704_, GameEvent.f_157816_, blockpos);
 @@ -72,7 +_,7 @@
                 return InteractionResultHolder.m_19100_(itemstack);
              } else {

--- a/patches/minecraft/net/minecraft/world/level/block/BucketPickup.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BucketPickup.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/block/BucketPickup.java
++++ b/net/minecraft/world/level/block/BucketPickup.java
+@@ -7,8 +_,9 @@
+ import net.minecraft.world.level.LevelAccessor;
+ import net.minecraft.world.level.block.state.BlockState;
+ 
+-public interface BucketPickup {
++public interface BucketPickup extends net.minecraftforge.common.extensions.IForgeBucketPickup {
+    ItemStack m_142598_(LevelAccessor p_152719_, BlockPos p_152720_, BlockState p_152721_);
+ 
++   @Deprecated//Forge: Use state sensitive variant instead
+    Optional<SoundEvent> m_142298_();
+ }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBucketPickup.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBucketPickup.java
@@ -35,6 +35,8 @@ public interface IForgeBucketPickup
     /**
      * State sensitive variant of {@link BucketPickup#getPickupSound()}.
      *
+     * Override to change the pickup sound based on the {@link BlockState} of the object being picked up.
+     *
      * @param state State
      *
      * @return Sound event for pickup sound or empty if there isn't a pickup sound.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBucketPickup.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBucketPickup.java
@@ -1,0 +1,46 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.extensions;
+
+import java.util.Optional;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.level.block.BucketPickup;
+import net.minecraft.world.level.block.state.BlockState;
+
+public interface IForgeBucketPickup
+{
+
+    private BucketPickup self()
+    {
+        return (BucketPickup) this;
+    }
+
+    /**
+     * State sensitive variant of {@link BucketPickup#getPickupSound()}.
+     *
+     * @param state State
+     *
+     * @return Sound event for pickup sound or empty if there isn't a pickup sound.
+     */
+    default Optional<SoundEvent> getPickupSound(BlockState state)
+    {
+        return self().getPickupSound();
+    }
+}


### PR DESCRIPTION
In Mekanism I have a few blocks that support both water logging and lava logging, but without access to the state there is no way to determine which pickup sound should be used as I can't determine if the block is water logged or lava logged. I debated providing access to the level and position but decided against it as fluid states aren't position sensitive, *and* it would have required a larger patch in BucketItem to move getting the pickup sound to above actually picking the fluid up.