### PR TITLE
[1.18.x] Allow structures to have an empty spawn list

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
@@ -35,13 +35,21 @@ public interface IForgeStructureFeature
 
     /**
      * Gets the default list of spawns for this structure, of the specified category.
-     *
-     * @apiNote Implement this over any of the type specific getSpecial functions in StructureFeature.
      */
-    @SuppressWarnings("incomplete-switch")
     default List<MobSpawnSettings.SpawnerData> getDefaultSpawnList(MobCategory category)
     {
         return Collections.emptyList();
+    }
+
+    /**
+     * Allows for an empty spawn list from {@link #getDefaultSpawnList(MobCategory)} to be used. Effectively prevents mob spawning
+     * in this structure for a given category, as long as the spawn list hasn't had anything added to it.
+     * @param category
+     * @return True if an empty spawn list can be used.
+     */
+    default boolean allowEmptySpawnsForCategory(MobCategory category)
+    {
+        return false;
     }
 
     /**


### PR DESCRIPTION
The goal of this PR is to allow for a structure to have an empty spawn list, effectively preventing mob spawns for a given category within the structure, bringing back a behavior from 1.16 that used to allow for this.

To achieve this, `IForgeStructureFeature#allowEmptySpawnsForCategory(MobCategory)` was added. Returning `true` in this method allows an empty list to be used for mob spawning. This method does not outright prevent mob spawning, it only allows for "no spawns" to be an option. The default return value of this method is `false`, retaining the current behavior.

Although it's currently possible to prevent mob spawns within a structure using the `LivingSpawnEvent.CheckSpawn` event, doing so is notably more taxing due to all mobs needing to make an extra check for if they're inside the structure in question. With this PR, preventing spawns is baked into the process of getting the spawns, resulting in a minimal performance hit.

This PR should not produce any breaking changes. It also should not produce any logistical changes for existing structures since they will default to the current behavior.

For testing, replacing the method in `IForgeStructureFeature` with this code will make it so that both Ocean Monuments and Desert Temples are allowed to have empty spawn lists for the monster category. This does not affect the Ocean Monument since it still has guardians in its spawn list. However, this will prevent the Desert Temple from spawning hostile mobs since it would normally have an empty spawn list. (Images included for proof of this)

```java
default boolean allowEmptySpawnsForCategory(MobCategory category)
{
    System.out.print("checking " + self().getFeatureName() + " " + category.name());
    if ((self() == StructureFeature.OCEAN_MONUMENT || self() == StructureFeature.DESERT_PYRAMID) && category == MobCategory.MONSTER) 
    {
        System.out.println(" = allow empty");
        return true;
    }
    System.out.println(" = default");
    return false;
}
```

Desert Temple with no hostile spawns inside. Water placed to prevent spawns on the surface. All mobs are given the glowing effect to see them.
![2022-01-16_21 53 08](https://user-images.githubusercontent.com/15661705/149702385-519e4ffe-878f-4d31-ac11-ecd4fe0a20a5.png)

Ocean Monument with guardians still spawning
![2022-01-16_21 53 50](https://user-images.githubusercontent.com/15661705/149702492-eeae6274-fcd4-4ece-8256-0462c4d67b4a.png)

