### PR TITLE
[1.18.x] [event] add EnderManAngerEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -21,7 +21,7 @@
     boolean m_32534_(Player p_32535_) {
        ItemStack itemstack = p_32535_.m_150109_().f_35975_.get(3);
 -      if (itemstack.m_150930_(Blocks.f_50143_.m_5456_())) {
-+      if (itemstack.isEnderMask(p_32535_, this)) {
++      if (net.minecraftforge.common.ForgeHooks.shouldSuppressEnderManAnger(this, p_32535_, itemstack)) {
           return false;
        } else {
           Vec3 vec3 = p_32535_.m_20252_(1.0F).m_82541_();

--- a/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -16,15 +16,12 @@
     }
  
     protected void m_8097_() {
-@@ -194,7 +_,10 @@
+@@ -194,7 +_,7 @@
  
     boolean m_32534_(Player p_32535_) {
        ItemStack itemstack = p_32535_.m_150109_().f_35975_.get(3);
 -      if (itemstack.m_150930_(Blocks.f_50143_.m_5456_())) {
-+      net.minecraftforge.eventbus.api.Event.Result result = net.minecraftforge.common.ForgeHooks.onEnderManAnger(this, p_32535_);
-+      if (result != net.minecraftforge.eventbus.api.Event.Result.DEFAULT) {
-+         return result == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
-+      } else if (itemstack.isEnderMask(p_32535_, this)) {
++      if (net.minecraftforge.common.ForgeHooks.shouldSuppressEnderManAnger(this, p_32535_, itemstack)) {
           return false;
        } else {
           Vec3 vec3 = p_32535_.m_20252_(1.0F).m_82541_();

--- a/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -16,12 +16,15 @@
     }
  
     protected void m_8097_() {
-@@ -194,7 +_,7 @@
+@@ -194,7 +_,10 @@
  
     boolean m_32534_(Player p_32535_) {
        ItemStack itemstack = p_32535_.m_150109_().f_35975_.get(3);
 -      if (itemstack.m_150930_(Blocks.f_50143_.m_5456_())) {
-+      if (net.minecraftforge.common.ForgeHooks.shouldSuppressEnderManAnger(this, p_32535_, itemstack)) {
++      net.minecraftforge.eventbus.api.Event.Result result = net.minecraftforge.common.ForgeHooks.onEnderManAnger(this, p_32535_);
++      if (result != net.minecraftforge.eventbus.api.Event.Result.DEFAULT) {
++         return result == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
++      } else if (itemstack.isEnderMask(p_32535_, this)) {
           return false;
        } else {
           Vec3 vec3 = p_32535_.m_20252_(1.0F).m_82541_();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1457,7 +1457,7 @@ public class ForgeHooks
 
     public static boolean shouldSuppressEnderManAnger(EnderMan enderMan, Player player, ItemStack mask)
     {
-        return MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player)) || mask.isEnderMask(player, enderMan);
+        return mask.isEnderMask(player, enderMan) || MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player));
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1294,7 +1294,7 @@ public class ForgeHooks
         boolean generateBonusChest = wgs.generateBonusChest();
         Registry<LevelStem> originalRegistry = wgs.dimensions();
         Optional<String> legacyCustomOptions = wgs.legacyCustomOptions;
-
+        
         // make a copy of the dimension registry; for dimensions that specify that they should use the server seed instead
         // of the hardcoded json seed, recreate them with the correct seed
         MappedRegistry<LevelStem> seededRegistry = new MappedRegistry<>(Registry.LEVEL_STEM_REGISTRY, Lifecycle.experimental(), (Function<LevelStem, Holder.Reference<LevelStem>>)null);
@@ -1311,10 +1311,10 @@ public class ForgeHooks
                 seededRegistry.register(key, dimension, originalRegistry.lifecycle(dimension));
             }
         }
-
+        
         return new WorldGenSettings(seed, generateFeatures, generateBonusChest, seededRegistry, legacyCustomOptions);
     }
-
+    
     /** Called in the LevelStem codec builder to add extra fields to dimension jsons **/
     public static App<Mu<LevelStem>, LevelStem> expandLevelStemCodec(RecordCodecBuilder.Instance<LevelStem> builder, Supplier<App<Mu<LevelStem>, LevelStem>> vanillaFieldsSupplier)
     {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -155,7 +155,6 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fml.ModContainer;
@@ -1456,11 +1455,9 @@ public class ForgeHooks
         }
     }
 
-    public static Event.Result onEnderManAnger(EnderMan enderMan, Player player)
+    public static boolean shouldSuppressEnderManAnger(EnderMan enderMan, Player player, ItemStack mask)
     {
-        EnderManAngerEvent event = new EnderManAngerEvent(enderMan, player);
-        MinecraftForge.EVENT_BUS.post(event);
-        return event.getResult();
+        return MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player)) || mask.isEnderMask(player, enderMan);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -57,6 +56,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
@@ -132,6 +132,7 @@ import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
+import net.minecraftforge.event.entity.living.EnderManAngerEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -1452,6 +1453,11 @@ public class ForgeHooks
         {
             return fallback;
         }
+    }
+
+    public static boolean shouldSuppressEnderManAnger(EnderMan enderMan, Player player, ItemStack mask)
+    {
+        return MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player)) || mask.isEnderMask(player, enderMan);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -155,6 +155,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fml.ModContainer;
@@ -1294,7 +1295,7 @@ public class ForgeHooks
         boolean generateBonusChest = wgs.generateBonusChest();
         Registry<LevelStem> originalRegistry = wgs.dimensions();
         Optional<String> legacyCustomOptions = wgs.legacyCustomOptions;
-        
+
         // make a copy of the dimension registry; for dimensions that specify that they should use the server seed instead
         // of the hardcoded json seed, recreate them with the correct seed
         MappedRegistry<LevelStem> seededRegistry = new MappedRegistry<>(Registry.LEVEL_STEM_REGISTRY, Lifecycle.experimental(), (Function<LevelStem, Holder.Reference<LevelStem>>)null);
@@ -1311,10 +1312,10 @@ public class ForgeHooks
                 seededRegistry.register(key, dimension, originalRegistry.lifecycle(dimension));
             }
         }
