### PR TITLE
Rework fog events

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/FogRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/FogRenderer.java.patch
@@ -1,13 +1,6 @@
 --- a/net/minecraft/client/renderer/FogRenderer.java
 +++ b/net/minecraft/client/renderer/FogRenderer.java
-@@ -173,24 +_,42 @@
- 
-       if (f_109010_ != 0.0F && f_109011_ != 0.0F && f_109012_ != 0.0F) {
-          float f8 = Math.min(1.0F / f_109010_, Math.min(1.0F / f_109011_, 1.0F / f_109012_));
-+         // Forge: fix MC-4647 and MC-10480
-+         if (Float.isInfinite(f8)) f8 = Math.nextAfter(f8, 0.0);
-          f_109010_ = f_109010_ * (1.0F - f6) + f_109010_ * f8 * f6;
-          f_109011_ = f_109011_ * (1.0F - f6) + f_109011_ * f8 * f6;
+@@ -178,19 +_,36 @@
           f_109012_ = f_109012_ * (1.0F - f6) + f_109012_ * f8 * f6;
        }
  
@@ -36,6 +29,7 @@
        FogShape fogshape = FogShape.SPHERE;
        float f;
        float f1;
++      // TODO: remove this hook in 1.19
 +      float hook = net.minecraftforge.client.ForgeHooksClient.getFogDensity(p_109026_, p_109025_, partialTicks, 0.1F);
 +      if (hook >= 0) {
 +         f = -8.0f;
@@ -48,7 +42,7 @@
        RenderSystem.m_157445_(f);
        RenderSystem.m_157443_(f1);
        RenderSystem.m_202160_(fogshape);
-+      net.minecraftforge.client.ForgeHooksClient.onFogRender(p_109026_, p_109025_, partialTicks, f1);
++      net.minecraftforge.client.ForgeHooksClient.onFogRender(p_109026_, p_109025_, partialTicks, f, f1, fogshape);
     }
  
     public static void m_109036_() {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.client;
 
 import com.google.common.collect.ImmutableMap;
+
+import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.datafixers.util.Either;
@@ -389,9 +391,9 @@ public class ForgeHooksClient
         return -1;
     }
 
-    public static void onFogRender(FogMode type, Camera camera, float partialTick, float distance)
+    public static void onFogRender(FogMode type, Camera camera, float partialTick, float nearDistance, float farDistance, FogShape shape)
     {
-        MinecraftForge.EVENT_BUS.post(new EntityViewRenderEvent.RenderFogEvent(type, camera, partialTick, distance));
+        MinecraftForge.EVENT_BUS.post(new EntityViewRenderEvent.RenderFogEvent(type, camera, partialTick, nearDistance, farDistance, shape));
     }
 
     public static EntityViewRenderEvent.CameraSetup onCameraSetup(GameRenderer renderer, Camera camera, float partial)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -391,9 +391,24 @@ public class ForgeHooksClient
         return -1;
     }
 
+    /**
+     * @deprecated to be removed in 1.19, use other onFogRender hook with more params
+     */
+    @Deprecated(forRemoval = true, since = "1.18.2")
+    public static void onFogRender(FogMode type, Camera camera, float partialTick, float distance)
+    {
+        MinecraftForge.EVENT_BUS.post(new EntityViewRenderEvent.RenderFogEvent(type, camera, partialTick, distance));
+    }
+
     public static void onFogRender(FogMode type, Camera camera, float partialTick, float nearDistance, float farDistance, FogShape shape)
     {
-        MinecraftForge.EVENT_BUS.post(new EntityViewRenderEvent.RenderFogEvent(type, camera, partialTick, nearDistance, farDistance, shape));
+        EntityViewRenderEvent.RenderFogEvent event = new EntityViewRenderEvent.RenderFogEvent(type, camera, partialTick, nearDistance, farDistance, shape);
+        if (MinecraftForge.EVENT_BUS.post(event))
+        {
+            RenderSystem.setShaderFogStart(event.getNearPlaneDistance());
+            RenderSystem.setShaderFogEnd(event.getFarPlaneDistance());
+            RenderSystem.setShaderFogShape(event.getFogShape());
+        }
     }
 
     public static EntityViewRenderEvent.CameraSetup onCameraSetup(GameRenderer renderer, Camera camera, float partial)

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -46,7 +46,7 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
         return partialTicks;
     }
 
