### PR TITLE
Add missing module exports arg to server arguments list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,6 +436,7 @@ def sharedFmlonlyForge = { Project prj ->
             run.jvmArgs '-p', prj.configurations.moduleonly.files.collect { it.path }.join(File.pathSeparator)
         }
         run.jvmArgs '--add-modules', 'ALL-MODULE-PATH'
+        // Additions to these JVM module args should be mirrored to server_files/args.txt and other similar blocks in the buildscript
         run.jvmArgs '--add-opens', 'java.base/java.util.jar=cpw.mods.securejarhandler'
         run.jvmArgs '--add-exports', 'java.base/sun.security.util=cpw.mods.securejarhandler'
         run.jvmArgs '--add-exports', 'jdk.naming.dns/com.sun.jndi.dns=java.naming'
@@ -624,6 +625,7 @@ project(':fmlonly') {
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{"\${library_directory}/${it.downloads.artifact.path}"}.join('${classpath_separator}'),
                           '--add-modules', 'ALL-MODULE-PATH',
+                          // Additions to these JVM module args should be mirrored to server_files/args.txt and other similar blocks in the buildscript
                           '--add-opens', 'java.base/java.util.jar=cpw.mods.securejarhandler',
                           '--add-exports', 'java.base/sun.security.util=cpw.mods.securejarhandler',
                           '--add-exports', 'jdk.naming.dns/com.sun.jndi.dns=java.naming'
@@ -1194,7 +1196,7 @@ project(':forge') {
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{'${library_directory}/' + it.downloads.artifact.path}.join('${classpath_separator}'),
                           '--add-modules', 'ALL-MODULE-PATH',
-                          // Additions to these JVM module args should be mirrored to server_files/args.txt, for the server
+                          // Additions to these JVM module args should be mirrored to server_files/args.txt and other similar blocks in the buildscript
                           '--add-opens', 'java.base/java.util.jar=cpw.mods.securejarhandler',
                           '--add-exports', 'java.base/sun.security.util=cpw.mods.securejarhandler',
                           '--add-exports', 'jdk.naming.dns/com.sun.jndi.dns=java.naming'

--- a/build.gradle
+++ b/build.gradle
@@ -1194,6 +1194,7 @@ project(':forge') {
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{'${library_directory}/' + it.downloads.artifact.path}.join('${classpath_separator}'),
                           '--add-modules', 'ALL-MODULE-PATH',
+                          // Additions to these JVM module args should be mirrored to server_files/args.txt, for the server
                           '--add-opens', 'java.base/java.util.jar=cpw.mods.securejarhandler',
                           '--add-exports', 'java.base/sun.security.util=cpw.mods.securejarhandler',
                           '--add-exports', 'jdk.naming.dns/com.sun.jndi.dns=java.naming'

--- a/server_files/args.txt
+++ b/server_files/args.txt
@@ -2,6 +2,7 @@
 --add-modules @MODULES@
 --add-opens java.base/java.util.jar=cpw.mods.securejarhandler
 --add-exports java.base/sun.security.util=cpw.mods.securejarhandler
+--add-exports jdk.naming.dns/com.sun.jndi.dns=java.naming
 -DignoreList=@IGNORE_LIST@
 -DlibraryDirectory=libraries
 -DlegacyClassPath=@CLASS_PATH@


### PR DESCRIPTION
This PR adds the missing JVM argument line `--add-exports jdk.naming.dns/com.sun.jndi.dns=java.naming` to the server arguments list (`server_files/args.txt`), matching the JVM arguments list for the client profile as defined in the buildscript.

To reduce future similar errors, a comment was also added to the aforementioned buildscript section to remind editors that changes to those lines should be mirrored to the server arguments list.


This PR was prompted by @Sm0keySa1m0n's discovery and subsequent report of this issue's existence on the dedicated server on the official Forge Project discord, and requested by @SizableShrimp. 