### PR TITLE
Add missing Locale parameter to String.format calls

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,7 +86,7 @@ public class ModList
     }
 
     private String fileToLine(IModFile mf) {
-        return String.format("%-50.50s|%-30.30s|%-30.30s|%-20.20s|%-10.10s|Manifest: %s", mf.getFileName(),
+        return String.format(Locale.ENGLISH, "%-50.50s|%-30.30s|%-30.30s|%-20.20s|%-10.10s|Manifest: %s", mf.getFileName(),
                 mf.getModInfos().get(0).getDisplayName(),
                 mf.getModInfos().get(0).getModId(),
                 mf.getModInfos().get(0).getVersion(),

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,7 @@ import net.minecraftforge.fml.loading.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 public class ModConfig
@@ -54,7 +55,7 @@ public class ModConfig
 
     private static String defaultConfigName(Type type, String modId) {
         // config file name would be "forge-client.toml" and "forge-server.toml"
-        return String.format("%s-%s.toml", modId, type.extension());
+        return String.format(Locale.ROOT, "%s-%s.toml", modId, type.extension());
     }
     public Type getType() {
         return type;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,13 +21,15 @@ package net.minecraftforge.fml.loading.moddiscovery;
 
 import net.minecraftforge.forgespi.language.IModFileInfo;
 
+import java.util.Locale;
+
 public class InvalidModFileException extends RuntimeException
 {
     private final IModFileInfo modFileInfo;
 
     public InvalidModFileException(String message, IModFileInfo modFileInfo)
     {
-        super(String.format("%s (%s)", message, ((ModFileInfo)modFileInfo).getFile().getFileName()));
+        super(String.format(Locale.ENGLISH, "%s (%s)", message, ((ModFileInfo)modFileInfo).getFile().getFileName()));
         this.modFileInfo = modFileInfo;
     }
 }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
@@ -73,7 +73,7 @@
 +         domain = texture.substring(0, idx);
 +         texture = texture.substring(idx + 1);
 +      }
-+      String s1 = String.format(java.util.Locale.ROOT, "%s:textures/models/armor/%s_layer_%d%s.png", domain, texture, (m_117128_(slot) ? 2 : 1), type == null ? "" : String.format("_%s", type));
++      String s1 = String.format(java.util.Locale.ROOT, "%s:textures/models/armor/%s_layer_%d%s.png", domain, texture, (m_117128_(slot) ? 2 : 1), type == null ? "" : String.format(java.util.Locale.ROOT, "_%s", type));
 +
 +      s1 = net.minecraftforge.client.ForgeHooksClient.getArmorTexture(entity, stack, s1, slot, type);
 +      ResourceLocation resourcelocation = f_117070_.get(s1);

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
@@ -73,7 +73,7 @@
 +         domain = texture.substring(0, idx);
 +         texture = texture.substring(idx + 1);
 +      }
-+      String s1 = String.format("%s:textures/models/armor/%s_layer_%d%s.png", domain, texture, (m_117128_(slot) ? 2 : 1), type == null ? "" : String.format("_%s", type));
++      String s1 = String.format(java.util.Locale.ROOT, "%s:textures/models/armor/%s_layer_%d%s.png", domain, texture, (m_117128_(slot) ? 2 : 1), type == null ? "" : String.format("_%s", type));
 +
 +      s1 = net.minecraftforge.client.ForgeHooksClient.getArmorTexture(entity, stack, s1, slot, type);
 +      ResourceLocation resourcelocation = f_117070_.get(s1);

--- a/patches/minecraft/net/minecraft/server/dedicated/ServerWatchdog.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/ServerWatchdog.java.patch
@@ -5,7 +5,7 @@
              ThreadInfo[] athreadinfo = threadmxbean.dumpAllThreads(true, true);
              StringBuilder stringbuilder = new StringBuilder();
 -            Error error = new Error("Watchdog");
-+            Error error = new Error(String.format("ServerHangWatchdog detected that a single server tick took %.2f seconds (should be max 0.05)", k / 1000F)); // Forge: don't just make a crash report with a seemingly-inexplicable Error
++            Error error = new Error(String.format(java.util.Locale.ENGLISH, "ServerHangWatchdog detected that a single server tick took %.2f seconds (should be max 0.05)", k / 1000F)); // Forge: don't just make a crash report with a seemingly-inexplicable Error
  
              for(ThreadInfo threadinfo : athreadinfo) {
                 if (threadinfo.getThreadId() == this.f_139782_.m_6304_().getId()) {

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -52,7 +52,7 @@
              this.m_9209_(serverlevel);
 +            return this;//forge: this is part of the ITeleporter patch
 +            });//Forge: End vanilla logic
-+            if (e != this) throw new java.lang.IllegalArgumentException(String.format("Teleporter %s returned not the player entity but instead %s, expected PlayerEntity %s", teleporter, e, this));
++            if (e != this) throw new java.lang.IllegalArgumentException(String.format(java.util.Locale.ENGLISH, "Teleporter %s returned not the player entity but instead %s, expected PlayerEntity %s", teleporter, e, this));
              this.f_8906_.m_141995_(new ClientboundPlayerAbilitiesPacket(this.m_150110_()));
              playerlist.m_11229_(this, p_9180_);
              playerlist.m_11292_(this);

--- a/patches/minecraft/net/minecraft/server/packs/AbstractPackResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/packs/AbstractPackResources.java.patch
@@ -8,6 +8,6 @@
 +   @Override
 +   public String toString()
 +   {
-+      return String.format("%s: %s", getClass().getName(), f_10203_.getPath());
++      return String.format(java.util.Locale.ROOT, "%s: %s", getClass().getName(), f_10203_.getPath());
 +   }
  }

--- a/src/main/java/net/minecraftforge/client/loading/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/client/loading/EarlyLoaderGUI.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,6 +34,7 @@ import org.lwjgl.system.MemoryUtil;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
 import java.nio.ByteBuffer;
+import java.util.Locale;
 
 public class EarlyLoaderGUI {
     private final Minecraft minecraft;
@@ -119,7 +120,7 @@ public class EarlyLoaderGUI {
         final MemoryUsage heapusage = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
         final MemoryUsage offheapusage = ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage();
         final float pctmemory = (float) heapusage.getUsed() / heapusage.getMax();
-        String memory = String.format("Memory Heap: %d / %d MB (%.1f%%)  OffHeap: %d MB", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, pctmemory * 100.0, offheapusage.getUsed() >> 20);
+        String memory = String.format(Locale.ENGLISH, "Memory Heap: %d / %d MB (%.1f%%)  OffHeap: %d MB", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, pctmemory * 100.0, offheapusage.getUsed() >> 20);
 
         final int i = Mth.hsvToRgb((1.0f - (float)Math.pow(pctmemory, 1.5f)) / 3f, 1.0f, 0.5f);
         memorycolour[2] = ((i) & 0xFF) / 255.0f;

--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -125,7 +125,7 @@ public class ModelLoaderRegistry
         {
             if (!loaders.containsKey(loaderId))
             {
-                throw new IllegalStateException(String.format("Model loader '%s' not found. Registered loaders: %s", loaderId,
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Model loader '%s' not found. Registered loaders: %s", loaderId,
                         loaders.keySet().stream().map(ResourceLocation::toString).collect(Collectors.joining(", "))));
             }
 

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,6 +34,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -157,7 +158,7 @@ public class B3DModel
         {
             if(brush > brushes.size())
             {
-                throw new IOException(String.format("brush %s is out of range", brush));
+                throw new IOException(String.format(Locale.ENGLISH, "brush %s is out of range", brush));
             }
             else if(brush == -1) return null;
             return brushes.get(brush);
@@ -169,7 +170,7 @@ public class B3DModel
         {
             if(vertex > vertices.size())
             {
-                throw new IOException(String.format("vertex %s is out of range", vertex));
+                throw new IOException(String.format(Locale.ENGLISH, "vertex %s is out of range", vertex));
             }
             return vertices.get(vertex);
         }
@@ -225,7 +226,7 @@ public class B3DModel
             if(version / 100 > Parser.version / 100)
                 throw new IOException("Unsupported major model version: " + ((float)version / 100));
             if(version % 100 > Parser.version % 100)
-                logger.warn(String.format("Minor version difference in model: %s", ((float)version / 100)));
+                logger.warn(String.format(Locale.ENGLISH, "Minor version difference in model: %s", ((float)version / 100)));
             List<Texture> textures = Collections.emptyList();
             List<Brush> brushes = Collections.emptyList();
             Node<?> root = null;
@@ -325,7 +326,7 @@ public class B3DModel
                         tex_coords[i] = new Vector4f(buf.getFloat(), buf.getFloat(), buf.getFloat(), buf.getFloat());
                         break;
                     default:
-                        logger.error(String.format("Unsupported number of texture coords: %s", tex_coord_set_size));
+                        logger.error(String.format(Locale.ENGLISH, "Unsupported number of texture coords: %s", tex_coord_set_size));
                         tex_coords[i] = new Vector4f(0, 0, 0, 1);
                     }
                 }
@@ -586,7 +587,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Texture [path=%s, flags=%s, blend=%s, pos=%s, scale=%s, rot=%s]", path, flags, blend, pos, scale, rot);
+            return String.format(Locale.ENGLISH, "Texture [path=%s, flags=%s, blend=%s, pos=%s, scale=%s, rot=%s]", path, flags, blend, pos, scale, rot);
         }
     }
 
@@ -642,7 +643,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Brush [name=%s, color=%s, shininess=%s, blend=%s, fx=%s, textures=%s]", name, color, shininess, blend, fx, textures);
+            return String.format(Locale.ENGLISH, "Brush [name=%s, color=%s, shininess=%s, blend=%s, fx=%s, textures=%s]", name, color, shininess, blend, fx, textures);
         }
     }
 
