### PR TITLE
Fix experimental settings warning triggering when no worldgen datapacks are present

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1306,8 +1306,8 @@ public class ForgeHooks
     {
             App<Mu<LevelStem>, LevelStem> vanillaFields = vanillaFieldsSupplier.get();
             return builder.group(vanillaFields).and(
-                    Codec.BOOL.optionalFieldOf("forge:use_server_seed", false).forGetter(levelStem -> levelStem.useServerSeed()))
-                .apply(builder, (stem, useServerSeed) -> new LevelStem(stem.typeSupplier(), stem.generator(), useServerSeed));
+                    Codec.BOOL.optionalFieldOf("forge:use_server_seed", false).stable().forGetter(levelStem -> levelStem.useServerSeed()))
+                .apply(builder, builder.stable((stem, useServerSeed) -> new LevelStem(stem.typeSupplier(), stem.generator(), useServerSeed)));
     }
 
     public static void writeAdditionalLevelSaveData(WorldData worldData, CompoundTag levelTag)


### PR DESCRIPTION
This marks the decoders in ForgeHooks#expandLevelStemCodec as stable to avoid triggering the experimental settings warning when only vanilla dimensions are present.

To avoid further regressions, these tests were performed:

* Forge client in dev environment with no custom dimensions or other worldgen files: experimental warning does not appear when creating a world (correct behavior)
* Forge client in dev environment with one custom dimension (identical to the overworld): experimental warning appears when creating a world (correct behavior)

Fixes #8414