### PR TITLE
[1.18.x] Update Forge Auto Renaming Tool to 0.1.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     BINPATCH_TOOL = 'net.minecraftforge:binarypatcher:1.0.12:fatjar'
     INSTALLER_TOOLS = 'net.minecraftforge:installertools:1.2.10'
     JAR_SPLITTER = 'net.minecraftforge:jarsplitter:1.1.4'
-    FART = 'net.minecraftforge:ForgeAutoRenamingTool:0.1.17:all'
+    FART = 'net.minecraftforge:ForgeAutoRenamingTool:0.1.22:all'
     MIN_TAG_FOR_CHANGELOG = "39.0"
 }
 


### PR DESCRIPTION
Changelog:
* https://github.com/MinecraftForge/ForgeAutoRenamingTool/pull/16
* https://github.com/MinecraftForge/ForgeAutoRenamingTool/pull/13

This requires a bump to the version in MCPConfig in the next Minecraft Version