### PR TITLE
[1.18.x] Fix FMLOnly in forgedev and userdev

### DIFF
--- a/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyBindings.java
+++ b/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyBindings.java
@@ -1,3 +1,8 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.fmlonly;
 
 import net.minecraftforge.eventbus.api.BusBuilder;

--- a/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyMod.java
+++ b/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyMod.java
@@ -1,0 +1,6 @@
+package net.minecraftforge.fmlonly;
+
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("fmlonly")
+public class FMLOnlyMod {}

--- a/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyMod.java
+++ b/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyMod.java
@@ -1,3 +1,8 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.fmlonly;
 
 import net.minecraftforge.fml.common.Mod;

--- a/fmlonly/src/main/java/net/minecraftforge/fmlonlyclient/ClientModLoader.java
+++ b/fmlonly/src/main/java/net/minecraftforge/fmlonlyclient/ClientModLoader.java
@@ -1,20 +1,6 @@
 /*
- * Minecraft Forge
- * Copyright (c) 2016-2021.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation version 2.1
- * of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 package net.minecraftforge.fmlonlyclient;

--- a/fmlonly/src/main/resources/META-INF/mods.toml
+++ b/fmlonly/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,16 @@
+modLoader="javafml"
+loaderVersion="[24,]"
+issueTrackerURL="https://www.minecraftforge.net/"
+license="LGPL v2.1"
+
+[[mods]]
+modId="fmlonly"
+# We use the global forge version
+version="${global.forgeVersion}"
+updateJSONURL="https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json"
+displayName="Forge"
+credits="Anyone who has contributed on Github and supports our development"
+authors="LexManos,cpw"
+description='''
+    Forge, a broad compatibility API.
+    '''


### PR DESCRIPTION
This is a simple PR that fixes a regression introduced by [Forge version 39.0.59](https://github.com/MinecraftForge/MinecraftForge/commit/476e20ae96014a13731068c96dfb5d095134d0f8). FMLOnly now loads properly in forgedev and userdev. Production was unaffected by this regression. Forgedev, userdev, and production were all tested and seem to work with this fix. Providing a `mods.toml` and declaring FMLOnly as a mod allows fmlloader to detect and load it properly. The `mods.toml` info is basically a copy of the forge variant. Because fmlonly does not add hooks for the mods button, this will basically never be seen during normal play.