### PR TITLE
Fix entity type for Zombie's LivingConversionEvent to Drowned

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/ZombieEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/ZombieEntity.java.patch
@@ -6,7 +6,7 @@
              --this.field_204708_bE;
 -            if (this.field_204708_bE < 0) {
 +
-+            if (this.field_204708_bE < 0 && net.minecraftforge.event.ForgeEventFactory.canLivingConvert(this, EntityType.field_200725_aD, (timer) -> this.field_204708_bE = timer)) {
++            if (this.field_204708_bE < 0 && net.minecraftforge.event.ForgeEventFactory.canLivingConvert(this, EntityType.field_204724_o, (timer) -> this.field_204708_bE = timer)) {
                 this.func_207302_dI();
              }
           } else if (this.func_204703_dA()) {


### PR DESCRIPTION
This PR is an LTS backport of #8479, which fixes #8399 by changing the `EntityType` used when firing `LivingConversionEvent.Pre` from the incorrect `ZOMBIE` type to the correct `DROWNED` type.