### PR TITLE
[1.18.x] Added a Hunger-System API

### DIFF
--- a/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
+++ b/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
@@ -17,6 +17,15 @@
     }
  
     public void m_6742_(LivingEntity p_19467_, int p_19468_) {
+@@ -51,7 +_,7 @@
+       } else if (this == MobEffects.f_19615_) {
+          p_19467_.m_6469_(DamageSource.f_19320_, 1.0F);
+       } else if (this == MobEffects.f_19612_ && p_19467_ instanceof Player) {
+-         ((Player)p_19467_).m_36399_(0.005F * (float)(p_19468_ + 1));
++         ((Player)p_19467_).m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded((Player)p_19467_, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.EFFECT_HUNGER, 0.005F * (float)(p_19468_ + 1)));
+       } else if (this == MobEffects.f_19618_ && p_19467_ instanceof Player) {
+          if (!p_19467_.f_19853_.f_46443_) {
+             ((Player)p_19467_).m_36324_().m_38707_(p_19468_ + 1, 1.0F);
 @@ -179,4 +_,29 @@
     public boolean m_19486_() {
        return this.f_19447_ == MobEffectCategory.BENEFICIAL;

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -8,6 +8,15 @@
     public static final String f_150081_ = "OfflinePlayer:";
     public static final int f_150082_ = 16;
     public static final int f_150083_ = 20;
+@@ -136,7 +_,7 @@
+    protected PlayerEnderChestContainer f_36094_ = new PlayerEnderChestContainer();
+    public final InventoryMenu f_36095_;
+    public AbstractContainerMenu f_36096_;
+-   protected FoodData f_36097_ = new FoodData();
++   protected FoodData f_36097_ = new FoodData(this);
+    protected int f_36098_;
+    public float f_36099_;
+    public float f_36100_;
 @@ -162,6 +_,9 @@
     private final ItemCooldowns f_36087_ = this.m_7478_();
     @Nullable
@@ -63,6 +72,22 @@
        if (this.m_20175_(Pose.SWIMMING)) {
           Pose pose;
           if (this.m_21255_()) {
+@@ -469,11 +_,13 @@
+ 
+       if (this.f_19853_.m_46791_() == Difficulty.PEACEFUL && this.f_19853_.m_46469_().m_46207_(GameRules.f_46139_)) {
+          if (this.m_21223_() < this.m_21233_() && this.f_19797_ % 20 == 0) {
+-            this.m_5634_(1.0F);
++            net.minecraftforge.event.hunger.HealthRegenEvent.PeacefulRegen peacefulHealthRegenEvent = net.minecraftforge.event.ForgeEventFactory.onPeacefulHealthRegen(this);
++            if (!peacefulHealthRegenEvent.isCanceled()) this.m_5634_(peacefulHealthRegenEvent.getDeltaHealth());
+          }
+ 
+          if (this.f_36097_.m_38721_() && this.f_19797_ % 10 == 0) {
+-            this.f_36097_.m_38705_(this.f_36097_.m_38702_() + 1);
++            net.minecraftforge.event.hunger.HungerRegenEvent.PeacefulRegen peacefulHungerRegenEvent = net.minecraftforge.event.ForgeEventFactory.onPeacefulHungerRegen(this);
++            if (!peacefulHungerRegenEvent.isCanceled()) this.f_36097_.addFood(peacefulHungerRegenEvent.getDeltaHunger());
+          }
+       }
+ 
 @@ -569,6 +_,7 @@
     }
  
@@ -141,7 +166,7 @@
              });
              if (this.f_20935_.m_41619_()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {
-@@ -877,10 +_,13 @@
+@@ -877,20 +_,23 @@
  
     protected void m_6475_(DamageSource p_36312_, float p_36313_) {
        if (!this.m_6673_(p_36312_)) {
@@ -155,9 +180,11 @@
           float f = p_36313_ - f2;
           if (f > 0.0F && f < 3.4028235E37F) {
              this.m_36222_(Stats.f_12933_, Math.round(f * 10.0F));
-@@ -889,8 +_,8 @@
+          }
+ 
           if (f2 != 0.0F) {
-             this.m_36399_(p_36312_.m_19377_());
+-            this.m_36399_(p_36312_.m_19377_());
++            this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.DAMAGE_TAKEN, p_36312_.m_19377_()));
              float f1 = this.m_21223_();
 -            this.m_21153_(this.m_21223_() - f2);
              this.m_21231_().m_19289_(p_36312_, f1, f2);
@@ -259,6 +286,15 @@
                          this.m_21008_(InteractionHand.MAIN_HAND, ItemStack.f_41583_);
                       }
                    }
+@@ -1176,7 +_,7 @@
+                      }
+                   }
+ 
+-                  this.m_36399_(0.1F);
++                  this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.ATTACK_ENTITY, 0.1F));
+                } else {
+                   this.f_19853_.m_6263_((Player)null, this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12315_, this.m_5720_(), 1.0F, 1.0F);
+                   if (flag4) {
 @@ -1200,7 +_,7 @@
        }
  
@@ -285,6 +321,58 @@
        } else {
           boolean flag = block.m_5568_();
           boolean flag1 = p_36131_.m_8055_(p_36132_.m_7494_()).m_60734_().m_5568_();
+@@ -1337,9 +_,9 @@
+       super.m_6135_();
+       this.m_36220_(Stats.f_12926_);
+       if (this.m_20142_()) {
+-         this.m_36399_(0.2F);
++         this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.SPRINTING_JUMP, 0.2F));
+       } else {
+-         this.m_36399_(0.05F);
++         this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.NORMAL_JUMP, 0.05F));
+       }
+ 
+    }
+@@ -1397,19 +_,19 @@
+             int i = Math.round((float)Math.sqrt(p_36379_ * p_36379_ + p_36380_ * p_36380_ + p_36381_ * p_36381_) * 100.0F);
+             if (i > 0) {
+                this.m_36222_(Stats.f_12924_, i);
+-               this.m_36399_(0.01F * (float)i * 0.01F);
++               this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_SWIM, 0.01F * (float)i * 0.01F));
+             }
+          } else if (this.m_204029_(FluidTags.f_13131_)) {
+             int j = Math.round((float)Math.sqrt(p_36379_ * p_36379_ + p_36380_ * p_36380_ + p_36381_ * p_36381_) * 100.0F);
+             if (j > 0) {
+                this.m_36222_(Stats.f_13001_, j);
+-               this.m_36399_(0.01F * (float)j * 0.01F);
++               this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_UNDERWATER, 0.01F * (float)j * 0.01F));
+             }
+          } else if (this.m_20069_()) {
+             int k = Math.round((float)Math.sqrt(p_36379_ * p_36379_ + p_36381_ * p_36381_) * 100.0F);
+             if (k > 0) {
+                this.m_36222_(Stats.f_12997_, k);
+-               this.m_36399_(0.01F * (float)k * 0.01F);
++               this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_ONWATER, 0.01F * (float)k * 0.01F));
+             }
+          } else if (this.m_6147_()) {
+             if (p_36380_ > 0.0D) {
+@@ -1420,13 +_,13 @@
+             if (l > 0) {
+                if (this.m_20142_()) {
+                   this.m_36222_(Stats.f_12996_, l);
+-                  this.m_36399_(0.1F * (float)l * 0.01F);
++                  this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_SPRINT, 0.1F * (float)l * 0.01F));
+                } else if (this.m_6047_()) {
+                   this.m_36222_(Stats.f_12995_, l);
+-                  this.m_36399_(0.0F * (float)l * 0.01F);
++                  this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_CROUCH, 0.0F * (float)l * 0.01F));
+                } else {
+                   this.m_36222_(Stats.f_12994_, l);
+-                  this.m_36399_(0.0F * (float)l * 0.01F);
++                  this.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(this, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.MOVEMENT_WALK_ONLAND, 0.0F * (float)l * 0.01F));
+                }
+             }
+          } else if (this.m_21255_()) {
 @@ -1465,6 +_,7 @@
  
     public boolean m_142535_(float p_150093_, float p_150094_, DamageSource p_150095_) {

--- a/patches/minecraft/net/minecraft/world/food/FoodData.java.patch
+++ b/patches/minecraft/net/minecraft/world/food/FoodData.java.patch
@@ -1,0 +1,176 @@
+--- a/net/minecraft/world/food/FoodData.java
++++ b/net/minecraft/world/food/FoodData.java
+@@ -14,64 +_,95 @@
+    private float f_38698_;
+    private int f_38699_;
+    private int f_38700_ = 20;
++   // FORGE START
++   private Player player;
++   private int starveTimer;
++   // FORGE END
+ 
++   @Deprecated // Forge: Provided for backwards compatibility. Use the Player-specific constructor instead.
+    public FoodData() {
++      this(null);
++   }
++
++   public FoodData(Player player) {
+       this.f_38697_ = 5.0F;
++      this.player = player;
+    }
+ 
++   // Forge: Don't call this unless the player is not consuming food. Use eat(Item, ItemStack) instead.
+    public void m_38707_(int p_38708_, float p_38709_) {
+-      this.f_38696_ = Math.min(p_38708_ + this.f_38696_, 20);
++      if (net.minecraftforge.event.ForgeEventFactory.onFoodDataAddition(this.player, new net.minecraftforge.common.hunger.FoodValues(p_38708_, p_38709_))) return;
++      this.f_38696_ = Math.min(p_38708_ + this.f_38696_, net.minecraftforge.event.ForgeEventFactory.getMaxHunger(this.player));
+       this.f_38697_ = Math.min(this.f_38697_ + (float)p_38708_ * p_38709_ * 2.0F, (float)this.f_38696_);
+    }
+ 
+    public void m_38712_(Item p_38713_, ItemStack p_38714_) {
+-      if (p_38713_.m_41472_()) {
+-         FoodProperties foodproperties = p_38713_.m_41473_();
+-         this.m_38707_(foodproperties.m_38744_(), foodproperties.m_38745_());
++      net.minecraftforge.common.hunger.FoodValues modifiedFoodValues = net.minecraftforge.common.hunger.FoodValues.get(p_38714_, this.player);
++      if (modifiedFoodValues != null) {
++         int prevFoodLevel = this.f_38696_;
++         float prevSaturationLevel = this.f_38697_;
++         this.m_38707_(modifiedFoodValues.nutrition(), modifiedFoodValues.saturationModifier());
++         net.minecraftforge.event.ForgeEventFactory.onFoodEaten(modifiedFoodValues, this.f_38696_ - prevFoodLevel, this.f_38697_ - prevSaturationLevel, p_38714_, this.player);
+       }
+ 
+    }
+ 
+    public void m_38710_(Player p_38711_) {
+-      Difficulty difficulty = p_38711_.f_19853_.m_46791_();
++      if (this.player == null) this.player = p_38711_; // Forge: Safety-check, in-case the class was constructed without the player-specific constructor
+       this.f_38700_ = this.f_38696_;
+-      if (this.f_38698_ > 4.0F) {
+-         this.f_38698_ -= 4.0F;
+-         if (this.f_38697_ > 0.0F) {
+-            this.f_38697_ = Math.max(this.f_38697_ - 1.0F, 0.0F);
+-         } else if (difficulty != Difficulty.PEACEFUL) {
+-            this.f_38696_ = Math.max(this.f_38696_ - 1, 0);
++      net.minecraftforge.eventbus.api.Event.Result allowExhaustionResult = net.minecraftforge.event.ForgeEventFactory.fireAllowExhaustionEvent(p_38711_);
++      float maxExhaustion = net.minecraftforge.event.ForgeEventFactory.getMaxExhaustion(p_38711_);
++      if (allowExhaustionResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowExhaustionResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && this.f_38698_ > maxExhaustion)) {
++         net.minecraftforge.event.hunger.ExhaustionEvent.Exhausted exhaustedEvent = net.minecraftforge.event.ForgeEventFactory.onExhausted(p_38711_, maxExhaustion, this.f_38698_);
++         this.f_38698_ = Math.max(this.f_38698_ + exhaustedEvent.getDeltaExhaustion(), 0.0F);
++         if (!exhaustedEvent.isCanceled()) {
++            this.f_38697_ = Math.max(this.f_38697_ + exhaustedEvent.getDeltaSaturation(), 0.0F);
++            this.f_38696_ = Math.max(this.f_38696_ + exhaustedEvent.getDeltaHunger(), 0);
+          }
+       }
+ 
+       boolean flag = p_38711_.f_19853_.m_46469_().m_46207_(GameRules.f_46139_);
+-      if (flag && this.f_38697_ > 0.0F && p_38711_.m_36325_() && this.f_38696_ >= 20) {
+-         ++this.f_38699_;
+-         if (this.f_38699_ >= 10) {
+-            float f = Math.min(this.f_38697_, 6.0F);
+-            p_38711_.m_5634_(f / 6.0F);
+-            this.m_38703_(f);
+-            this.f_38699_ = 0;
+-         }
+-      } else if (flag && this.f_38696_ >= 18 && p_38711_.m_36325_()) {
+-         ++this.f_38699_;
+-         if (this.f_38699_ >= 80) {
+-            p_38711_.m_5634_(1.0F);
+-            this.m_38703_(6.0F);
+-            this.f_38699_ = 0;
+-         }
+-      } else if (this.f_38696_ <= 0) {
+-         ++this.f_38699_;
+-         if (this.f_38699_ >= 80) {
+-            if (p_38711_.m_21223_() > 10.0F || difficulty == Difficulty.HARD || p_38711_.m_21223_() > 1.0F && difficulty == Difficulty.NORMAL) {
+-               p_38711_.m_6469_(DamageSource.f_19313_, 1.0F);
+-            }
+-
++      net.minecraftforge.eventbus.api.Event.Result allowSaturatedRegenResult = net.minecraftforge.event.ForgeEventFactory.fireAllowSaturatedRegenEvent(p_38711_);
++      boolean shouldDoSaturatedRegen = allowSaturatedRegenResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowSaturatedRegenResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && flag && this.f_38697_ > 0.0F && p_38711_.m_36325_() && this.f_38696_ >= 20);
++      net.minecraftforge.eventbus.api.Event.Result allowRegenResult = shouldDoSaturatedRegen ? net.minecraftforge.eventbus.api.Event.Result.DENY : net.minecraftforge.event.ForgeEventFactory.fireAllowRegenEvent(p_38711_);
++      boolean shouldDoRegen = allowRegenResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowRegenResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && flag && this.f_38696_ >= 18 && p_38711_.m_36325_());
++      if (shouldDoSaturatedRegen) {
++         ++this.f_38699_;
++         if (this.f_38699_ >= net.minecraftforge.event.ForgeEventFactory.getSaturatedRegenTickPeriod(p_38711_)) {
++            net.minecraftforge.event.hunger.HealthRegenEvent.SaturatedRegen saturatedRegenEvent = net.minecraftforge.event.ForgeEventFactory.onSaturatedRegen(p_38711_);
++            if (!saturatedRegenEvent.isCanceled()) {
++               p_38711_.m_5634_(saturatedRegenEvent.getDeltaHealth());
++               this.m_38703_(saturatedRegenEvent.getDeltaExhaustion());
++            }
++            this.f_38699_ = 0;
++         }
++      } else if (shouldDoRegen) {
++         ++this.f_38699_;
++         if (this.f_38699_ >= net.minecraftforge.event.ForgeEventFactory.getHealthRegenTickPeriod(p_38711_)) {
++            net.minecraftforge.event.hunger.HealthRegenEvent.Regen regenEvent = net.minecraftforge.event.ForgeEventFactory.onHealthRegen(p_38711_);
++            if (!regenEvent.isCanceled()) {
++               p_38711_.m_5634_(regenEvent.getDeltaHealth());
++               this.m_38703_(regenEvent.getDeltaExhaustion());
++            }
+             this.f_38699_ = 0;
+          }
+       } else {
+          this.f_38699_ = 0;
+       }
++      net.minecraftforge.eventbus.api.Event.Result allowStarvationResult = net.minecraftforge.event.ForgeEventFactory.fireAllowStarvationEvent(p_38711_);
++      if (allowStarvationResult == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (allowStarvationResult == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && this.f_38696_ <= 0)) {
++         ++this.starveTimer;
++         if (this.starveTimer >= net.minecraftforge.event.ForgeEventFactory.getStarveTickPeriod(p_38711_)) {
++            net.minecraftforge.event.hunger.StarvationEvent.Starve starveEvent = net.minecraftforge.event.ForgeEventFactory.onStarvation(p_38711_);
++            if (!starveEvent.isCanceled()) {
++               p_38711_.m_6469_(DamageSource.f_19313_, starveEvent.getStarveDamage());
++            }
++
++            this.starveTimer = 0;
++         }
++      } else {
++         this.starveTimer = 0;
++      }
+ 
+    }
+ 
+@@ -81,6 +_,7 @@
+          this.f_38699_ = p_38716_.m_128451_("foodTickTimer");
+          this.f_38697_ = p_38716_.m_128457_("foodSaturationLevel");
+          this.f_38698_ = p_38716_.m_128457_("foodExhaustionLevel");
++         this.starveTimer = p_38716_.m_128451_("foodStarveTimer");
+       }
+ 
+    }
+@@ -90,6 +_,7 @@
+       p_38720_.m_128405_("foodTickTimer", this.f_38699_);
+       p_38720_.m_128350_("foodSaturationLevel", this.f_38697_);
+       p_38720_.m_128350_("foodExhaustionLevel", this.f_38698_);
++      p_38720_.m_128405_("foodStarveTimer", this.starveTimer);
+    }
+ 
+    public int m_38702_() {
+@@ -101,11 +_,11 @@
+    }
+ 
+    public boolean m_38721_() {
+-      return this.f_38696_ < 20;
++      return this.f_38696_ < net.minecraftforge.event.ForgeEventFactory.getMaxHunger(this.player);
+    }
+ 
+    public void m_38703_(float p_38704_) {
+-      this.f_38698_ = Math.min(this.f_38698_ + p_38704_, 40.0F);
++      this.f_38698_ = Math.min(this.f_38698_ + p_38704_, net.minecraftforge.event.ForgeEventFactory.getExhaustionCap(this.player));
+    }
+ 
+    public float m_150380_() {
+@@ -127,4 +_,14 @@
+    public void m_150378_(float p_150379_) {
+       this.f_38698_ = p_150379_;
+    }
++
++   /* ============================== FORGE START ============================== */
++   public void addFood(int deltaFood) {
++      this.f_38696_ += deltaFood;
++   }
++
++   public void addSaturation(float deltaSaturation) {
++      this.f_38697_ += deltaSaturation;
++   }
++   /* =============================== FORGE END =============================== */
+ }

--- a/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
@@ -56,6 +56,15 @@
     public float m_7325_() {
        return this.f_60444_;
     }
+@@ -355,7 +_,7 @@
+ 
+    public void m_6240_(Level p_49827_, Player p_49828_, BlockPos p_49829_, BlockState p_49830_, @Nullable BlockEntity p_49831_, ItemStack p_49832_) {
+       p_49828_.m_36246_(Stats.f_12949_.m_12902_(this));
+-      p_49828_.m_36399_(0.005F);
++      p_49828_.m_36399_(net.minecraftforge.event.ForgeEventFactory.onExhaustionAdded(p_49828_, net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions.HARVEST_BLOCK, 0.005F));
+       m_49881_(p_49830_, p_49827_, p_49829_, p_49831_, p_49828_, p_49832_);
+    }
+ 
 @@ -384,8 +_,10 @@
  
     public void m_5548_(BlockGetter p_49821_, Entity p_49822_) {

--- a/patches/minecraft/net/minecraft/world/level/block/CakeBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CakeBlock.java.patch
@@ -1,0 +1,41 @@
+--- a/net/minecraft/world/level/block/CakeBlock.java
++++ b/net/minecraft/world/level/block/CakeBlock.java
+@@ -26,7 +_,7 @@
+ import net.minecraft.world.phys.shapes.CollisionContext;
+ import net.minecraft.world.phys.shapes.VoxelShape;
+ 
+-public class CakeBlock extends Block {
++public class CakeBlock extends Block implements net.minecraftforge.common.hunger.IEdible {
+    public static final int f_152742_ = 6;
+    public static final IntegerProperty f_51180_ = BlockStateProperties.f_61412_;
+    public static final int f_152743_ = m_152746_(0);
+@@ -75,11 +_,12 @@
+    }
+ 
+    protected static InteractionResult m_51185_(LevelAccessor p_51186_, BlockPos p_51187_, BlockState p_51188_, Player p_51189_) {
+-      if (!p_51189_.m_36391_(false)) {
++      CakeBlock block = (CakeBlock)p_51188_.m_60734_();
++      if (!p_51189_.m_36391_(block.canAlwaysEat())) {
+          return InteractionResult.PASS;
+       } else {
+          p_51189_.m_36220_(Stats.f_12942_);
+-         p_51189_.m_36324_().m_38707_(2, 0.1F);
++         p_51189_.m_36324_().m_38712_(block.m_5456_(), new ItemStack(block));
+          int i = p_51188_.m_61143_(f_51180_);
+          p_51186_.m_142346_(p_51189_, GameEvent.f_157806_, p_51187_);
+          if (i < 6) {
+@@ -120,4 +_,14 @@
+    public boolean m_7357_(BlockState p_51193_, BlockGetter p_51194_, BlockPos p_51195_, PathComputationType p_51196_) {
+       return false;
+    }
++
++   /* ============================== FORGE START ============================== */
++   public net.minecraftforge.common.hunger.FoodValues getFoodValues(ItemStack stack) {
++      return new net.minecraftforge.common.hunger.FoodValues(2, 0.1F);
++   }
++
++   public boolean canAlwaysEat() {
++      return false;
++   }
++   /* =============================== FORGE END =============================== */
+ }

--- a/src/main/java/net/minecraftforge/common/hunger/ExhaustingAction.java
+++ b/src/main/java/net/minecraftforge/common/hunger/ExhaustingAction.java
@@ -1,0 +1,65 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.hunger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Represents an action that could add exhaustion to the Player by performing it.
+ * This is used in the {@code ExhaustionAdded} event to classify which action was performed when the event was fired.
+ * For the vanilla actions, see {@link net.minecraftforge.event.hunger.ExhaustionEvent.ExhaustingActions}.
+ * To create your own action, call {@link #get(String)} and supply your action name.
+ */
+@SuppressWarnings("ClassCanBeRecord")
+public class ExhaustingAction
+{
+    private static final Map<String, ExhaustingAction> actions = new ConcurrentHashMap<>();
+
+    /**
+     * Returns all registered actions.
+     * This collection can be kept around, and will update itself in response to changes to the map.
+     * See {@link ConcurrentHashMap#values()} for details.
+     */
+    public static Collection<ExhaustingAction> getActions()
+    {
+        return Collections.unmodifiableCollection(actions.values());
+    }
+
+    /**
+     * Gets or creates a new ExhaustingAction for the given name.
+     */
+    public static ExhaustingAction get(String name)
+    {
+        return actions.computeIfAbsent(name, ExhaustingAction::new);
+    }
+
+    /**
+     * Returns the name of this exhausting action
+     */
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ExhaustingAction[" + name + "]";
+    }
+
+    private final String name;
+
+    /**
+     * Use {@link #get(String)} to get or create a ExhaustingAction
+     */
+    private ExhaustingAction(String name)
+    {
+        this.name = name;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/hunger/FoodValues.java
+++ b/src/main/java/net/minecraftforge/common/hunger/FoodValues.java
@@ -1,0 +1,101 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.hunger;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.ForgeEventFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * FoodValues is a record used to retrieve and hold food values.
+ *
+ * To get food values for any given food, use any of the static {@link #get} methods.
+ *
+ * <pre>
+ * {@code
+ * FoodValues appleFoodValues = FoodValues.get(new ItemStack(Items.APPLE));
+ * }
+ * </pre>
+ */
+public record FoodValues(int nutrition, float saturationModifier)
+{
+    /**
+     * @return The amount of saturation that the food values would provide, ignoring any limits.
+     */
+    public float getUnboundedSaturationIncrement()
+    {
+        return nutrition * saturationModifier * 2f;
+    }
+
+    /**
+     * @return The bounded amount of saturation that the food values would provide to this player,
+     * taking their max hunger level into account.
+     */
+    public float getSaturationIncrement(Player player)
+    {
+        return Math.min(ForgeEventFactory.getMaxHunger(player), getUnboundedSaturationIncrement());
+    }
+
+    /**
+     * Get unmodified (vanilla) food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues getUnmodified(@Nonnull ItemStack stack)
+    {
+        if (stack != ItemStack.EMPTY)
+        {
+            if (stack.isEdible())
+            {
+                FoodProperties food = stack.getItem().getFoodProperties();
+                return new FoodValues(food.getNutrition(), food.getSaturationModifier());
+            }
+            else if (stack.getItem() instanceof IEdible edible)
+            {
+                return edible.getFoodValues(stack);
+            }
+            else if (stack.getItem() instanceof BlockItem blockItem)
+            {
+                if (blockItem.getBlock() instanceof IEdible edible)
+                {
+                    return edible.getFoodValues(stack);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get player-agnostic food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues get(@Nonnull ItemStack stack)
+    {
+        return get(stack, null);
+    }
+
+    /**
+     * Get player-specific food values.
+     *
+     * @return The food values, or null if none were found.
+     */
+    public static FoodValues get(@Nonnull ItemStack stack, @Nullable Player player)
+    {
+        FoodValues foodValues = getUnmodified(stack);
+        if (foodValues != null)
+        {
+            return ForgeEventFactory.getFoodValues(foodValues, stack, player);
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/hunger/IEdible.java
+++ b/src/main/java/net/minecraftforge/common/hunger/IEdible.java
@@ -1,0 +1,31 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.hunger;
+
+import net.minecraft.world.item.ItemStack;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Interface to be applied to non-standard food items or blocks that are edible, in order to obtain their food values.
+ * For example, Forge implements this interface on {@link net.minecraft.world.level.block.CakeBlock}.
+ * It is recommended to add a {@link net.minecraft.world.food.FoodProperties} object to your item and not use this interface.
+ */
+public interface IEdible
+{
+    /**
+     * Obtain the FoodValues for this object
+     * @param stack The ItemStack containing this edible object
+     * @return The FoodValues for the object.
+     */
+    FoodValues getFoodValues(@Nonnull ItemStack stack);
+
+    /**
+     * @return true if this edible object can be eaten even when the player's hunger is full
+     * @see net.minecraft.world.food.FoodProperties#canAlwaysEat()
+     */
+    boolean canAlwaysEat();
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -85,6 +85,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.hunger.ExhaustingAction;
+import net.minecraftforge.common.hunger.FoodValues;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
@@ -123,6 +125,12 @@ import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
+import net.minecraftforge.event.hunger.ExhaustionEvent;
+import net.minecraftforge.event.hunger.FoodEvent;
+import net.minecraftforge.event.hunger.HealthRegenEvent;
+import net.minecraftforge.event.hunger.HungerEvent;
+import net.minecraftforge.event.hunger.HungerRegenEvent;
+import net.minecraftforge.event.hunger.StarvationEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
@@ -921,5 +929,143 @@ public class ForgeEventFactory
     public static void onPostServerTick(BooleanSupplier haveTime)
     {
         MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END, haveTime));
+    }
+
+    public static int getMaxHunger(Player player)
+    {
+        HungerEvent.GetMaxHunger event = new HungerEvent.GetMaxHunger(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMaxHunger();
+    }
+
+    public static FoodValues getFoodValues(FoodValues originalFoodValues, ItemStack stack, @Nullable Player player)
+    {
+        FoodEvent.GetFoodValues event = new FoodEvent.GetFoodValues(originalFoodValues, stack, player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getFoodValues();
+    }
+
+    public static boolean onFoodDataAddition(Player player, FoodValues foodValuesToBeAdded)
+    {
+        FoodEvent.FoodDataAddition event = new FoodEvent.FoodDataAddition(foodValuesToBeAdded, player);
+        return MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    public static void onFoodEaten(FoodValues foodValues, int nutritionAdded, float saturationAdded, ItemStack stack, Player player)
+    {
+        FoodEvent.FoodEaten event = new FoodEvent.FoodEaten(foodValues, nutritionAdded, saturationAdded, stack, player);
+        MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    public static float getExhaustionCap(Player player)
+    {
+        ExhaustionEvent.GetExhaustionCap event = new ExhaustionEvent.GetExhaustionCap(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getExhaustionLevelCap();
+    }
+
+    public static Result fireAllowExhaustionEvent(Player player)
+    {
+        ExhaustionEvent.AllowExhaustion event = new ExhaustionEvent.AllowExhaustion(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static float getMaxExhaustion(Player player)
+    {
+        ExhaustionEvent.GetMaxExhaustion event = new ExhaustionEvent.GetMaxExhaustion(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMaxExhaustionLevel();
+    }
+
+    public static ExhaustionEvent.Exhausted onExhausted(Player player, float exhaustionToRemove, float currentExhaustionLevel)
+    {
+        ExhaustionEvent.Exhausted event = new ExhaustionEvent.Exhausted(player, exhaustionToRemove, currentExhaustionLevel);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static Result fireAllowSaturatedRegenEvent(Player player)
+    {
+        HealthRegenEvent.AllowSaturatedRegen event = new HealthRegenEvent.AllowSaturatedRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static Result fireAllowRegenEvent(Player player)
+    {
+        HealthRegenEvent.AllowRegen event = new HealthRegenEvent.AllowRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static int getSaturatedRegenTickPeriod(Player player)
+    {
+        HealthRegenEvent.GetSaturatedRegenTickPeriod event = new HealthRegenEvent.GetSaturatedRegenTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRegenTickPeriod();
+    }
+
+    public static HealthRegenEvent.SaturatedRegen onSaturatedRegen(Player player)
+    {
+        HealthRegenEvent.SaturatedRegen event = new HealthRegenEvent.SaturatedRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static int getHealthRegenTickPeriod(Player player)
+    {
+        HealthRegenEvent.GetRegenTickPeriod event = new HealthRegenEvent.GetRegenTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRegenTickPeriod();
+    }
+
+    public static HealthRegenEvent.Regen onHealthRegen(Player player)
+    {
+        HealthRegenEvent.Regen event = new HealthRegenEvent.Regen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static Result fireAllowStarvationEvent(Player player)
+    {
+        StarvationEvent.AllowStarvation event = new StarvationEvent.AllowStarvation(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
+
+    public static int getStarveTickPeriod(Player player)
+    {
+        StarvationEvent.GetStarveTickPeriod event = new StarvationEvent.GetStarveTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getStarveTickPeriod();
+    }
+
+    public static StarvationEvent.Starve onStarvation(Player player)
+    {
+        StarvationEvent.Starve event = new StarvationEvent.Starve(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static HealthRegenEvent.PeacefulRegen onPeacefulHealthRegen(Player player)
+    {
+        HealthRegenEvent.PeacefulRegen event = new HealthRegenEvent.PeacefulRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static HungerRegenEvent.PeacefulRegen onPeacefulHungerRegen(Player player)
+    {
+        HungerRegenEvent.PeacefulRegen event = new HungerRegenEvent.PeacefulRegen(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static float onExhaustionAdded(Player player, ExhaustingAction action, float deltaExhaustion)
+    {
+        ExhaustionEvent.ExhaustionAdded event = new ExhaustionEvent.ExhaustionAdded(player, action, deltaExhaustion);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getDeltaExhaustion();
     }
 }

--- a/src/main/java/net/minecraftforge/event/hunger/ExhaustionEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/ExhaustionEvent.java
@@ -1,0 +1,293 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.hunger.ExhaustingAction;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all ExhaustionEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class ExhaustionEvent extends Event
+{
+    private final Player player;
+
+    protected ExhaustionEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this ExhaustionEvent pertains to.
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not exhaustion is allowed for the {@link #player}.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow exhaustion without condition.
+     * {@link Result#DENY} will deny exhaustion without condition.
+     */
+    @HasResult
+    public static class AllowExhaustion extends ExhaustionEvent
+    {
+        public AllowExhaustion(Player player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Class of actions that cause exhaustion in vanilla Minecraft
+     * @see ExhaustionAdded
+     * @see ExhaustingAction
+     */
+    public static class ExhaustingActions
+    {
+        public static final ExhaustingAction HARVEST_BLOCK = ExhaustingAction.get("harvest_block");
+        public static final ExhaustingAction NORMAL_JUMP = ExhaustingAction.get("normal_jump");
+        public static final ExhaustingAction SPRINTING_JUMP = ExhaustingAction.get("sprinting_jump");
+        public static final ExhaustingAction ATTACK_ENTITY = ExhaustingAction.get("attack_entity");
+        public static final ExhaustingAction DAMAGE_TAKEN = ExhaustingAction.get("damage_taken");
+        public static final ExhaustingAction EFFECT_HUNGER = ExhaustingAction.get("effect_hunger");
+        public static final ExhaustingAction MOVEMENT_SWIM = ExhaustingAction.get("movement_swim");
+        public static final ExhaustingAction MOVEMENT_WALK_UNDERWATER = ExhaustingAction.get("movement_walk_underwater");
+        public static final ExhaustingAction MOVEMENT_WALK_ONWATER = ExhaustingAction.get("movement_walk_onwater");
+        public static final ExhaustingAction MOVEMENT_SPRINT = ExhaustingAction.get("movement_sprint");
+        public static final ExhaustingAction MOVEMENT_CROUCH = ExhaustingAction.get("movement_crouch");
+        public static final ExhaustingAction MOVEMENT_WALK_ONLAND = ExhaustingAction.get("movement_walk_onland");
+    }
+
+    /**
+     * Fired each time a {@link #player} does something that changes exhaustion in vanilla Minecraft.
+     * This includes actions such as jumping, sprinting, etc.
+     * The full list of vanilla sources is in {@link ExhaustingActions}.
+     * Modders can create their own sources by calling {@link ExhaustingAction#get(String)}
+     *
+     * This event is fired whenever {@link Player#causeFoodExhaustion} is called from within Minecraft code.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class ExhaustionAdded extends ExhaustionEvent
+    {
+        private final ExhaustingAction action;
+        private float deltaExhaustion;
+
+        public ExhaustionAdded(Player player, ExhaustingAction action, float deltaExhaustion)
+        {
+            super(player);
+            this.action = action;
+            this.deltaExhaustion = deltaExhaustion;
+        }
+
+        /**
+         * @return The action the player performed in order to warrant potentially adding exhaustion.
+         */
+        public ExhaustingAction getAction()
+        {
+            return action;
+        }
+
+        /**
+         * @return The amount of exhaustion to be added to the player.
+         */
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        /**
+         * @param deltaExhaustion The new amount of exhaustion to be added to the player.
+         */
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+
+    /**
+     * Fired every time max exhaustion level is retrieved to allow control over its value.
+     *
+     * {@link #maxExhaustionLevel} contains the exhaustion level that will trigger a hunger/saturation decrement.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetMaxExhaustion extends ExhaustionEvent
+    {
+        private float maxExhaustionLevel;
+
+        public GetMaxExhaustion(Player player)
+        {
+            super(player);
+            this.maxExhaustionLevel = 4.0F;
+        }
+
+        /**
+         * @return The maximum amount of exhaustion this player must reach before triggering a hunger/saturation
+         *         decrement.
+         */
+        public float getMaxExhaustionLevel()
+        {
+            return maxExhaustionLevel;
+        }
+
+        /**
+         * @param maxExhaustionLevel The new maximum amount of exhaustion this player must reach before triggering a
+         *                           hunger/saturation decrement.
+         */
+        public void setMaxExhaustionLevel(float maxExhaustionLevel)
+        {
+            this.maxExhaustionLevel = maxExhaustionLevel;
+        }
+    }
+
+    /**
+     * Fired once exhaustionLevel exceeds maxExhaustionLevel (see {@link GetMaxExhaustion}),
+     * in order to control how exhaustion affects hunger/saturation.
+     *
+     * {@link #currentExhaustionLevel} contains the exhaustion level of the {@link #player}.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level (default: -{@link GetMaxExhaustion#maxExhaustionLevel}).
+     * {@link #deltaHunger} contains the delta to be applied to hunger.
+     * {@link #deltaSaturation} contains the delta to be applied to saturation.
+     *
+     * Note: {@link #deltaHunger} and {@link #deltaSaturation} will vary depending on their vanilla conditionals.
+     * For example, deltaHunger will be 0 when this event is fired in Peaceful difficulty.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to hunger and saturation.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    @Cancelable
+    public static class Exhausted extends ExhaustionEvent
+    {
+        private final float currentExhaustionLevel;
+        private float deltaExhaustion;
+        private int deltaHunger;
+        private float deltaSaturation;
+
+        public Exhausted(Player player, float exhaustionToRemove, float currentExhaustionLevel)
+        {
+            super(player);
+            this.currentExhaustionLevel = currentExhaustionLevel;
+            this.deltaExhaustion = -exhaustionToRemove;
+
+            boolean shouldDecreaseSaturationLevel = player.getFoodData().getSaturationLevel() > 0.0F;
+            this.deltaSaturation = shouldDecreaseSaturationLevel ? -1.0F : 0.0F;
+
+            boolean shouldDecreaseFoodLevel = !shouldDecreaseSaturationLevel && player.level.getDifficulty() != Difficulty.PEACEFUL;
+            this.deltaHunger = shouldDecreaseFoodLevel ? -1 : 0;
+        }
+
+        /**
+         * @return The player's current exhaustion level.
+         */
+        public float getCurrentExhaustionLevel()
+        {
+            return currentExhaustionLevel;
+        }
+
+        /**
+         * @return The amount of exhaustion to be added (or subtracted generally) to the player.
+         */
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        /**
+         * @param deltaExhaustion The new amount of exhaustion to be added (or subtracted) to the player.
+         */
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+
+        /**
+         * @return The amount of hunger/nutrition to be added (or subtracted generally) to the player.
+         */
+        public int getDeltaHunger()
+        {
+            return deltaHunger;
+        }
+
+        /**
+         * @param deltaHunger The new amount of hunger/nutrition to be added (or subtracted) to the player.
+         */
+        public void setDeltaHunger(int deltaHunger)
+        {
+            this.deltaHunger = deltaHunger;
+        }
+
+        /**
+         * @return The amount of saturation to be added (or subtracted generally) to the player.
+         */
+        public float getDeltaSaturation()
+        {
+            return deltaSaturation;
+        }
+
+        /**
+         * @param deltaSaturation The new amount of saturation to be added (or subtracted) to the player.
+         */
+        public void setDeltaSaturation(float deltaSaturation)
+        {
+            this.deltaSaturation = deltaSaturation;
+        }
+    }
+
+    /**
+     * Fired every time the exhaustion level is capped to allow control over the cap.
+     *
+     * {@link #exhaustionLevelCap} contains the exhaustion level that will be used to cap the exhaustion level.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetExhaustionCap extends ExhaustionEvent
+    {
+        private float exhaustionLevelCap;
+
+        public GetExhaustionCap(Player player)
+        {
+            super(player);
+            this.exhaustionLevelCap = 40.0F;
+        }
+
+        /**
+         * @return The maximum amount of exhaustion that can be added to the player at one time (in one action).
+         */
+        public float getExhaustionLevelCap()
+        {
+            return exhaustionLevelCap;
+        }
+
+        /**
+         * @param exhaustionLevelCap The new maximum amount of exhaustion that can be added to the player at on time.
+         */
+        public void setExhaustionLevelCap(float exhaustionLevelCap)
+        {
+            this.exhaustionLevelCap = exhaustionLevelCap;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/FoodEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/FoodEvent.java
@@ -1,0 +1,180 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base class for all FoodEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class FoodEvent extends Event
+{
+    private final Player player;
+
+    protected FoodEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this FoodEvent pertains to. Might be null in some cases.
+     * @see FoodEvent.GetFoodValues
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired every time food values are retrieved to allow control over their values.
+     * For this event, player can be null, which would indicate that the values should be player-independent.
+     *
+     * {@link #foodValues} contains the food values of the food associated with the {@link #itemstack}.
+     * {@link #originalFoodValues} contains the food values of the food associated with the {@link #itemstack} before the GetFoodValues event was fired.
+     * {@link #itemstack} contains the food in question.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetFoodValues extends FoodEvent
+    {
+        private FoodValues foodValues;
+        private final FoodValues originalFoodValues;
+        private final ItemStack itemstack;
+
+        public GetFoodValues(FoodValues originalFoodValues, ItemStack itemstack, @Nullable Player player)
+        {
+            super(player);
+            this.foodValues = originalFoodValues;
+            this.originalFoodValues = originalFoodValues;
+            this.itemstack = itemstack;
+        }
+
+        /**
+         * @return The current food values for the given food.
+         */
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+
+        /**
+         * @param foodValues The new food values for the given food.
+         */
+        public void setFoodValues(FoodValues foodValues)
+        {
+            this.foodValues = foodValues;
+        }
+
+        /**
+         * @return The food values for the given food before any modifications (the base values).
+         */
+        public FoodValues getOriginalFoodValues()
+        {
+            return originalFoodValues;
+        }
+
+        /**
+         * @return The food ItemStack itself.
+         */
+        public ItemStack getItemStack()
+        {
+            return itemstack;
+        }
+    }
+
+    /**
+     * Fired after {@link net.minecraft.world.food.FoodData#eat(Item, ItemStack)}, containing the effects and context for the food that was eaten.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class FoodEaten extends FoodEvent
+    {
+        private final FoodValues foodValues;
+        private final int nutritionAdded;
+        private final float saturationAdded;
+        private final ItemStack food;
+
+        public FoodEaten(FoodValues foodValues, int nutritionAdded, float saturationAdded, ItemStack food, Player player)
+        {
+            super(player);
+            this.foodValues = foodValues;
+            this.nutritionAdded = nutritionAdded;
+            this.saturationAdded = saturationAdded;
+            this.food = food;
+        }
+
+        /**
+         * @return The food values of the food eaten.
+         */
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+
+        /**
+         * @return The actual amount of hunger/nutrition added.
+         */
+        public int getNutritionAdded()
+        {
+            return nutritionAdded;
+        }
+
+        /**
+         * @return The actual amount of saturation added.
+         */
+        public float getSaturationAdded()
+        {
+            return saturationAdded;
+        }
+
+        /**
+         * @return The food ItemStack itself.
+         */
+        public ItemStack getItemStack() {
+            return food;
+        }
+    }
+
+    /**
+     * Fired when nutrition/saturation is added to a player's FoodData.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, the nutrition and saturation of the FoodData will not change.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    @Cancelable
+    public static class FoodDataAddition extends FoodEvent
+    {
+        private final FoodValues foodValues;
+
+        public FoodDataAddition(FoodValues foodValues, Player player)
+        {
+            super(player);
+            this.foodValues = foodValues;
+        }
+
+        /**
+         * @return The food values of the food being eaten.
+         */
+        public FoodValues getFoodValues()
+        {
+            return foodValues;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HealthRegenEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HealthRegenEvent.java
@@ -1,0 +1,306 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HealthRegenEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HealthRegenEvent extends Event
+{
+    private final Player player;
+
+    protected HealthRegenEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this HealthRegenEvent pertains to.
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodData update to determine whether or not health regen from food is allowed for the {@link #player}.
+     * However, this event will not be fired if saturated regen occurs, as saturated health regen will take precedence
+     * over normal health regen (see {@link AllowSaturatedRegen}).
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow regen without condition.
+     * {@link Result#DENY} will deny regen without condition.
+     */
+    @HasResult
+    public static class AllowRegen extends HealthRegenEvent
+    {
+        public AllowRegen(Player player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the regen tick period is retrieved to allow control over its value.
+     *
+     * {@link #regenTickPeriod} contains the number of ticks between each regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetRegenTickPeriod extends HealthRegenEvent
+    {
+        private int regenTickPeriod;
+
+        public GetRegenTickPeriod(Player player)
+        {
+            super(player);
+            this.regenTickPeriod = 80;
+        }
+
+        /**
+         * @return The amount of time, in ticks, between unsaturated health regen events.
+         */
+        public int getRegenTickPeriod()
+        {
+            return regenTickPeriod;
+        }
+
+        /**
+         * @param regenTickPeriod The new amount of time, in ticks, between unsaturated health regen events.
+         */
+        public void setRegenTickPeriod(int regenTickPeriod)
+        {
+            this.regenTickPeriod = regenTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the ticks since last regen reaches regenTickPeriod (see {@link GetRegenTickPeriod}),
+     * in order to control how regen affects health/exhaustion.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to health and exhaustion.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class Regen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+        private float deltaExhaustion;
+
+        public Regen(Player player)
+        {
+            super(player);
+            this.deltaHealth = 1.0F;
+            this.deltaExhaustion = 6.0F;
+        }
+
+        /**
+         * @return The amount of health to be restored.
+         */
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        /**
+         * @param deltaHealth The new amount of health to be restored.
+         */
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+
+        /**
+         * @return The amount of exhaustion to be added as part of this regen operation.
+         */
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        /**
+         * @param deltaExhaustion The new amount of exhaustion to be added as part of this regen operation.
+         */
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+
+    /**
+     * Fired every second for each player while in Peaceful difficulty,
+     * in order to control how much health to passively regenerate.
+     *
+     * This event is never fired if the game rule "naturalRegeneration" is false.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip healing the player.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class PeacefulRegen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+
+        public PeacefulRegen(Player player)
+        {
+            super(player);
+            this.deltaHealth = 1.0F;
+        }
+
+        /**
+         * @return The amount of health to be restored.
+         */
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        /**
+         * @param deltaHealth The new amount of health to be restored.
+         */
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+    }
+
+    /**
+     * Fired each FoodData update to determine whether or health regen from full hunger + saturation is allowed for the {@link #player}.
+     *
+     * Saturated health regen will take precedence over normal health regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow regen without condition.
+     * {@link Result#DENY} will deny regen without condition.
+     */
+    @HasResult
+    public static class AllowSaturatedRegen extends HealthRegenEvent
+    {
+        public AllowSaturatedRegen(Player player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the saturated regen tick period is retrieved to allow control over its value.
+     *
+     * {@link #regenTickPeriod} contains the number of ticks between each saturated regen.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetSaturatedRegenTickPeriod extends HealthRegenEvent
+    {
+        private int regenTickPeriod;
+
+        public GetSaturatedRegenTickPeriod(Player player)
+        {
+            super(player);
+            this.regenTickPeriod = 10;
+        }
+
+        /**
+         * @return The amount of time, in ticks, between saturated health regen events.
+         */
+        public int getRegenTickPeriod()
+        {
+            return regenTickPeriod;
+        }
+
+        /**
+         * @param regenTickPeriod The new amount of time, in ticks, between saturated health regen events.
+         */
+        public void setRegenTickPeriod(int regenTickPeriod)
+        {
+            this.regenTickPeriod = regenTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the ticks since last regen reaches regenTickPeriod (see {@link GetSaturatedRegenTickPeriod}),
+     * in order to control how regen affects health/exhaustion.
+     *
+     * By default, the amount of health restored depends on the player's current saturation level.
+     *
+     * {@link #deltaHealth} contains the delta to be applied to health.
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip applying the delta values to health and exhaustion.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class SaturatedRegen extends HealthRegenEvent
+    {
+        private float deltaHealth;
+        private float deltaExhaustion;
+
+        public SaturatedRegen(Player player)
+        {
+            super(player);
+            this.deltaExhaustion = Math.min(player.getFoodData().getSaturationLevel(), 6.0F);
+            this.deltaHealth = deltaExhaustion / 6.0F;
+        }
+
+        /**
+         * @return The amount of health to be restored.
+         */
+        public float getDeltaHealth()
+        {
+            return deltaHealth;
+        }
+
+        /**
+         * @param deltaHealth The new amount of health to be restored.
+         */
+        public void setDeltaHealth(float deltaHealth)
+        {
+            this.deltaHealth = deltaHealth;
+        }
+
+        /**
+         * @return The amount of exhaustion to be added as part of this regen operation.
+         */
+        public float getDeltaExhaustion()
+        {
+            return deltaExhaustion;
+        }
+
+        /**
+         * @param deltaExhaustion The new amount of exhaustion to be added as part of this regen operation.
+         */
+        public void setDeltaExhaustion(float deltaExhaustion)
+        {
+            this.deltaExhaustion = deltaExhaustion;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HungerEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HungerEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HungerEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HungerEvent extends Event
+{
+    private final Player player;
+
+    public HungerEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this HungerEvent pertains to.
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired every time max hunger level is retrieved to allow control over its value.
+     *
+     * Note: This also affects max saturation, as saturation is bounded by the player's
+     * current hunger level (that is, a max of 40 hunger would also mean a max of 40
+     * saturation).
+     *
+     * {@link #maxHunger} contains the max hunger of the player.
+     * {@link #player} contains the player.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a result. {@link HasResult}
+     */
+    public static class GetMaxHunger extends HungerEvent
+    {
+        private int maxHunger;
+
+        public GetMaxHunger(Player player)
+        {
+            super(player);
+            this.maxHunger = 20;
+        }
+
+        /**
+         * @return The maximum amount of hunger/nutrition (and by proxy, saturation) this player can have.
+         */
+        public int getMaxHunger()
+        {
+            return maxHunger;
+        }
+
+        /**
+         * @param maxHunger The new maximum amount of hunger/nutrition (and by proxy, saturation) this player can have.
+         */
+        public void setMaxHunger(int maxHunger)
+        {
+            this.maxHunger = maxHunger;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/HungerRegenEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/HungerRegenEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all HealthRegenEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HungerRegenEvent extends Event
+{
+    private final Player player;
+
+    public HungerRegenEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this HungerRegenEvent pertains to.
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired twice every second for each player while in Peaceful difficulty,
+     * in order to control how much hunger to passively regenerate.
+     *
+     * This event is never fired if the game rule "naturalRegeneration" is false.
+     *
+     * {@link #deltaHunger} contains the delta to be applied to hunger.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip adding hunger to the player.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class PeacefulRegen extends HungerRegenEvent
+    {
+        private int deltaHunger;
+
+        public PeacefulRegen(Player player)
+        {
+            super(player);
+            this.deltaHunger = 1;
+        }
+
+        /**
+         * @return The amount of hunger/nutrition to be added.
+         */
+        public int getDeltaHunger()
+        {
+            return deltaHunger;
+        }
+
+        /**
+         * @param deltaHunger The new amount of hunger/nutrition to be added.
+         */
+        public void setDeltaHunger(int deltaHunger)
+        {
+            this.deltaHunger = deltaHunger;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/hunger/StarvationEvent.java
+++ b/src/main/java/net/minecraftforge/event/hunger/StarvationEvent.java
@@ -1,0 +1,131 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.hunger;
+
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Base class for all StarvationEvent events.
+ *
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class StarvationEvent extends Event
+{
+    private final Player player;
+
+    public StarvationEvent(Player player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * @return The player for which this StarvationEvent pertains to.
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Fired each FoodData update to determine whether or not starvation is allowed for the {@link #player}.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event uses the {@link Result}. {@link HasResult}
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow starvation without condition.
+     * {@link Result#DENY} will deny starvation without condition.
+     */
+    @HasResult
+    public static class AllowStarvation extends StarvationEvent
+    {
+        public AllowStarvation(Player player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the starve tick period is retrieved to allow control over its value.
+     *
+     * {@link #starveTickPeriod} contains the number of ticks between starvation damage being done.
+     *
+     * This event is not {@link Cancelable}.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    public static class GetStarveTickPeriod extends StarvationEvent
+    {
+        private int starveTickPeriod;
+
+        public GetStarveTickPeriod(Player player)
+        {
+            super(player);
+            this.starveTickPeriod = 80;
+        }
+
+        /**
+         * @return The amount of time, in ticks, between starvation damage events.
+         */
+        public int getStarveTickPeriod()
+        {
+            return starveTickPeriod;
+        }
+
+        /**
+         * @param starveTickPeriod The new amount of time, in ticks, between starvation damage events.
+         */
+        public void setStarveTickPeriod(int starveTickPeriod)
+        {
+            this.starveTickPeriod = starveTickPeriod;
+        }
+    }
+
+    /**
+     * Fired once the time since last starvation damage reaches starveTickPeriod (see {@link GetStarveTickPeriod}),
+     * in order to control how much starvation damage to do.
+     *
+     * {@link #starveDamage} contains the amount of damage to deal from starvation.
+     *
+     * This event is {@link Cancelable}.
+     * If this event is canceled, it will skip dealing starvation damage.
+     *
+     * This event does not have a {@link Result}. {@link HasResult}
+     */
+    @Cancelable
+    public static class Starve extends StarvationEvent
+    {
+        private float starveDamage;
+
+        public Starve(Player player)
+        {
+            super(player);
+
+            Difficulty difficulty = player.level.getDifficulty();
+            boolean shouldDoDamage = player.getHealth() > 10.0F || difficulty == Difficulty.HARD || player.getHealth() > 1.0F && difficulty == Difficulty.NORMAL;
+            this.starveDamage = shouldDoDamage ? 1.0F : 0.0F;
+        }
+
+        /**
+         * @return The amount of damage to be dealt to the player as a result of starvation.
+         */
+        public float getStarveDamage()
+        {
+            return starveDamage;
+        }
+
+        /**
+         * @param starveDamage The new amount of damage to be dealt to the player as a result of starvation.
+         */
+        public void setStarveDamage(float starveDamage)
+        {
+            this.starveDamage = starveDamage;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/EdibleBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/EdibleBlockTest.java
@@ -1,0 +1,96 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.common.hunger.IEdible;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ObjectHolder;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Tests that implementing IEdible on a block works as expected.
+ * Creates a block that when right-clicked rewards 10 hunger points and 20 saturation.
+ */
+@Mod(EdibleBlockTest.MODID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class EdibleBlockTest
+{
+    private static final boolean ENABLED = false;
+    static final String MODID = "edible_block_test";
+    private static final String BLOCKID = "forge_edible_block";
+
+    @ObjectHolder(BLOCKID)
+    private static Block EDIBLE_BLOCK;
+
+    @SubscribeEvent
+    public static void registerBlocks(RegistryEvent.Register<Block> event)
+    {
+        if (ENABLED) event.getRegistry().register(new ForgeEdibleBlock(BlockBehaviour.Properties.of(Material.CAKE).strength(0.5F).sound(SoundType.WOOL)));
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if (ENABLED) event.getRegistry().register(new BlockItem(EDIBLE_BLOCK, new Item.Properties()).setRegistryName(MODID, BLOCKID));
+    }
+
+    public static class ForgeEdibleBlock extends Block implements IEdible
+    {
+        public ForgeEdibleBlock(Properties properties)
+        {
+            super(properties);
+            setRegistryName(EdibleBlockTest.MODID, EdibleBlockTest.BLOCKID);
+        }
+
+        @Override
+        public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit)
+        {
+            if (!player.canEat(this.canAlwaysEat()))
+            {
+                return InteractionResult.PASS;
+            }
+            else
+            {
+                if (!level.isClientSide)
+                {
+                    player.getFoodData().eat(this.asItem(), new ItemStack(this));
+                    level.removeBlock(pos, false);
+                }
+                return InteractionResult.SUCCESS;
+            }
+        }
+
+        @Override
+        public FoodValues getFoodValues(@Nonnull ItemStack stack)
+        {
+            return new FoodValues(10, 1.0F);
+        }
+
+        @Override
+        public boolean canAlwaysEat()
+        {
+            return true;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/ExhaustionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/ExhaustionEventTest.java
@@ -1,0 +1,92 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.ExhaustionEvent;
+import net.minecraftforge.event.hunger.HungerRegenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Tests all of the {@link ExhaustionEvent}s.
+ * Changes made by this mod to test for:
+ * - Maximum exhaustion level a player can have increased from 4.0 -> 30.0
+ * - Maximum exhaustion addition at one time increased from 40.0 -> 90.0
+ * - Non-sprinting jumps should apply a random amount of exhaustion each time
+ * - Sprinting jumps should apply 90 exhaustion each time
+ * - All other exhausting actions should be 1.5x their normal rate
+ * - Hunger loss should occur in peaceful difficulty
+ *   * Standard peaceful hunger regen has also been disabled in this test mod to more easily facilitate testing this one
+ */
+@Mod("exhaustion_event_test")
+@Mod.EventBusSubscriber
+public class ExhaustionEventTest
+{
+    private static final boolean ENABLED = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    public static void onGetMaxExhaustion(ExhaustionEvent.GetMaxExhaustion event)
+    {
+        // Increase the maximum exhaustion level to 30
+        if (ENABLED) event.setMaxExhaustionLevel(30.0F);
+    }
+
+    @SubscribeEvent
+    public static void onExhausted(ExhaustionEvent.Exhausted event)
+    {
+        // This will enable hunger loss in peaceful difficulty
+        if (ENABLED)
+        {
+            if (event.getPlayer().getFoodData().getSaturationLevel() <= 0)
+            {
+                event.setDeltaHunger(-1);
+            }
+            LOGGER.info("onExhausted exhaustion=" + event.getCurrentExhaustionLevel());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onExhaustionAdded(ExhaustionEvent.ExhaustionAdded event)
+    {
+        if (ENABLED)
+        {
+            // Randomize exhaustion for each normal jump
+            if (event.getAction() == ExhaustionEvent.ExhaustingActions.NORMAL_JUMP)
+            {
+                event.setDeltaExhaustion((float)Math.random());
+            }
+            // Apply a large amount of exhaustion for each sprinting jump
+            // Note: This is over the default addition cap of 40, but also over the modified cap of 90 below.
+            //       So in theory, this should actually only do 90 units of exhaustion
+            else if (event.getAction() == ExhaustionEvent.ExhaustingActions.SPRINTING_JUMP)
+            {
+                event.setDeltaExhaustion(100.0F);
+            }
+            // Otherwise, scale all exhaustion additions by 1.5x
+            else
+            {
+                event.setDeltaExhaustion(event.getDeltaExhaustion() * 1.5F);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onGetExhaustionCap(ExhaustionEvent.GetExhaustionCap event)
+    {
+        // Increase the max exhaustion addition cap to 90
+        if (ENABLED) event.setExhaustionLevelCap(90.0F);
+    }
+
+    @SubscribeEvent
+    public static void onPeacefulRegen(HungerRegenEvent.PeacefulRegen event)
+    {
+        // Peaceful hunger regen is canceled to more easily test the Exhausted event
+        if (ENABLED) event.setCanceled(true);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/FoodEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/FoodEventTest.java
@@ -1,0 +1,74 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraft.world.item.Items;
+import net.minecraftforge.common.hunger.FoodValues;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.hunger.FoodEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Tests all of the {@link FoodEvent}s.
+ * Changes made by this mod to test for:
+ * - Apple's FoodValues are changed to 19 nutrition and 36 saturation
+ * - All other foods have their food values changed to be (20 - playerFoodLevel) / 8, with a 1.0 saturation modifier
+ * - The player should not be allowed to increase their hunger or saturation if their hunger is already over halfway filled
+ * - If the player just ate food that healed at least 1 hunger point, heal the player half a heart
+ */
+@Mod("food_event_test")
+@Mod.EventBusSubscriber
+public class FoodEventTest
+{
+    private static final boolean ENABLED = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    public static void onGetFoodValues(FoodEvent.GetFoodValues event)
+    {
+        // Apples should now restore 19 hunger and provide 1 saturation.
+        // All other foods will have their nutrition scaled based on the current player's food level.
+        if (ENABLED && event.getPlayer() != null)
+        {
+            if (event.getItemStack().getItem() == Items.APPLE)
+            {
+                event.setFoodValues(new FoodValues(19, 1.0F));
+            }
+            else
+            {
+                event.setFoodValues(new FoodValues((20 - event.getPlayer().getFoodData().getFoodLevel()) / 8, 1.0F));
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onFoodStatsAddition(FoodEvent.FoodDataAddition event)
+    {
+        // If the player's hunger level is over halfway filled, cancel the food stats addition
+        if (ENABLED && event.getPlayer().getFoodData().getFoodLevel() > ForgeEventFactory.getMaxHunger(event.getPlayer()) / 2)
+        {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onFoodEaten(FoodEvent.FoodEaten event)
+    {
+        // Log what was eaten
+        // If it added more than 1 nutrition, heal the player one half of a heart
+        if (ENABLED)
+        {
+            LOGGER.info(event.getPlayer().getDisplayName().getString() + " ate " + event.getItemStack().toString());
+            if (event.getNutritionAdded() >= 1)
+            {
+                event.getPlayer().heal(1.0F);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HealthRegenEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HealthRegenEventTest.java
@@ -1,0 +1,93 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HealthRegenEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HealthRegenEvent}s.
+ * Changes made by this mod to test for:
+ * - Normal health regen (unsaturated)
+ *   - Should occur no matter the food level or the state of the "naturalRegeneration" gamerule
+ *   - Tick period reduced from 80 -> 10
+ *   - Should always heal one full heart at a time
+ *   - Exhaustion added halved from 6.0 -> 3.0
+ * - Standard peaceful health regeneration should not occur
+ *   - You _should_ however still be getting regen from the other changes in this testmod
+ * - Saturated health regen
+ *   - Should be allowed under the default vanilla logic
+ *   - Tick period doubled from 10 -> 20
+ *   - Should always heal half a heart at a time
+ *   - Exhaustion added held constant at 1.0
+ */
+@Mod("health_regen_event_test")
+@Mod.EventBusSubscriber
+public class HealthRegenEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAllowHealthRegen(HealthRegenEvent.AllowRegen event)
+    {
+        // Allow health regen at all times, unless the player is already fully healed. Meaning:
+        // - ignore food level
+        // - ignore naturalRegeneration gamerule
+        if (ENABLED && event.getPlayer().isHurt()) event.setResult(Event.Result.ALLOW);
+    }
+
+    @SubscribeEvent
+    public static void onGetRegenTickPeriod(HealthRegenEvent.GetRegenTickPeriod event)
+    {
+        // Reduce health regen tick period to 10 ticks
+        if (ENABLED) event.setRegenTickPeriod(10);
+    }
+
+    @SubscribeEvent
+    public static void onRegen(HealthRegenEvent.Regen event)
+    {
+        // Heal a whole heart at a time, and halve the amount of exhaustion added
+        if (ENABLED)
+        {
+            event.setDeltaHealth(2.0F);
+            event.setDeltaExhaustion(3.0F);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPeacefulRegen(HealthRegenEvent.PeacefulRegen event)
+    {
+        // Disable standard peaceful-mode health regen
+        if (ENABLED) event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onAllowSaturatedRegen(HealthRegenEvent.AllowSaturatedRegen event)
+    {
+        // Use the default vanilla logic
+        if (ENABLED) event.setResult(Event.Result.DEFAULT);
+    }
+
+    @SubscribeEvent
+    public static void onGetSaturatedRegenTickPeriod(HealthRegenEvent.GetSaturatedRegenTickPeriod event)
+    {
+        // Double the normal saturated regen tick period
+        if (ENABLED) event.setRegenTickPeriod(20);
+    }
+
+    @SubscribeEvent
+    public static void onSaturatedRegen(HealthRegenEvent.SaturatedRegen event)
+    {
+        // Always heal half a heart, and only add 1 exhaustion each time
+        if (ENABLED)
+        {
+            event.setDeltaHealth(1);
+            event.setDeltaExhaustion(1.0F);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HungerCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HungerCommandTest.java
@@ -1,0 +1,168 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.food.FoodData;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.server.command.EnumArgument;
+
+/**
+ * NOTE: This does NOT test a feature in Forge itself. This instead provides a utility to those who are testing
+ * other test mods within this package, and want to quickly change various FoodData levels on their player.
+ * It is recommended to enable this mod when testing other mods within this package.
+ *
+ * This command adds:
+ * - /hunger list: Lists Hunger/Saturation/Exhaustion levels to chat
+ * - /hunger add [nutrition/saturation/exhaustion] [delta]: Adds (or subtracts) a given amount from the chosen stat
+ * - /hunger set [nutrition/saturation/exhaustion] [value]: Sets the given stat to the provided value
+ * - /hunger heal: Sets nutrition and saturation values to their max and resets exhaustion to 0
+ * - /hunger starve: Sets nutrition, saturation, and exhaustion to 0
+ */
+@Mod("hunger_command_test")
+@Mod.EventBusSubscriber
+public class HungerCommandTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void registerCommands(RegisterCommandsEvent event)
+    {
+        if (ENABLED)
+        {
+            event.getDispatcher().register(
+                Commands.literal("hunger")
+                    .then(hungerListCommand())
+                    .then(hungerAddCommand())
+                    .then(hungerSetCommand())
+                    .then(hungerHealCommand())
+                    .then(hungerStarveCommand())
+            );
+        }
+    }
+
+    private enum HungerStatType
+    {
+        NUTRITION,
+        SATURATION,
+        EXHAUSTION
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> hungerListCommand()
+    {
+        return Commands.literal("list")
+            .requires(cs -> cs.hasPermission(0))
+            .executes(ctx -> {
+                ServerPlayer player = ctx.getSource().getPlayerOrException();
+                int maxHunger = ForgeEventFactory.getMaxHunger(player);
+                ctx.getSource().sendSuccess(new TextComponent("Hunger: ")
+                    .append(Integer.toString(player.getFoodData().getFoodLevel()))
+                    .append("/")
+                    .append(Integer.toString(maxHunger)), false);
+                ctx.getSource().sendSuccess(new TextComponent("Saturation: ")
+                    .append(Float.toString(player.getFoodData().getSaturationLevel()))
+                    .append("/")
+                    .append(Float.toString(player.getFoodData().getFoodLevel()))
+                    .append(" (")
+                    .append(Float.toString(maxHunger))
+                    .append(")"), false);
+                ctx.getSource().sendSuccess(new TextComponent("Exhaustion: ")
+                    .append(Float.toString(player.getFoodData().getExhaustionLevel()))
+                    .append("/")
+                    .append(Float.toString(ForgeEventFactory.getMaxExhaustion(player)))
+                    .append(" (")
+                    .append(Float.toString(ForgeEventFactory.getExhaustionCap(player)))
+                    .append(")"), false);
+                return 3;
+            });
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> hungerAddCommand()
+    {
+        return Commands.literal("add")
+            .requires(cs -> cs.hasPermission(0))
+            .then(Commands.argument("stat", EnumArgument.enumArgument(HungerStatType.class))
+                .then(Commands.argument("delta", FloatArgumentType.floatArg())
+                    .executes(ctx -> {
+                        ServerPlayer player = ctx.getSource().getPlayerOrException();
+                        Float delta = ctx.getArgument("delta", Float.class);
+                        switch (ctx.getArgument("stat", HungerStatType.class))
+                        {
+                            case NUTRITION -> {
+                                int foodDelta = Mth.clamp(delta.intValue(), -player.getFoodData().getFoodLevel(), ForgeEventFactory.getMaxHunger(player) - player.getFoodData().getFoodLevel());
+                                player.getFoodData().addFood(foodDelta);
+                            }
+                            case SATURATION -> {
+                                float satDelta = Mth.clamp(delta, -player.getFoodData().getSaturationLevel(), player.getFoodData().getFoodLevel() - player.getFoodData().getSaturationLevel());
+                                player.getFoodData().addSaturation(satDelta);
+                            }
+                            case EXHAUSTION -> {
+                                float exhaustDelta = Mth.clamp(delta, -player.getFoodData().getExhaustionLevel(), Float.MAX_VALUE); // Upper bound taken care of by below call
+                                player.getFoodData().addExhaustion(exhaustDelta);
+                            }
+                        }
+                        return 0;
+                    })
+                )
+            );
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> hungerSetCommand()
+    {
+        return Commands.literal("set")
+            .requires(cs -> cs.hasPermission(0))
+            .then(Commands.argument("stat", EnumArgument.enumArgument(HungerStatType.class))
+                .then(Commands.argument("value", FloatArgumentType.floatArg(0.0F))
+                    .executes(ctx -> {
+                        ServerPlayer player = ctx.getSource().getPlayerOrException();
+                        Float value = ctx.getArgument("value", Float.class);
+                        switch (ctx.getArgument("stat", HungerStatType.class))
+                        {
+                            case NUTRITION -> player.getFoodData().setFoodLevel(Math.min(value.intValue(), ForgeEventFactory.getMaxHunger(player)));
+                            case SATURATION -> player.getFoodData().setSaturation(Math.min(value, player.getFoodData().getFoodLevel()));
+                            case EXHAUSTION -> player.getFoodData().setExhaustion(Math.min(value, ForgeEventFactory.getMaxExhaustion(player)));
+                        }
+                        return 0;
+                    })
+                )
+            );
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> hungerHealCommand()
+    {
+        return Commands.literal("heal")
+            .requires(cs -> cs.hasPermission(0))
+            .executes(ctx -> {
+                ServerPlayer player = ctx.getSource().getPlayerOrException();
+                player.getFoodData().setFoodLevel(ForgeEventFactory.getMaxHunger(player));
+                player.getFoodData().setSaturation(player.getFoodData().getFoodLevel());
+                player.getFoodData().setExhaustion(0.0F);
+                return 0;
+            });
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> hungerStarveCommand()
+    {
+        return Commands.literal("starve")
+            .requires(cs -> cs.hasPermission(0))
+            .executes(ctx -> {
+                FoodData foodData = ctx.getSource().getPlayerOrException().getFoodData();
+                foodData.setFoodLevel(0);
+                foodData.setSaturation(0.0F);
+                foodData.setExhaustion(0.0F);
+                return 0;
+            });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HungerEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HungerEventTest.java
@@ -1,0 +1,31 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HungerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HungerEvent}s.
+ * Changes made by this mod to test for:
+ * - Maximum hunger is increased from 20 -> 60.
+ *   - It should look visually the same on the HUD, but you should notice it visually changes less often.
+ *   - You can also do a `/hunger list` if you have the HungerCommandTest mod enabled.
+ */
+@Mod("hunger_event_test")
+@Mod.EventBusSubscriber
+public class HungerEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onGetMaxHunger(HungerEvent.GetMaxHunger event)
+    {
+        // Increase maximum hunger to 60
+        if (ENABLED) event.setMaxHunger(60);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/HungerRegenEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/HungerRegenEventTest.java
@@ -1,0 +1,29 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.HungerRegenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link HungerRegenEvent}s.
+ * Changes made by this mod to test for:
+ * - On peaceful difficulty, hunger should regen until it is over 10 points
+ */
+@Mod("hunger_regen_event_test")
+@Mod.EventBusSubscriber
+public class HungerRegenEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onPeacefulRegen(HungerRegenEvent.PeacefulRegen event)
+    {
+        // Peaceful regen of hunger will occur until it is over 10 hunger points filled
+        if (ENABLED) event.setDeltaHunger(event.getPlayer().getFoodData().getFoodLevel() <= 10 ? 1 : 0);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/StarvationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/StarvationEventTest.java
@@ -1,0 +1,46 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.hunger;
+
+import net.minecraftforge.event.hunger.StarvationEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests all of the {@link StarvationEvent}s.
+ * Changes made by this mod to test for:
+ * - Starvation should occur at all times, even when nutrition is greater than 0
+ * - Starvation tick period doubled from 80 -> 160
+ * - Starvation damage will always be half a heart. Even when half a heart is left.
+ */
+@Mod("starvation_event_test")
+@Mod.EventBusSubscriber
+public class StarvationEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAllowStarvation(StarvationEvent.AllowStarvation event)
+    {
+        // Starvation should occur at all times
+        if (ENABLED) event.setResult(Event.Result.ALLOW);
+    }
+
+    @SubscribeEvent
+    public static void onGetStarveTickPeriod(StarvationEvent.GetStarveTickPeriod event)
+    {
+        // Double the default starvation tick period
+        if (ENABLED) event.setStarveTickPeriod(160);
+    }
+
+    @SubscribeEvent
+    public static void onStarve(StarvationEvent.Starve event)
+    {
+        // Always deal half a heart of damage
+        if (ENABLED) event.setStarveDamage(1);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/hunger/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/hunger/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package net.minecraftforge.debug.hunger;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -202,5 +202,21 @@ license="LGPL v2.1"
     modId="potion_size_event_test"
 [[mods]]
     modId="hide_neighbor_face_test"
+[[mods]]
+    modId="edible_block_test"
+[[mods]]
+    modId="exhaustion_event_test"
+[[mods]]
+    modId="food_event_test"
+[[mods]]
+    modId="health_regen_event_test"
+[[mods]]
+    modId="hunger_command_test"
+[[mods]]
+    modId="hunger_event_test"
+[[mods]]
+    modId="hunger_regen_event_test"
+[[mods]]
+    modId="starvation_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
_This is the 1.18 version of #7266. The below is mostly copy-pasta'd from that PR's description since there were no substantial changes in the port._

---

**This is an event-driven API that allows for control of the hunger system in the game. Things like food, health regen, hunger regen, exhaustion, starvation, etc. This was actually a PR I had made 6 years ago (#1758), but broke and never fixed. Until now!**

The goal of this system is to allow modders to change values/behaviors that were previously hard-coded in the game. Some examples include:

* Changing the nutrition and saturation values of foods eaten
* Allow foods to have different nutrition and saturation values per-player
* Change the amount of exhaustion added for each exhausting action the player does
* Control how and when health and hunger regeneration occurs
* Control how and when starvation occurs
* and more!

There is a lot that is allowed by this system. A good overview of everything would be to check the test mods that are included with this PR.

Other more technical things that this PR does include:

* `FoodData` now takes a `Player` upon construction that is used throughout the class when querying values. This allows `FoodData` to operate more player-dependently than before, allowing for operations to occur based on what player is trying to perform them.
* The `foodTimer` in `FoodData` has been separated into the `foodTimer` and `starveTimer`. This allows starvation to happen independently from the exhaustion/regeneration timer.
* A `FoodValues` class is provided to allow for easy use of nutrition and saturation values for food objects.
* An `IEdible` interface is provided that can be applied to non-standard food objects so that they can be included in the system. For a vanilla example, Cake now implements this interface. It is still recommended and preferred to include a `FoodProperties` object when constructing your item over implementing this interface.
  * The original author of this system, @squeek502, notes that he was never completely satisfied with this approach of including non-standard food items and wonders if there is a better solution. If you have an idea, please let me know!
* Fire events while in peaceful mode to allow modders to control how health/hunger regen happens in peaceful

---

This system would be used by mods such as [Hunger Overhaul](https://www.curseforge.com/minecraft/mc-mods/hunger-overhaul) and [The Spice Of Life](https://www.curseforge.com/minecraft/mc-mods/the-spice-of-life) to fundamentally change how the hunger system works in the game.

This system was originally written by @squeek502 for [AppleCore](https://www.curseforge.com/minecraft/mc-mods/applecore), and was first attempted to be upstreamed by me way back in the 1.7.10/1.8 days (as noted above). He has offered his code into the [Public Domain](https://github.com/squeek502/AppleCore/blob/1.12.2/LICENSE), and as such I am re-attempting to put this system into Forge! Since this code was originally written for a different Minecraft version, there is a good chance that there are better ways to do some of what we are trying to do. If that is the case, please let me know and I will gladly learn the new systems and how best to be doing what we are attempting. (I haven't really been actively modding Minecraft since the 1.8 days, haha)