### PR TITLE
Add missing shear and elytra game events

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/animal/MushroomCow.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/MushroomCow.java.patch
@@ -18,12 +18,13 @@
           this.m_5851_(SoundSource.PLAYERS);
           this.m_146852_(GameEvent.f_157781_, p_28941_);
           if (!this.f_19853_.f_46443_) {
-@@ -145,7 +_,16 @@
+@@ -145,7 +_,17 @@
        }
     }
  
 +   @Override
 +   public java.util.List<ItemStack> onSheared(@javax.annotation.Nullable Player player, @javax.annotation.Nonnull ItemStack item, Level world, BlockPos pos, int fortune) {
++      this.m_146852_(GameEvent.f_157781_, player);
 +      return shearInternal(player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/entity/animal/Sheep.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Sheep.java.patch
@@ -18,7 +18,7 @@
           if (!this.f_19853_.f_46443_ && this.m_6220_()) {
              this.m_5851_(SoundSource.PLAYERS);
              this.m_146852_(GameEvent.f_157781_, p_29853_);
-@@ -357,5 +_,27 @@
+@@ -357,5 +_,28 @@
  
     protected float m_6431_(Pose p_29850_, EntityDimensions p_29851_) {
        return 0.95F * p_29851_.f_20378_;
@@ -33,6 +33,7 @@
 +   @Override
 +   public java.util.List<ItemStack> onSheared(@Nullable Player player, @javax.annotation.Nonnull ItemStack item, Level world, BlockPos pos, int fortune) {
 +      world.m_6269_(null, this, SoundEvents.f_12344_, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
++      this.m_146852_(GameEvent.f_157781_, player);
 +      if (!world.f_46443_) {
 +         this.m_29878_(true);
 +         int i = 1 + this.f_19796_.nextInt(3);

--- a/patches/minecraft/net/minecraft/world/entity/animal/SnowGolem.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/SnowGolem.java.patch
@@ -36,7 +36,7 @@
           this.m_5851_(SoundSource.PLAYERS);
           this.m_146852_(GameEvent.f_157781_, p_29920_);
           if (!this.f_19853_.f_46443_) {
-@@ -193,5 +_,21 @@
+@@ -193,5 +_,22 @@
  
     public Vec3 m_7939_() {
        return new Vec3(0.0D, (double)(0.75F * this.m_20192_()), (double)(this.m_20205_() * 0.4F));
@@ -51,6 +51,7 @@
 +   @Override
 +   public java.util.List<ItemStack> onSheared(@Nullable Player player, @javax.annotation.Nonnull ItemStack item, Level world, BlockPos pos, int fortune) {
 +      world.m_6269_(null, this, SoundEvents.f_12480_, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
++      this.m_146852_(GameEvent.f_157781_, player);
 +      if (!world.m_5776_()) {
 +         m_29936_(false);
 +         return java.util.Collections.singletonList(new ItemStack(Items.f_42047_));

--- a/patches/minecraft/net/minecraft/world/item/ElytraItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ElytraItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/ElytraItem.java
 +++ b/net/minecraft/world/item/ElytraItem.java
-@@ -43,6 +_,19 @@
+@@ -43,6 +_,25 @@
        }
     }
  
@@ -11,8 +11,14 @@
 +
 +   @Override
 +   public boolean elytraFlightTick(ItemStack stack, net.minecraft.world.entity.LivingEntity entity, int flightTicks) {
-+      if (!entity.f_19853_.f_46443_ && (flightTicks + 1) % 20 == 0) {
-+         stack.m_41622_(1, entity, e -> e.m_21166_(net.minecraft.world.entity.EquipmentSlot.CHEST));
++      if (!entity.f_19853_.f_46443_) {
++         int nextFlightTick = flightTicks + 1;
++         if (nextFlightTick % 10 == 0) {
++            if (nextFlightTick % 20 == 0) {
++               stack.m_41622_(1, entity, e -> e.m_21166_(net.minecraft.world.entity.EquipmentSlot.CHEST));
++            }
++            entity.m_146850_(net.minecraft.world.level.gameevent.GameEvent.f_157807_);
++         }
 +      }
 +      return true;
 +   }

--- a/src/test/java/net/minecraftforge/debug/item/CustomElytraTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomElytraTest.java
@@ -30,6 +30,7 @@ import net.minecraft.client.model.PlayerModel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -103,10 +104,18 @@ public class CustomElytraTest
         @Override
         public boolean elytraFlightTick(ItemStack stack, LivingEntity entity, int flightTicks)
         {
-            //Adding 1 to ticksElytraFlying prevents damage on the very first tick.
-            if (!entity.level.isClientSide && (flightTicks + 1) % 20 == 0)
+            if (!entity.level.isClientSide)
             {
-                stack.hurtAndBreak(1, entity, e -> e.broadcastBreakEvent(EquipmentSlot.CHEST));
+                //Adding 1 to flightTicks prevents damage on the very first tick.
+                int nextFlightTick = flightTicks + 1;
+                if (nextFlightTick % 10 == 0)
+                {
+                    if (nextFlightTick % 20 == 0)
+                    {
+                        stack.hurtAndBreak(1, entity, e -> e.broadcastBreakEvent(EquipmentSlot.CHEST));
+                    }
+                    entity.gameEvent(GameEvent.ELYTRA_FREE_FALL);
+                }
             }
             return true;
         }


### PR DESCRIPTION
While testing another PR I am writing I noticed that forge's redirecting of shearing entities to `IForgeShearable#onSheared` had not been updated to also fire vanilla's `SHEAR` GameEvent. This PR just adds those missing calls in.