### PR TITLE
Add Forge default Fluid Physic tag

### DIFF
--- a/patches/minecraft/net/minecraft/tags/FluidTags.java.patch
+++ b/patches/minecraft/net/minecraft/tags/FluidTags.java.patch
@@ -1,20 +1,9 @@
 --- a/net/minecraft/tags/FluidTags.java
 +++ b/net/minecraft/tags/FluidTags.java
-@@ -11,6 +_,9 @@
-    public static final Tag.Named<Fluid> f_13131_ = m_13134_("water");
-    public static final Tag.Named<Fluid> f_13132_ = m_13134_("lava");
- 
-+   /** Default Fluid Tag for Physics */
-+   public static final Tag.Named<Fluid> DEFAULT = m_13134_("default");
-+
-    private FluidTags() {
-    }
- 
-@@ -28,5 +_,13 @@
-    @Deprecated
+@@ -29,4 +_,12 @@
     public static List<Tag<Fluid>> m_144300_() {
        return f_144297_;
-+   }
+    }
 +
 +   public static net.minecraftforge.common.Tags.IOptionalNamedTag<Fluid> createOptional(net.minecraft.resources.ResourceLocation name) {
 +      return createOptional(name, null);
@@ -22,5 +11,5 @@
 +
 +   public static net.minecraftforge.common.Tags.IOptionalNamedTag<Fluid> createOptional(net.minecraft.resources.ResourceLocation name, @javax.annotation.Nullable java.util.Set<java.util.function.Supplier<Fluid>> defaults) {
 +      return f_13130_.createOptional(name, defaults);
-    }
++   }
  }

--- a/patches/minecraft/net/minecraft/tags/FluidTags.java.patch
+++ b/patches/minecraft/net/minecraft/tags/FluidTags.java.patch
@@ -1,9 +1,20 @@
 --- a/net/minecraft/tags/FluidTags.java
 +++ b/net/minecraft/tags/FluidTags.java
-@@ -29,4 +_,12 @@
+@@ -11,6 +_,9 @@
+    public static final Tag.Named<Fluid> f_13131_ = m_13134_("water");
+    public static final Tag.Named<Fluid> f_13132_ = m_13134_("lava");
+ 
++   /** Default Fluid Tag for Physics */
++   public static final Tag.Named<Fluid> DEFAULT = m_13134_("default");
++
+    private FluidTags() {
+    }
+ 
+@@ -28,5 +_,13 @@
+    @Deprecated
     public static List<Tag<Fluid>> m_144300_() {
        return f_144297_;
-    }
++   }
 +
 +   public static net.minecraftforge.common.Tags.IOptionalNamedTag<Fluid> createOptional(net.minecraft.resources.ResourceLocation name) {
 +      return createOptional(name, null);
@@ -11,5 +22,5 @@
 +
 +   public static net.minecraftforge.common.Tags.IOptionalNamedTag<Fluid> createOptional(net.minecraft.resources.ResourceLocation name, @javax.annotation.Nullable java.util.Set<java.util.function.Supplier<Fluid>> defaults) {
 +      return f_13130_.createOptional(name, defaults);
-+   }
+    }
  }

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -1,6 +1,10 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -114,7 +_,7 @@
+@@ -111,10 +_,11 @@
+ import net.minecraft.world.phys.shapes.VoxelShape;
+ import net.minecraft.world.scores.PlayerTeam;
+ import net.minecraft.world.scores.Team;
++import net.minecraftforge.common.Tags;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -125,6 +129,33 @@
           this.m_5496_(soundtype.m_56776_(), soundtype.m_56773_() * 0.15F, soundtype.m_56774_());
        }
     }
+@@ -1042,7 +_,7 @@
+       if (this.m_6069_()) {
+          this.m_20282_(this.m_20142_() && this.m_20069_() && !this.m_20159_());
+       } else {
+-         this.m_20282_(this.m_20142_() && this.m_5842_() && !this.m_20159_() && this.f_19853_.m_6425_(this.f_19826_).m_76153_(FluidTags.f_13131_));
++         this.m_20282_(this.m_20142_() && this.m_5842_() && !this.m_20159_() && this.f_19853_.m_6425_(this.f_19826_).m_76153_(FluidTags.f_13131_) || this.f_19853_.m_6425_(this.f_19826_).m_76153_(Tags.Fluids.DEFAULT_FLUID_PHYSIC));
+       }
+ 
+    }
+@@ -1058,7 +_,7 @@
+    void m_20074_() {
+       if (this.m_20202_() instanceof Boat) {
+          this.f_19798_ = false;
+-      } else if (this.m_19943_(FluidTags.f_13131_, 0.014D)) {
++      } else if (this.m_19943_(FluidTags.f_13131_, 0.014D) || this.m_19943_(Tags.Fluids.DEFAULT_FLUID_PHYSIC, 0.014D)) {
+          if (!this.f_19798_ && !this.f_19803_) {
+             this.m_5841_();
+          }
+@@ -1073,7 +_,7 @@
+    }
+ 
+    private void m_20323_() {
+-      this.f_19800_ = this.m_19941_(FluidTags.f_13131_);
++      this.f_19800_ = this.m_19941_(FluidTags.f_13131_) || this.m_19941_(Tags.Fluids.DEFAULT_FLUID_PHYSIC);
+       this.f_19801_ = null;
+       double d0 = this.m_20188_() - (double)0.11111111F;
+       Entity entity = this.m_20202_();
 @@ -1142,9 +_,10 @@
        int k = Mth.m_14107_(this.m_20189_());
        BlockPos blockpos = new BlockPos(i, j, k);

--- a/src/generated/resources/data/forge/tags/fluids/default_fluid_physic.json
+++ b/src/generated/resources/data/forge/tags/fluids/default_fluid_physic.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -23,7 +23,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.Tag.Named;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -23,6 +23,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.Tag;
 import net.minecraft.tags.Tag.Named;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
@@ -421,6 +422,7 @@ public class Tags
         private static void init() {}
 
         public static final IOptionalNamedTag<Fluid> MILK = tag("milk");
+        public static final IOptionalNamedTag<Fluid> DEFAULT_FLUID_PHYSIC = tag("default_fluid_physic");
 
         private static IOptionalNamedTag<Fluid> tag(String name)
         {


### PR DESCRIPTION
This is a PR that add the Tag ```"forge:fluid_physics"``` if you add your fluid to it, It has the Water Physic (so can it not anymore brake recpies or a other things that you need for fluid Tag checks)