### PR TITLE
Create parent directories when creating empty config files

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -81,6 +81,7 @@ public class ConfigFileTypeHandler {
     }
 
     private boolean setupConfigFile(final ModConfig modConfig, final Path file, final ConfigFormat<?> conf) throws IOException {
+        Files.createDirectories(file.getParent());
         Path p = defaultConfigPath.resolve(modConfig.getFileName());
         if (Files.exists(p)) {
             LOGGER.info(CONFIG, "Loading default config file from path {}", p);


### PR DESCRIPTION
If a config file name is for a subfolder, Forge will fail to create the config file (because the parent folder does not exist). This leads to [crashes like this](https://forums.minecraftforge.net/topic/107412-forge-server-crashing/?tab=comments#comment-480429).