### PR TITLE
Provide damage source context to Item#onDestroyed(ItemEntity)

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -69,6 +69,15 @@
        if (this.m_6673_(p_32013_)) {
           return false;
        } else if (!this.m_32055_().m_41619_() && this.m_32055_().m_150930_(Items.f_42686_) && p_32013_.m_19372_()) {
+@@ -248,7 +_,7 @@
+          this.f_31987_ = (int)((float)this.f_31987_ - p_32014_);
+          this.m_146852_(GameEvent.f_157808_, p_32013_.m_7639_());
+          if (this.f_31987_ <= 0) {
+-            this.m_32055_().m_150924_(this);
++            this.m_32055_().onDestroyed(this, p_32013_);
+             this.m_146870_();
+          }
+ 
 @@ -260,6 +_,7 @@
        p_32050_.m_128376_("Health", (short)this.f_31987_);
        p_32050_.m_128376_("Age", (short)this.f_31985_);

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -12,7 +12,7 @@
     protected static final UUID f_41374_ = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
     protected static final UUID f_41375_ = UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3");
     public static final int f_150884_ = 64;
-@@ -95,7 +_,8 @@
+@@ -95,12 +_,15 @@
              f_150883_.error("Item classes should end with Item and {} doesn't.", (Object)s);
           }
        }
@@ -22,6 +22,13 @@
     }
  
     public void m_5929_(Level p_41428_, LivingEntity p_41429_, ItemStack p_41430_, int p_41431_) {
+    }
+ 
++   /** @deprecated Forge: Use damage source sensitive version */
++   @Deprecated
+    public void m_142023_(ItemEntity p_150887_) {
+    }
+ 
 @@ -141,10 +_,12 @@
        return this.m_41472_() ? p_41411_.m_5584_(p_41410_, p_41409_) : p_41409_;
     }

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -226,7 +226,15 @@
        return multimap;
     }
  
-@@ -954,6 +_,23 @@
+@@ -948,12 +_,31 @@
+       this.m_41720_().m_5929_(p_41732_, p_41733_, this, p_41734_);
+    }
+ 
++   /** @deprecated Forge: Use damage source sensitive version */
++   @Deprecated
+    public void m_150924_(ItemEntity p_150925_) {
+       this.m_41720_().m_142023_(p_150925_);
+    }
  
     public boolean m_41614_() {
        return this.m_41720_().m_41472_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.Multimap;
 
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.block.state.BlockState;
@@ -671,6 +672,17 @@ public interface IForgeItem
      */
     default <T extends LivingEntity> int damageItem(ItemStack stack, int amount, T entity, Consumer<T> onBroken) {
         return amount;
+    }
+
+    /**
+     * Called when an item entity for this stack is destroyed. Note: The {@link ItemStack} can be retrieved from the item entity.
+     *
+     * @param itemEntity   The item entity that was destroyed.
+     * @param damageSource Damage source that caused the item entity to "die".
+     */
+    default void onDestroyed(ItemEntity itemEntity, DamageSource damageSource)
+    {
+        self().onDestroyed(itemEntity);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.extensions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
@@ -281,6 +282,17 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     default void onHorseArmorTick(Level world, Mob horse)
     {
         self().getItem().onHorseArmorTick(self(), world, horse);
+    }
+
+    /**
+     * Called when an item entity for this stack is destroyed.
+     *
+     * @param itemEntity   The item entity that was destroyed.
+     * @param damageSource Damage source that caused the item entity to "die".
+     */
+    default void onDestroyed(ItemEntity itemEntity, DamageSource damageSource)
+    {
+        self().getItem().onDestroyed(itemEntity, damageSource);
     }
 
     /**


### PR DESCRIPTION
Relatively straightforward PR that provides access to the damage source as part of the context for `Item#onDestroyed`. My use case is that I am planning on making my items able to drop their contents if they are destroyed (similar to shulker boxes), but only if they are destroyed when they don't have any security mode set OR if the player that caused the destruction has "ownership" of the item via our security system. To achieve this I need to be able to access the player (or entity) via `DamageSource#getEntity`