### PR TITLE
Make has(TagKey) protected

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -186,6 +186,7 @@ protected net.minecraft.data.loot.EntityLoot f_124366_ # ENTITY_ON_FIRE
 protected net.minecraft.data.loot.EntityLoot m_124371_(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
 protected net.minecraft.data.loot.EntityLoot m_124380_(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
 protected net.minecraft.data.recipes.RecipeProvider f_125970_ # generator
+protected net.minecraft.data.recipes.RecipeProvider m_206406_(Lnet/minecraft/tags/TagKey;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # has
 protected net.minecraft.data.recipes.RecipeProvider m_125977_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # has
 protected net.minecraft.data.recipes.RecipeProvider m_125979_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/advancements/critereon/EnterBlockTrigger$TriggerInstance; # insideOf
 protected net.minecraft.data.recipes.RecipeProvider m_126011_([Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # inventoryTrigger


### PR DESCRIPTION
In forge 1.18.2, the method `net.minecraft.data.recipes.RecipeProvider#has(net/minecraft/tags/TagKey)` is private not as `has(ItemLike)`.
This PR adds an entry to the forge AT config to make this method public.

This is the first time I contribute to Forge, so I'm sorry if I forgot something.