### PR TITLE
[1.18.x] Add Attribute to prevent EnderMan angering

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -21,7 +21,7 @@
     boolean m_32534_(Player p_32535_) {
        ItemStack itemstack = p_32535_.m_150109_().f_35975_.get(3);
 -      if (itemstack.m_150930_(Blocks.f_50143_.m_5456_())) {
-+      if (itemstack.isEnderMask(p_32535_, this)) {
++      if (itemstack.isEnderMask(p_32535_, this) || p_32535_.m_21133_(net.minecraftforge.common.ForgeMod.ENDER_MASKING.get()) > 0) {
           return false;
        } else {
           Vec3 vec3 = p_32535_.m_20252_(1.0F).m_82541_();

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -23,7 +23,7 @@
  
     public static AttributeSupplier.Builder m_36340_() {
 -      return LivingEntity.m_21183_().m_22268_(Attributes.f_22281_, 1.0D).m_22268_(Attributes.f_22279_, (double)0.1F).m_22266_(Attributes.f_22283_).m_22266_(Attributes.f_22286_);
-+       return LivingEntity.m_21183_().m_22268_(Attributes.f_22281_, 1.0D).m_22268_(Attributes.f_22279_, (double) 0.1F).m_22266_(Attributes.f_22283_).m_22266_(Attributes.f_22286_).m_22266_(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).m_22266_(Attributes.f_22282_);
++       return LivingEntity.m_21183_().m_22268_(Attributes.f_22281_, 1.0D).m_22268_(Attributes.f_22279_, (double) 0.1F).m_22266_(Attributes.f_22283_).m_22266_(Attributes.f_22286_).m_22266_(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).m_22266_(net.minecraftforge.common.ForgeMod.ENDER_MASKING.get()).m_22266_(Attributes.f_22282_);
     }
  
     protected void m_8097_() {

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -108,7 +108,7 @@ public class ForgeMod
     public static final RegistryObject<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("forge.swimSpeed", 1.0D, 0.0D, 1024.0D).setSyncable(true));
     public static final RegistryObject<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("forge.nameTagDistance", 64.0D, 0.0D, 64.0).setSyncable(true));
     public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
-
+    public static final RegistryObject<Attribute> ENDER_MASKING = ATTRIBUTES.register("ender_masking", () -> new RangedAttribute("forge.enderMasking", 0, 0, 1).setSyncable(true));
     public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("generic.reachDistance", 5.0D, 0.0D, 1024.0D).setSyncable(true));
 
     private static boolean enableMilkFluid = false;

--- a/src/test/java/net/minecraftforge/debug/entity/EnderMaskingAttributeTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/EnderMaskingAttributeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2022.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.entity;
+
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod("ender_masking_attribute_test")
+public class EnderMaskingAttributeTest {
+    private static final boolean ENABLED = true;
+    private static final DeferredRegister<MobEffect> EFFECTS = DeferredRegister.create(ForgeRegistries.MOB_EFFECTS, "ender_masking_attribute_test");
+    private static final RegistryObject<MobEffect> ENDER_MASKING = EFFECTS.register("ender_masking", () -> new MobEffect(MobEffectCategory.BENEFICIAL, 0x6900a1){}.addAttributeModifier(ForgeMod.ENDER_MASKING.get(), "9bbcc190-1257-470c-9c86-3ddf0157c681", 1, AttributeModifier.Operation.ADDITION));
+
+    public EnderMaskingAttributeTest() {
+        if (ENABLED) {
+            EFFECTS.register(FMLJavaModLoadingContext.get().getModEventBus());
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/EnderMaskingAttributeTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/EnderMaskingAttributeTest.java
@@ -30,13 +30,16 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 @Mod("ender_masking_attribute_test")
-public class EnderMaskingAttributeTest {
+public class EnderMaskingAttributeTest
+{
     private static final boolean ENABLED = true;
     private static final DeferredRegister<MobEffect> EFFECTS = DeferredRegister.create(ForgeRegistries.MOB_EFFECTS, "ender_masking_attribute_test");
     private static final RegistryObject<MobEffect> ENDER_MASKING = EFFECTS.register("ender_masking", () -> new MobEffect(MobEffectCategory.BENEFICIAL, 0x6900a1){}.addAttributeModifier(ForgeMod.ENDER_MASKING.get(), "9bbcc190-1257-470c-9c86-3ddf0157c681", 1, AttributeModifier.Operation.ADDITION));
 
-    public EnderMaskingAttributeTest() {
-        if (ENABLED) {
+    public EnderMaskingAttributeTest()
+    {
+        if (ENABLED)
+        {
             EFFECTS.register(FMLJavaModLoadingContext.get().getModEventBus());
         }
     }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -196,5 +196,7 @@ license="LGPL v2.1"
     modId="registry_object_test"
 [[mods]]
     modId="hidden_tooltip_parts"
+[[mods]]
+    modId="ender_masking_attribute_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR is an alternative to #8406 using an attribute instead of an event as requested by @diesieben07 on discord.

It adds an attribute called `ender_masking` (name open for discussion) which prevents endermen from angering if the value is greater than 0 (which is default).

This PR also adds a test mod for it adding an effect that modifies the attribute to add 1.