### PR TITLE
Use UTF-8 charset for Java compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1543,6 +1543,10 @@ project(':forge') {
     }
     // Since we need the modules in the bootstrap, we need to make sure they are compiled before we do each run
     afterEvaluate { prepareRuns.dependsOn(':fmlcore:jar', ':fmlloader:jar', ':javafmllanguage:jar', ':mclanguage:jar') }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+    }
 }
 
 //evaluationDependsOnChildren()

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -210,3 +210,7 @@ publishing {
         }
     }
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+}


### PR DESCRIPTION
Gradle only treats buildscripts as UTF-8 by default. Java compilation tasks use the OS' default character set, which can vary and can sometimes cause issues with certain characters such as box drawings in Javadocs. This patch sets Java compilation tasks in the MDK and Forge to use UTF-8 instead.