### PR TITLE
[1.18.x] Allow new Multi-noise Climate Parameters to be added

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/biome/Climate.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/biome/Climate.java.patch
@@ -1,0 +1,88 @@
+--- a/net/minecraft/world/level/biome/Climate.java
++++ b/net/minecraft/world/level/biome/Climate.java
+@@ -145,7 +_,7 @@
+       }
+    }
+ 
+-   public static record ParameterPoint(Climate.Parameter f_186863_, Climate.Parameter f_186864_, Climate.Parameter f_186865_, Climate.Parameter f_186866_, Climate.Parameter f_186867_, Climate.Parameter f_186868_, long f_186869_) {
++   public static record ParameterPoint(Climate.Parameter temperature, Climate.Parameter humidity, Climate.Parameter continentalness, Climate.Parameter erosion, Climate.Parameter depth, Climate.Parameter weirdness, long offset, net.minecraftforge.common.BiomeManager.ParameterPointExtensions extensions) {
+       public static final Codec<Climate.ParameterPoint> f_186862_ = RecordCodecBuilder.create((p_186885_) -> {
+          return p_186885_.group(Climate.Parameter.f_186812_.fieldOf("temperature").forGetter((p_186905_) -> {
+             return p_186905_.f_186863_;
+@@ -161,15 +_,18 @@
+             return p_186888_.f_186868_;
+          }), Codec.floatRange(0.0F, 1.0F).fieldOf("offset").xmap(Climate::m_186779_, Climate::m_186796_).forGetter((p_186881_) -> {
+             return p_186881_.f_186869_;
+-         })).apply(p_186885_, Climate.ParameterPoint::new);
++         }), net.minecraftforge.common.BiomeManager.ParameterPointExtensions.CODEC.optionalFieldOf("extensions").xmap(o -> o.orElse(net.minecraftforge.common.BiomeManager.ParameterPointExtensions.getDefault()), a -> java.util.Objects.equals(a, net.minecraftforge.common.BiomeManager.ParameterPointExtensions.getDefault()) ? java.util.Optional.empty() : java.util.Optional.of(a)).forGetter(ParameterPoint::extensions)).apply(p_186885_, Climate.ParameterPoint::new);
+       });
+ 
++      public ParameterPoint(Climate.Parameter f_186863_, Climate.Parameter f_186864_, Climate.Parameter f_186865_, Climate.Parameter f_186866_, Climate.Parameter f_186867_, Climate.Parameter f_186868_, long f_186869_) {
++         this(f_186863_, f_186864_, f_186865_, f_186866_, f_186867_, f_186868_, f_186869_, net.minecraftforge.common.BiomeManager.ParameterPointExtensions.getDefault());
++      }
+       long m_186882_(Climate.TargetPoint p_186883_) {
+-         return Mth.m_184643_(this.f_186863_.m_186825_(p_186883_.f_187003_)) + Mth.m_184643_(this.f_186864_.m_186825_(p_186883_.f_187004_)) + Mth.m_184643_(this.f_186865_.m_186825_(p_186883_.f_187005_)) + Mth.m_184643_(this.f_186866_.m_186825_(p_186883_.f_187006_)) + Mth.m_184643_(this.f_186867_.m_186825_(p_186883_.f_187007_)) + Mth.m_184643_(this.f_186868_.m_186825_(p_186883_.f_187008_)) + Mth.m_184643_(this.f_186869_);
++         return Mth.m_184643_(this.f_186863_.m_186825_(p_186883_.f_187003_)) + Mth.m_184643_(this.f_186864_.m_186825_(p_186883_.f_187004_)) + Mth.m_184643_(this.f_186865_.m_186825_(p_186883_.f_187005_)) + Mth.m_184643_(this.f_186866_.m_186825_(p_186883_.f_187006_)) + Mth.m_184643_(this.f_186867_.m_186825_(p_186883_.f_187007_)) + Mth.m_184643_(this.f_186868_.m_186825_(p_186883_.f_187008_)) + Mth.m_184643_(this.f_186869_) + p_186883_.extensions.fitness(this.extensions);
+       }
+ 
+       protected List<Climate.Parameter> m_186879_() {
+-         return ImmutableList.of(this.f_186863_, this.f_186864_, this.f_186865_, this.f_186866_, this.f_186867_, this.f_186868_, new Climate.Parameter(this.f_186869_, this.f_186869_));
++         return this.extensions.extendedParameterSpace(this.f_186863_, this.f_186864_, this.f_186865_, this.f_186866_, this.f_186867_, this.f_186868_, this.f_186869_);
+       }
+    }
+ 
+@@ -187,8 +_,8 @@
+             throw new IllegalArgumentException("Need at least one value to build the search tree.");
+          } else {
+             int i = p_186936_.get(0).getFirst().m_186879_().size();
+-            if (i != 7) {
+-               throw new IllegalStateException("Expecting parameter space to be 7, got " + i);
++            if (i != 7 + net.minecraftforge.common.BiomeManager.getClimateParameterExtensionsCount()) {
++               throw new IllegalStateException("Expecting parameter space to be " + (7 + net.minecraftforge.common.BiomeManager.getClimateParameterExtensionsCount()) + ", got " + i);
+             } else {
+                List<Climate.RTree.Leaf<T>> list = p_186936_.stream().map((p_186934_) -> {
+                   return new Climate.RTree.Leaf<T>(p_186934_.getFirst(), p_186934_.getSecond());
+@@ -295,15 +_,15 @@
+          if (p_186947_.isEmpty()) {
+             throw new IllegalArgumentException("SubTree needs at least one child");
+          } else {
+-            int i = 7;
++            int i = 7 + net.minecraftforge.common.BiomeManager.getClimateParameterExtensionsCount();
+             List<Climate.Parameter> list = Lists.newArrayList();
+ 
+-            for(int j = 0; j < 7; ++j) {
++            for(int j = 0; j < i; ++j) {
+                list.add((Climate.Parameter)null);
+             }
+ 
+             for(Climate.RTree.Node<T> node : p_186947_) {
+-               for(int k = 0; k < 7; ++k) {
++               for(int k = 0; k < i; ++k) {
+                   list.set(k, node.f_186956_[k].m_186836_(list.get(k)));
+                }
+             }
+@@ -344,7 +_,7 @@
+          protected long m_186959_(long[] p_186960_) {
+             long i = 0L;
+ 
+-            for(int j = 0; j < 7; ++j) {
++            for(int j = 0; j < 7 + net.minecraftforge.common.BiomeManager.getClimateParameterExtensionsCount(); ++j) {
+                i += Mth.m_184643_(this.f_186956_[j].m_186825_(p_186960_[j]));
+             }
+ 
+@@ -447,10 +_,13 @@
+       }
+    }
+ 
+-   public static record TargetPoint(long f_187003_, long f_187004_, long f_187005_, long f_187006_, long f_187007_, long f_187008_) {
++   public static record TargetPoint(long temperature, long humidity, long continentalness, long erosion, long depth, long weirdness, net.minecraftforge.common.BiomeManager.TargetPointExtensions extensions) {
++      public TargetPoint(long f_187003_, long f_187004_, long f_187005_, long f_187006_, long f_187007_, long f_187008_) {
++         this(f_187003_, f_187004_, f_187005_, f_187006_, f_187007_, f_187008_, net.minecraftforge.common.BiomeManager.TargetPointExtensions.zero());
++      }
+       @VisibleForTesting
+       protected long[] m_187016_() {
+-         return new long[]{this.f_187003_, this.f_187004_, this.f_187005_, this.f_187006_, this.f_187007_, this.f_187008_, 0L};
++         return this.extensions.extendParameterArray(this.f_187003_, this.f_187004_, this.f_187005_, this.f_187006_, this.f_187007_, this.f_187008_);
+       }
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/level/levelgen/NoiseSampler.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/NoiseSampler.java.patch
@@ -12,7 +12,7 @@
        this.f_188919_ = m_189068_(Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189253_), k, l, 0, 2.6666666666666665D);
        this.f_188921_ = m_189068_(Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189254_), k, l, 0, 2.6666666666666665D);
        this.f_188941_ = Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189255_);
-+      this.climateParameterExtensionSamplers = net.minecraftforge.common.BiomeManager.setupClimateParameterExtensionFunctions(p_188950_, p_188953_, positionalrandomfactory);
++      this.climateParameterExtensionSamplers = net.minecraftforge.common.BiomeManager.setupClimateParameterExtensionSamplers(p_188950_, p_188953_, positionalrandomfactory);
     }
  
     private static NoiseChunk.InterpolatableNoise m_189068_(NormalNoise p_189069_, int p_189070_, int p_189071_, int p_189072_, double p_189073_) {

--- a/patches/minecraft/net/minecraft/world/level/levelgen/NoiseSampler.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/NoiseSampler.java.patch
@@ -1,0 +1,27 @@
+--- a/net/minecraft/world/level/levelgen/NoiseSampler.java
++++ b/net/minecraft/world/level/levelgen/NoiseSampler.java
+@@ -84,6 +_,7 @@
+    private final PositionalRandomFactory f_188924_;
+    private final List<Climate.ParameterPoint> f_188925_ = (new OverworldBiomeBuilder()).m_187154_();
+    private final boolean f_188926_;
++   private final net.minecraftforge.common.BiomeManager.ClimateParameterSampler[] climateParameterExtensionSamplers;
+ 
+    public NoiseSampler(NoiseSettings p_188950_, boolean p_188951_, long p_188952_, Registry<NormalNoise.NoiseParameters> p_188953_, WorldgenRandom.Algorithm p_188954_) {
+       this.f_158643_ = p_188950_;
+@@ -162,6 +_,7 @@
+       this.f_188919_ = m_189068_(Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189253_), k, l, 0, 2.6666666666666665D);
+       this.f_188921_ = m_189068_(Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189254_), k, l, 0, 2.6666666666666665D);
+       this.f_188941_ = Noises.m_189305_(p_188953_, positionalrandomfactory, Noises.f_189255_);
++      this.climateParameterExtensionSamplers = net.minecraftforge.common.BiomeManager.setupClimateParameterExtensionFunctions(p_188950_, p_188953_, positionalrandomfactory);
+    }
+ 
+    private static NoiseChunk.InterpolatableNoise m_189068_(NormalNoise p_189069_, int p_189070_, int p_189071_, int p_189072_, double p_189073_) {
+@@ -362,7 +_,7 @@
+       double d1 = (double)p_188978_ + this.m_188972_(p_188978_, p_188979_, p_188977_);
+       double d2 = p_188980_.f_189137_();
+       double d3 = this.m_189013_(QuartPos.m_175402_(p_188978_), p_188980_.f_189141_());
+-      return Climate.m_186781_((float)this.m_189107_(d0, d1, d2), (float)this.m_189116_(d0, d1, d2), (float)p_188980_.f_189138_(), (float)p_188980_.f_189140_(), (float)d3, (float)p_188980_.f_189139_());
++      return net.minecraftforge.common.BiomeManager.TargetPointExtensions.extendedTargetPoint(p_188977_, p_188978_, p_188979_, d0, d1, d2, (float)this.m_189107_(d0, d1, d2), (float)this.m_189116_(d0, d1, d2), (float)p_188980_.f_189138_(), (float)p_188980_.f_189140_(), (float)d3, (float)p_188980_.f_189139_(), this.climateParameterExtensionSamplers);
+    }
+ 
+    public TerrainInfo m_188965_(int p_188966_, int p_188967_, float p_188968_, float p_188969_, float p_188970_, Blender p_188971_) {

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -19,25 +19,36 @@
 
 package net.minecraftforge.common;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 
-import net.minecraft.util.random.WeightedRandom;
-import net.minecraft.world.entity.ai.behavior.ShufflingList;
+import com.mojang.datafixers.util.Function3;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Keyable;
+import com.mojang.serialization.codecs.SimpleMapCodec;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.levelgen.NoiseSampler;
+import net.minecraft.world.level.levelgen.NoiseSettings;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.synth.NormalNoise.NoiseParameters;
+
+import javax.annotation.Nullable;
+import java.util.*;
 
 public class BiomeManager
 {
     private static TrackedList<BiomeEntry>[] biomes = setupBiomes();
     private static final List<ResourceKey<Biome>> additionalOverworldBiomes = new ArrayList<>();
     private static final List<ResourceKey<Biome>> additionalOverworldBiomesView = Collections.unmodifiableList(additionalOverworldBiomes);
+    private static final List<ClimateParameterExtension> climateParameterExtensions = new ArrayList<>();
+    private static final List<Climate.Parameter> defaultClimateParameterExtensionValues = new ArrayList<>();
 
     private static TrackedList<BiomeEntry>[] setupBiomes()
     {
@@ -110,6 +121,29 @@ public class BiomeManager
     }
 
     /**
+     * Adds a new {@link net.minecraft.world.level.biome.Climate.ParameterPoint} parameter that can be used for additional customization of biome selection in multi-noise biome sources.
+     * <p><b>Only call this method during mod loading!</b></p>
+     *
+     * @param name A {@link ResourceLocation} to use as the name for the {@link ClimateParameterExtension}.
+     * @param defaultValue A {@link Climate.Parameter} instance to use as the default value for the new parameter.
+     * @param samplerFactory A factory for creating a {@link ClimateParameterSampler} instance that will get used for computing the parameter coordinate value in {@link TargetPointExtensions}.
+     * @return A new {@link ClimateParameterExtension} containing the name, default value, factory, and ID for the new parameter.
+     * @see ClimateParameterSampler
+     * @see ClimateParameterExtension
+     */
+    public static synchronized ClimateParameterExtension addClimateParameter(ResourceLocation name, Climate.Parameter defaultValue, Function3<NoiseSettings, Registry<NoiseParameters>, PositionalRandomFactory, ClimateParameterSampler> samplerFactory)
+    {
+        if (getClimateParameterExtension(name) != null)
+            throw new IllegalArgumentException("A ClimateParameterExtension with the name '" + name + "' already exists!");
+        ClimateParameterExtension climateParameterExtension = new ClimateParameterExtension(name, defaultValue, samplerFactory, climateParameterExtensions.size());
+        climateParameterExtensions.add(climateParameterExtension);
+        defaultClimateParameterExtensionValues.add(defaultValue);
+        ParameterPointExtensions.DEFAULT = new ParameterPointExtensions();
+        TargetPointExtensions.ZERO = new TargetPointExtensions(new long[climateParameterExtensions.size()]);
+        return climateParameterExtension;
+    }
+
+    /**
      * @return list of biomes that might be generated in the overworld in addition to the vanilla biomes
      */
     public static List<ResourceKey<Biome>> getAdditionalOverworldBiomes()
@@ -129,6 +163,85 @@ public class BiomeManager
         int idx = type.ordinal();
         TrackedList<BiomeEntry> list = idx > biomes.length ? null : biomes[idx];
         return list == null ? false : list.isModded();
+    }
+
+    /**
+     * Tries to get a {@link ClimateParameterExtension} by its name.
+     * <p><b>Only call this method after mod loading!</b></p>
+     *
+     * @param name The name of the {@link ClimateParameterExtension} to look up.
+     * @return A {@link ClimateParameterExtension} looked up by its name, or null if no {@link ClimateParameterExtension} existed with the given name.
+     * @see ClimateParameterExtension
+     */
+    @Nullable
+    public static ClimateParameterExtension getClimateParameterExtension(ResourceLocation name)
+    {
+        for (ClimateParameterExtension climateParameterExtension : climateParameterExtensions)
+        {
+            if (climateParameterExtension.name.equals(name))
+            {
+                return climateParameterExtension;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets an array of all the default climate parameter extension values.
+     * <p><b>Only call this method after mod loading!</b></p>
+     * 
+     * @return An array of all the default climate parameter extension values.
+     * @see #addClimateParameter(ResourceLocation, Climate.Parameter, Function3)
+     */
+    public static Climate.Parameter[] getDefaultClimateParameterExtensionValues()
+    {
+        return defaultClimateParameterExtensionValues.toArray(new Climate.Parameter[0]);
+    }
+
+    /**
+     * Gets the number of added climate parameter extensions.
+     * <p><b>Only call this method after mod loading!</b></p>
+     * 
+     * @return The number of added climate parameter extensions.
+     * @see #addClimateParameter(ResourceLocation, Climate.Parameter, Function3) 
+     */
+    public static int getClimateParameterExtensionsCount()
+    {
+        return climateParameterExtensions.size();
+    }
+
+    /**
+     * Creates an array of {@link ClimateParameterSampler} instances with each element corresponding to an added {@link ClimateParameterExtension}.
+     * <p><b>Only call this method after mod loading!</b></p>
+     *
+     * @param settings A {@link NoiseSettings} instance to use for configuration.
+     * @param registry A {@link Registry} for {@link NoiseParameters} for getting registered {@link NoiseParameters} instances.
+     * @param positionalRandomFactory A {@link PositionalRandomFactory} instance for creating {@link net.minecraft.world.level.levelgen.RandomSource} instances.
+     * @see #addClimateParameter(ResourceLocation, Climate.Parameter, Function3)
+     * @see ClimateParameterExtension
+     * @see ClimateParameterSampler
+     * @return An array of {@link ClimateParameterSampler} instances with each element corresponding to an added {@link ClimateParameterExtension}.
+     */
+    public static ClimateParameterSampler[] setupClimateParameterExtensionFunctions(NoiseSettings settings, Registry<NoiseParameters> registry, PositionalRandomFactory positionalRandomFactory)
+    {
+        int count = getClimateParameterExtensionsCount();
+        ClimateParameterSampler[] climateParameterSamplers = new ClimateParameterSampler[count];
+        for (int i = 0; i < count; i++)
+        {
+            climateParameterSamplers[i] = climateParameterExtensions.get(i).samplerFactory.apply(settings, registry, positionalRandomFactory);
+        }
+        return climateParameterSamplers;
+    }
+
+    /**
+     * Gets a view of all the added {@link ClimateParameterExtension} instances.
+     * <p><b>Only call this method after mod loading!</b></p>
+     *
+     * @return A view of all the added {@link ClimateParameterExtension} instances.
+     */
+    public static List<ClimateParameterExtension> getClimateParameterExtensions()
+    {
+        return ImmutableList.copyOf(climateParameterExtensions);
     }
 
     public static enum BiomeType
@@ -235,6 +348,324 @@ public class BiomeManager
         public boolean isModded()
         {
             return isModded;
+        }
+    }
+
+    /**
+     * Represents a new {@link net.minecraft.world.level.biome.Climate.ParameterPoint} parameter that can be used for additional customization of biome selection in multi-noise biome sources.
+     * <p>Instances of this class can only be created from the {@link #addClimateParameter(ResourceLocation, Climate.Parameter, Function3)} method.</p>
+     *
+     * @see #addClimateParameter(ResourceLocation, Climate.Parameter, Function3)
+     * @see ClimateParameterSampler
+     */
+    public static final class ClimateParameterExtension
+    {
+        public static final Codec<ClimateParameterExtension> CODEC = ResourceLocation.CODEC.flatXmap(location ->
+        {
+            ClimateParameterExtension climateParameterExtension = getClimateParameterExtension(location);
+            return climateParameterExtension == null ? DataResult.error("Unknown Climate Parameter Extension: " + location) : DataResult.success(climateParameterExtension);
+        }, climateParameterExtension -> DataResult.success(climateParameterExtension.name));
+        public final ResourceLocation name;
+        public final Climate.Parameter defaultValue;
+        public final Function3<NoiseSettings, Registry<NoiseParameters>, PositionalRandomFactory, ClimateParameterSampler> samplerFactory;
+        public final int id;
+
+        private ClimateParameterExtension(ResourceLocation name, Climate.Parameter defaultValue, Function3<NoiseSettings, Registry<NoiseParameters>, PositionalRandomFactory, ClimateParameterSampler> samplerFactory, int id)
+        {
+            this.name = name;
+            this.defaultValue = defaultValue;
+            this.samplerFactory = samplerFactory;
+            this.id = id;
+        }
+    }
+
+    /**
+     * The functional interface used for computing the parameter value of an added {@link ClimateParameterExtension} when sampling a {@link Climate.TargetPoint}.
+     *
+     * @see TargetPointExtensions#extendedTargetPoint(int, int, int, double, double, double, float, float, float, float, float, float, ClimateParameterSampler[])
+     */
+    @FunctionalInterface
+    public interface ClimateParameterSampler
+    {
+        /**
+         * Samples the parameter value at a position.
+         *
+         * @param fromBlockX The x pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param fromBlockY The y pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param fromBlockZ The z pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param shiftedX The value of fromBlockX but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @param shiftedY The value of fromBlockY but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @param shiftedZ The value of fromBlockZ but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @see net.minecraft.world.level.levelgen.NoiseSampler#target(int, int, int, NoiseSampler.FlatNoiseData)
+         * @return The parameter value at a position.
+         */
+        float sample(int fromBlockX, int fromBlockY, int fromBlockZ, double shiftedX, double shiftedY, double shiftedZ);
+    }
+
+    /**
+     * Holds the extended {@link Climate.Parameter} values in a {@link Climate.ParameterPoint} instance for all the added climate parameter extensions.
+     * <p>Use {@link #CODEC} for serializing and deserializing instances of this class.</p>
+     * <p><b>Only use this class after mod loading!</b></p>
+     *
+     * @see #addClimateParameter(ResourceLocation, Climate.Parameter, Function3)
+     */
+    public static final class ParameterPointExtensions
+    {
+        //Default parameter extension values are cached for performance
+        private static ParameterPointExtensions DEFAULT = new ParameterPointExtensions();
+        public static final Codec<ParameterPointExtensions> CODEC = new SimpleMapCodec<>(ClimateParameterExtension.CODEC, Climate.Parameter.CODEC, Keyable.forStrings(() -> climateParameterExtensions.stream().map(climateParameterExtension -> climateParameterExtension.name.toString()))).codec().xmap(map ->
+        {
+            if (map.isEmpty()) return ParameterPointExtensions.DEFAULT;
+            Climate.Parameter[] parameters = getDefaultClimateParameterExtensionValues();
+            map.forEach((climateParameterExtension, parameter) -> parameters[climateParameterExtension.id] = parameter);
+            return new ParameterPointExtensions(parameters);
+        }, parameters ->
+        {
+            Climate.Parameter[] internalParameters = parameters.parameters;
+            Map<ClimateParameterExtension, Climate.Parameter> map = new HashMap<>();
+            for (int i = 0; i < internalParameters.length; i++)
+            {
+                map.put(climateParameterExtensions.get(i), internalParameters[i]);
+            }
+            return map;
+        });
+        private final Climate.Parameter[] parameters;
+
+        private ParameterPointExtensions(Climate.Parameter[] parameters)
+        {
+            this.parameters = parameters;
+        }
+
+        /**
+         * Constructs a new {@link ParameterPointExtensions} instance from an array of pairs containing a {@link ClimateParameterExtension} instance and a corresponding {@link Climate.Parameter}.
+         *
+         * @param entries An array of pairs containing a {@link ClimateParameterExtension} instance and a corresponding {@link Climate.Parameter}.
+         */
+        @SafeVarargs
+        public ParameterPointExtensions(Pair<ClimateParameterExtension, Climate.Parameter>... entries)
+        {
+            this(getDefaultClimateParameterExtensionValues());
+            for (var pair : entries)
+            {
+                this.parameters[pair.getFirst().id] = pair.getSecond();
+            }
+        }
+
+        /**
+         * Gets the default {@link ParameterPointExtensions} instance that contains the default values for all the added climate parameter extensions.
+         * <p><b>Only call this method after mod loading!</b></p>
+         *
+         * @return The default {@link ParameterPointExtensions} instance that contains the default values for all the added climate parameter extensions.
+         */
+        public static ParameterPointExtensions getDefault()
+        {
+            return DEFAULT;
+        }
+
+        /**
+         * Gets the {@link Climate.Parameter} corresponding to a given {@link ClimateParameterExtension}.
+         *
+         * @param extension A {@link ClimateParameterExtension} to get its {@link Climate.Parameter}.
+         * @return The {@link Climate.Parameter} corresponding to the given {@link ClimateParameterExtension}.
+         */
+        public Climate.Parameter getParameter(ClimateParameterExtension extension)
+        {
+            return this.parameters[extension.id];
+        }
+
+        /**
+         * Merges the parameter extension values with vanilla's parameter values.
+         *
+         * @param temperature A {@link Climate.Parameter} instance for the temperature parameter.
+         * @param humidity A {@link Climate.Parameter} instance for the humidity parameter.
+         * @param continentalness A {@link Climate.Parameter} instance for the continentalness parameter.
+         * @param erosion A {@link Climate.Parameter} instance for the erosion parameter.
+         * @param depth A {@link Climate.Parameter} instance for the depth parameter.
+         * @param weirdness A {@link Climate.Parameter} instance for the weirdness parameter.
+         * @param offset The offset parameter.
+         * @return An immutable list containing the parameter extension values merged with vanilla's parameter values.
+         */
+        public List<Climate.Parameter> extendedParameterSpace(Climate.Parameter temperature, Climate.Parameter humidity, Climate.Parameter continentalness, Climate.Parameter erosion, Climate.Parameter depth, Climate.Parameter weirdness, long offset)
+        {
+            ImmutableList.Builder<Climate.Parameter> builder = new ImmutableList.Builder<>();
+            builder.add(temperature, humidity, continentalness, erosion, depth, weirdness, new Climate.Parameter(offset, offset));
+            builder.add(this.parameters);
+            return builder.build();
+        }
+
+        /**
+         * Gets a copy of the internal {@link #parameters}.
+         *
+         * @return A copy of the internal {@link #parameters}.
+         */
+        public Climate.Parameter[] getParameters()
+        {
+            return Arrays.copyOf(this.parameters, this.parameters.length);
+        }
+
+        @Override
+        public String toString()
+        {
+            Climate.Parameter[] parameters = this.parameters;
+            int max = parameters.length - 1;
+            if (max == -1) return "{}";
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append('{');
+            for (int i = 0; ; i++)
+            {
+                stringBuilder.append(climateParameterExtensions.get(i).name).append("=").append(parameters[i].toString());
+                if (i == max)
+                    return stringBuilder.append('}').toString();
+                stringBuilder.append(", ");
+            }
+        }
+    }
+
+    /**
+     * Holds the extended climate parameter values in a {@link net.minecraft.world.level.biome.Climate.TargetPoint} instance for all the added climate parameter extensions.
+     * <p><b>Only use this class after mod loading!</b></p>
+     */
+    public static final class TargetPointExtensions
+    {
+        //Default target point extension values are cached for performance
+        private static TargetPointExtensions ZERO = new TargetPointExtensions(new long[0]);
+        private final long[] parameters;
+
+        private TargetPointExtensions(long[] parameters)
+        {
+            this.parameters = parameters;
+        }
+
+        /**
+         * Constructs a new {@link TargetPointExtensions} instance from an array of pairs containing a {@link ClimateParameterExtension} instance and a corresponding parameter value.
+         *
+         * @param parameters An array of pairs containing a {@link ClimateParameterExtension} instance and a corresponding parameter value.
+         */
+        @SafeVarargs
+        public TargetPointExtensions(Pair<ClimateParameterExtension, Long>... parameters)
+        {
+            this.parameters = new long[getClimateParameterExtensionsCount()];
+            for (var pair : parameters)
+            {
+                this.parameters[pair.getFirst().id] = pair.getSecond();
+            }
+        }
+
+        /**
+         * Gets a {@link TargetPointExtensions} instance containing all zero values.
+         *
+         * @return A {@link TargetPointExtensions} instance containing all zero values.
+         */
+        public static TargetPointExtensions zero()
+        {
+            return ZERO;
+        }
+
+        /**
+         * Creates a new {@link Climate.TargetPoint} containing vanilla parameter values and sampled extended climate parameter values.
+         *
+         * @param fromBlockX The x pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param fromBlockY The y pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param fromBlockZ The z pos being sampled at, bit-shifted by {@link net.minecraft.core.QuartPos#fromBlock(int)}.
+         * @param shiftedX The value of fromBlockX but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @param shiftedY The value of fromBlockY but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @param shiftedZ The value of fromBlockZ but quadruply offset by the {@link net.minecraft.world.level.levelgen.Noises#SHIFT} noise.
+         * @param temperature The temperature noise value.
+         * @param humidity The humidity noise value.
+         * @param continentalness The continentalness noise value.
+         * @param erosion The erosion noise value.
+         * @param depth The depth value.
+         * @param weirdness The weirdness noise value.
+         * @param climateParameterSamplers An array of {@link ClimateParameterSampler} instances to sample the extended climate parameter values.
+         * @return A new {@link Climate.TargetPoint} containing sampled vanilla parameter values and sampled extended climate parameter values.
+         * @see ClimateParameterSampler
+         */
+        public static Climate.TargetPoint extendedTargetPoint(int fromBlockX, int fromBlockY, int fromBlockZ, double shiftedX, double shiftedY, double shiftedZ, float temperature, float humidity, float continentalness, float erosion, float depth, float weirdness, ClimateParameterSampler[] climateParameterSamplers)
+        {
+            int count = getClimateParameterExtensionsCount();
+            if (count == 0)
+                return Climate.target(Climate.quantizeCoord(temperature), Climate.quantizeCoord(humidity), Climate.quantizeCoord(continentalness), Climate.quantizeCoord(erosion), Climate.quantizeCoord(depth), Climate.quantizeCoord(weirdness));
+            long[] quantizedParameters = new long[count];
+            for (int i = 0; i < count; i++)
+            {
+                quantizedParameters[i] = Climate.quantizeCoord(climateParameterSamplers[i].sample(fromBlockX, fromBlockY, fromBlockZ, shiftedX, shiftedY, shiftedZ));
+            }
+            return new Climate.TargetPoint(Climate.quantizeCoord(temperature), Climate.quantizeCoord(humidity), Climate.quantizeCoord(continentalness), Climate.quantizeCoord(erosion), Climate.quantizeCoord(depth), Climate.quantizeCoord(weirdness), new TargetPointExtensions(quantizedParameters));
+        }
+
+        /**
+         * Computes the fitness of a given {@link ParameterPointExtensions} instance.
+         *
+         * @param extensions A {@link ParameterPointExtensions} instance to compare against.
+         * @return The fitness of the given {@link ParameterPointExtensions} instance.
+         */
+        public long fitness(ParameterPointExtensions extensions)
+        {
+            int count = getClimateParameterExtensionsCount();
+            if (count == 0) return 0L;
+            long fitness = 0L;
+            Climate.Parameter[] extensionsParameters = extensions.parameters;
+            long[] parameters = this.parameters;
+            for (int i = 0; i < count; i++)
+            {
+                fitness += Mth.square(extensionsParameters[i].distance(parameters[i]));
+            }
+            return fitness;
+        }
+
+        /**
+         * Concatenates vanilla's climate parameter values with the internal {@link #parameters}.
+         *
+         * @param temperature The temperature parameter value.
+         * @param humidity The humidity parameter value.
+         * @param continentalness The continentalness parameter value.
+         * @param erosion The erosion parameter value.
+         * @param depth The depth parameter value.
+         * @param weirdness The weirdness parameter value.
+         * @return An array containing vanilla climate parameter values concatenated with the internal {@link #parameters}.
+         */
+        public long[] extendParameterArray(long temperature, long humidity, long continentalness, long erosion, long depth, long weirdness)
+        {
+            int count = getClimateParameterExtensionsCount();
+            if (count == 0)
+                return new long[] {temperature, humidity, continentalness, erosion, depth, weirdness, 0L};
+            long[] parameterArray = new long[7 + count];
+            parameterArray[0] = temperature;
+            parameterArray[1] = humidity;
+            parameterArray[2] = continentalness;
+            parameterArray[3] = erosion;
+            parameterArray[4] = depth;
+            parameterArray[5] = weirdness;
+            parameterArray[6] = 0L;
+            System.arraycopy(this.parameters, 0, parameterArray, 7, count);
+            return parameterArray;
+        }
+
+        /**
+         * Gets a copy of the internal {@link #parameters}.
+         *
+         * @return A copy of the internal {@link #parameters}.
+         */
+        public long[] getParameters()
+        {
+            return Arrays.copyOf(this.parameters, this.parameters.length);
+        }
+
+        @Override
+        public String toString()
+        {
+            long[] parameters = this.parameters;
+            int max = parameters.length - 1;
+            if (max == -1) return "{}";
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append('{');
+            for (int i = 0; ; i++)
+            {
+                stringBuilder.append(climateParameterExtensions.get(i).name).append("=").append(parameters[i]);
+                if (i == max)
+                    return stringBuilder.append('}').toString();
+                stringBuilder.append(", ");
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -222,7 +222,7 @@ public class BiomeManager
      * @see ClimateParameterSampler
      * @return An array of {@link ClimateParameterSampler} instances with each element corresponding to an added {@link ClimateParameterExtension}.
      */
-    public static ClimateParameterSampler[] setupClimateParameterExtensionFunctions(NoiseSettings settings, Registry<NoiseParameters> registry, PositionalRandomFactory positionalRandomFactory)
+    public static ClimateParameterSampler[] setupClimateParameterExtensionSamplers(NoiseSettings settings, Registry<NoiseParameters> registry, PositionalRandomFactory positionalRandomFactory)
     {
         int count = getClimateParameterExtensionsCount();
         ClimateParameterSampler[] climateParameterSamplers = new ClimateParameterSampler[count];

--- a/src/test/java/net/minecraftforge/debug/world/ClimateParameterExtensionsTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ClimateParameterExtensionsTest.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.core.QuartPos;
+import net.minecraft.core.Registry;
+import net.minecraft.data.BuiltinRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.levelgen.Noises;
+import net.minecraft.world.level.levelgen.synth.NormalNoise;
+import net.minecraftforge.common.BiomeManager;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+/**
+ * To see the distribution of the added climate parameters you must go to the custom dimension (use: /execute in climate_parameter_extensions_test:extended run tp ...).
+ * <p>You should observe a mostly mountainous terrain with forest biomes at lower y values, snowy slope peaks at high y values, oceans, and uncommon frozen oceans.</p>
+ *
+ * <p>Note: This mod adds a data asset located at: /data/climate_parameter_extensions_test/dimension/extended.json</p>
+ */
+@Mod(ClimateParameterExtensionsTest.MODID)
+public class ClimateParameterExtensionsTest
+{
+    public static final String MODID = "climate_parameter_extensions_test";
+    private static final ResourceKey<NormalNoise.NoiseParameters> MODDEDNESS = ResourceKey.create(Registry.NOISE_REGISTRY, new ResourceLocation(MODID, "moddedness"));
+    private static final ResourceKey<NormalNoise.NoiseParameters> MODDEDNESS_LARGE = ResourceKey.create(Registry.NOISE_REGISTRY, new ResourceLocation(MODID, "moddedness_large"));
+
+    public ClimateParameterExtensionsTest()
+    {
+        //We add two new climate parameters here, one for a proportion of the level's height, and one for a new noise named 'moddedness'
+        BiomeManager.addClimateParameter(new ResourceLocation(MODID, "height"), Climate.Parameter.point(0.0F), (noiseSettings, registry, positionalRandomFactory) ->
+        {
+            int height = noiseSettings.height();
+            float m = 1.0F / height;
+            float b = 1.0F - (height + noiseSettings.minY()) * m;
+            return (fromBlockX, fromBlockY, fromBlockZ, shiftedX, shiftedY, shiftedZ) -> Mth.clamp(m * QuartPos.toBlock(fromBlockY) + b, 0.0F, 1.0F);
+        });
+        BiomeManager.addClimateParameter(new ResourceLocation(MODID, "moddedness"), Climate.Parameter.point(0.0F), (noiseSettings, registry, positionalRandomFactory) ->
+        {
+            NormalNoise noise = Noises.instantiate(registry, positionalRandomFactory, noiseSettings.largeBiomes() ? MODDEDNESS_LARGE : MODDEDNESS);
+            return (fromBlockX, fromBlockY, fromBlockZ, shiftedX, shiftedY, shiftedZ) -> (float) noise.getValue(shiftedX, 0.0F, shiftedZ);
+        });
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::registerNoises);
+    }
+
+    private void registerNoises(FMLCommonSetupEvent event)
+    {
+        event.enqueueWork(() ->
+        {
+            BuiltinRegistries.register(BuiltinRegistries.NOISE, MODDEDNESS, new NormalNoise.NoiseParameters(-10, 1.5, 0.0, 1.0, 0.0, 0.0, 0.5));
+            BuiltinRegistries.register(BuiltinRegistries.NOISE, MODDEDNESS_LARGE, new NormalNoise.NoiseParameters(-12, 1.5, 0.0, 1.0, 0.0, 0.0, 0.5));
+        });
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -188,5 +188,7 @@ license="LGPL v2.1"
     modId="ingredient_invalidation"
 [[mods]]
     modId="client_command_test"
+[[mods]]
+    modId="climate_parameter_extensions_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/data/climate_parameter_extensions_test/dimension/extended.json
+++ b/src/test/resources/data/climate_parameter_extensions_test/dimension/extended.json
@@ -1,0 +1,198 @@
+{
+  "type": "minecraft:overworld",
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": 0,
+    "settings": {
+      "ore_veins_enabled": false,
+      "noodle_caves_enabled": true,
+      "legacy_random_source": false,
+      "disable_mob_generation": true,
+      "aquifers_enabled": true,
+      "noise_caves_enabled": true,
+      "surface_rule": {
+        "sequence": [
+          {
+            "if_true": {
+              "random_name": "minecraft:bedrock_floor",
+              "true_at_and_below": {
+                "above_bottom": 0
+              },
+              "false_at_and_above": {
+                "above_bottom": 6
+              },
+              "type": "minecraft:vertical_gradient"
+            },
+            "then_run": {
+              "result_state": {
+                "Name": "minecraft:bedrock"
+              },
+              "type": "minecraft:block"
+            },
+            "type": "minecraft:condition"
+          }
+        ],
+        "type": "minecraft:sequence"
+      },
+      "sea_level": 128,
+      "structures": {
+        "structures": {}
+      },
+      "noise": {
+        "terrain_shaper": {
+          "offset": {
+            "coordinate": "continents",
+            "points": [
+              {
+                "location": -1.25,
+                "value": 0.0,
+                "derivative": 0.0
+              },
+              {
+                "location": -0.25,
+                "value": 0.25,
+                "derivative": 0.0
+              },
+              {
+                "location": 0.0,
+                "value": 1.0,
+                "derivative": 0.25
+              },
+              {
+                "location": 1.25,
+                "value": 1.25,
+                "derivative": 0.0
+              }
+            ]
+          },
+          "factor": 2.0,
+          "jaggedness": 0.0
+        },
+        "size_horizontal": 1,
+        "size_vertical": 1,
+        "sampling": {
+          "xz_scale": 1.0,
+          "y_scale": 1.0,
+          "xz_factor": 80.0,
+          "y_factor": 160.0
+        },
+        "top_slide": {
+          "target": -0.075,
+          "size": 2,
+          "offset": 3
+        },
+        "bottom_slide": {
+          "target": 0.125,
+          "size": 3,
+          "offset": 0
+        },
+        "min_y": -64,
+        "height": 384
+      },
+      "default_block": {
+        "Name": "minecraft:stone"
+      },
+      "default_fluid": {
+        "Properties": {
+          "level": "0"
+        },
+        "Name": "minecraft:water"
+      }
+    },
+    "biome_source": {
+      "biomes": [
+        {
+          "parameters": {
+            "erosion": 0.0,
+            "depth": 0.0,
+            "weirdness": 0.0,
+            "offset": 0.0,
+            "temperature": 0.0,
+            "humidity": 0.0,
+            "continentalness": [
+              -1.25,
+              -0.35
+            ],
+            "extensions": {
+              "climate_parameter_extensions_test:height": [
+                0.0,
+                0.65
+              ]
+            }
+          },
+          "biome": "minecraft:ocean"
+        },
+        {
+          "parameters": {
+            "erosion": 0.0,
+            "depth": 0.0,
+            "weirdness": 0.0,
+            "offset": 0.0,
+            "temperature": 0.0,
+            "humidity": 0.0,
+            "continentalness": [
+              -1.25,
+              -0.35
+            ],
+            "extensions": {
+              "climate_parameter_extensions_test:height": [
+                0.0,
+                0.65
+              ],
+              "climate_parameter_extensions_test:moddedness": [
+                0.4,
+                1.0
+              ]
+            }
+          },
+          "biome": "minecraft:frozen_ocean"
+        },
+        {
+          "parameters": {
+            "erosion": 0.0,
+            "depth": 0.0,
+            "weirdness": 0.0,
+            "offset": 0.0,
+            "temperature": 0.0,
+            "humidity": 0.0,
+            "continentalness": 0,
+            "extensions": {
+              "climate_parameter_extensions_test:height": [
+                0.0,
+                0.65
+              ],
+              "climate_parameter_extensions_test:moddedness": [
+                -1.0,
+                1.0
+              ]
+            }
+          },
+          "biome": "minecraft:forest"
+        },
+        {
+          "parameters": {
+            "erosion": 0.0,
+            "depth": 0.0,
+            "weirdness": 0.0,
+            "offset": 0.0,
+            "temperature": 0.0,
+            "humidity": 0.0,
+            "continentalness": 0,
+            "extensions": {
+              "climate_parameter_extensions_test:height": [
+                0.65,
+                1.0
+              ],
+              "climate_parameter_extensions_test:moddedness": [
+                -1.0,
+                1.0
+              ]
+            }
+          },
+          "biome": "minecraft:snowy_slopes"
+        }
+      ],
+      "type": "minecraft:multi_noise"
+    }
+  }
+}


### PR DESCRIPTION
# Background
Minecraft 1.18 introduced the `MultiNoiseBiomeSource`, a biome source in which biomes get distributed by climate parameter points. Every climate parameter point is made up of 7 climate parameters: `temperature`, `humidity`, `continentalness`, `erosion`, `depth`, `weirdness`, and `offset`.
A `ParameterList` contains parameter points paired with biomes and is used to search for the most fitting biome for a sampled `TargetPoint`. A `TargetPoint` contains sampled values for every climate parameter, excluding `offset`.

There is a video by Henrik Kniberg that goes into detail about how the multi-noise biome source works and what each of the climate parameters does: https://www.youtube.com/watch?v=TycBrFKEteU

All of these parameters uniquely customize the distribution of biomes, but there is a flaw with the system. When people add a new biome to an existing configured `MultiNoiseBiomeSource`, there tend to be awkward distribution issues because specific areas have gotten sliced for specific biome sections.
For example, a mod that adds a new ocean biome to the overworld has tight constraints because the only climate parameter that differentiates the overworld's oceans is `temperature`. One solution to this problem is to add a new climate parameter for a slice of the world that will use that mod's ocean distribution, but that is easier said than done.

## Implementation
`Climate` and `NoiseSampler` have gotten patched to allow for extensible, and highly customizable, climate parameters.
A new system has gotten added to Forge's `BiomeManager` class that handles the extensible climate parameters.
New climate parameters are added by calling the `BiomeManager#addClimateParameter(...)` method during mod loading.

However, this is only one step needed for compatible modification of multi-noise biome sources as a simple way to add new entries to configured multi-noise biome sources currently doesn't exist.
Fortunately, there is a PR open right now that adds this missing step: <https://github.com/MinecraftForge/MinecraftForge/pull/8316>

## Test Mod
The `climate_parameter_extensions_test` test mod adds two new climate parameters: `height` and `moddedness`.

`height` is a parameter value between 0 and 1 inclusive that's a percentage of the dimension's height.
`moddedness` is a parameter value that uses a new noise that comes in a large form when large biomes are enabled.

A new dimension file is located at `/data/climate_parameter_extensions_test/dimension/extended.json` and makes use of these two added climate parameters.

## Concerns
### Performance Impacts
Multi-noise sampling is frequently processed, and a large amount of added climate parameters may slow world generation down for all multi-noise biome sources. During my testing with 7 added climate parameters (double the amount of vanilla), I did not notice any slowing of worldgen performance on my laptop and PC, but other machines should get tested.
### Risks of affecting existing systems
There may be mods with custom systems that assume only 7 climate parameters are possible, and this PR could mess up distributions or even break them.
### Distribution issues can still occur if used incorrectly
If new biome entries get added to configured multi-noise biome sources without accounting for the possibility that other mods may want to do the same, distribution issues can still occur. Essentially, modders need to be aware that other mods may add their own slices and should modify the entires of configured multi-noise biome sources with that in mind.