### PR TITLE
Replace '-' with '.' in mod JPMS module ids to avoid crash

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -191,7 +191,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
 
     @Override
     public String moduleName() {
-        return getMods().get(0).getModId();
+        return getMods().get(0).getModId().replace('-', '.');
     }
 
     @Override


### PR DESCRIPTION
Rationale:
 * `-` is valid in modids (or was before 1.17, but is still treated as valid and is still a valid resource location namespace), while `.` is not
 * `.` is valid in JPMS module names, while `-` is not

To restore the old behavior, one could simply replace `-` with `.` while constructing the module name (which is done in this PR)