### PR TITLE
Fix FoliagePlacerType and TreeDecoratorType registry

### DIFF
--- a/patches/minecraft/net/minecraft/core/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/core/Registry.java.patch
@@ -149,7 +149,7 @@
        return BlockStateProviderType.f_68752_;
     });
 -   public static final Registry<FoliagePlacerType<?>> f_122858_ = m_122999_(f_122848_, () -> {
-+   public static final Registry<FoliagePlacerType<?>> f_122858_ = forge(f_122848_, () -> {
++   @Deprecated public static final Registry<FoliagePlacerType<?>> f_122858_ = forge(f_122848_, () -> {
        return FoliagePlacerType.f_68591_;
     });
     public static final Registry<TrunkPlacerType<?>> f_122859_ = m_122999_(f_122849_, () -> {

--- a/patches/minecraft/net/minecraft/core/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/core/Registry.java.patch
@@ -140,7 +140,7 @@
        return StructureFeature.f_67014_;
     });
     public static final ResourceKey<Registry<StructurePieceType>> f_122842_ = m_122978_("worldgen/structure_piece");
-@@ -311,7 +_,7 @@
+@@ -311,10 +_,10 @@
     public static final ResourceKey<Registry<Codec<? extends SurfaceRules.RuleSource>>> f_194572_ = m_122978_("worldgen/material_rule");
     public static final ResourceKey<Registry<StructureProcessorType<?>>> f_122854_ = m_122978_("worldgen/structure_processor");
     public static final ResourceKey<Registry<StructurePoolElementType<?>>> f_122855_ = m_122978_("worldgen/structure_pool_element");
@@ -148,7 +148,11 @@
 +   @Deprecated public static final Registry<BlockStateProviderType<?>> f_122856_ = forge(f_122846_, () -> {
        return BlockStateProviderType.f_68752_;
     });
-    public static final Registry<FoliagePlacerType<?>> f_122858_ = m_122999_(f_122848_, () -> {
+-   public static final Registry<FoliagePlacerType<?>> f_122858_ = m_122999_(f_122848_, () -> {
++   public static final Registry<FoliagePlacerType<?>> f_122858_ = forge(f_122848_, () -> {
+       return FoliagePlacerType.f_68591_;
+    });
+    public static final Registry<TrunkPlacerType<?>> f_122859_ = m_122999_(f_122849_, () -> {
 @@ -365,16 +_,32 @@
        return m_122981_(p_123000_, Lifecycle.experimental(), p_123001_);
     }

--- a/patches/minecraft/net/minecraft/core/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/core/Registry.java.patch
@@ -140,7 +140,7 @@
        return StructureFeature.f_67014_;
     });
     public static final ResourceKey<Registry<StructurePieceType>> f_122842_ = m_122978_("worldgen/structure_piece");
-@@ -311,10 +_,10 @@
+@@ -311,16 +_,16 @@
     public static final ResourceKey<Registry<Codec<? extends SurfaceRules.RuleSource>>> f_194572_ = m_122978_("worldgen/material_rule");
     public static final ResourceKey<Registry<StructureProcessorType<?>>> f_122854_ = m_122978_("worldgen/structure_processor");
     public static final ResourceKey<Registry<StructurePoolElementType<?>>> f_122855_ = m_122978_("worldgen/structure_pool_element");
@@ -153,6 +153,13 @@
        return FoliagePlacerType.f_68591_;
     });
     public static final Registry<TrunkPlacerType<?>> f_122859_ = m_122999_(f_122849_, () -> {
+       return TrunkPlacerType.f_70315_;
+    });
+-   public static final Registry<TreeDecoratorType<?>> f_122860_ = m_122999_(f_122850_, () -> {
++   @Deprecated public static final Registry<TreeDecoratorType<?>> f_122860_ = forge(f_122850_, () -> {
+       return TreeDecoratorType.f_70043_;
+    });
+    public static final Registry<FeatureSizeType<?>> f_122888_ = m_122999_(f_122851_, () -> {
 @@ -365,16 +_,32 @@
        return m_122981_(p_123000_, Lifecycle.experimental(), p_123001_);
     }


### PR DESCRIPTION
Currently `FoliagePlacerType` and `TreeDecoratorType ` forge registries are not working but they exist. The actual registries weren't wrapped by forge. Probably was missed during an update. This PR patches this and wraps the registries to make it work.