@@ -731,7 +732,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Vertex [pos=%s, normal=%s, color=%s, texCoords=%s]", pos, normal, color, java.util.Arrays.toString(texCoords));
+            return String.format(Locale.ENGLISH, "Vertex [pos=%s, normal=%s, color=%s, texCoords=%s]", pos, normal, color, java.util.Arrays.toString(texCoords));
         }
     }
 
@@ -780,7 +781,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Face [v1=%s, v2=%s, v3=%s]", v1, v2, v3);
+            return String.format(Locale.ENGLISH, "Face [v1=%s, v2=%s, v3=%s]", v1, v2, v3);
         }
 
         public Vector3f getNormal()
@@ -838,7 +839,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Key [pos=%s, scale=%s, rot=%s]", pos, scale, rot);
+            return String.format(Locale.ENGLISH, "Key [pos=%s, scale=%s, rot=%s]", pos, scale, rot);
         }
     }
 
@@ -880,7 +881,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Animation [flags=%s, frames=%s, fps=%s, keys=...]", flags, frames, fps);
+            return String.format(Locale.ENGLISH, "Animation [flags=%s, frames=%s, fps=%s, keys=...]", flags, frames, fps);
         }
     }
 
@@ -1007,7 +1008,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Node [name=%s, kind=%s, pos=%s, scale=%s, rot=%s, keys=..., nodes=..., animation=%s]", name, kind, pos, scale, rot, animation);
+            return String.format(Locale.ENGLISH, "Node [name=%s, kind=%s, pos=%s, scale=%s, rot=%s, keys=..., nodes=..., animation=%s]", name, kind, pos, scale, rot, animation);
         }
     }
 
