### PR TITLE
Introduce an attribute for step height

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -17,6 +17,14 @@
     private final EntityType<?> f_19847_;
     private int f_19848_ = f_19843_.incrementAndGet();
     public boolean f_19850_;
+@@ -175,6 +_,7 @@
+    public double f_19790_;
+    public double f_19791_;
+    public double f_19792_;
++   @Deprecated // Forge - see IForgeEntity#getStepHeight
+    public float f_19793_;
+    public boolean f_19794_;
+    protected final Random f_19796_ = new Random();
 @@ -229,6 +_,7 @@
     private BlockState f_185934_ = null;
  
@@ -108,6 +116,21 @@
              return blockpos1;
           }
        }
+@@ -791,10 +_,10 @@
+       boolean flag1 = p_20273_.f_82480_ != vec3.f_82480_;
+       boolean flag2 = p_20273_.f_82481_ != vec3.f_82481_;
+       boolean flag3 = this.f_19861_ || flag1 && p_20273_.f_82480_ < 0.0D;
+-      if (this.f_19793_ > 0.0F && flag3 && (flag || flag2)) {
+-         Vec3 vec31 = m_198894_(this, new Vec3(p_20273_.f_82479_, (double)this.f_19793_, p_20273_.f_82481_), aabb, this.f_19853_, list);
+-         Vec3 vec32 = m_198894_(this, new Vec3(0.0D, (double)this.f_19793_, 0.0D), aabb.m_82363_(p_20273_.f_82479_, 0.0D, p_20273_.f_82481_), this.f_19853_, list);
+-         if (vec32.f_82480_ < (double)this.f_19793_) {
++      if (this.getStepHeight() > 0.0F && flag3 && (flag || flag2)) {
++         Vec3 vec31 = m_198894_(this, new Vec3(p_20273_.f_82479_, (double)this.getStepHeight(), p_20273_.f_82481_), aabb, this.f_19853_, list);
++         Vec3 vec32 = m_198894_(this, new Vec3(0.0D, (double)this.getStepHeight(), 0.0D), aabb.m_82363_(p_20273_.f_82479_, 0.0D, p_20273_.f_82481_), this.f_19853_, list);
++         if (vec32.f_82480_ < (double)this.getStepHeight()) {
+             Vec3 vec33 = m_198894_(this, new Vec3(p_20273_.f_82479_, 0.0D, p_20273_.f_82481_), aabb.m_82383_(vec32), this.f_19853_, list).m_82549_(vec32);
+             if (vec33.m_165925_() > vec31.m_165925_()) {
+                vec31 = vec33;
 @@ -929,7 +_,7 @@
     protected void m_7355_(BlockPos p_20135_, BlockState p_20136_) {
        if (!p_20136_.m_60767_().m_76332_()) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -15,7 +15,7 @@
  
     public static AttributeSupplier.Builder m_21183_() {
 -      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_);
-+      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_).m_22266_(net.minecraftforge.common.ForgeMod.SWIM_SPEED.get()).m_22266_(net.minecraftforge.common.ForgeMod.NAMETAG_DISTANCE.get()).m_22266_(net.minecraftforge.common.ForgeMod.ENTITY_GRAVITY.get());
++      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_).m_22266_(net.minecraftforge.common.ForgeMod.SWIM_SPEED.get()).m_22266_(net.minecraftforge.common.ForgeMod.NAMETAG_DISTANCE.get()).m_22266_(net.minecraftforge.common.ForgeMod.ENTITY_GRAVITY.get()).m_22266_(net.minecraftforge.common.ForgeMod.STEP_HEIGHT_ADDITION.get());
     }
  
     protected void m_7840_(double p_20990_, boolean p_20991_, BlockState p_20992_, BlockPos p_20993_) {

--- a/patches/minecraft/net/minecraft/world/entity/ai/control/MoveControl.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/control/MoveControl.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/control/MoveControl.java
++++ b/net/minecraft/world/entity/ai/control/MoveControl.java
+@@ -99,7 +_,7 @@
+          BlockPos blockpos = this.f_24974_.m_142538_();
+          BlockState blockstate = this.f_24974_.f_19853_.m_8055_(blockpos);
+          VoxelShape voxelshape = blockstate.m_60812_(this.f_24974_.f_19853_, blockpos);
+-         if (d2 > (double)this.f_24974_.f_19793_ && d0 * d0 + d1 * d1 < (double)Math.max(1.0F, this.f_24974_.m_20205_()) || !voxelshape.m_83281_() && this.f_24974_.m_20186_() < voxelshape.m_83297_(Direction.Axis.Y) + (double)blockpos.m_123342_() && !blockstate.m_204336_(BlockTags.f_13103_) && !blockstate.m_204336_(BlockTags.f_13039_)) {
++         if (d2 > (double)this.f_24974_.getStepHeight() && d0 * d0 + d1 * d1 < (double)Math.max(1.0F, this.f_24974_.m_20205_()) || !voxelshape.m_83281_() && this.f_24974_.m_20186_() < voxelshape.m_83297_(Direction.Axis.Y) + (double)blockpos.m_123342_() && !blockstate.m_204336_(BlockTags.f_13103_) && !blockstate.m_204336_(BlockTags.f_13039_)) {
+             this.f_24974_.m_21569_().m_24901_();
+             this.f_24981_ = MoveControl.Operation.JUMPING;
+          }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -192,7 +192,39 @@
                       this.m_21008_(p_36159_, ItemStack.f_41583_);
                    }
  
-@@ -1041,6 +_,7 @@
+@@ -992,7 +_,7 @@
+          double d1 = p_36201_.f_82481_;
+          double d2 = 0.05D;
+ 
+-         while(d0 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(d0, (double)(-this.f_19793_), 0.0D))) {
++         while(d0 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(d0, (double)(-this.getStepHeight()), 0.0D))) {
+             if (d0 < 0.05D && d0 >= -0.05D) {
+                d0 = 0.0D;
+             } else if (d0 > 0.0D) {
+@@ -1002,7 +_,7 @@
+             }
+          }
+ 
+-         while(d1 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(0.0D, (double)(-this.f_19793_), d1))) {
++         while(d1 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(0.0D, (double)(-this.getStepHeight()), d1))) {
+             if (d1 < 0.05D && d1 >= -0.05D) {
+                d1 = 0.0D;
+             } else if (d1 > 0.0D) {
+@@ -1012,7 +_,7 @@
+             }
+          }
+ 
+-         while(d0 != 0.0D && d1 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(d0, (double)(-this.f_19793_), d1))) {
++         while(d0 != 0.0D && d1 != 0.0D && this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(d0, (double)(-this.getStepHeight()), d1))) {
+             if (d0 < 0.05D && d0 >= -0.05D) {
+                d0 = 0.0D;
+             } else if (d0 > 0.0D) {
+@@ -1037,10 +_,11 @@
+    }
+ 
+    private boolean m_36386_() {
+-      return this.f_19861_ || this.f_19789_ < this.f_19793_ && !this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(0.0D, (double)(this.f_19789_ - this.f_19793_), 0.0D));
++      return this.f_19861_ || this.f_19789_ < this.getStepHeight() && !this.f_19853_.m_45756_(this, this.m_142469_().m_82386_(0.0D, (double)(this.f_19789_ - this.getStepHeight()), 0.0D));
     }
  
     public void m_5706_(Entity p_36347_) {

--- a/patches/minecraft/net/minecraft/world/level/pathfinder/AmphibiousNodeEvaluator.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/pathfinder/AmphibiousNodeEvaluator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/pathfinder/AmphibiousNodeEvaluator.java
++++ b/net/minecraft/world/level/pathfinder/AmphibiousNodeEvaluator.java
+@@ -45,7 +_,7 @@
+       BlockPathTypes blockpathtypes1 = this.m_77567_(this.f_77313_, p_164677_.f_77271_, p_164677_.f_77272_, p_164677_.f_77273_);
+       int j;
+       if (this.f_77313_.m_21439_(blockpathtypes) >= 0.0F && blockpathtypes1 != BlockPathTypes.STICKY_HONEY) {
+-         j = Mth.m_14143_(Math.max(1.0F, this.f_77313_.f_19793_));
++         j = Mth.m_14143_(Math.max(1.0F, this.f_77313_.getStepHeight()));
+       } else {
+          j = 0;
+       }

--- a/patches/minecraft/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
 +++ b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
+@@ -113,7 +_,7 @@
+       BlockPathTypes blockpathtypes = this.m_77567_(this.f_77313_, p_77641_.f_77271_, p_77641_.f_77272_ + 1, p_77641_.f_77273_);
+       BlockPathTypes blockpathtypes1 = this.m_77567_(this.f_77313_, p_77641_.f_77271_, p_77641_.f_77272_, p_77641_.f_77273_);
+       if (this.f_77313_.m_21439_(blockpathtypes) >= 0.0F && blockpathtypes1 != BlockPathTypes.STICKY_HONEY) {
+-         j = Mth.m_14143_(Math.max(1.0F, this.f_77313_.f_19793_));
++         j = Mth.m_14143_(Math.max(1.0F, this.f_77313_.getStepHeight()));
+       }
+ 
+       double d0 = this.m_142213_(new BlockPos(p_77641_.f_77271_, p_77641_.f_77272_, p_77641_.f_77273_));
 @@ -476,6 +_,8 @@
  
     protected static BlockPathTypes m_77643_(BlockGetter p_77644_, BlockPos p_77645_) {

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -93,6 +93,7 @@ public class ForgeMod
     public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
 
     public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("generic.reachDistance", 5.0D, 0.0D, 1024.0D).setSyncable(true));
+    public static final RegistryObject<Attribute> STEP_HEIGHT_ADDITION = ATTRIBUTES.register("step_height_addition", () -> new RangedAttribute("forge.stepHeight", 0.0D, -512.0D, 512.0D).setSyncable(true));
 
     private static boolean enableMilkFluid = false;
     public static final RegistryObject<Fluid> MILK = RegistryObject.of(new ResourceLocation("milk"), ForgeRegistries.FLUIDS);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -8,6 +8,7 @@ package net.minecraftforge.common.extensions;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,6 +20,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.HitResult;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.entity.PartEntity;
@@ -188,5 +190,23 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     default PartEntity<?>[] getParts()
     {
         return null;
+    }
+
+    /**
+     * {@return Return the height in blocks the Entity can step up without needing to jump}
+     * This is the sum of vanilla's {@link Entity#maxUpStep} field and the current value
+     * of the {@link net.minecraftforge.common.ForgeMod#STEP_HEIGHT_ADDITION} attribute,
+     * (if this Entity is a {@link LivingEntity}), clamped at 0.
+     */
+    default float getStepHeight()
+    {
+        var vanillaStep = self().maxUpStep;
+        if (self() instanceof LivingEntity living)
+        {
+            return (float) Math.max(0, vanillaStep + living.getAttributeValue(ForgeMod.STEP_HEIGHT_ADDITION.get()));
+        } else
+        {
+            return vanillaStep;
+        }
     }
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -188,6 +188,7 @@
   "forge.nameTagDistance": "Nametag Render Distance",
   "forge.entity_gravity": "Entity Gravity",
   "generic.reachDistance": "Reach Distance",
+  "forge.stepHeight": "Step Height",
 
   "fluid.minecraft.milk": "Milk",
   "fluid.minecraft.flowing_milk": "Milk",


### PR DESCRIPTION
Very similar to the reach distance attribute. Basically this is a primitive field modders like to tweak a lot, and it's tricky to make sure you apply/remove things at the right time lest you get into a bad state. Perfect use for attributes, something Mojang chronically forgets exists.

Adds the new attribute, and new method that queries the combined old field + attribute value. Writes to the old field are kept while all reads of the old field are redirected to the new method.

Test: https://gfycat.com/compassionatehonoredlhasaapso
I show what happens with three helmets, with +1, +2, and +5 step height. Note that the default player step height is 0.6, so with the +1 helmet I can step up 1.6 blocks and clear the grass + slab.