### PR TITLE
[1.18.x] Fix comparison of custom ParticleRenderTypes

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1074,7 +1074,11 @@ public class ForgeHooksClient
             {
                 return vanillaComparator.compare(typeOne, typeTwo);
             }
-            return Boolean.compare(vanillaTwo, vanillaOne);
+            if (!vanillaOne && !vanillaTwo)
+            {
+                return Integer.compare(typeOne.hashCode(), typeTwo.hashCode());
+            }
+            return vanillaOne ? -1 : 1;
         };
     }
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1076,7 +1076,7 @@ public class ForgeHooksClient
             }
             if (!vanillaOne && !vanillaTwo)
             {
-                return Integer.compare(typeOne.hashCode(), typeTwo.hashCode());
+                return Integer.compare(System.identityHashCode(typeOne), System.identityHashCode(typeTwo));
             }
             return vanillaOne ? -1 : 1;
         };

--- a/src/test/java/net/minecraftforge/debug/client/rendering/CustomParticleTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CustomParticleTypeTest.java
@@ -58,6 +58,21 @@ public class CustomParticleTypeTest
                 ParticleRenderType.TERRAIN_SHEET.end(tess);
             }
         };
+        private static final ParticleRenderType CUSTOM_TYPE_TWO = new ParticleRenderType()
+        {
+            @Override
+            public void begin(BufferBuilder buffer, TextureManager texMgr)
+            {
+                Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
+                ParticleRenderType.TERRAIN_SHEET.begin(buffer, texMgr);
+            }
+
+            @Override
+            public void end(Tesselator tess)
+            {
+                ParticleRenderType.TERRAIN_SHEET.end(tess);
+            }
+        };
 
         private static class CustomParticle extends TerrainParticle
         {
@@ -72,6 +87,19 @@ public class CustomParticleTypeTest
                 return CUSTOM_TYPE;
             }
         }
+        private static class AnotherCustomParticle extends TerrainParticle
+        {
+            public AnotherCustomParticle(ClientLevel level, double x, double y, double z)
+            {
+                super(level, x, y, z, 0, .25, 0, Blocks.SAND.defaultBlockState());
+            }
+
+            @Override
+            public ParticleRenderType getRenderType()
+            {
+                return CUSTOM_TYPE_TWO;
+            }
+        }
 
         @SubscribeEvent
         public static void onClientTick(final TickEvent.ClientTickEvent event)
@@ -83,6 +111,7 @@ public class CustomParticleTypeTest
             if (player == null || level == null || !player.isShiftKeyDown()) { return; }
 
             Minecraft.getInstance().particleEngine.add(new CustomParticle(level, player.getX(), player.getY(), player.getZ()));
+            Minecraft.getInstance().particleEngine.add(new AnotherCustomParticle(level, player.getX(), player.getY(), player.getZ()));
         }
     }
 }


### PR DESCRIPTION
This PR fixes an oversight in the `ParticleRenderType` comparator implemented in #8378 which breaks the contract of `TreeMap` leading to all particles with custom `ParticleRenderType`s being put into the queue of the first `ParticleRenderType` that is put into the map.

Without the fix:
![Screenshot 2022-01-11 003531](https://user-images.githubusercontent.com/11262040/148857122-e848cd85-a582-4984-8742-28bea3218bbc.png)

With the fix:
![Screenshot 2022-01-11 003646](https://user-images.githubusercontent.com/11262040/148857137-ccfccc81-e59f-4dfa-9e30-ed5db77fb7f2.png)