@@ -1081,7 +1082,7 @@ public class B3DModel
         @Override
         public String toString()
         {
-            return String.format("Mesh [pivot=%s, brush=%s, data=...]", super.toString(), brush);
+            return String.format(Locale.ENGLISH, "Mesh [pivot=%s, brush=%s, data=...]", super.toString(), brush);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
@@ -105,6 +106,7 @@ public final class CapabilityDispatcher implements INBTSerializable<CompoundTag>
             {
                 throw new RuntimeException(
                         String.format(
+                                Locale.ENGLISH,
                                 "Provider %s.getCapability() returned null; return LazyOptional.empty() instead!",
                                 c.getClass().getTypeName()
                         )

--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,7 @@ package net.minecraftforge.event;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -235,7 +236,7 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
             public void remap(T target)
             {
                 Validate.notNull(target, "Remap target can not be null");
-                Validate.isTrue(pool.getKey(target) != null, String.format("The specified entry %s hasn't been registered in registry yet.", target));
+                Validate.isTrue(pool.getKey(target) != null, String.format(Locale.ENGLISH, "The specified entry %s hasn't been registered in registry yet.", target));
                 action = Action.REMAP;
                 this.target = target;
             }

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,6 +41,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraftforge.entity.IEntityAdditionalSpawnData;
 import net.minecraftforge.network.NetworkEvent;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -146,7 +147,7 @@ public class PlayMessages
                 EntityType<?> type = Registry.ENTITY_TYPE.byId(msg.typeId);
                 if (type == null)
                 {
-                    throw new RuntimeException(String.format("Could not spawn entity (id %d) with unknown type at (%f, %f, %f)", msg.entityId, msg.posX, msg.posY, msg.posZ));
+                    throw new RuntimeException(String.format(Locale.ENGLISH, "Could not spawn entity (id %d) with unknown type at (%f, %f, %f)", msg.entityId, msg.posX, msg.posY, msg.posZ));
                 }
 
                 Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get().getDirection().getReceptionSide());

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -351,7 +351,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
             idToUse = availabilityMap.nextClearBit(min);
 
         if (idToUse > max)
-            throw new RuntimeException(String.format("Invalid id %d - maximum id range exceeded.", idToUse));
+            throw new RuntimeException(String.format(Locale.ENGLISH, "Invalid id %d - maximum id range exceeded.", idToUse));
 
         V oldEntry = getRaw(key);
         if (oldEntry == value) // already registered, return prev registration's id
@@ -362,9 +362,9 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         if (oldEntry != null) // duplicate name
         {
             if (!this.allowOverrides)
-                throw new IllegalArgumentException(String.format("The name %s has been registered twice, for %s and %s.", key, getRaw(key), value));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "The name %s has been registered twice, for %s and %s.", key, getRaw(key), value));
             if (owner == null)
-                throw new IllegalStateException(String.format("Could not determine owner for the override on %s. Value: %s", key, value));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Could not determine owner for the override on %s. Value: %s", key, value));
             LOGGER.debug(REGISTRIES,"Registry {} Override: {} {} -> {}", this.name, key, oldEntry, value);
             idToUse = this.getID(oldEntry);
         }
