### PR TITLE
Clear local variable table on RuntimeEnumExtender transformation

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
@@ -1,20 +1,6 @@
 /*
- * Minecraft Forge
- * Copyright (c) 2016-2021.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 package net.minecraftforge.fml.common.asm;
@@ -149,6 +135,19 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
 
             mtd.access |= Opcodes.ACC_SYNCHRONIZED;
             mtd.instructions.clear();
+            mtd.localVariables.clear();
+            if (mtd.tryCatchBlocks != null)
+            {
+                mtd.tryCatchBlocks.clear();
+            }
+            if (mtd.visibleLocalVariableAnnotations != null)
+            {
+                mtd.visibleLocalVariableAnnotations.clear();
+            }
+            if (mtd.invisibleLocalVariableAnnotations != null)
+            {
+                mtd.invisibleLocalVariableAnnotations.clear();
+            }
             InstructionAdapter ins = new InstructionAdapter(mtd);
 
             int vars = 0;


### PR DESCRIPTION
**1.18.x PR** | [1.16.x PR](https://github.com/MinecraftForge/MinecraftForge/pull/8340)

This is a "proper" fix for clearing the state of the LVT in the `create` functions due to an exposure of debugging with Mixins. 

## The Crash

Traditionally, I am always writing mixins for SpongeForge, and lately I discovered a crash that was invariably caused by Mixin's debugging tool (`-Dmixin.debug.export=true`) when a Mixin targeted `net.minecraft.entity.EntityClassification`, it'd cause the export to trigger `ClassNode.accept()` to dump the class, and the LVT for the method modified by `RuntimeEnumExtender` doesn't match the expected LVT (the LVT still had the original LVT for the thrown exception).

The various logs and exports that were related to Mixin troubleshooting: https://gist.github.com/gabizou/beef7061791cdf3fdebb46b810362300

## The reproduction

1. Add a Mixin:
```java
@Mixin(EntityClassification)
public abstract class EntityClassificationMixin {
}
```
2. Run Minecraft with `-Dmixin.debug.export=true`
3. Crash occurs as above, and the exported Mixin code appears as above (but this isn't the final class loaded by ModLauncher)

## The Resulting class
The javap output of the loaded class in both with the mixing above and without the mixing: https://gist.github.com/gabizou/9d4926c4d4eaddac128db73ae770759d

Tagging @Mumfrey to help get any further details that I might've missed.
