### PR TITLE
Fix climbable hook to set `lastClimbablePos` field

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -227,7 +227,7 @@
        p_147241_ *= 1.0D - this.m_21133_(Attributes.f_22278_);
        if (!(p_147241_ <= 0.0D)) {
           this.f_19812_ = true;
-@@ -1388,15 +_,7 @@
+@@ -1388,15 +_,9 @@
        } else {
           BlockPos blockpos = this.m_142538_();
           BlockState blockstate = this.m_146900_();
@@ -240,7 +240,9 @@
 -         } else {
 -            return false;
 -         }
-+         return net.minecraftforge.common.ForgeHooks.isLivingOnLadder(blockstate, f_19853_, blockpos, this);
++         Optional<BlockPos> ladderPos = net.minecraftforge.common.ForgeHooks.isLivingOnLadder(blockstate, f_19853_, blockpos, this);
++         if (ladderPos.isPresent()) this.f_20957_ = ladderPos;
++         return ladderPos.isPresent();
        }
     }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -352,13 +353,13 @@ public class ForgeHooks
         return Math.max(0,event.getVisibilityModifier());
     }
 
-    public static boolean isLivingOnLadder(@Nonnull BlockState state, @Nonnull Level world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity)
+    public static Optional<BlockPos> isLivingOnLadder(@Nonnull BlockState state, @Nonnull Level world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity)
     {
-        boolean isSpectator = (entity instanceof Player && ((Player)entity).isSpectator());
-        if (isSpectator) return false;
+        boolean isSpectator = (entity instanceof Player && entity.isSpectator());
+        if (isSpectator) return Optional.empty();
         if (!ForgeConfig.SERVER.fullBoundingBoxLadders.get())
         {
-            return state.isLadder(world, pos, entity);
+            return state.isLadder(world, pos, entity) ? Optional.of(pos) : Optional.empty();
         }
         else
         {
@@ -376,12 +377,12 @@ public class ForgeHooks
                         state = world.getBlockState(tmp);
                         if (state.isLadder(world, tmp, entity))
                         {
-                            return true;
+                            return Optional.of(tmp);
                         }
                     }
                 }
             }
-            return false;
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
This PR fixes #8370 by modifying `ForgeHooks#isLivingOnLadder` to return an `Optional<BlockPos>` indicating the position of the ladder/climbable block, and changing the corresponding patch in `LivingEntity` to set the `lastClimbablePos` field to that optional if it has a value, mimicing vanilla behavior.

Tested by falling off a ladder, weeping vines, and twisted vines from a sufficient height to die, which shows the expected specialized fall death messages.