### PR TITLE
[1.18.2] Add hook for making custom boots that can walk on powdered snow

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/PowderSnowBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PowderSnowBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/PowderSnowBlock.java
++++ b/net/minecraft/world/level/block/PowderSnowBlock.java
+@@ -109,7 +_,7 @@
+       if (p_154256_.m_6095_().m_204039_(EntityTypeTags.f_144291_)) {
+          return true;
+       } else {
+-         return p_154256_ instanceof LivingEntity ? ((LivingEntity)p_154256_).m_6844_(EquipmentSlot.FEET).m_150930_(Items.f_42463_) : false;
++         return p_154256_ instanceof LivingEntity ? ((LivingEntity)p_154256_).m_6844_(EquipmentSlot.FEET).canWalkOnPowderedSnow((LivingEntity)p_154256_) : false;
+       }
+    }
+ 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -708,6 +708,20 @@ public interface IForgeItem
     }
 
     /**
+     * Called by the powdered snow block to check if a living entity wearing this can walk on the snow, granting the same behavior as leather boots.
+     * Only affects items worn in the boots slot.
+     *
+     * @param stack  Stack instance
+     * @param wearer The entity wearing this ItemStack
+     *
+     * @return True if the entity can walk on powdered snow
+     */
+    default boolean canWalkOnPowderedSnow(ItemStack stack, LivingEntity wearer)
+    {
+        return stack.is(Items.LEATHER_BOOTS);
+    }
+
+    /**
      * Used to test if this item can be damaged, but with the ItemStack in question.
      * Please note that in some cases no ItemStack is available, so the stack-less method will be used.
      *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -469,6 +469,19 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     {
         return self().getItem().elytraFlightTick(self(), entity, flightTicks);
     }
+
+    /**
+     * Called by the powdered snow block to check if a living entity wearing this can walk on the snow, granting the same behavior as leather boots.
+     * Only affects items worn in the boots slot.
+     *
+     * @param wearer The entity wearing this ItemStack
+     *
+     * @return True if the entity can walk on powdered snow
+     */
+    default boolean canWalkOnPowderedSnow(LivingEntity wearer)
+    {
+        return self().getItem().canWalkOnPowderedSnow(self(), wearer);
+    }
     
     /**
      * Get a bounding box ({@link AABB}) of a sweep attack.

--- a/src/test/java/net/minecraftforge/debug/item/SnowBootsTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/SnowBootsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.item;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ArmorMaterials;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod(SnowBootsTest.MODID)
+public class SnowBootsTest
+{
+    public static final String MODID = "snow_boots_test";
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+
+    public static RegistryObject<Item> snow_boots = ITEMS.register("snow_boots", () ->
+        new ArmorItem(ArmorMaterials.DIAMOND, EquipmentSlot.FEET, (new Item.Properties().tab(CreativeModeTab.TAB_MISC)))
+        {
+            @Override
+            public boolean canWalkOnPowderedSnow(ItemStack stack, LivingEntity wearer) {
+                return wearer.getHealth() < 10;
+            }
+        }
+    );
+
+    public SnowBootsTest()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ITEMS.register(modEventBus);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -85,6 +85,8 @@ license="LGPL v2.1"
 [[mods]]
     modId="custom_elytra_test"
 [[mods]]
+    modId="snow_boots_test"
+[[mods]]
     modId="finite_water_test"
 [[mods]]
     modId="scaffolding_test"


### PR DESCRIPTION
Pretty straightforward patch, this replaces the hardcoded check for leather boots with a new `IForgeItem` hook that allow modded boots to act as "snow boots". Since the method already had access to a living entity, I decided to include that as additional context to the method, allowing entity sensitive snow boots.

My usecase for this is I make a mod that adds armor variants that are intended to replace the vanilla armor progression, but at this time I have no way to replicate leather boots powdered snow behavior. So I really only need item NBT sensitive ultimately.

Included in this PR is a test mod that adds "snow boots", which allow the player to walk on the powdered snow if they have less than 5 hearts remaining.