### PR TITLE
Fix regressions for onAddedTo/RemovedFromWorld and related events

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -104,15 +104,19 @@
        }
     }
  
-@@ -764,7 +_,48 @@
+@@ -764,7 +_,56 @@
        this.m_8853_(p_8846_);
     }
  
++   /** @deprecated To be removed in 1.19. See {@link #removePlayerImmediately(ServerPlayer, Entity.RemovalReason)} as a possible replacement. */
++   @Deprecated(forRemoval = true, since = "1.18.1")
 +   public void removePlayer(ServerPlayer p_8850_, boolean keepData) {
 +      p_8850_.m_146870_();
 +      this.removeEntity(p_8850_, keepData);
 +   }
 +
++   /** @deprecated To be removed in 1.19. See {@link Entity#setRemoved(Entity.RemovalReason)} as a possible replacement. */
++   @Deprecated(forRemoval = true, since = "1.18.1")
 +   public void removeEntityComplete(Entity p_8865_, boolean keepData) {
 +      if(p_8865_.isMultipartEntity()) {
 +         for(net.minecraftforge.entity.PartEntity<?> parts : p_8865_.getParts()) {
@@ -136,10 +140,14 @@
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_8865_, this));
 +   }
 +
++   /** @deprecated To be removed in 1.19. See {@link Entity#setRemoved(Entity.RemovalReason)} as a possible replacement. */
++   @Deprecated(forRemoval = true, since = "1.18.1")
 +   public void removeEntity(Entity entity) {
 +      removeEntity(entity, false);
 +   }
 +
++   /** @deprecated To be removed in 1.19. See {@link Entity#setRemoved(Entity.RemovalReason)} as a possible replacement. */
++   @Deprecated(forRemoval = true, since = "1.18.1")
 +   public void removeEntity(Entity p_8868_, boolean keepData) {
 +      if (this.f_8557_) {
 +         throw (IllegalStateException) net.minecraft.Util.m_137570_(new IllegalStateException("Removing entity while ticking!"));

--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -104,7 +104,7 @@
        }
     }
  
-@@ -764,7 +_,56 @@
+@@ -764,7 +_,55 @@
        this.m_8853_(p_8846_);
     }
  
@@ -135,9 +135,8 @@
 +         this.f_143246_.remove(((Mob)p_8865_).m_21573_());
 +      }
 +
-+      p_8865_.onRemovedFromWorld();
 +      p_8865_.m_146870_();
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_8865_, this));
++      // onRemovedFromWorld and EntityLeaveWorldEvent are called by discard, so no need to do it ourselves here lest we double-call
 +   }
 +
 +   /** @deprecated To be removed in 1.19. See {@link Entity#setRemoved(Entity.RemovalReason)} as a possible replacement. */

--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -253,3 +253,12 @@
                 ServerLevel.this.f_143247_.remove(enderdragonpart.m_142049_());
              }
           }
+@@ -1531,6 +_,8 @@
+             gameeventlistenerregistrar.m_157854_(p_143375_.f_19853_);
+          }
+ 
++         p_143375_.onRemovedFromWorld();
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_143375_, ServerLevel.this));
+       }
+    }
+ }

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -8,7 +8,7 @@
        boolean flag = this.f_19853_.m_46469_().m_46207_(GameRules.f_46142_);
        if (flag) {
           Component component = this.m_21231_().m_19293_();
-@@ -685,13 +_,14 @@
+@@ -685,11 +_,12 @@
     }
  
     @Nullable
