### PR TITLE
[LTS] Fix climbable hook to set lastClimbablePos field

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -225,7 +225,7 @@
        p_233627_1_ = (float)((double)p_233627_1_ * (1.0D - this.func_233637_b_(Attributes.field_233820_c_)));
        if (!(p_233627_1_ <= 0.0F)) {
           this.field_70160_al = true;
-@@ -1322,16 +_,7 @@
+@@ -1322,16 +_,9 @@
        } else {
           BlockPos blockpos = this.func_233580_cy_();
           BlockState blockstate = this.func_213339_cH();
@@ -239,7 +239,9 @@
 -         } else {
 -            return false;
 -         }
-+         return net.minecraftforge.common.ForgeHooks.isLivingOnLadder(blockstate, field_70170_p, blockpos, this);
++         Optional<BlockPos> ladderPos = net.minecraftforge.common.ForgeHooks.isLivingOnLadderPos(blockstate, field_70170_p, blockpos, this);
++         if (ladderPos.isPresent()) this.field_233624_bE_ = ladderPos;
++         return ladderPos.isPresent();
        }
     }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -422,13 +422,20 @@ public class ForgeHooks
         return Math.max(0,event.getVisibilityModifier());
     }
 
+    /** @deprecated Use {@link #isLivingOnLadderPos(BlockState, World, BlockPos, LivingEntity)} instead in 1.16. */
+    @Deprecated
     public static boolean isLivingOnLadder(@Nonnull BlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity)
     {
-        boolean isSpectator = (entity instanceof PlayerEntity && ((PlayerEntity)entity).isSpectator());
-        if (isSpectator) return false;
+        return isLivingOnLadderPos(state, world, pos, entity).isPresent();
+    }
+
+    public static Optional<BlockPos> isLivingOnLadderPos(@Nonnull BlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity)
+    {
+        boolean isSpectator = (entity instanceof PlayerEntity && entity.isSpectator());
+        if (isSpectator) return Optional.empty();
         if (!ForgeConfig.SERVER.fullBoundingBoxLadders.get())
         {
-            return state.isLadder(world, pos, entity);
+            return state.isLadder(world, pos, entity) ? Optional.of(pos) : Optional.empty();
         }
         else
         {
@@ -446,12 +453,12 @@ public class ForgeHooks
                         state = world.getBlockState(tmp);
                         if (state.isLadder(world, tmp, entity))
                         {
-                            return true;
+                            return Optional.of(tmp);
                         }
                     }
                 }
             }
-            return false;
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
This PR is an LTS backport of #8372 which fixes #8370 by applying the same fix described in the original PR, but modified to avoid a breaking change in `ForgeHooks`. 

Instead of modifying the signature of `ForgeHooks#isLivingOnLadder` to return `Optional<BlockPos>`, a new method named `isLivingOnLadderPos` is created for that purpose. The original `isLivingOnLadder` method is marked deprecated and redirected to use `isLivingOnLadderPos`, and the `LivingEntity` patch is changed to use the new method as well.