### PR TITLE
[1.18.x] [event] Add event for lightning strikes

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LightningBolt.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LightningBolt.java.patch
@@ -8,7 +8,7 @@
  
     public LightningBolt(EntityType<? extends LightningBolt> p_20865_, Level p_20866_) {
        super(p_20865_, p_20866_);
-@@ -74,6 +_,14 @@
+@@ -74,8 +_,17 @@
  
     }
  
@@ -22,7 +22,10 @@
 +
     public void m_8119_() {
        super.m_8119_();
++      if (net.minecraftforge.common.ForgeHooks.onLightningStrike(this, this.m_147162_())) return;
        if (this.f_20860_ == 2) {
+          if (this.f_19853_.m_5776_()) {
+             this.f_19853_.m_7785_(this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12090_, SoundSource.WEATHER, 10000.0F, 0.8F + this.f_19796_.nextFloat() * 0.2F, false);
 @@ -123,6 +_,7 @@
              List<Entity> list1 = this.f_19853_.m_6249_(this, new AABB(this.m_20185_() - 3.0D, this.m_20186_() - 3.0D, this.m_20189_() - 3.0D, this.m_20185_() + 3.0D, this.m_20186_() + 6.0D + 3.0D, this.m_20189_() + 3.0D), Entity::m_6084_);
  

--- a/patches/minecraft/net/minecraft/world/entity/LightningBolt.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LightningBolt.java.patch
@@ -22,7 +22,7 @@
 +
     public void m_8119_() {
        super.m_8119_();
-+      if (net.minecraftforge.common.ForgeHooks.onLightningStrike(this, this.m_147162_())) return;
++      if (net.minecraftforge.common.ForgeHooks.onLightningStrike(this, this.m_147162_())) {this.m_142687_(RemovalReason.DISCARDED);return;}
        if (this.f_20860_ == 2) {
           if (this.f_19853_.m_5776_()) {
              this.f_19853_.m_7785_(this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12090_, SoundSource.WEATHER, 10000.0F, 0.8F + this.f_19796_.nextFloat() * 0.2F, false);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -49,6 +49,7 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.core.*;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -128,6 +129,7 @@ import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.event.entity.LightningStrikeEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
@@ -1400,5 +1402,10 @@ public class ForgeHooks
             });
             LOGGER.error(WORLDPERSISTENCE, buf.toString());
         }
+    }
+
+    public static boolean onLightningStrike(LightningBolt lightningBolt, BlockPos pos)
+    {
+        return MinecraftForge.EVENT_BUS.post(new LightningStrikeEvent(lightningBolt, pos));
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Event that fires when a lightning strikes.
- * Cancel to prevent vanilla behavior.
+ * Cancel to prevent vanilla behavior and remove the LightningBolt.
  */
 @Cancelable
 public class LightningStrikeEvent extends Event

--- a/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Event that fires when a lightning strikes.
- * Cancel to prevent vanilla behaviour.
+ * Cancel to prevent vanilla behavior.
  */
 @Cancelable
 public class LightningStrikeEvent extends Event

--- a/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/LightningStrikeEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LightningBolt;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Event that fires when a lightning strikes.
+ * Cancel to prevent vanilla behaviour.
+ */
+@Cancelable
+public class LightningStrikeEvent extends Event
+{
+    private final LightningBolt bolt;
+    private final BlockPos pos;
+
+    public LightningStrikeEvent(LightningBolt bolt, BlockPos pos)
+    {
+        this.bolt = bolt;
+        this.pos = pos;
+    }
+
+    /**
+     * @return The strike position of the lightning bolt.
+     */
+    public BlockPos getStrikePos()
+    {
+        return pos;
+    }
+
+    /**
+     * @return The lightning bolt instance that is striking.
+     */
+    public LightningBolt getLightningBolt()
+    {
+        return bolt;
+    }
+}


### PR DESCRIPTION
This PR adds a LightningStrikeEvent that fires on each of the 3 ticks of a LightningBolt which when cancelled prevents vanilla behavior and removes the lightning bolt.