### PR TITLE
[1.18.x] Fix Mob Spawner logic with CustomSpawnRules

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
@@ -5,7 +5,7 @@
                    if (entity instanceof Mob) {
                       Mob mob = (Mob)entity;
 -                     if (this.f_45444_.m_186574_().isEmpty() && !mob.m_5545_(p_151312_, MobSpawnType.SPAWNER) || !mob.m_6914_(p_151312_)) {
-+                     if (!net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(this.f_45444_, mob, p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this)) {
++                     if (!net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(mob, p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this, this.f_45444_.f_186562_())) {
                          continue;
                       }
  

--- a/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
@@ -5,7 +5,7 @@
                    if (entity instanceof Mob) {
                       Mob mob = (Mob)entity;
 -                     if (this.f_45444_.m_186574_().isEmpty() && !mob.m_5545_(p_151312_, MobSpawnType.SPAWNER) || !mob.m_6914_(p_151312_)) {
-+                     if (!net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(mob, p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this)) {
++                     if (!net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(this.f_45444_, mob, p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this)) {
                          continue;
                       }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -216,7 +216,7 @@ public class ForgeEventFactory
     {
         Result result = canEntitySpawn(entity, world, x, y, z, spawner, MobSpawnType.SPAWNER);
         if (result == Result.DEFAULT)
-            return !(spawnRules.isEmpty() && !entity.checkSpawnRules(world, MobSpawnType.SPAWNER) || !entity.checkSpawnObstruction(world)); // vanilla logic (inverted)
+            return (!spawnRules.isEmpty() || entity.checkSpawnRules(world, MobSpawnType.SPAWNER)) && entity.checkSpawnObstruction(world); // vanilla logic (inverted)
         else
             return result == Result.ALLOW;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -205,7 +205,7 @@ public class ForgeEventFactory
         return event.getResult();
     }
 
-    public static boolean canEntitySpawnSpawner(SpawnData spawnData, Mob entity, Level world, float x, float y, float z, BaseSpawner spawner)
+    public static boolean canEntitySpawnSpawner(SpawnData spawnData, Mob entity, LevelAccessor world, float x, float y, float z, BaseSpawner spawner)
     {
         Result result = canEntitySpawn(entity, world, x, y, z, spawner, MobSpawnType.SPAWNER);
         if (result == Result.DEFAULT)
@@ -214,7 +214,7 @@ public class ForgeEventFactory
             return result == Result.ALLOW;
     }
 
-    public static boolean doSpecialSpawn(Mob entity, Level world, float x, float y, float z, BaseSpawner spawner, MobSpawnType spawnReason)
+    public static boolean doSpecialSpawn(Mob entity, LevelAccessor world, float x, float y, float z, BaseSpawner spawner, MobSpawnType spawnReason)
     {
         return MinecraftForge.EVENT_BUS.post(new LivingSpawnEvent.SpecialSpawn(entity, world, x, y, z, spawner, spawnReason));
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -83,6 +83,7 @@ import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.SpawnData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.storage.ServerLevelData;
@@ -204,11 +205,11 @@ public class ForgeEventFactory
         return event.getResult();
     }
 
-    public static boolean canEntitySpawnSpawner(Mob entity, Level world, float x, float y, float z, BaseSpawner spawner)
+    public static boolean canEntitySpawnSpawner(SpawnData spawnData, Mob entity, Level world, float x, float y, float z, BaseSpawner spawner)
     {
         Result result = canEntitySpawn(entity, world, x, y, z, spawner, MobSpawnType.SPAWNER);
         if (result == Result.DEFAULT)
-            return entity.checkSpawnRules(world, MobSpawnType.SPAWNER) && entity.checkSpawnObstruction(world); // vanilla logic (inverted)
+            return !(spawnData.getCustomSpawnRules().isEmpty() && !entity.checkSpawnRules(world, MobSpawnType.SPAWNER) || !entity.checkSpawnObstruction(world)); // vanilla logic (inverted)
         else
             return result == Result.ALLOW;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -205,13 +205,27 @@ public class ForgeEventFactory
         return event.getResult();
     }
 
-    public static boolean canEntitySpawnSpawner(SpawnData spawnData, Mob entity, LevelAccessor world, float x, float y, float z, BaseSpawner spawner)
+    // TODO 1.18.2/1.19 remove in favor of LevelAccessor & CustomSpawnRules version
+    @Deprecated
+    public static boolean canEntitySpawnSpawner(Mob entity, Level world, float x, float y, float z, BaseSpawner spawner)
+    {
+        return canEntitySpawnSpawner(entity, world, x, y, z, spawner, Optional.empty());
+    }
+
+    public static boolean canEntitySpawnSpawner(Mob entity, LevelAccessor world, float x, float y, float z, BaseSpawner spawner, Optional<SpawnData.CustomSpawnRules> spawnRules)
     {
         Result result = canEntitySpawn(entity, world, x, y, z, spawner, MobSpawnType.SPAWNER);
         if (result == Result.DEFAULT)
-            return !(spawnData.getCustomSpawnRules().isEmpty() && !entity.checkSpawnRules(world, MobSpawnType.SPAWNER) || !entity.checkSpawnObstruction(world)); // vanilla logic (inverted)
+            return !(spawnRules.isEmpty() && !entity.checkSpawnRules(world, MobSpawnType.SPAWNER) || !entity.checkSpawnObstruction(world)); // vanilla logic (inverted)
         else
             return result == Result.ALLOW;
+    }
+
+    // TODO 1.18.2/1.19 remove in favor of LevelAccessor version
+    @Deprecated
+    public static boolean doSpecialSpawn(Mob entity, Level world, float x, float y, float z, BaseSpawner spawner, MobSpawnType spawnReason)
+    {
+        return doSpecialSpawn(entity, (LevelAccessor) world, x, y, z, spawner, spawnReason);
     }
 
     public static boolean doSpecialSpawn(Mob entity, LevelAccessor world, float x, float y, float z, BaseSpawner spawner, MobSpawnType spawnReason)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -144,6 +144,13 @@ public class LivingSpawnEvent extends LivingEvent
             this.spawnReason = spawnReason;
         }
 
+        // TODO remove 1.18.2/1.19 in favor of LevelAccessor version
+        @Deprecated
+        public SpecialSpawn(Mob entity, Level world, double x, double y, double z, @Nullable BaseSpawner spawner, MobSpawnType spawnReason)
+        {
+            this(entity, (LevelAccessor) world, x, y, z, spawner, spawnReason);
+        }
+
         @Nullable
         public BaseSpawner getSpawner()
         {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -137,7 +137,7 @@ public class LivingSpawnEvent extends LivingEvent
         /**
          * @param spawner the position of a tileentity or approximate position of an entity that initiated the spawn if any
          */
-        public SpecialSpawn(Mob entity, Level world, double x, double y, double z, @Nullable BaseSpawner spawner, MobSpawnType spawnReason)
+        public SpecialSpawn(Mob entity, LevelAccessor world, double x, double y, double z, @Nullable BaseSpawner spawner, MobSpawnType spawnReason)
         {
             super(entity, world, x, y, z);
             this.spawner = spawner;


### PR DESCRIPTION
When using a spawner entry with custom spawn rules added in 1.18, those rules are not used properly when attempting to spawn the mob, resulting in the spawner failing even when it should succeed. This PR aims to fix that, matching vanilla behavior.

This could be a breaking change, since `ForgeEventFactory.canEntitySpawnSpawner` needed an additional argument, however this could be made nullable with a method using the original arguments if that's a concern.

Supplied are two commands for mob spawner blocks, one that spawns Creepers with normal light restrictions, and another that only spawns Creepers in bright skylight. For testing, I placed both spawners exposed on the surface during the day. The normal spawner shouldn't work under these conditions, while the one with custom rules should. Doing this underground, in the dark, switches it such that the normal spawner works and the custom rule spawner stops.


Normal Spawner:

`/setblock ~ ~ ~ minecraft:spawner{Delay:20s,MaxNearbyEntities:6s,MaxSpawnDelay:100s,MinSpawnDelay:90s,RequiredPlayerRange:16s,SpawnCount:1s,SpawnPotentials:[{data:{entity:{id:"minecraft:creeper"}},weight:1}],SpawnRange:4s}`

Bright Skylight only (Non-functional in current Forge):

`/setblock ~ ~ ~ minecraft:spawner{Delay:20s,MaxNearbyEntities:6s,MaxSpawnDelay:100s,MinSpawnDelay:90s,RequiredPlayerRange:16s,SpawnCount:1s,SpawnPotentials:[{data:{custom_spawn_rules:{sky_light_limit:[10,15]},entity:{id:"minecraft:creeper"}},weight:1}],SpawnRange:4s}`