### PR TITLE
[1.18.x] Fix TerrainParticle rendering black under certain conditions

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/ParticleEngine.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleEngine.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/client/particle/ParticleEngine.java
 +++ b/net/minecraft/client/particle/ParticleEngine.java
-@@ -70,7 +_,7 @@
+@@ -66,11 +_,11 @@
+    private static final int f_172264_ = 16384;
+    private static final List<ParticleRenderType> f_107288_ = ImmutableList.of(ParticleRenderType.f_107429_, ParticleRenderType.f_107430_, ParticleRenderType.f_107432_, ParticleRenderType.f_107431_, ParticleRenderType.f_107433_);
+    protected ClientLevel f_107287_;
+-   private final Map<ParticleRenderType, Queue<Particle>> f_107289_ = Maps.newIdentityHashMap();
++   private final Map<ParticleRenderType, Queue<Particle>> f_107289_ = Maps.newTreeMap(net.minecraftforge.client.ForgeHooksClient.makeParticleRenderTypeComparator(f_107288_));
     private final Queue<TrackingEmitter> f_107290_ = Queues.newArrayDeque();
     private final TextureManager f_107291_;
     private final Random f_107292_ = new Random();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,6 +31,7 @@ import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.locale.Language;
@@ -128,6 +129,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1045,4 +1047,19 @@ public class ForgeHooksClient
                 .toList();
     }
 
+    public static Comparator<ParticleRenderType> makeParticleRenderTypeComparator(List<ParticleRenderType> renderOrder)
+    {
+        Comparator<ParticleRenderType> vanillaComparator = Comparator.comparingInt(renderOrder::indexOf);
+        return (typeOne, typeTwo) ->
+        {
+            boolean vanillaOne = renderOrder.contains(typeOne);
+            boolean vanillaTwo = renderOrder.contains(typeTwo);
+
+            if (vanillaOne && vanillaTwo)
+            {
+                return vanillaComparator.compare(typeOne, typeTwo);
+            }
+            return Boolean.compare(vanillaTwo, vanillaOne);
+        };
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/client/rendering/CustomParticleTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CustomParticleTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.Tesselator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.*;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(CustomParticleTypeTest.MOD_ID)
+public class CustomParticleTypeTest
+{
+    public static final String MOD_ID = "custom_particle_type_test";
+    private static final boolean ENABLED = true;
+
+    public CustomParticleTypeTest() { }
+
+    @Mod.EventBusSubscriber(modid = CustomParticleTypeTest.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+    public static class ClientEvents
+    {
+        private static final ParticleRenderType CUSTOM_TYPE = new ParticleRenderType()
+        {
+            @Override
+            public void begin(BufferBuilder buffer, TextureManager texMgr)
+            {
+                Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
+                ParticleRenderType.TERRAIN_SHEET.begin(buffer, texMgr);
+            }
+
+            @Override
+            public void end(Tesselator tess)
+            {
+                ParticleRenderType.TERRAIN_SHEET.end(tess);
+            }
+        };
+
+        private static class CustomParticle extends TerrainParticle
+        {
+            public CustomParticle(ClientLevel level, double x, double y, double z)
+            {
+                super(level, x, y, z, 0, .25, 0, Blocks.OBSIDIAN.defaultBlockState());
+            }
+
+            @Override
+            public ParticleRenderType getRenderType()
+            {
+                return CUSTOM_TYPE;
+            }
+        }
+
+        @SubscribeEvent
+        public static void onClientTick(final TickEvent.ClientTickEvent event)
+        {
+            if (!ENABLED || event.phase != TickEvent.Phase.START) { return; }
+
+            ClientLevel level = Minecraft.getInstance().level;
+            Player player = Minecraft.getInstance().player;
+            if (player == null || level == null || !player.isShiftKeyDown()) { return; }
+
+            Minecraft.getInstance().particleEngine.add(new CustomParticle(level, player.getX(), player.getY(), player.getZ()));
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -174,5 +174,7 @@ license="LGPL v2.1"
     modId="part_entity_test"
 [[mods]]
     modId="capabilities_test"
+[[mods]]
+    modId="custom_particle_type_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Fixes an issue with particle rendering caused by the way Forge allows custom `ParticleRenderType`s to work. This issue manifest in `TerrainParticle`s (used for the particle cloud when a block breaks) drawing black under certain circumstances like picking up an item from the ground.
This issue was overlooked in https://github.com/MinecraftForge/MinecraftForge/pull/8291 because it is only randomly reproducable and may seemingly not happen at all for certain people.

See the initial report here: https://discord.com/channels/313125603924639766/437001959950778368/929506604091600916
See the issue analysis here: https://discord.com/channels/313125603924639766/852298000042164244/929812529344045077

This PR also adds a test mod to check whether custom `ParticleRenderType`s are properly sorted in relation to vanilla `ParticleRenderType`s and rendered accordingly.