@@ -21,19 +21,14 @@
 -      if (resourcekey == Level.f_46430_ && p_9180_.m_46472_() == Level.f_46428_) {
 +      if (resourcekey == Level.f_46430_ && p_9180_.m_46472_() == Level.f_46428_ && teleporter.isVanilla()) { //Forge: Fix non-vanilla teleporters triggering end credits
           this.m_19877_();
--         this.m_183503_().m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
-+         this.m_183503_().removePlayer(this, true); //Forge: The player entity is cloned so keep the data until after cloning calls copyFrom
+          this.m_183503_().m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
           if (!this.f_8944_) {
-             this.f_8944_ = true;
-             this.f_8906_.m_141995_(new ClientboundGameEventPacket(ClientboundGameEventPacket.f_132157_, this.f_8928_ ? 0.0F : 1.0F));
-@@ -705,14 +_,15 @@
-          this.f_8906_.m_141995_(new ClientboundChangeDifficultyPacket(leveldata.m_5472_(), leveldata.m_5474_()));
+@@ -706,13 +_,14 @@
           PlayerList playerlist = this.f_8924_.m_6846_();
           playerlist.m_11289_(this);
--         serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
+          serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
 -         this.m_146912_();
 -         PortalInfo portalinfo = this.m_7937_(p_9180_);
-+         serverlevel.removeEntity(this, true); //Forge: the player entity is moved to the new world, NOT cloned. So keep the data alive with no matching invalidate call.
 +         this.revive();
 +         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_9180_, this::m_7937_);
           if (portalinfo != null) {
@@ -182,9 +177,8 @@
           this.f_8906_.m_141995_(new ClientboundRespawnPacket(p_9000_.m_6042_(), p_9000_.m_46472_(), BiomeManager.m_47877_(p_9000_.m_7328_()), this.f_8941_.m_9290_(), this.f_8941_.m_9293_(), p_9000_.m_46659_(), p_9000_.m_8584_(), true));
           this.f_8906_.m_141995_(new ClientboundChangeDifficultyPacket(leveldata.m_5472_(), leveldata.m_5474_()));
           this.f_8924_.m_6846_().m_11289_(this);
--         serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
+          serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
 -         this.m_146912_();
-+         serverlevel.removePlayer(this, true); //Forge: The player entity itself is moved, and not cloned. So we need to keep the data alive with no matching invalidate call later.
 +         this.revive();
           this.m_7678_(p_9001_, p_9002_, p_9003_, p_9004_, p_9005_);
           this.m_143425_(p_9000_);

--- a/patches/minecraft/net/minecraft/world/level/entity/PersistentEntitySectionManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/entity/PersistentEntitySectionManager.java.patch
@@ -17,6 +17,29 @@
        if (!this.m_157557_(p_157539_)) {
           return false;
        } else {
+@@ -104,12 +_,14 @@
+    public void m_157552_(Stream<T> p_157553_) {
+       p_157553_.forEach((p_157607_) -> {
+          this.m_157538_(p_157607_, true);
++         if (p_157607_ instanceof Entity entity) entity.onAddedToWorld();
+       });
+    }
+ 
+    public void m_157559_(Stream<T> p_157560_) {
+       p_157560_.forEach((p_157605_) -> {
+          this.m_157538_(p_157605_, false);
++         if (p_157605_ instanceof Entity entity) entity.onAddedToWorld();
+       });
+    }
+ 
+@@ -248,6 +_,7 @@
+       while((chunkentities = this.f_157500_.poll()) != null) {
+          chunkentities.m_156792_().forEach((p_157593_) -> {
+             this.m_157538_(p_157593_, true);
++            if (p_157593_ instanceof Entity entity) entity.onAddedToWorld();
+          });
+          this.f_157498_.put(chunkentities.m_156791_().m_45588_(), PersistentEntitySectionManager.ChunkLoadStatus.LOADED);
+       }
 @@ -350,11 +_,13 @@
  
     class Callback implements EntityInLevelCallback {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -148,6 +148,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
      *
      * @return True if this entity is being tracked by a world
      */
+    // TODO: rename in 1.19 to isAddedToLevel
     boolean isAddedToWorld();
 
     /**
@@ -155,6 +156,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
      * ticking list. Can be overriden, but needs to call super
      * to prevent MC-136995.
      */
+    // TODO: rename in 1.19 to onAddedToLevel
     void onAddedToWorld();
 
     /**
@@ -162,6 +164,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
      * ticking list. Can be overriden, but needs to call super
      * to prevent MC-136995.
      */
+    // TODO: rename in 1.19 to onRemovedFromLevel
     void onRemovedFromWorld();
 
     /**


### PR DESCRIPTION
This PR fixes some regressions relating to entities:
- Terminally deprecates the `ServerLevel#removeEntityComplete` family of methods, as they've been made redundant by Mojang's changes to entity removal mechanics. This also removes existing calls to those methods, which fixes #8262.
  To be more specific, the removal mechanics are now handled by the entity callbacks in `ServerLevel.EntityCallbacks` anad `ClientLevel.EntityCallbacks`, which are invoked by `Entity#setRemoved` calls.
- Adds missing calls to `Entity#onAddedToWorld`, `Entity#onRemovedFromWorld`, and `EntityLeaveWorldEvent` for various situations, which fixes #8427 and fixes #8448.

Please see the individual commits and their messages for a bit more detail regarding these changes.