### PR TITLE
Provide NPE protection against out of order init of the TYPES and REF

### DIFF
--- a/src/main/java/net/minecraftforge/datafix/ForgeSchema.java
+++ b/src/main/java/net/minecraftforge/datafix/ForgeSchema.java
@@ -47,8 +47,8 @@ class ForgeSchema extends Schema
     //Can not be final, needs to be initialized on the fly!
     //Constructor invocation order and the what not!
     private Map<String, Supplier<TypeTemplate>> TYPE_TEMPLATES = Maps.newConcurrentMap();
-    private Map<String, Type<?>>                TYPES          = Maps.newConcurrentMap();
-    private Map<String, Integer>                RECURSIVE_TYPES     = Maps.newConcurrentMap();
+    private Map<String, Type<?>>                TYPES;
+    private Map<String, Integer>                RECURSIVE_TYPES;
 
     private final Map<String, Supplier<TypeTemplate>> MODDED_ENTITY_TYPES = Maps.newConcurrentMap();
     private final Map<String, Supplier<TypeTemplate>> MODDED_BLOCK_ENTITY_TYPES = Maps.newConcurrentMap();
@@ -60,6 +60,16 @@ class ForgeSchema extends Schema
     ForgeSchema(final int versionKey, final Schema parent, final Schema wrapped)
     {
         super(versionKey, parent);
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newConcurrentMap();
+        }
+
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newConcurrentMap();
+        }
+
         this.wrapped = wrapped;
 
         final int subVersion = DataFixUtils.getSubVersion(versionKey);
@@ -86,14 +96,14 @@ class ForgeSchema extends Schema
         //Set it to a none null value, so the super type can do its initial construction.
         if (RECURSIVE_TYPES == null)
         {
-            RECURSIVE_TYPES = Maps.newHashMap();
+            RECURSIVE_TYPES = Maps.newConcurrentMap();
         }
 
         //This is potentially invoked from the super constructor, so our field init code has not run yet.
         //Set it to a none null value, so the super type can do its initial construction.
         if (TYPE_TEMPLATES == null)
         {
-            TYPE_TEMPLATES = Maps.newHashMap();
+            TYPE_TEMPLATES = Maps.newConcurrentMap();
         }
 
         //Result map.