-    //TODO: remove in 1.19
+    @Deprecated(forRemoval = true, since = "1.18.2")
     private static class FogEvent extends EntityViewRenderEvent
     {
         private final FogMode mode;
@@ -61,13 +61,13 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
     }
 
     /**
-     * MODDERS: use RenderFogEvent
+     * @deprecated Use RenderFogEvent. This event will be removed as the other event has better functionality.
      *
      * Event that allows any feature to customize the fog density the player sees.
      * NOTE: In order to make this event have an effect, you must cancel the event
      */
     @Cancelable
-    @Deprecated //TODO: remove in 1.19
+    @Deprecated(forRemoval = true, since = "1.18.2")
     public static class FogDensity extends FogEvent
     {
         private float density;
@@ -91,30 +91,37 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
 
     /**
      * This event allows for customization of parameters related to fog rendering. The plane distances are based on the player's render distance.
+     * For the event to have an effect, you must cancel it.
      *
+     * The FogMode is NOT customizable. It describes the type of fog being modified.
      * A FogMode of FOG_SKY is the skybox's fog.
      * A FogMode of FOG_TERRAIN is what the fog induced by render distance uses. This works best for reducing the camera's visibility.
      */
-    public static class RenderFogEvent extends EntityViewRenderEvent
+    @HasResult // TODO: remove in 1.19. Setting a result for this event has no effect.
+    @Cancelable
+    public static class RenderFogEvent extends FogEvent // TODO: In 1.19, change superclass to EntityViewRenderEvent
     {
         private final FogMode type;
-        private final float farPlaneDistance;
-        private final float nearPlaneDistance;
-        private final FogShape fogShape;
+        private float farPlaneDistance;
+        private float nearPlaneDistance;
+        private FogShape fogShape;
 
-        @Deprecated //TODO: remove in 1.19
+        /**
+         * @deprecated Use other constructor with all the params. Will be removed in 1.19
+         */
+        @Deprecated(forRemoval = true, since = "1.18.2")
         public RenderFogEvent(FogMode type, Camera camera, float partialTicks, float distance)
         {
-            this(type, camera, partialTicks, 0f, distance, FogShape.SPHERE);
+            this(type, camera, partialTicks, -8f, distance, FogShape.SPHERE);
         }
 
         public RenderFogEvent(FogMode type, Camera camera, float partialTicks, float nearPlaneDistance, float farPlaneDistance, FogShape fogShape)
         {
-            super(Minecraft.getInstance().gameRenderer, camera, partialTicks);
+            super(type, camera, partialTicks);
             this.type = type;
-            this.farPlaneDistance = farPlaneDistance;
-            this.nearPlaneDistance = nearPlaneDistance;
-            this.fogShape = fogShape;
+            setFarPlaneDistance(farPlaneDistance);
+            setNearPlaneDistance(nearPlaneDistance);
+            setFogShape(fogShape);
         }
 
         public FogMode getMode()
@@ -139,17 +146,17 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
 
         public void setFarPlaneDistance(float distance)
         {
-            RenderSystem.setShaderFogEnd(distance);
+            farPlaneDistance = distance;
         }
 
         public void setNearPlaneDistance(float distance)
         {
-            RenderSystem.setShaderFogStart(distance);
+            nearPlaneDistance = distance;
         }
 
         public void setFogShape(FogShape shape)
         {
-            RenderSystem.setShaderFogShape(shape);
+            fogShape = shape;
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -12,7 +12,6 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 import com.mojang.blaze3d.shaders.FogShape;
-import com.mojang.blaze3d.systems.RenderSystem;
 
 /**
  * Event that hooks into GameRenderer, allowing any feature to customize visual attributes
@@ -157,6 +156,16 @@ public abstract class EntityViewRenderEvent extends net.minecraftforge.eventbus.
         public void setFogShape(FogShape shape)
         {
             fogShape = shape;
+        }
+
+        public void scaleFarPlaneDistance(float factor)
+        {
+            farPlaneDistance *= factor;
+        }
+
+        public void scaleNearPlaneDistance(float factor)
+        {
+            nearPlaneDistance *= factor;
         }
     }
 


### PR DESCRIPTION
This is a continuation of #8338

The 1.18.1 and 1.18.2 updates changed some stuff related to how the setupFog method works, fixing some oddities, and notably adding a fog shape feature. The 8+ year old FogDensity event no longer serves a real purpose, given that the render event has had the same capabilities for a few updates now (since RenderSystem calls can be made anywhere).

This PR deprecates FogDensityEvent, the old RenderFogEvent constructor, and adds helper methods for the necessary render system calls, for which it also provides getters for vanilla's values. It also removes an old redundant patch (see previous pr description). There should not be any breaking changes.