### PR TITLE
Apply nullable annotations to LootingLevelEvent

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -347,7 +347,7 @@ public class ForgeHooks
         return (MinecraftForge.EVENT_BUS.post(event) ? null : new float[]{event.getDistance(), event.getDamageMultiplier()});
     }
 
-    public static int getLootingLevel(Entity target, @Nullable Entity killer, DamageSource cause)
+    public static int getLootingLevel(Entity target, @Nullable Entity killer, @Nullable DamageSource cause)
     {
         int looting = 0;
         if (killer instanceof LivingEntity)
@@ -357,7 +357,7 @@ public class ForgeHooks
         return looting;
     }
 
-    public static int getLootingLevel(LivingEntity target, DamageSource cause, int level)
+    public static int getLootingLevel(LivingEntity target, @Nullable DamageSource cause, int level)
     {
         LootingLevelEvent event = new LootingLevelEvent(target, cause, level);
         MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -20,20 +20,25 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.world.damagesource.DamageSource;
 
 public class LootingLevelEvent extends LivingEvent {
 
+    @Nullable
     private final DamageSource damageSource;
 
     private int lootingLevel;
 
-    public LootingLevelEvent(LivingEntity entity, DamageSource damageSource, int lootingLevel) {
+    public LootingLevelEvent(LivingEntity entity, @Nullable DamageSource damageSource, int lootingLevel) {
         super(entity);
         this.damageSource = damageSource;
         this.lootingLevel = lootingLevel;
     }
 
+    @Nullable
     public DamageSource getDamageSource() {
         return damageSource;
     }


### PR DESCRIPTION
The DamageSource parameter is incorrectly not marked as nullable in the call chain for this event.  Forge calls it with a (potentially) null parameter in the LootContext patch
https://github.com/MinecraftForge/MinecraftForge/blob/476e20ae96014a13731068c96dfb5d095134d0f8/patches/minecraft/net/minecraft/world/level/storage/loot/LootContext.java.patch#L7-L10
`m_78953_` -> `getParamOrNull`

This PR applies the `@Nullable` annotations all the way up the call chain, and would close #7714 