@@ -373,16 +373,16 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         if (foundId != null)
         {
             V otherThing = this.ids.get(foundId);
-            throw new IllegalArgumentException(String.format("The object %s{%x} has been registered twice, using the names %s and %s. (Other object at this id is %s{%x})", value, System.identityHashCode(value), getKey(value), key, otherThing, System.identityHashCode(otherThing)));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "The object %s{%x} has been registered twice, using the names %s and %s. (Other object at this id is %s{%x})", value, System.identityHashCode(value), getKey(value), key, otherThing, System.identityHashCode(otherThing)));
         }
 
         if (isLocked())
-            throw new IllegalStateException(String.format("The object %s (name %s) is being added too late.", value, key));
+            throw new IllegalStateException(String.format(Locale.ENGLISH, "The object %s (name %s) is being added too late.", value, key));
 
         if (defaultKey != null && defaultKey.equals(key))
         {
             if (this.defaultValue != null)
-                throw new IllegalStateException(String.format("Attemped to override already set default value. This is not allowed: The object %s (name %s)", value, key));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Attemped to override already set default value. This is not allowed: The object %s (name %s)", value, key));
             this.defaultValue = value;
         }
 
@@ -432,7 +432,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     void addAlias(ResourceLocation from, ResourceLocation to)
     {
         if (this.isLocked())
-            throw new IllegalStateException(String.format("Attempted to register the alias %s -> %s to late", from, to));
+            throw new IllegalStateException(String.format(Locale.ENGLISH, "Attempted to register the alias %s -> %s to late", from, to));
 
         if (from.equals(to))
         {
@@ -447,7 +447,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     void addDummy(ResourceLocation key)
     {
         if (this.isLocked())
-            throw new IllegalStateException(String.format("Attempted to register the dummy %s to late", key));
+            throw new IllegalStateException(String.format(Locale.ENGLISH, "Attempted to register the dummy %s to late", key));
         this.dummies.add(key);
         LOGGER.trace(REGISTRIES,"Registry {} dummy: {}", this.name, key);
     }
@@ -502,23 +502,23 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
 
             // name lookup failed -> obj is not in the obj<->name map
             if (name == null)
-                throw new IllegalStateException(String.format("Registry entry for %s %s, id %d, doesn't yield a name.", registryName, obj, id));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Registry entry for %s %s, id %d, doesn't yield a name.", registryName, obj, id));
 
             // id is too high
             if (id > max)
-                throw new IllegalStateException(String.format("Registry entry for %s %s, name %s uses the too large id %d.", registryName, obj, name, id));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Registry entry for %s %s, name %s uses the too large id %d.", registryName, obj, name, id));
 
             // id -> obj lookup is inconsistent
             if (getValue(id) != obj)
-                throw new IllegalStateException(String.format("Registry entry for id %d, name %s, doesn't yield the expected %s %s.", id, name, registryName, obj));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Registry entry for id %d, name %s, doesn't yield the expected %s %s.", id, name, registryName, obj));
 
             // name -> obj lookup is inconsistent
             if (getValue(name) != obj)
-                throw new IllegalStateException(String.format("Registry entry for name %s, id %d, doesn't yield the expected %s %s.", name, id, registryName, obj));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Registry entry for name %s, id %d, doesn't yield the expected %s %s.", name, id, registryName, obj));
 
             // name -> id lookup is inconsistent
             if (getID(name) != id)
-                throw new IllegalStateException(String.format("Registry entry for name %s doesn't yield the expected id %d.", name, id));
+                throw new IllegalStateException(String.format(Locale.ENGLISH, "Registry entry for name %s doesn't yield the expected id %d.", name, id));
 
             /*
             // entry is blocked, thus should be empty

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -245,7 +245,7 @@ public class GameData
     public static <K extends IForgeRegistryEntry<K>> K register_impl(K value)
     {
         Validate.notNull(value, "Attempted to register a null object");
-        Validate.notNull(value.getRegistryName(), String.format("Attempt to register object without having set a registry name %s (type %s)", value, value.getClass().getName()));
+        Validate.notNull(value.getRegistryName(), String.format(Locale.ENGLISH, "Attempt to register object without having set a registry name %s (type %s)", value, value.getClass().getName()));
         final IForgeRegistry<K> registry = RegistryManager.ACTIVE.getRegistry(value.getRegistryType());
         Validate.notNull(registry, "Attempted to registry object without creating registry first: " + value.getRegistryType().getName());
         registry.register(value);
@@ -439,11 +439,11 @@ public class GameData
                 if (block.getRegistryName().getNamespace().equals("minecraft") && !oldContainer.getProperties().equals(newContainer.getProperties()))
                 {
                     String oldSequence = oldContainer.getProperties().stream()
-                            .map(s -> String.format("%s={%s}", s.getName(),
+                            .map(s -> String.format(Locale.ENGLISH, "%s={%s}", s.getName(),
                                     s.getPossibleValues().stream().map(Object::toString).collect(Collectors.joining( "," ))))
                             .collect(Collectors.joining(";"));
                     String newSequence = newContainer.getProperties().stream()
-                            .map(s -> String.format("%s={%s}", s.getName(),
+                            .map(s -> String.format(Locale.ENGLISH, "%s={%s}", s.getName(),
                                     s.getPossibleValues().stream().map(Object::toString).collect(Collectors.joining( "," ))))
                             .collect(Collectors.joining(";"));
 
@@ -634,7 +634,7 @@ public class GameData
                 PoiType oldType = map.put(state, obj);
                 if (oldType != null)
                 {
-                    throw new IllegalStateException(String.format("Point of interest types %s and %s both list %s in their blockstates, this is not allowed. Blockstates can only have one point of interest type each.", oldType, obj, state));
+                    throw new IllegalStateException(String.format(Locale.ENGLISH, "Point of interest types %s and %s both list %s in their blockstates, this is not allowed. Blockstates can only have one point of interest type each.", oldType, obj, state));
                 }
             });
         }

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Queue;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -92,7 +93,7 @@ class ObjectHolderRef implements Consumer<Predicate<ResourceLocation>>
 
         if (this.injectedObject == null || !isValid())
         {
-            throw new IllegalStateException(String.format("The ObjectHolder annotation cannot apply to a field that does not map to a registry. Ensure the registry was created during the RegistryEvent.NewRegistry event. (found : %s at %s.%s)", field.getType().getName(), field.getDeclaringClass().getName(), field.getName()));
+            throw new IllegalStateException(String.format(Locale.ENGLISH, "The ObjectHolder annotation cannot apply to a field that does not map to a registry. Ensure the registry was created during the RegistryEvent.NewRegistry event. (found : %s at %s.%s)", field.getType().getName(), field.getDeclaringClass().getName(), field.getName()));
         }
 
         field.setAccessible(true);

--- a/src/main/java/net/minecraftforge/resource/DelegatingResourcePack.java
+++ b/src/main/java/net/minecraftforge/resource/DelegatingResourcePack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -167,7 +167,7 @@ public class DelegatingResourcePack extends AbstractPackResources
     private static String getFullPath(PackType type, ResourceLocation location)
     {
         // stolen from ResourcePack
-        return String.format("%s/%s/%s", type.getDirectory(), location.getNamespace(), location.getPath());
+        return String.format(Locale.ROOT, "%s/%s/%s", type.getDirectory(), location.getNamespace(), location.getPath());
     }
 
 }

--- a/src/main/java/net/minecraftforge/resource/PathResourcePack.java
+++ b/src/main/java/net/minecraftforge/resource/PathResourcePack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -188,6 +189,6 @@ public class PathResourcePack extends AbstractPackResources
     @Override
     public String toString()
     {
-        return String.format("%s: %s", getClass().getName(), getSource());
+        return String.format(Locale.ROOT, "%s: %s", getClass().getName(), getSource());
     }
 }

--- a/src/main/java/net/minecraftforge/resource/ResourcePackLoader.java
+++ b/src/main/java/net/minecraftforge/resource/ResourcePackLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -61,7 +62,7 @@ public class ResourcePackLoader {
         modResourcePacks = ModList.get().getModFiles().stream()
                 .filter(mf->mf.requiredLanguageLoaders().stream().noneMatch(ls->ls.languageName().equals("minecraft")))
                 .map(mf -> Pair.of(mf, createPackForMod(mf)))
-                .collect(Collectors.toMap(p -> p.getFirst().getFile(), Pair::getSecond, (u,v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },  LinkedHashMap::new));
+                .collect(Collectors.toMap(p -> p.getFirst().getFile(), Pair::getSecond, (u,v) -> { throw new IllegalStateException(String.format(Locale.ENGLISH, "Duplicate key %s", u)); },  LinkedHashMap::new));
         resourcePacks.addPackFinder(packFinder.apply(modResourcePacks));
     }
 

--- a/src/main/java/net/minecraftforge/server/LanguageHook.java
+++ b/src/main/java/net/minecraftforge/server/LanguageHook.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -80,7 +80,7 @@ public class LanguageHook
     }
 
     private static void loadLanguage(String langName, MinecraftServer server) {
-        String langFile = String.format("lang/%s.json", langName);
+        String langFile = String.format(Locale.ROOT, "lang/%s.json", langName);
         ResourceManager resourceManager = server.getServerResources().getResourceManager();
         resourceManager.getNamespaces().forEach(namespace -> {
             try {

--- a/src/main/java/net/minecraftforge/server/command/ModListCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/ModListCommand.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.fml.ModList;
+
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 class ModListCommand {
@@ -35,7 +37,7 @@ class ModListCommand {
                             ctx.getSource().sendSuccess(new TranslatableComponent("commands.forge.mods.list",
                                     ModList.get().applyForEachModFile(modFile ->
                                             // locator - filename : firstmod (version) - numberofmods\n
-                                            String.format("%s %s : %s (%s) - %d",
+                                            String.format(Locale.ROOT, "%s %s : %s (%s) - %d",
                                                     modFile.getLocator().name().replace(' ', '_'),
                                                     modFile.getFileName(),
                                                     modFile.getModInfos().get(0).getModId(),

--- a/src/main/java/net/minecraftforge/server/command/TextComponentHelper.java
+++ b/src/main/java/net/minecraftforge/server/command/TextComponentHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,8 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.network.ConnectionType;
 import net.minecraftforge.network.NetworkHooks;
 
+import java.util.Locale;
+
 public class TextComponentHelper
 {
     private TextComponentHelper() {}
@@ -41,7 +43,7 @@ public class TextComponentHelper
     {
         if (isVanillaClient(source))
         {
-            return new TextComponent(String.format(Language.getInstance().getOrDefault(translation), args));
+            return new TextComponent(String.format(Locale.ENGLISH, Language.getInstance().getOrDefault(translation), args));
         }
         return new TranslatableComponent(translation, args);
     }

--- a/src/main/java/net/minecraftforge/server/permission/exceptions/UnregisteredPermissionException.java
+++ b/src/main/java/net/minecraftforge/server/permission/exceptions/UnregisteredPermissionException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,13 +21,15 @@ package net.minecraftforge.server.permission.exceptions;
 
 import net.minecraftforge.server.permission.nodes.PermissionNode;
 
+import java.util.Locale;
+
 public class UnregisteredPermissionException extends RuntimeException
 {
     private PermissionNode node;
 
     public UnregisteredPermissionException(PermissionNode node)
     {
-        super(String.format("Tried to query PermissionNode '%s' although it has not been Registered", node.getNodeName()));
+        super(String.format(Locale.ENGLISH, "Tried to query PermissionNode '%s' although it has not been Registered", node.getNodeName()));
         this.node = node;
     }
 

--- a/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,6 +33,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 public class ForgeConfigSpecTest
@@ -82,7 +83,7 @@ public class ForgeConfigSpecTest
         final ForgeConfigSpec.ConfigValue<T> simpleValue = builder.define(configKey, defaultKeyValue);
         final ForgeConfigSpec spec = builder.build();
 
-        final String configPath = String.format(TEST_CONFIG_PATH_TEMPLATE, testName);
+        final String configPath = String.format(Locale.ROOT, TEST_CONFIG_PATH_TEMPLATE, testName);
         final File configFile = new File(configPath);
         configFile.getParentFile().mkdirs();
         configFile.createNewFile();

--- a/src/test/java/net/minecraftforge/debug/CapabilitiesTest.java
+++ b/src/test/java/net/minecraftforge/debug/CapabilitiesTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,6 +44,7 @@ import net.minecraftforge.fml.util.thread.EffectiveSide;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Mod(CapabilitiesTest.MODID)
@@ -125,7 +126,7 @@ public class CapabilitiesTest
                 }
             });
 
-            messages.add(String.format("Attached capability to %s in %s", event.getObject().getClass(), EffectiveSide.get()));
+            messages.add(String.format(Locale.ENGLISH, "Attached capability to %s in %s", event.getObject().getClass(), EffectiveSide.get()));
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
+++ b/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -906,7 +907,7 @@ public class DataGeneratorTest
         }
 
         private void blockstateError(Block block, String fmt, Object... args) {
-            errors.add("Generated blockstate for block " + block + " " + String.format(fmt, args));
+            errors.add("Generated blockstate for block " + block + " " + String.format(Locale.ENGLISH, fmt, args));
         }
 
         @Override

--- a/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BlockEntityOnLoadTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 @Mod("be_onload_test")
 public class BlockEntityOnLoadTest
@@ -120,7 +121,7 @@ public class BlockEntityOnLoadTest
                 LOGGER.info("[BE_ONLOAD] TestBlockEntity#tick at pos {} for {}", worldPosition, this);
                 if (!loaded)
                 {
-                    throw new IllegalStateException(String.format("BlockEntity at %s ticked before onLoad()!", getBlockPos()));
+                    throw new IllegalStateException(String.format(Locale.ENGLISH, "BlockEntity at %s ticked before onLoad()!", getBlockPos()));
                 }
             }
         }

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,6 +20,7 @@
 package net.minecraftforge.debug.block;
 
 import java.util.List;
+import java.util.Locale;
 
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -93,7 +94,7 @@ public class PistonEventTest
             {
                 if (pistonHelper.resolve())
                 {
-                    player.sendMessage(new TextComponent(String.format("Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getToPush().size(), pistonHelper.getToDestroy().size())), player.getUUID());
+                    player.sendMessage(new TextComponent(String.format(Locale.ENGLISH, "Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getToPush().size(), pistonHelper.getToDestroy().size())), player.getUUID());
                 }
                 else
                 {
@@ -138,7 +139,7 @@ public class PistonEventTest
                     BlockPos targetPos = event.getFaceOffsetPos().relative(event.getDirection());
                     boolean canPush = PistonBaseBlock.isPushable(event.getWorld().getBlockState(targetPos), (Level) event.getWorld(), event.getFaceOffsetPos(), event.getDirection().getOpposite(), false, event.getDirection());
                     boolean isAir = event.getWorld().isEmptyBlock(targetPos);
-                    player.sendMessage(new TextComponent(String.format("Piston will retract moving %d blocks", !isAir && canPush ? 1 : 0)), player.getUUID());
+                    player.sendMessage(new TextComponent(String.format(Locale.ENGLISH, "Piston will retract moving %d blocks", !isAir && canPush ? 1 : 0)), player.getUUID());
                 }
                 else
                 {

--- a/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/OverlayLayersTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,6 +30,7 @@ import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.List;
+import java.util.Locale;
 
 @Mod("overlay_layers_test")
 public class OverlayLayersTest
@@ -57,7 +58,7 @@ public class OverlayLayersTest
         for(int i=0;i<overlays.size();i++)
         {
             OverlayRegistry.OverlayEntry entry = overlays.get(i);
-            event.getLeft().add(String.format(overlayIndex == i ? "> %s [%s] <" : "  %s [%s]  ", entry.getDisplayName(), entry.isEnabled()));
+            event.getLeft().add(String.format(Locale.ENGLISH, overlayIndex == i ? "> %s [%s] <" : "  %s [%s]  ", entry.getDisplayName(), entry.isEnabled()));
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -40,6 +40,6 @@ public class BiomeLoadingEventTest {
     }
     public void onBiomeLoading(BiomeLoadingEvent event){
         ResourceLocation biome = event.getName();
-        LOGGER.info(String.format(Locale.ENGLISH, "Biome loaded: %s", biome.toString()));
+        LOGGER.info("Biome loaded: {}", biome);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,8 @@ import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Locale;
+
 @Mod(BiomeLoadingEventTest.MODID)
 public class BiomeLoadingEventTest {
     static final String MODID = "biome_loading_event_test";
@@ -38,6 +40,6 @@ public class BiomeLoadingEventTest {
     }
     public void onBiomeLoading(BiomeLoadingEvent event){
         ResourceLocation biome = event.getName();
-        LOGGER.info(String.format("Biome loaded: %s", biome.toString()));
+        LOGGER.info(String.format(Locale.ENGLISH, "Biome loaded: %s", biome.toString()));
     }
 }


### PR DESCRIPTION
For example on `ar_SA` `1` is formatted as `١`, which is not desired when creating a path or ResourceLocation.

This becomes apparent when wearing armor with a locale of `ar_SA`, which will immediately crash the game if the armor model is on screen.