### PR TITLE
Lower custom item entity replacement from highest to high so mods can cancel it during a specific tick

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -47,7 +47,7 @@ import net.minecraftforge.server.command.ConfigCommand;
 
 public class ForgeInternalHandler
 {
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public void onEntityJoinWorld(EntityJoinWorldEvent event)
     {
         Entity entity = event.getEntity();


### PR DESCRIPTION
This is a proposed "solution" to the one issue that I can think of with handling cleanup in the block remove method instead of the tile remove method as suggested here: https://github.com/MinecraftForge/MinecraftForge/pull/8303#issuecomment-1009469666

The issue is that lots of mods have adopted the "standard" of if you want to move a block without dropping the contents you remove the block entity and then set the block to air/your "carrier block". This means that mods would not be able to do any cleanup they may require in the remove block method as they won't have the block entity available to do so.

This PR will allow mods to go back to an older standard that stopped working in 1.16 or more specifically this commit https://github.com/MinecraftForge/MinecraftForge/commit/72d05d17a92b7060d6262d9553f4b7d5d6bc0a8f due to delaying custom item entities by a tick. The old standard was as follows:
- set a boolean flag
- remove the block
- in an `EntityJoinWorld` listener, if flag is set and `entity insteanceof ItemEntity`, then discard entity + cancel event
- unset the boolean flag

This older standard relied on the fact that when the block is removed it will drop any item/contents immediately so that they could be caught between setting and unsetting the boolean flag, though with the change in 1.16 that made any items with custom item entities happen a tick later to prevent deadlocks with replacing the entities at specific times.

The way this PR provides a solution and enables the older standard to be taken up again (so that mods can do all their required cleanup from the block's `onRemove` method) is by lowering the priority of Forge's listener for replacing custom item listeners from HIGHEST to HIGH so that mods can listen on HIGHEST and outright cancel it if they need to.