### PR TITLE
Fix comment for permission handler config setting 

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -85,7 +85,7 @@ public class ForgeConfig {
                     .define("fixAdvancementLoading", true);
 
             permissionHandler = builder
-                    .comment("")
+                    .comment("The permission handler used by the server. Defaults to forge:default_handler if no such handler with that name is registered.")
                     .translation("forge.configgui.permissionHandler")
                     .define("permissionHandler", "forge:default_handler");
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -549,7 +549,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public Builder comment(String comment)
         {
             hasInvalidComment = comment == null || comment.isEmpty();
-            if(hasInvalidComment)
+            if (hasInvalidComment)
             {
                 comment = "No comment";
             }
@@ -559,7 +559,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public Builder comment(String... comment)
         {
             hasInvalidComment = comment == null || comment.length < 1 || (comment.length == 1 && comment[0].isEmpty());
-            if(hasInvalidComment)
+            if (hasInvalidComment)
             {
                 comment = new String[] {"No comment"};
             }
@@ -628,7 +628,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             if (hasInvalidComment)
             {
                 hasInvalidComment = false;
-                if(!FMLEnvironment.production)
+                if (!FMLEnvironment.production)
                 {
                     LogManager.getLogger().error(CORE, "Null comment for config option {}, this is invalid and may be disallowed in the future.",
                             DOT_JOINER.join(path));

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2022.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
This PR fixed #8465 by setting a proper comment for the `server.permissionHandler` config setting in Forge's config. This also improves the invalid comment check, by moving it to a place where it has access to the actual config path for the setting being defined, rather than having only access to the current path (the category in which the setting will be under).