### PR TITLE
[1.16.x] Prevent setting window icon on OSX

### DIFF
--- a/patches/minecraft/net/minecraft/client/MainWindow.java.patch
+++ b/patches/minecraft/net/minecraft/client/MainWindow.java.patch
@@ -9,6 +9,14 @@
        if (monitor != null) {
           VideoMode videomode = monitor.func_197992_a(this.field_198125_l ? this.field_198124_k : Optional.empty());
           this.field_198120_g = this.field_198127_n = monitor.func_197989_c() + videomode.func_198064_a() / 2 - this.field_198129_p / 2;
+@@ -136,6 +_,7 @@
+ 
+    public void func_216529_a(InputStream p_216529_1_, InputStream p_216529_2_) {
+       RenderSystem.assertThread(RenderSystem::isInInitPhase);
++      if (net.minecraft.client.Minecraft.field_142025_a) return;
+ 
+       try (MemoryStack memorystack = MemoryStack.stackPush()) {
+          if (p_216529_1_ == null) {
 @@ -271,6 +_,7 @@
        GLFW.glfwGetFramebufferSize(this.field_198119_f, aint, aint1);
        this.field_198131_r = aint[0];


### PR DESCRIPTION
When forcing LWJGL to version 3.3.0 in order to support M1 Macs, setting a window icon crashes the game.
This has been fixed in Minecraft 1.18 but still happens in 1.16, so this is sort of a weird backport fix!