### PR TITLE
Fix long keybinds making shorter ones unreadable

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/controls/KeyBindsList.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/controls/KeyBindsList.java.patch
@@ -1,6 +1,38 @@
 --- a/net/minecraft/client/gui/screens/controls/KeyBindsList.java
 +++ b/net/minecraft/client/gui/screens/controls/KeyBindsList.java
-@@ -51,7 +_,7 @@
+@@ -40,18 +_,37 @@
+          }
+ 
+          Component component = Component.m_237115_(keymapping.m_90860_());
+-         int i = p_193862_.f_91062_.m_92852_(component);
++
++         // FORGE: max width for the keybind descriptions to make all readable, clip any strings that are too long
++         String plainText = component.getString();
++         String clippedMessage = "";
++
++         int i = 0;
++
++         for (int j = 0; j <= plainText.length(); j++) {
++            String checkString = plainText.substring(0, j);
++            i = p_193862_.f_91062_.m_92895_(plainText.substring(0, j));
++            if(i <= 185) {
++               clippedMessage = checkString;
++            } else {
++               clippedMessage = clippedMessage.substring(0, Math.max(clippedMessage.length() - 3, 0));
++               clippedMessage += "...";
++               i = p_193862_.f_91062_.m_92895_(clippedMessage);
++               break;
++            }
++         }
++
+          if (i > this.f_193859_) {
+             this.f_193859_ = i;
+          }
+ 
+-         this.m_7085_(new KeyBindsList.KeyEntry(keymapping, component));
++         this.m_7085_(new KeyBindsList.KeyEntry(keymapping, Component.m_237113_(clippedMessage)));
+       }
+ 
     }
  
     protected int m_5756_() {


### PR DESCRIPTION
In mods such as JEI at the default scaling value their translation strings can be too long making the text unreadable for other mods.
![image](https://user-images.githubusercontent.com/3209834/151677047-376dcfd9-420a-4810-983d-4351102cb9ba.png)

![image](https://user-images.githubusercontent.com/3209834/151676930-4c792988-3aa4-4ef6-af5d-66391888b5a4.png)

Fix
![image](https://user-images.githubusercontent.com/3209834/151676967-a63c682a-396b-4548-802b-c30e6018dbe5.png)

Just adding a max limit to how far they can offset so only mods with long names are affected.

I was considering making it change the text to ... but that would cause issues where you are right at the border and want another symbol, so decided this was probably better.