### PR TITLE
[1.18.x] Use wither as griefing entity for roses

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -193,7 +193,7 @@
           boolean flag = false;
           if (p_21269_ instanceof WitherBoss) {
 -            if (this.f_19853_.m_46469_().m_46207_(GameRules.f_46132_)) {
-+            if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.f_19853_, this)) {
++            if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.f_19853_, p_21269_)) {
                 BlockPos blockpos = this.m_142538_();
                 BlockState blockstate = Blocks.f_50070_.m_49966_();
 -               if (this.f_19853_.m_8055_(blockpos).m_60795_() && blockstate.m_60710_(this.f_19853_, blockpos)) {


### PR DESCRIPTION
A MobGriefingEvent is fired when a LivingEntity is killed by a WitherEntity, the outcome of the event is used to determine whether to create a WitherRoseBlock or WitherRose item.

The entity passed to the MobGriefingEvent is currently the LivingEntity being killed, but I feel that it would be more intuitive if it was the WitherEntity itself.
All other mobGriefing events are based on the entity taking an action (movement, attacking etc.) so it feels like the attacking Wither should be the owner of this particular behaviour, rather than the entity who is passively dying.

I realise this deviates slightly from how the other MobGriefingEvents are done, so I'll accept this being rejected if its not something that warrants consideration/discussion.

Context:
I have a mod that toggles mobGriefing for individual entity types separately.
The Wither killing entities with different mobGriefing values feels awkward, because some will turn in to blocks and others will turn in to items.  
Switching the griefing entity to the Wither for this event allows that behaviour to be consistent again.

This PR is a new version of #7763, based off the 1.18.x branch, due to issues with merging/renaming branches.