@@ -141,40 +151,12 @@ class ForgeSchema extends Schema
     @Override
     public Set<String> types()
     {
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (RECURSIVE_TYPES == null)
-        {
-            RECURSIVE_TYPES = Maps.newHashMap();
-        }
-
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (TYPE_TEMPLATES == null)
-        {
-            TYPE_TEMPLATES = Maps.newHashMap();
-        }
-
         return TYPES.keySet();
     }
 
     @Override
     public Type<?> getTypeRaw(final DSL.TypeReference type)
     {
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (RECURSIVE_TYPES == null)
-        {
-            RECURSIVE_TYPES = Maps.newHashMap();
-        }
-
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (TYPE_TEMPLATES == null)
-        {
-            TYPE_TEMPLATES = Maps.newHashMap();
-        }
-
         final String name = type.typeName();
         return TYPES.computeIfAbsent(name, key -> {
             throw new IllegalArgumentException("Unknown type: " + name);
@@ -184,20 +166,6 @@ class ForgeSchema extends Schema
     @Override
     public Type<?> getType(final DSL.TypeReference type)
     {
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (RECURSIVE_TYPES == null)
-        {
-            RECURSIVE_TYPES = Maps.newHashMap();
-        }
-
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (TYPE_TEMPLATES == null)
-        {
-            TYPE_TEMPLATES = Maps.newHashMap();
-        }
-
         final String name = type.typeName();
         final Type<?> type1 = TYPES.computeIfAbsent(name, key -> {
             throw new IllegalArgumentException("Unknown type: " + name);
@@ -214,16 +182,9 @@ class ForgeSchema extends Schema
     {
         //This is potentially invoked from the super constructor, so our field init code has not run yet.
         //Set it to a none null value, so the super type can do its initial construction.
-        if (RECURSIVE_TYPES == null)
-        {
-            RECURSIVE_TYPES = Maps.newHashMap();
-        }
-
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
         if (TYPE_TEMPLATES == null)
         {
-            TYPE_TEMPLATES = Maps.newHashMap();
+            TYPE_TEMPLATES = Maps.newConcurrentMap();
         }
 
         return TYPE_TEMPLATES.getOrDefault(name, () -> {
@@ -238,14 +199,7 @@ class ForgeSchema extends Schema
         //Set it to a none null value, so the super type can do its initial construction.
         if (RECURSIVE_TYPES == null)
         {
-            RECURSIVE_TYPES = Maps.newHashMap();
-        }
-
-        //This is potentially invoked from the super constructor, so our field init code has not run yet.
-        //Set it to a none null value, so the super type can do its initial construction.
-        if (TYPE_TEMPLATES == null)
-        {
-            TYPE_TEMPLATES = Maps.newHashMap();
+            RECURSIVE_TYPES = Maps.newConcurrentMap();
         }
 
         final int id = RECURSIVE_TYPES.getOrDefault(name, -1);
@@ -333,14 +287,14 @@ class ForgeSchema extends Schema
         //Set it to a none null value, so the super type can do its initial construction.
         if (TYPE_TEMPLATES == null)
         {
-            TYPE_TEMPLATES = Maps.newHashMap();
+            TYPE_TEMPLATES = Maps.newConcurrentMap();
         }
 
         //This is invoked from the super constructor, so our field init code has not run yet.
         //Set it to a none null value, so the super type can do its initial construction.
         if (RECURSIVE_TYPES == null)
         {
-            RECURSIVE_TYPES = Maps.newHashMap();
+            RECURSIVE_TYPES = Maps.newConcurrentMap();
         }
 
         TYPE_TEMPLATES.put(type.typeName(), template);

--- a/src/main/java/net/minecraftforge/datafix/ForgeSchema.java
+++ b/src/main/java/net/minecraftforge/datafix/ForgeSchema.java
@@ -48,8 +48,8 @@ class ForgeSchema extends Schema
     //Constructor invocation order and the what not!
     private Map<String, Supplier<TypeTemplate>> TYPE_TEMPLATES = Maps.newConcurrentMap();
     private Map<String, Type<?>>                TYPES          = Maps.newConcurrentMap();
+    private Map<String, Integer>                RECURSIVE_TYPES     = Maps.newConcurrentMap();
 
-    private final Map<String, Integer>                RECURSIVE_TYPES = Maps.newConcurrentMap();
     private final Map<String, Supplier<TypeTemplate>> MODDED_ENTITY_TYPES = Maps.newConcurrentMap();
     private final Map<String, Supplier<TypeTemplate>> MODDED_BLOCK_ENTITY_TYPES = Maps.newConcurrentMap();
 
@@ -82,6 +82,20 @@ class ForgeSchema extends Schema
      */
     protected Map<String, Type<?>> buildTypes()
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         //Result map.
         final Map<String, Type<?>> types = Maps.newConcurrentMap();
 
@@ -127,12 +141,40 @@ class ForgeSchema extends Schema
     @Override
     public Set<String> types()
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         return TYPES.keySet();
     }
 
     @Override
     public Type<?> getTypeRaw(final DSL.TypeReference type)
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         final String name = type.typeName();
         return TYPES.computeIfAbsent(name, key -> {
             throw new IllegalArgumentException("Unknown type: " + name);
@@ -142,6 +184,20 @@ class ForgeSchema extends Schema
     @Override
     public Type<?> getType(final DSL.TypeReference type)
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         final String name = type.typeName();
         final Type<?> type1 = TYPES.computeIfAbsent(name, key -> {
             throw new IllegalArgumentException("Unknown type: " + name);
@@ -156,6 +212,20 @@ class ForgeSchema extends Schema
     @Override
     public TypeTemplate resolveTemplate(final String name)
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         return TYPE_TEMPLATES.getOrDefault(name, () -> {
             throw new IllegalArgumentException("Unknown type: " + name);
         }).get();
@@ -164,6 +234,20 @@ class ForgeSchema extends Schema
     @Override
     public TypeTemplate id(final String name)
     {
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
+        }
+
+        //This is potentially invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (TYPE_TEMPLATES == null)
+        {
+            TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
         final int id = RECURSIVE_TYPES.getOrDefault(name, -1);
         if (id != -1)
         {
@@ -250,6 +334,13 @@ class ForgeSchema extends Schema
         if (TYPE_TEMPLATES == null)
         {
             TYPE_TEMPLATES = Maps.newHashMap();
+        }
+
+        //This is invoked from the super constructor, so our field init code has not run yet.
+        //Set it to a none null value, so the super type can do its initial construction.
+        if (RECURSIVE_TYPES == null)
+        {
+            RECURSIVE_TYPES = Maps.newHashMap();
         }
 
         TYPE_TEMPLATES.put(type.typeName(), template);


### PR DESCRIPTION
This provides a hotfix against the crash that occurs because of #8242 somehow.
It just checks against a null field when it is called from the super and sets the map early.

This just works now, no clue why it worked before....