### PR TITLE
[1.18.x] Implement full support for IPv6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,6 +373,8 @@ def sharedFmlonlyForge = { Project prj ->
                 args '--version', 'MOD_DEV'
                 args '--assetIndex', '{asset_index}'
                 args '--assetsDir', '{assets_root}'
+
+                jvmArgs '-Djava.net.preferIPv6Addresses=system'
             }
 
             server {
@@ -384,6 +386,8 @@ def sharedFmlonlyForge = { Project prj ->
                 }
 
                 args '--launchTarget', "${launchPrefix}serveruserdev"
+
+                jvmArgs '-Djava.net.preferIPv6Addresses=system'
             }
 
             if (prj.name == 'forge') {
@@ -417,6 +421,8 @@ def sharedFmlonlyForge = { Project prj ->
         run.args '--fml.mcVersion', MC_VERSION
         run.args '--fml.forgeGroup', prj.group
         run.args '--fml.mcpVersion', MCP_VERSION
+
+        run.jvmArgs '-Djava.net.preferIPv6Addresses=system'
 
         if (run.name.contains('client')) {
             run.client true
@@ -620,7 +626,8 @@ project(':fmlonly') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ["-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
+                    jvm: ['-Djava.net.preferIPv6Addresses=system',
+                          "-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${fmlonly_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{"\${library_directory}/${it.downloads.artifact.path}"}.join('${classpath_separator}'),
@@ -1192,7 +1199,8 @@ project(':forge') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ["-DignoreList=${forge_client.properties.ignoreList},\${version_name}.jar",
+                    jvm: ['-Djava.net.preferIPv6Addresses=system',
+                          "-DignoreList=${forge_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${forge_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{'${library_directory}/' + it.downloads.artifact.path}.join('${classpath_separator}'),

--- a/build.gradle
+++ b/build.gradle
@@ -373,8 +373,6 @@ def sharedFmlonlyForge = { Project prj ->
                 args '--version', 'MOD_DEV'
                 args '--assetIndex', '{asset_index}'
                 args '--assetsDir', '{assets_root}'
-
-                jvmArgs '-Djava.net.preferIPv6Addresses=system'
             }
 
             server {
@@ -386,8 +384,6 @@ def sharedFmlonlyForge = { Project prj ->
                 }
 
                 args '--launchTarget', "${launchPrefix}serveruserdev"
-
-                jvmArgs '-Djava.net.preferIPv6Addresses=system'
             }
 
             if (prj.name == 'forge') {
@@ -626,8 +622,7 @@ project(':fmlonly') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ['-Djava.net.preferIPv6Addresses=system',
-                          "-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
+                    jvm: ["-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${fmlonly_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{"\${library_directory}/${it.downloads.artifact.path}"}.join('${classpath_separator}'),

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -5,21 +5,26 @@
           this.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LanServerDetection.f_120082_));
           this.f_120088_ = new MulticastSocket(4445);
 -         this.f_120087_ = InetAddress.getByName("224.0.2.60");
-+         if (net.minecraftforge.network.NetworkConstants.USE_IPV6) {
-+            this.f_120087_ = InetAddress.getByName("FF7E:230::60"); // todo: contact IANA and ask if this is the right equiv and compliant with the IPv6 Multicast Address Space Registry
++         if (net.minecraftforge.network.DualStackUtils.isIPv6(net.minecraftforge.network.DualStackUtils.getLocalAddress())) {
++            this.f_120087_ = InetAddress.getByName("FF75:230::60"); // todo: determine the correct/ideal multicast IPv6 address
 +         } else {
 +            this.f_120087_ = InetAddress.getByName("224.0.2.60");
 +         }
           this.f_120088_.setSoTimeout(5000);
           this.f_120088_.joinGroup(this.f_120087_);
        }
-@@ -88,7 +_,11 @@
+@@ -88,7 +_,16 @@
           String s = LanServerPinger.m_120111_(p_120097_);
           String s1 = LanServerPinger.m_120116_(p_120097_);
           if (s1 != null) {
 -            s1 = p_120098_.getHostAddress() + ":" + s1;
-+            if (net.minecraftforge.network.NetworkConstants.USE_IPV6) {
-+               s1 = "[" + p_120098_.getHostAddress() + "]:" + s1;
++            if (net.minecraftforge.network.DualStackUtils.isIPv6(p_120098_)) {
++               // compress to short form
++               final String compressedIP = p_120098_.getHostAddress();/*
++                       .replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")
++                       .replaceFirst("^0::","::");*/
++
++               s1 = "[" + compressedIP + "]:" + s1;
 +            } else {
 +               s1 = p_120098_.getHostAddress() + ":" + s1;
 +            }

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/server/LanServerDetection.java
++++ b/net/minecraft/client/server/LanServerDetection.java
+@@ -33,7 +_,11 @@
+          this.setDaemon(true);
+          this.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LanServerDetection.f_120082_));
+          this.f_120088_ = new MulticastSocket(4445);
+-         this.f_120087_ = InetAddress.getByName("224.0.2.60");
++         if (net.minecraftforge.network.NetworkConstants.USE_IPV6) {
++            this.f_120087_ = InetAddress.getByName("FF7E:230::60"); // todo: contact IANA and ask if this is the right equiv and compliant with the IPv6 Multicast Address Space Registry
++         } else {
++            this.f_120087_ = InetAddress.getByName("224.0.2.60");
++         }
+          this.f_120088_.setSoTimeout(5000);
+          this.f_120088_.joinGroup(this.f_120087_);
+       }
+@@ -88,7 +_,11 @@
+          String s = LanServerPinger.m_120111_(p_120097_);
+          String s1 = LanServerPinger.m_120116_(p_120097_);
+          if (s1 != null) {
+-            s1 = p_120098_.getHostAddress() + ":" + s1;
++            if (net.minecraftforge.network.NetworkConstants.USE_IPV6) {
++               s1 = "[" + p_120098_.getHostAddress() + "]:" + s1;
++            } else {
++               s1 = p_120098_.getHostAddress() + ":" + s1;
++            }
+             boolean flag = false;
+ 
+             for(LanServer lanserver : this.f_120092_) {

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -1,15 +1,11 @@
 --- a/net/minecraft/client/server/LanServerDetection.java
 +++ b/net/minecraft/client/server/LanServerDetection.java
-@@ -33,7 +_,11 @@
+@@ -33,7 +_,7 @@
           this.setDaemon(true);
           this.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LanServerDetection.f_120082_));
           this.f_120088_ = new MulticastSocket(4445);
 -         this.f_120087_ = InetAddress.getByName("224.0.2.60");
-+         if (net.minecraftforge.network.DualStackUtils.isIPv6(net.minecraftforge.network.DualStackUtils.getLocalAddress())) {
-+            this.f_120087_ = InetAddress.getByName("FF75:230::60");
-+         } else {
-+            this.f_120087_ = InetAddress.getByName("224.0.2.60");
-+         }
++         this.f_120087_ = InetAddress.getByName(LanServerPinger.f_174974_);
           this.f_120088_.setSoTimeout(5000);
           this.f_120088_.joinGroup(this.f_120087_);
        }
@@ -17,7 +13,6 @@
           String s = LanServerPinger.m_120111_(p_120097_);
           String s1 = LanServerPinger.m_120116_(p_120097_);
           if (s1 != null) {
--            s1 = p_120098_.getHostAddress() + ":" + s1;
 +            if (net.minecraftforge.network.DualStackUtils.isIPv6(p_120098_)) {
 +               final String ip;
 +
@@ -29,7 +24,7 @@
 +
 +               s1 = "[" + ip + "]:" + s1;
 +            } else {
-+               s1 = p_120098_.getHostAddress() + ":" + s1;
+             s1 = p_120098_.getHostAddress() + ":" + s1;
 +            }
              boolean flag = false;
  

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -13,7 +13,7 @@
           String s = LanServerPinger.m_120111_(p_120097_);
           String s1 = LanServerPinger.m_120116_(p_120097_);
           if (s1 != null) {
-+            if (net.minecraftforge.network.DualStackUtils.isIPv6(p_120098_)) {
++            if (net.minecraftforge.network.DualStackUtils.checkIPv6(p_120098_)) {
 +               final String ip;
 +
 +               // compress to short form if enabled in config

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -6,25 +6,28 @@
           this.f_120088_ = new MulticastSocket(4445);
 -         this.f_120087_ = InetAddress.getByName("224.0.2.60");
 +         if (net.minecraftforge.network.DualStackUtils.isIPv6(net.minecraftforge.network.DualStackUtils.getLocalAddress())) {
-+            this.f_120087_ = InetAddress.getByName("FF75:230::60"); // todo: determine the correct/ideal multicast IPv6 address
++            this.f_120087_ = InetAddress.getByName("FF75:230::60");
 +         } else {
 +            this.f_120087_ = InetAddress.getByName("224.0.2.60");
 +         }
           this.f_120088_.setSoTimeout(5000);
           this.f_120088_.joinGroup(this.f_120087_);
        }
-@@ -88,7 +_,16 @@
+@@ -88,7 +_,19 @@
           String s = LanServerPinger.m_120111_(p_120097_);
           String s1 = LanServerPinger.m_120116_(p_120097_);
           if (s1 != null) {
 -            s1 = p_120098_.getHostAddress() + ":" + s1;
 +            if (net.minecraftforge.network.DualStackUtils.isIPv6(p_120098_)) {
-+               // compress to short form
-+               final String compressedIP = p_120098_.getHostAddress();/*
-+                       .replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")
-+                       .replaceFirst("^0::","::");*/
++               final String ip;
 +
-+               s1 = "[" + compressedIP + "]:" + s1;
++               // compress to short form if enabled in config
++               if (net.minecraftforge.common.ForgeConfig.CLIENT.compressLanIPv6Addresses.get())
++                  ip = com.google.common.net.InetAddresses.toAddrString(p_120098_);
++               else
++                  ip = p_120098_.getHostAddress();
++
++               s1 = "[" + ip + "]:" + s1;
 +            } else {
 +               s1 = p_120098_.getHostAddress() + ":" + s1;
 +            }

--- a/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/client/server/LanServerPinger.java
 +++ b/net/minecraft/client/server/LanServerPinger.java
-@@ -4,6 +_,7 @@
- import java.net.DatagramPacket;
- import java.net.DatagramSocket;
- import java.net.InetAddress;
-+import java.net.InetSocketAddress;
- import java.nio.charset.StandardCharsets;
- import java.util.concurrent.atomic.AtomicInteger;
- import net.minecraft.DefaultUncaughtExceptionHandler;
 @@ -16,7 +_,8 @@
  public class LanServerPinger extends Thread {
     private static final AtomicInteger f_120101_ = new AtomicInteger(0);

--- a/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/server/LanServerPinger.java
++++ b/net/minecraft/client/server/LanServerPinger.java
+@@ -16,7 +_,7 @@
+ public class LanServerPinger extends Thread {
+    private static final AtomicInteger f_120101_ = new AtomicInteger(0);
+    private static final Logger f_120102_ = LogManager.getLogger();
+-   public static final String f_174974_ = "224.0.2.60";
++   public static final String f_174974_ = net.minecraftforge.network.NetworkConstants.USE_IPV6 ? "FF7E:230::60" : "224.0.2.60";
+    public static final int f_174975_ = 4445;
+    private static final long f_174976_ = 1500L;
+    private final String f_120103_;
+@@ -39,7 +_,7 @@
+ 
+       while(!this.isInterrupted() && this.f_120105_) {
+          try {
+-            InetAddress inetaddress = InetAddress.getByName("224.0.2.60");
++            InetAddress inetaddress = InetAddress.getByName(f_174974_);
+             DatagramPacket datagrampacket = new DatagramPacket(abyte, abyte.length, inetaddress, 4445);
+             this.f_120104_.send(datagrampacket);
+          } catch (IOException ioexception) {

--- a/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
@@ -3,7 +3,7 @@
 @@ -16,7 +_,7 @@
  public class LanServerPinger extends Thread {
     private static final AtomicInteger f_120101_ = new AtomicInteger(0);
-    private static final Logger f_120102_ = LogManager.getLogger();
+    private static final Logger f_120102_ = LogUtils.getLogger();
 -   public static final String f_174974_ = "224.0.2.60";
 +   public static final String f_174974_ = net.minecraftforge.network.DualStackUtils.getMulticastGroup();
     public static final int f_174975_ = 4445;

--- a/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
@@ -1,11 +1,20 @@
 --- a/net/minecraft/client/server/LanServerPinger.java
 +++ b/net/minecraft/client/server/LanServerPinger.java
-@@ -16,7 +_,7 @@
+@@ -4,6 +_,7 @@
+ import java.net.DatagramPacket;
+ import java.net.DatagramSocket;
+ import java.net.InetAddress;
++import java.net.InetSocketAddress;
+ import java.nio.charset.StandardCharsets;
+ import java.util.concurrent.atomic.AtomicInteger;
+ import net.minecraft.DefaultUncaughtExceptionHandler;
+@@ -16,7 +_,8 @@
  public class LanServerPinger extends Thread {
     private static final AtomicInteger f_120101_ = new AtomicInteger(0);
     private static final Logger f_120102_ = LogManager.getLogger();
 -   public static final String f_174974_ = "224.0.2.60";
-+   public static final String f_174974_ = net.minecraftforge.network.NetworkConstants.USE_IPV6 ? "FF7E:230::60" : "224.0.2.60";
++   public static final String f_174974_ =
++           net.minecraftforge.network.DualStackUtils.isIPv6(net.minecraftforge.network.DualStackUtils.getLocalAddress()) ? "FF75:230::60" : "224.0.2.60";
     public static final int f_174975_ = 4445;
     private static final long f_174976_ = 1500L;
     private final String f_120103_;

--- a/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerPinger.java.patch
@@ -1,12 +1,11 @@
 --- a/net/minecraft/client/server/LanServerPinger.java
 +++ b/net/minecraft/client/server/LanServerPinger.java
-@@ -16,7 +_,8 @@
+@@ -16,7 +_,7 @@
  public class LanServerPinger extends Thread {
     private static final AtomicInteger f_120101_ = new AtomicInteger(0);
     private static final Logger f_120102_ = LogManager.getLogger();
 -   public static final String f_174974_ = "224.0.2.60";
-+   public static final String f_174974_ =
-+           net.minecraftforge.network.DualStackUtils.isIPv6(net.minecraftforge.network.DualStackUtils.getLocalAddress()) ? "FF75:230::60" : "224.0.2.60";
++   public static final String f_174974_ = net.minecraftforge.network.DualStackUtils.getMulticastGroup();
     public static final int f_174975_ = 4445;
     private static final long f_174976_ = 1500L;
     private final String f_120103_;

--- a/patches/minecraft/net/minecraft/network/Connection.java.patch
+++ b/patches/minecraft/net/minecraft/network/Connection.java.patch
@@ -1,6 +1,15 @@
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
 @@ -87,6 +_,7 @@
+@@ -42,6 +_,7 @@
+ import net.minecraft.server.network.ServerLoginPacketListenerImpl;
+ import net.minecraft.util.LazyLoadedValue;
+ import net.minecraft.util.Mth;
++import net.minecraftforge.network.DualStackUtils;
+ import org.apache.commons.lang3.Validate;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -77,6 +_,7 @@
     private float f_129477_;
     private int f_129478_;
     private boolean f_129479_;
@@ -29,7 +38,7 @@
     }
  
     public static Connection m_178300_(InetSocketAddress p_178301_, boolean p_178302_) {
-+      if (p_178301_.getAddress() instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
++      net.minecraftforge.network.DualStackUtils.isIPv6(p_178301_.getAddress());
        final Connection connection = new Connection(PacketFlow.CLIENTBOUND);
 +      connection.activationHandler = net.minecraftforge.network.NetworkHooks::registerClientLoginChannel;
        Class<? extends SocketChannel> oclass;

--- a/patches/minecraft/net/minecraft/network/Connection.java.patch
+++ b/patches/minecraft/net/minecraft/network/Connection.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
-@@ -77,6 +_,7 @@
+@@ -87,6 +_,7 @@
     private float f_129477_;
     private int f_129478_;
     private boolean f_129479_;
@@ -29,7 +29,7 @@
     }
  
     public static Connection m_178300_(InetSocketAddress p_178301_, boolean p_178302_) {
-+      net.minecraftforge.network.DualStackUtils.isIPv6(p_178301_.getAddress());
++      net.minecraftforge.network.DualStackUtils.checkIPv6(p_178301_.getAddress());
        final Connection connection = new Connection(PacketFlow.CLIENTBOUND);
 +      connection.activationHandler = net.minecraftforge.network.NetworkHooks::registerClientLoginChannel;
        Class<? extends SocketChannel> oclass;

--- a/patches/minecraft/net/minecraft/network/Connection.java.patch
+++ b/patches/minecraft/net/minecraft/network/Connection.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
-@@ -87,6 +_,7 @@
-@@ -42,6 +_,7 @@
- import net.minecraft.server.network.ServerLoginPacketListenerImpl;
- import net.minecraft.util.LazyLoadedValue;
- import net.minecraft.util.Mth;
-+import net.minecraftforge.network.DualStackUtils;
- import org.apache.commons.lang3.Validate;
- import org.apache.logging.log4j.LogManager;
- import org.apache.logging.log4j.Logger;
 @@ -77,6 +_,7 @@
     private float f_129477_;
     private int f_129478_;

--- a/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/server/network/ServerConnectionListener.java
 +++ b/net/minecraft/server/network/ServerConnectionListener.java
+@@ -25,6 +_,7 @@
+ import io.netty.util.Timer;
+ import java.io.IOException;
+ import java.net.InetAddress;
++import java.net.InetSocketAddress;
+ import java.net.SocketAddress;
+ import java.util.Collections;
+ import java.util.Iterator;
 @@ -50,11 +_,12 @@
  
  public class ServerConnectionListener {
@@ -15,11 +23,12 @@
     });
     final MinecraftServer f_9702_;
     public volatile boolean f_9700_;
-@@ -67,6 +_,7 @@
+@@ -67,6 +_,8 @@
     }
  
     public void m_9711_(@Nullable InetAddress p_9712_, int p_9713_) throws IOException {
-+      if (p_9712_ instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
++      if (p_9712_ == null) p_9712_ = new InetSocketAddress(p_9713_).getAddress();
++      net.minecraftforge.network.DualStackUtils.isIPv6(p_9712_);
        synchronized(this.f_9703_) {
           Class<? extends ServerSocketChannel> oclass;
           LazyLoadedValue<? extends EventLoopGroup> lazyloadedvalue;

--- a/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/server/network/ServerConnectionListener.java
 +++ b/net/minecraft/server/network/ServerConnectionListener.java
-@@ -25,6 +_,7 @@
- import io.netty.util.Timer;
- import java.io.IOException;
- import java.net.InetAddress;
-+import java.net.InetSocketAddress;
- import java.net.SocketAddress;
- import java.util.Collections;
- import java.util.Iterator;
 @@ -50,11 +_,12 @@
  
  public class ServerConnectionListener {
@@ -27,7 +19,7 @@
     }
  
     public void m_9711_(@Nullable InetAddress p_9712_, int p_9713_) throws IOException {
-+      if (p_9712_ == null) p_9712_ = new InetSocketAddress(p_9713_).getAddress();
++      if (p_9712_ == null) p_9712_ = new java.net.InetSocketAddress(p_9713_).getAddress();
 +      net.minecraftforge.network.DualStackUtils.isIPv6(p_9712_);
        synchronized(this.f_9703_) {
           Class<? extends ServerSocketChannel> oclass;

--- a/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -20,7 +20,7 @@
  
     public void m_9711_(@Nullable InetAddress p_9712_, int p_9713_) throws IOException {
 +      if (p_9712_ == null) p_9712_ = new java.net.InetSocketAddress(p_9713_).getAddress();
-+      net.minecraftforge.network.DualStackUtils.isIPv6(p_9712_);
++      net.minecraftforge.network.DualStackUtils.checkIPv6(p_9712_);
        synchronized(this.f_9703_) {
           Class<? extends ServerSocketChannel> oclass;
           LazyLoadedValue<? extends EventLoopGroup> lazyloadedvalue;

--- a/server_files/args.txt
+++ b/server_files/args.txt
@@ -3,6 +3,7 @@
 --add-opens java.base/java.util.jar=cpw.mods.securejarhandler
 --add-exports java.base/sun.security.util=cpw.mods.securejarhandler
 --add-exports jdk.naming.dns/com.sun.jndi.dns=java.naming
+-Djava.net.preferIPv6Addresses=system
 -DignoreList=@IGNORE_LIST@
 -DlibraryDirectory=libraries
 -DlegacyClassPath=@CLASS_PATH@

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -120,6 +120,8 @@ public class ForgeConfig {
 
         public final BooleanValue forceSystemNanoTime;
 
+        public final BooleanValue compressLanIPv6Addresses;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -150,6 +152,11 @@ public class ForgeConfig {
                     .comment("Forces the use of System.nanoTime instead of glfwGetTime, as the main Util time provider")
                     .translation("forge.configgui.forceSystemNanoTime")
                     .define("forceSystemNanoTime", false);
+
+            compressLanIPv6Addresses = builder
+                    .comment("When enabled, Forge will convert discovered 'Open to LAN' IPv6 addresses to their more compact, compressed representation")
+                    .translation("forge.configgui.compressLanIPv6Addresses")
+                    .define("compressLanIPv6Addresses", true);
 
             builder.pop();
         }

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -1,20 +1,6 @@
 /*
- * Minecraft Forge
- * Copyright (c) 2016-2022.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 package net.minecraftforge.network;

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -41,14 +41,14 @@ public class DualStackUtils
      * @param hostAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
-    public static boolean isIPv6(final String hostAddress)
+    public static boolean checkIPv6(final String hostAddress)
     {
         final Optional<InetSocketAddress> hostAddr =
                 ServerNameResolver.DEFAULT
                         .resolveAddress(ServerAddress.parseString(hostAddress))
                         .map(ResolvedServerAddress::asInetSocketAddress);
 
-        if (hostAddr.isPresent()) return isIPv6(hostAddr.get().getAddress());
+        if (hostAddr.isPresent()) return checkIPv6(hostAddr.get().getAddress());
         else return false;
     }
 
@@ -59,7 +59,7 @@ public class DualStackUtils
      * @param inetAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
-    public static boolean isIPv6(final InetAddress inetAddress)
+    public static boolean checkIPv6(final InetAddress inetAddress)
     {
         if (inetAddress instanceof Inet6Address)
         {
@@ -96,5 +96,10 @@ public class DualStackUtils
         {
             return null;
         }
+    }
+
+    public static String getMulticastGroup() {
+        if (checkIPv6(getLocalAddress())) return "FF75:230::60";
+        else return "224.0.2.60";
     }
 }

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -1,0 +1,71 @@
+package net.minecraftforge.network;
+
+import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.client.multiplayer.resolver.ServerNameResolver;
+import net.minecraft.util.HttpUtil;
+
+import javax.annotation.Nullable;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+public class DualStackUtils {
+    /**
+     * Resolve the address and see if Java and the OS return an IPv6 or IPv4 one, then let netty know
+     * accordingly (it doesn't understand the java.net.preferIPv6Addresses=system property)
+     *
+     * @author Paint_Ninja
+     * @param hostAddress The address you want to check
+     * @return true if IPv6, false if IPv4
+     */
+    public static boolean isIPv6(final String hostAddress) {
+        final Optional<InetSocketAddress> hostAddr =
+                ServerNameResolver.DEFAULT
+                        .resolveAddress(ServerAddress.parseString(hostAddress))
+                        .map(ResolvedServerAddress::asInetSocketAddress);
+
+        if (hostAddr.isPresent()) return isIPv6(hostAddr.get().getAddress());
+        else return false;
+    }
+
+    /**
+     * Checks if an address is an IPv6 one or an IPv4 one, then lets netty know accordingly and returns the result
+     *
+     * @author Paint_Ninja
+     * @param inetAddress The address you want to check
+     * @return true if IPv6, false if IPv4
+     */
+    public static boolean isIPv6(final InetAddress inetAddress) {
+        if (inetAddress instanceof Inet6Address) {
+            System.setProperty("java.net.preferIPv4Stack", "false");
+            System.setProperty("java.net.preferIPv6Addresses", "true");
+            return true;
+        } else {
+            System.setProperty("java.net.preferIPv4Stack", "true");
+            System.setProperty("java.net.preferIPv6Addresses", "false");
+            return false;
+        }
+    }
+
+    // TODO: more thoroughly test getLocalAddress()
+    /**
+     * Get the device's local IP address, taking into account scenarios where the client's network adapter
+     * supports IPv6 and has it enabled but the router's LAN does not.
+     *
+     * @return the client's local IP address or null if unable
+     */
+    @Nullable
+    public static InetAddress getLocalAddress() {
+        final InetAddress localAddr = new InetSocketAddress(HttpUtil.getAvailablePort()).getAddress();
+        if (localAddr.isAnyLocalAddress()) return localAddr;
+
+        try {
+            return InetAddress.getByName("localhost");
+        } catch (final UnknownHostException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.network;
 
 import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
@@ -49,8 +68,7 @@ public class DualStackUtils {
             return false;
         }
     }
-
-    // TODO: more thoroughly test getLocalAddress()
+    
     /**
      * Get the device's local IP address, taking into account scenarios where the client's network adapter
      * supports IPv6 and has it enabled but the router's LAN does not.

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -37,7 +37,6 @@ public class DualStackUtils
      * Resolve the address and see if Java and the OS return an IPv6 or IPv4 one, then let Netty know
      * accordingly (it doesn't understand the {@code java.net.preferIPv6Addresses=system} property).
      *
-     * @author Paint_Ninja
      * @param hostAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
@@ -55,7 +54,6 @@ public class DualStackUtils
     /**
      * Checks if an address is an IPv6 one or an IPv4 one, lets Netty know accordingly and returns the result.
      *
-     * @author Paint_Ninja
      * @param inetAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
@@ -79,7 +77,6 @@ public class DualStackUtils
      * Get the device's local IP address, taking into account scenarios where the client's network adapter
      * supports IPv6 and has it enabled but the router's LAN does not.
      *
-     * @author Paint_Ninja
      * @return the client's local IP address or {@code null} if unable to determine it
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -55,6 +55,7 @@ public class DualStackUtils {
      * Get the device's local IP address, taking into account scenarios where the client's network adapter
      * supports IPv6 and has it enabled but the router's LAN does not.
      *
+     * @author Paint_Ninja
      * @return the client's local IP address or null if unable
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 public class DualStackUtils
 {
     /**
-     * Resolve the address and see if Java and the OS return an IPv6 or IPv4 one, then let netty know
-     * accordingly (it doesn't understand the java.net.preferIPv6Addresses=system property)
+     * Resolve the address and see if Java and the OS return an IPv6 or IPv4 one, then let Netty know
+     * accordingly (it doesn't understand the {@code java.net.preferIPv6Addresses=system} property).
      *
      * @author Paint_Ninja
      * @param hostAddress The address you want to check
@@ -53,7 +53,7 @@ public class DualStackUtils
     }
 
     /**
-     * Checks if an address is an IPv6 one or an IPv4 one, then lets netty know accordingly and returns the result
+     * Checks if an address is an IPv6 one or an IPv4 one, lets Netty know accordingly and returns the result.
      *
      * @author Paint_Ninja
      * @param inetAddress The address you want to check
@@ -80,7 +80,7 @@ public class DualStackUtils
      * supports IPv6 and has it enabled but the router's LAN does not.
      *
      * @author Paint_Ninja
-     * @return the client's local IP address or null if unable
+     * @return the client's local IP address or {@code null} if unable to determine it
      */
     @Nullable
     public static InetAddress getLocalAddress()

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -31,7 +31,8 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 
-public class DualStackUtils {
+public class DualStackUtils
+{
     /**
      * Resolve the address and see if Java and the OS return an IPv6 or IPv4 one, then let netty know
      * accordingly (it doesn't understand the java.net.preferIPv6Addresses=system property)
@@ -40,7 +41,8 @@ public class DualStackUtils {
      * @param hostAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
-    public static boolean isIPv6(final String hostAddress) {
+    public static boolean isIPv6(final String hostAddress)
+    {
         final Optional<InetSocketAddress> hostAddr =
                 ServerNameResolver.DEFAULT
                         .resolveAddress(ServerAddress.parseString(hostAddress))
@@ -57,12 +59,16 @@ public class DualStackUtils {
      * @param inetAddress The address you want to check
      * @return true if IPv6, false if IPv4
      */
-    public static boolean isIPv6(final InetAddress inetAddress) {
-        if (inetAddress instanceof Inet6Address) {
+    public static boolean isIPv6(final InetAddress inetAddress)
+    {
+        if (inetAddress instanceof Inet6Address)
+        {
             System.setProperty("java.net.preferIPv4Stack", "false");
             System.setProperty("java.net.preferIPv6Addresses", "true");
             return true;
-        } else {
+        }
+        else
+        {
             System.setProperty("java.net.preferIPv4Stack", "true");
             System.setProperty("java.net.preferIPv6Addresses", "false");
             return false;
@@ -77,13 +83,17 @@ public class DualStackUtils {
      * @return the client's local IP address or null if unable
      */
     @Nullable
-    public static InetAddress getLocalAddress() {
+    public static InetAddress getLocalAddress()
+    {
         final InetAddress localAddr = new InetSocketAddress(HttpUtil.getAvailablePort()).getAddress();
         if (localAddr.isAnyLocalAddress()) return localAddr;
 
-        try {
+        try
+        {
             return InetAddress.getByName("localhost");
-        } catch (final UnknownHostException e) {
+        }
+        catch (final UnknownHostException e)
+        {
             return null;
         }
     }

--- a/src/main/java/net/minecraftforge/network/NetworkConstants.java
+++ b/src/main/java/net/minecraftforge/network/NetworkConstants.java
@@ -6,9 +6,6 @@
 package net.minecraftforge.network;
 
 import io.netty.util.AttributeKey;
-import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
-import net.minecraft.client.multiplayer.resolver.ServerAddress;
-import net.minecraft.client.multiplayer.resolver.ServerNameResolver;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
 import net.minecraftforge.network.event.EventNetworkChannel;
@@ -16,11 +13,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
-import javax.annotation.Nullable;
-import java.net.Inet6Address;
-import java.net.InetSocketAddress;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Constants related to networking
@@ -31,8 +24,6 @@ public class NetworkConstants
     public static final int FMLNETVERSION = 2;
     public static final String NETVERSION = FMLNETMARKER + FMLNETVERSION;
     public static final String NOVERSION = "NONE";
-
-    public static final boolean USE_IPV6 = shouldUseIPv6();
 
     static final Marker NETWORK = MarkerManager.getMarker("FMLNETWORK");
     static final AttributeKey<String> FML_NETVERSION = AttributeKey.valueOf("fml:netversion");
@@ -53,27 +44,5 @@ public class NetworkConstants
 
     public static String init() {
         return NetworkConstants.NETVERSION;
-    }
-
-    /**
-     * Resolve a localhost address and see if Java and the OS return an IPv6 or IPv4 one, then let netty know
-     * accordingly (it doesn't understand the java.net.preferIPv6Addresses=system property)
-     *
-     * TODO: check on a per-hostname-basis instead of just localhost, just in case
-     *
-     * @return true if IPv6 is used, false if IPv4 is used
-     */
-    public static boolean shouldUseIPv6() {
-        final Optional<InetSocketAddress> localhostAddr =
-                ServerNameResolver.DEFAULT.resolveAddress(ServerAddress.parseString("localhost")).map(ResolvedServerAddress::asInetSocketAddress);
-        if (localhostAddr.isPresent() && localhostAddr.get().getAddress() instanceof Inet6Address) {
-            System.setProperty("java.net.preferIPv4Stack", "false");
-            System.setProperty("java.net.preferIPv6Addresses", "true");
-            return true;
-        } else {
-            System.setProperty("java.net.preferIPv4Stack", "true");
-            System.setProperty("java.net.preferIPv6Addresses", "false");
-            return false;
-        }
     }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkConstants.java
+++ b/src/main/java/net/minecraftforge/network/NetworkConstants.java
@@ -6,6 +6,9 @@
 package net.minecraftforge.network;
 
 import io.netty.util.AttributeKey;
+import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.client.multiplayer.resolver.ServerNameResolver;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
 import net.minecraftforge.network.event.EventNetworkChannel;
@@ -13,7 +16,12 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
+import javax.annotation.Nullable;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Optional;
+
 /**
  * Constants related to networking
  */
@@ -23,6 +31,8 @@ public class NetworkConstants
     public static final int FMLNETVERSION = 2;
     public static final String NETVERSION = FMLNETMARKER + FMLNETVERSION;
     public static final String NOVERSION = "NONE";
+
+    public static final boolean USE_IPV6 = shouldUseIPv6();
 
     static final Marker NETWORK = MarkerManager.getMarker("FMLNETWORK");
     static final AttributeKey<String> FML_NETVERSION = AttributeKey.valueOf("fml:netversion");
@@ -43,5 +53,27 @@ public class NetworkConstants
 
     public static String init() {
         return NetworkConstants.NETVERSION;
+    }
+
+    /**
+     * Resolve a localhost address and see if Java and the OS return an IPv6 or IPv4 one, then let netty know
+     * accordingly (it doesn't understand the java.net.preferIPv6Addresses=system property)
+     *
+     * TODO: check on a per-hostname-basis instead of just localhost, just in case
+     *
+     * @return true if IPv6 is used, false if IPv4 is used
+     */
+    public static boolean shouldUseIPv6() {
+        final Optional<InetSocketAddress> localhostAddr =
+                ServerNameResolver.DEFAULT.resolveAddress(ServerAddress.parseString("localhost")).map(ResolvedServerAddress::asInetSocketAddress);
+        if (localhostAddr.isPresent() && localhostAddr.get().getAddress() instanceof Inet6Address) {
+            System.setProperty("java.net.preferIPv4Stack", "false");
+            System.setProperty("java.net.preferIPv6Addresses", "true");
+            return true;
+        } else {
+            System.setProperty("java.net.preferIPv4Stack", "true");
+            System.setProperty("java.net.preferIPv6Addresses", "false");
+            return false;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkConstants.java
+++ b/src/main/java/net/minecraftforge/network/NetworkConstants.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import java.util.List;
-
 /**
  * Constants related to networking
  */


### PR DESCRIPTION
This PR fixes and enhances the small existing IPv6 patches in Forge, including:
- IPv6 support for Open to LAN and local server discovery
- Dual-stack resolution support for hostnames
- Compressed representation of Open to LAN IPv6 addresses with config option (enabled by default)

Successor of https://github.com/ForgeForce/MinecraftForge/pull/13