### PR TITLE
Fix issues with client only commands

### DIFF
--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -162,15 +162,17 @@ public class ClientCommandHandler
      */
     private static <S> void copy(CommandNode<S> sourceNode, CommandNode<S> resultNode)
     {
+        Map<CommandNode<S>, CommandNode<S>> newNodes = new IdentityHashMap<>();
+        newNodes.put(sourceNode, resultNode);
         for (CommandNode<S> child : sourceNode.getChildren())
         {
-            ArgumentBuilder<S, ?> builder = child.createBuilder();
-            CommandNode<S> copy = builder.build();
-            // prevent infinite recursion
-            if (child != sourceNode)
+            CommandNode<S> copy = newNodes.computeIfAbsent(child, innerChild ->
             {
-                copy(child, copy);
-            }
+                ArgumentBuilder<S, ?> builder = innerChild.createBuilder();
+                CommandNode<S> innerCopy = builder.build();
+                copy(innerChild, innerCopy);
+                return innerCopy;
+            });
             resultNode.addChild(copy);
         }
     }

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -305,31 +305,28 @@ public class ClientCommandHandler
             if (syntax.getType() == CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand())
             {
                 // in case of unknown command, let the server try and handle it
-                Minecraft.getInstance().player.chat(sendMessage);
+                return false;
             }
-            else
+            Minecraft.getInstance().player.sendMessage(
+                    new TextComponent("").append(ComponentUtils.fromMessage(syntax.getRawMessage())).withStyle(ChatFormatting.RED), Util.NIL_UUID);
+            if (syntax.getInput() != null && syntax.getCursor() >= 0)
             {
-                Minecraft.getInstance().player.sendMessage(
-                        new TextComponent("").append(ComponentUtils.fromMessage(syntax.getRawMessage())).withStyle(ChatFormatting.RED), Util.NIL_UUID);
-                if (syntax.getInput() != null && syntax.getCursor() >= 0)
+                int position = Math.min(syntax.getInput().length(), syntax.getCursor());
+                MutableComponent details = new TextComponent("")
+                        .withStyle(ChatFormatting.GRAY)
+                        .withStyle((style) -> style
+                                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, reader.getString())));
+                if (position > 10)
                 {
-                    int position = Math.min(syntax.getInput().length(), syntax.getCursor());
-                    MutableComponent details = new TextComponent("")
-                            .withStyle(ChatFormatting.GRAY)
-                            .withStyle((style) -> style
-                                    .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, reader.getString())));
-                    if (position > 10)
-                    {
-                        details.append("...");
-                    }
-                    details.append(syntax.getInput().substring(Math.max(0, position - 10), position));
-                    if (position < syntax.getInput().length())
-                    {
-                        details.append(new TextComponent(syntax.getInput().substring(position)).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE));
-                    }
-                    details.append(new TranslatableComponent("command.context.here").withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
-                    Minecraft.getInstance().player.sendMessage(new TextComponent("").append(details).withStyle(ChatFormatting.RED), Util.NIL_UUID);
+                    details.append("...");
                 }
+                details.append(syntax.getInput().substring(Math.max(0, position - 10), position));
+                if (position < syntax.getInput().length())
+                {
+                    details.append(new TextComponent(syntax.getInput().substring(position)).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE));
+                }
+                details.append(new TranslatableComponent("command.context.here").withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
+                Minecraft.getInstance().player.sendMessage(new TextComponent("").append(details).withStyle(ChatFormatting.RED), Util.NIL_UUID);
             }
         }
         catch (Exception generic)// Probably thrown by the command

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -278,26 +278,34 @@ public class ClientCommandHandler
         }
         catch (CommandSyntaxException syntax)// Usually thrown by the CommandDispatcher
         {
-            Minecraft.getInstance().player.sendMessage(
-                    new TextComponent("").append(ComponentUtils.fromMessage(syntax.getRawMessage())).withStyle(ChatFormatting.RED), Util.NIL_UUID);
-            if (syntax.getInput() != null && syntax.getCursor() >= 0)
+            if (syntax.getType() == CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand())
             {
-                int position = Math.min(syntax.getInput().length(), syntax.getCursor());
-                MutableComponent details = new TextComponent("")
-                        .withStyle(ChatFormatting.GRAY)
-                        .withStyle((style) -> style
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, reader.getString())));
-                if (position > 10)
+                // in case of unknown command, let the server try and handle it
+                Minecraft.getInstance().player.chat(sendMessage);
+            }
+            else
+            {
+                Minecraft.getInstance().player.sendMessage(
+                        new TextComponent("").append(ComponentUtils.fromMessage(syntax.getRawMessage())).withStyle(ChatFormatting.RED), Util.NIL_UUID);
+                if (syntax.getInput() != null && syntax.getCursor() >= 0)
                 {
-                    details.append("...");
+                    int position = Math.min(syntax.getInput().length(), syntax.getCursor());
+                    MutableComponent details = new TextComponent("")
+                            .withStyle(ChatFormatting.GRAY)
+                            .withStyle((style) -> style
+                                    .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, reader.getString())));
+                    if (position > 10)
+                    {
+                        details.append("...");
+                    }
+                    details.append(syntax.getInput().substring(Math.max(0, position - 10), position));
+                    if (position < syntax.getInput().length())
+                    {
+                        details.append(new TextComponent(syntax.getInput().substring(position)).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE));
+                    }
+                    details.append(new TranslatableComponent("command.context.here").withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
+                    Minecraft.getInstance().player.sendMessage(new TextComponent("").append(details).withStyle(ChatFormatting.RED), Util.NIL_UUID);
                 }
-                details.append(syntax.getInput().substring(Math.max(0, position - 10), position));
-                if (position < syntax.getInput().length())
-                {
-                    details.append(new TextComponent(syntax.getInput().substring(position)).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE));
-                }
-                details.append(new TranslatableComponent("command.context.here").withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
-                Minecraft.getInstance().player.sendMessage(new TextComponent("").append(details).withStyle(ChatFormatting.RED), Util.NIL_UUID);
             }
         }
         catch (Exception generic)// Probably thrown by the command

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -19,8 +19,11 @@
 
 package net.minecraftforge.common;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,6 +55,7 @@ public class MinecraftForge
 
        UsernameCache.load();
        TierSortingRegistry.init();
+       if (FMLEnvironment.dist == Dist.CLIENT) ClientCommandHandler.init();
    }
 
 /*

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -71,6 +71,7 @@ public net.minecraft.client.gui.screens.Screen f_169369_ # renderables
 public net.minecraft.client.gui.screens.worldselection.WorldGenSettingsComponent m_101404_(Lnet/minecraft/world/level/levelgen/WorldGenSettings;)V # updateSettings
 public net.minecraft.client.model.geom.LayerDefinitions f_171106_ # OUTER_ARMOR_DEFORMATION
 public net.minecraft.client.model.geom.LayerDefinitions f_171107_ # INNER_ARMOR_DEFORMATION
+public net.minecraft.client.multiplayer.ClientPacketListener f_104899_ # commands
 public net.minecraft.client.particle.ParticleEngine m_107378_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleEngine$SpriteParticleRegistration;)V # register
 public net.minecraft.client.particle.ParticleEngine m_107381_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V # register
 public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration


### PR DESCRIPTION
Fixes #8438. Fixes #8456.

1. Handles commands which are unknown on the client more gracefully, by delegating to the server. This fixes #8438. 
    Verified with local PaperMC + LuckPerms installation.
2. Improves handling of badly formed (infinite recursion) or absent command packets from some server implementations. This fixes #8456.
    Verified with local Limbo installation (with commands and without, through permissions).