-        
+
         return new WorldGenSettings(seed, generateFeatures, generateBonusChest, seededRegistry, legacyCustomOptions);
     }
-    
+
     /** Called in the LevelStem codec builder to add extra fields to dimension jsons **/
     public static App<Mu<LevelStem>, LevelStem> expandLevelStemCodec(RecordCodecBuilder.Instance<LevelStem> builder, Supplier<App<Mu<LevelStem>, LevelStem>> vanillaFieldsSupplier)
     {
@@ -1455,9 +1456,11 @@ public class ForgeHooks
         }
     }
 
-    public static boolean shouldSuppressEnderManAnger(EnderMan enderMan, Player player, ItemStack mask)
+    public static Event.Result onEnderManAnger(EnderMan enderMan, Player player)
     {
-        return MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player)) || mask.isEnderMask(player, enderMan);
+        EnderManAngerEvent event = new EnderManAngerEvent(enderMan, player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -19,7 +19,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event does not have a {@link Result}.
  */
 @Cancelable
-public class EnderManAngerEvent extends LivingEvent {
+public class EnderManAngerEvent extends LivingEvent
+{
     private final Player player;
 
     public EnderManAngerEvent(EnderMan enderman, Player player)

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.monster.EnderMan;

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -10,8 +10,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * This event is fired when an Enderman detects that a player is looking at them.
- * It will not be fired if the detection is prevented by {@link IForgeItem#isEnderMask}
+ * This event is fired on the forge bus before an Enderman detects that a player is looking at them.
+ * It will not be fired if the detection is already prevented by {@link IForgeItem#isEnderMask}
  * <p>
  * This event is {@link Cancelable}.
  * If this event is canceled, the Enderman will not target the player.

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -10,8 +10,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Event that is fired when an enderman checks if the player is looking at him.
- * If cancelled the enderman does not get angry at the player.
+ * This event is fired when an Enderman detects that a player is looking at them.
+ * It will not be fired if the detection is prevented by {@link IForgeItem#isEnderMask}
+ * <p>
+ * This event is {@link Cancelable}.
+ * If this event is canceled, the Enderman will not target the player.
+ * <p>
+ * This event does not have a {@link Result}.
  */
 @Cancelable
 public class EnderManAngerEvent extends LivingEvent {

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -25,7 +25,13 @@ import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Event that is fired when an enderman checks if the player is looking at him.
- * If cancelled the enderman does not get angry at the player.
+ * This Event has a result to determine what to do.
+ * The result values mean:
+ * <p>
+ * {@link Event.Result#DEFAULT}: the vanilla/forge logic is used ({@link net.minecraft.world.item.ItemStack#isEnderMask})<br>
+ * {@link Event.Result#ALLOW}: the enderman gets angry no matter what<br>
+ * {@link Event.Result#DENY}: the enderman won't get angry
+ * </p>
  */
 @Event.HasResult
 public class EnderManAngerEvent extends LivingEvent

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -1,41 +1,15 @@
-/*
- * Minecraft Forge
- * Copyright (c) 2016-2022.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- */
-
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * Event that is fired when an enderman checks if the player is looking at him.
- * This Event has a result to determine what to do.
- * The result values mean:
- * <p>
- * {@link Event.Result#DEFAULT}: the vanilla/forge logic is used ({@link net.minecraft.world.item.ItemStack#isEnderMask})<br>
- * {@link Event.Result#ALLOW}: the enderman gets angry no matter what<br>
- * {@link Event.Result#DENY}: the enderman won't get angry
- * </p>
+ * If cancelled the enderman does not get angry at the player.
  */
-@Event.HasResult
-public class EnderManAngerEvent extends LivingEvent
-{
+@Cancelable
+public class EnderManAngerEvent extends LivingEvent {
     private final Player player;
 
     public EnderManAngerEvent(EnderMan enderman, Player player)
@@ -45,7 +19,7 @@ public class EnderManAngerEvent extends LivingEvent
     }
 
     /**
-     * @return the player that is being checked
+     * The player that is being checked.
      */
     public Player getPlayer()
     {

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -36,4 +36,10 @@ public class EnderManAngerEvent extends LivingEvent
     {
         return player;
     }
+
+    @Override
+    public EnderMan getEntity()
+    {
+        return (EnderMan) super.getEntity();
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -28,10 +28,12 @@ import net.minecraftforge.eventbus.api.Event;
  * If cancelled the enderman does not get angry at the player.
  */
 @Event.HasResult
-public class EnderManAngerEvent extends LivingEvent {
+public class EnderManAngerEvent extends LivingEvent
+{
     private final Player player;
 
-    public EnderManAngerEvent(EnderMan enderman, Player player) {
+    public EnderManAngerEvent(EnderMan enderman, Player player)
+    {
         super(enderman);
         this.player = player;
     }
@@ -39,7 +41,8 @@ public class EnderManAngerEvent extends LivingEvent {
     /**
      * @return the player that is being checked
      */
-    public Player getPlayer() {
+    public Player getPlayer()
+    {
         return player;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -1,14 +1,33 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Event that is fired when an enderman checks if the player is looking at him.
  * If cancelled the enderman does not get angry at the player.
  */
-@Cancelable
+@Event.HasResult
 public class EnderManAngerEvent extends LivingEvent {
     private final Player player;
 
@@ -18,7 +37,7 @@ public class EnderManAngerEvent extends LivingEvent {
     }
 
     /**
-     * The player that is being checked.
+     * @return the player that is being checked
      */
     public Player getPlayer() {
         return player;

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderManAngerEvent.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+/**
+ * Event that is fired when an enderman checks if the player is looking at him.
+ * If cancelled the enderman does not get angry at the player.
+ */
+@Cancelable
+public class EnderManAngerEvent extends LivingEvent {
+    private final Player player;
+
+    public EnderManAngerEvent(EnderMan enderman, Player player) {
+        super(enderman);
+        this.player = player;
+    }
+
+    /**
+     * The player that is being checked.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+}


### PR DESCRIPTION
Adds a new event that is fired when an enderman checks if it should get angry at a player to make it possible to prevent endermen getting angry at that player by cancelling the event.