### PR TITLE
Add support for OnWorldRegistriesLoadedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -313,8 +313,11 @@
           return p_205187_::m_46934_;
        }, (p_210718_) -> {
           return (p_210712_, p_210713_) -> {
-@@ -1831,10 +_,10 @@
+@@ -1829,12 +_,13 @@
+                return WorldGenSettings.f_64600_.parse(dynamicops1, p_210687_);
+             });
              WorldGenSettings worldgensettings = dataresult.getOrThrow(false, Util.m_137489_("Error reading worldgen settings after loading data packs: ", f_90982_::error));
++            net.minecraftforge.event.async.ForgeAsyncEventFactories.doFireWorldRegistriesLoadedEvent(registryaccess$writable, dynamicops1, p_210712_, this, this::m_18701_);
              return Pair.of(new PrimaryLevelData(p_205187_, worldgensettings, dataresult.lifecycle()), registryaccess$writable.m_203557_());
           };
 -      }, false, Minecraft.ExperimentalDialogType.CREATE);

--- a/patches/minecraft/net/minecraft/server/Main.java.patch
+++ b/patches/minecraft/net/minecraft/server/Main.java.patch
@@ -66,6 +66,14 @@
           LevelSummary levelsummary = levelstoragesource$levelstorageaccess.m_78308_();
           if (levelsummary != null) {
              if (levelsummary.m_193020_()) {
+@@ -146,6 +_,7 @@
+                RegistryAccess.Writable registryaccess$writable = RegistryAccess.m_206197_();
+                DynamicOps<Tag> dynamicops = RegistryOps.m_206813_(NbtOps.f_128958_, registryaccess$writable, p_206543_);
+                WorldData worlddata1 = levelstoragesource$levelstorageaccess.m_211747_(dynamicops, p_206544_, registryaccess$writable.m_211816_());
++               net.minecraftforge.event.async.ForgeAsyncEventFactories.doFireWorldRegistriesLoadedEvent(registryaccess$writable, ((RegistryOps<Tag>) dynamicops).m_206831_(), p_206543_, net.minecraftforge.common.util.ExecutorUtils.getLocalThreadExecutor(), net.minecraftforge.common.util.ExecutorUtils::managedBlock);
+                if (worlddata1 != null) {
+                   return Pair.of(worlddata1, registryaccess$writable.m_203557_());
+                } else {
 @@ -181,22 +_,33 @@
           }
  

--- a/src/main/java/net/minecraftforge/common/util/ExecutorUtils.java
+++ b/src/main/java/net/minecraftforge/common/util/ExecutorUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.util;
+
+import net.minecraft.util.thread.ReentrantBlockableEventLoop;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
+
+public class ExecutorUtils {
+
+    private static final ThreadLocal<LocalEventLoop> localEventLoop = ThreadLocal.withInitial(LocalEventLoop::new);
+
+    public static Executor getLocalThreadExecutor() {
+        return localEventLoop.get();
+    }
+
+    public static void managedBlock(BooleanSupplier isDoneChecked) {
+        while(!isDoneChecked.getAsBoolean()) {
+            if (!localEventLoop.get().pollTask()) {
+                localEventLoop.get().waitForTasks();
+            }
+        }
+    }
+
+    private static class LocalEventLoop extends ReentrantBlockableEventLoop<Runnable> {
+
+        private final Thread localThread;
+
+        public LocalEventLoop() {
+            super(Thread.currentThread().getName());
+            localThread = Thread.currentThread();
+        }
+
+        @Override
+        protected @NotNull Runnable wrapRunnable(@NotNull Runnable runnable) {
+            return runnable;
+        }
+
+        @Override
+        protected boolean shouldRun(@NotNull Runnable runnable) {
+            return true;
+        }
+
+        @Override
+        protected @NotNull Thread getRunningThread() {
+            return localThread;
+        }
+
+        @Override
+        public void waitForTasks() {
+            super.waitForTasks();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/async/AbstractAsyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/async/AbstractAsyncEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.async;
+
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.task.IAsyncTaskConfigurator;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class AbstractAsyncEvent extends Event {
+
+    private final Supplier<IAsyncTaskConfigurator> taskConfiguratorSupplier;
+
+    protected AbstractAsyncEvent(Supplier<IAsyncTaskConfigurator> taskConfiguratorSupplier) {
+        this.taskConfiguratorSupplier = taskConfiguratorSupplier;
+    }
+
+    public void withAsyncTask(Consumer<IAsyncTaskConfigurator> configuratorConsumer) {
+        configuratorConsumer.accept(this.taskConfiguratorSupplier.get());
+    }
+}

--- a/src/main/java/net/minecraftforge/event/async/ForgeAsyncEventFactories.java
+++ b/src/main/java/net/minecraftforge/event/async/ForgeAsyncEventFactories.java
@@ -1,0 +1,70 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.async;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.DynamicOps;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.task.ForgeTaskFactories;
+import net.minecraftforge.task.IAsyncTaskConfigurator;
+import org.spongepowered.asm.mixin.Dynamic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ForgeAsyncEventFactories {
+
+    public static void doFireWorldRegistriesLoadedEvent(RegistryAccess registryAccess,
+                                                        DynamicOps<JsonElement> registryOps,
+                                                        ResourceManager resourceManager,
+                                                        Executor executor,
+                                                        Consumer<BooleanSupplier> managedBlocker)
+    {
+        fireOnForgeBus(
+                configuratorSupplier -> new OnWorldRegistriesLoadedEvent(configuratorSupplier, registryAccess, registryOps, resourceManager),
+                executor,
+                managedBlocker
+        );
+    }
+
+    private static <T extends AbstractAsyncEvent> boolean fireOnForgeBus(
+            final Function<Supplier<IAsyncTaskConfigurator>, T> eventBuilder,
+            final Executor executor,
+            final Consumer<BooleanSupplier> managedBlocker)
+    {
+        final List<IAsyncTaskConfigurator> configuratorList = Collections.synchronizedList(new ArrayList<>());
+        final ForgeTaskFactories.BarrierContext barrierContext = ForgeTaskFactories.barrierFor(executor);
+        final T event = eventBuilder.apply(() -> {
+            final IAsyncTaskConfigurator configurator = ForgeTaskFactories.simpleBarrierAware(barrierContext);
+            configuratorList.add(configurator);
+            return configurator;
+        });
+
+        final boolean cancelled = MinecraftForge.EVENT_BUS.post(event);
+
+        if (cancelled)
+            return true;
+
+        final CompletableFuture<?>[] allTasks = configuratorList.stream().map(ForgeTaskFactories::build)
+                        .toArray(CompletableFuture[]::new);
+        final CompletableFuture<Void> completionTask = CompletableFuture.allOf(allTasks);
+
+        barrierContext.start();
+        managedBlocker.accept(completionTask::isDone);
+
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/async/OnWorldRegistriesLoadedEvent.java
+++ b/src/main/java/net/minecraftforge/event/async/OnWorldRegistriesLoadedEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.async;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.DynamicOps;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.task.IAsyncTaskConfigurator;
+
+import java.util.function.Supplier;
+
+public class OnWorldRegistriesLoadedEvent extends AbstractAsyncEvent implements IModBusEvent {
+
+    private final RegistryAccess registryAccess;
+    private final DynamicOps<JsonElement> registryOps;
+    private final ResourceManager resourceManager;
+
+    OnWorldRegistriesLoadedEvent(Supplier<IAsyncTaskConfigurator> taskConfiguratorSupplier, RegistryAccess registryAccess, DynamicOps<JsonElement> registryOps, ResourceManager resourceManager) {
+        super(taskConfiguratorSupplier);
+        this.registryAccess = registryAccess;
+        this.registryOps = registryOps;
+        this.resourceManager = resourceManager;
+    }
+
+    public RegistryAccess getRegistryAccess() {
+        return registryAccess;
+    }
+
+    public DynamicOps<JsonElement> getRegistryOps() {
+        return registryOps;
+    }
+
+    public ResourceManager getResourceManager() {
+        return resourceManager;
+    }
+}

--- a/src/main/java/net/minecraftforge/task/BarrierAwareAsyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/BarrierAwareAsyncTaskConfigurator.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+class BarrierAwareAsyncTaskConfigurator extends ExecutorAsyncTaskConfigurator {
+
+    private final BarrierBuilder barrierBuilder;
+
+    BarrierAwareAsyncTaskConfigurator(
+            Executor asyncExecutor,
+            Executor syncExecutor,
+            BarrierBuilder barrierBuilder) {
+        super(asyncExecutor, syncExecutor);
+        this.barrierBuilder = barrierBuilder;
+    }
+
+    @Override
+    protected @NotNull <T> ExecutorTypedSyncTaskConfigurator<T> buildSyncExecutorConfigurator(CompletableFuture<T> asyncCode) {
+        return super.buildSyncExecutorConfigurator(
+                this.barrierBuilder.initial().thenComposeAsync((ignored) -> asyncCode, this.asyncExecutor)
+                        .thenComposeAsync(this.barrierBuilder::stage, this.syncExecutor)
+        );
+    }
+
+    public interface BarrierBuilder {
+        <T> CompletableFuture<T> stage(T input);
+
+        CompletableFuture<Void> initial();
+    }
+}

--- a/src/main/java/net/minecraftforge/task/ExecutorAsyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/ExecutorAsyncTaskConfigurator.java
@@ -1,0 +1,55 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+class ExecutorAsyncTaskConfigurator implements IAsyncTaskConfigurator, ICompletableFutureBuilder {
+
+    protected final Executor asyncExecutor;
+    protected final Executor syncExecutor;
+
+    protected ExecutorTypedSyncTaskConfigurator<?> syncTaskConfigurator = null;
+
+    ExecutorAsyncTaskConfigurator(Executor asyncExecutor, Executor syncExecutor) {
+        this.asyncExecutor = asyncExecutor;
+        this.syncExecutor = syncExecutor;
+    }
+
+    @Override
+    public ISyncTaskConfigurator async(Runnable code) {
+        return buildSyncExecutorConfigurator(CompletableFuture.runAsync(code, asyncExecutor));
+    }
+
+    @Override
+    public <T> ITypedSyncTaskConfigurator<T> async(Supplier<T> code) {
+        return buildSyncExecutorConfigurator(CompletableFuture.supplyAsync(code, asyncExecutor));
+    }
+
+    @Override
+    public void sync(Runnable runnable) {
+        buildSyncExecutorConfigurator(CompletableFuture.completedFuture(null)).sync(runnable);
+    }
+
+    @NotNull
+    protected  <T> ExecutorTypedSyncTaskConfigurator<T> buildSyncExecutorConfigurator(CompletableFuture<T> asyncCode) {
+        final ExecutorTypedSyncTaskConfigurator<T> result = new ExecutorTypedSyncTaskConfigurator<T>(
+                this.syncExecutor,
+                asyncCode
+        );
+
+        this.syncTaskConfigurator = result;
+        return result;
+    }
+
+    public CompletableFuture<Void> build() {
+        return syncTaskConfigurator.build();
+    }
+}

--- a/src/main/java/net/minecraftforge/task/ExecutorTypedSyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/ExecutorTypedSyncTaskConfigurator.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+class ExecutorTypedSyncTaskConfigurator<T> implements ITypedSyncTaskConfigurator<T>, ICompletableFutureBuilder  {
+
+    private final Executor syncExecutor;
+    private final CompletableFuture<T> asyncCode;
+
+    private CompletableFuture<Void> syncCode;
+
+    ExecutorTypedSyncTaskConfigurator(final Executor syncExecutor, CompletableFuture<T> asyncCode) {
+        this.syncExecutor = syncExecutor;
+        this.asyncCode = asyncCode;
+        this.syncCode = asyncCode.thenAcceptAsync((ignored) -> {}, syncExecutor);
+    }
+
+    @Override
+    public void sync(Consumer<T> consumer) {
+        this.syncCode = asyncCode.thenAcceptAsync(consumer, this.syncExecutor);
+    }
+
+    @Override
+    public void sync(Runnable runnable) {
+        this.syncCode = asyncCode.thenRunAsync(runnable, this.syncExecutor);
+    }
+
+    public CompletableFuture<Void> build() {
+        return syncCode;
+    }
+}

--- a/src/main/java/net/minecraftforge/task/ForgeTaskFactories.java
+++ b/src/main/java/net/minecraftforge/task/ForgeTaskFactories.java
@@ -1,0 +1,119 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import net.minecraft.Util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ForgeTaskFactories {
+
+    public static IAsyncTaskConfigurator simpleAsyncCapable(final Executor syncExecutor)
+    {
+          return simpleAsyncCapable(
+                  Util.backgroundExecutor(),
+                  syncExecutor
+          );
+    }
+
+    public static IAsyncTaskConfigurator simpleAsyncCapable(final Executor asyncExecutor, final Executor syncExecutor)
+    {
+        return new ExecutorAsyncTaskConfigurator(
+                asyncExecutor,
+                syncExecutor
+        );
+    }
+
+    public static IAsyncTaskConfigurator simpleBarrierAware(final BarrierContext barrierContext) {
+        return simpleBarrierAware(barrierContext, Util.backgroundExecutor());
+    }
+
+    public static IAsyncTaskConfigurator simpleBarrierAware(final BarrierContext barrierContext, final Executor asyncExecutor) {
+        return simpleBarrierAware(barrierContext, asyncExecutor, barrierContext.getBarrierExecutor());
+    }
+
+    public static IAsyncTaskConfigurator simpleBarrierAware(final BarrierContext barrierContext, final Executor asyncExecutor, final Executor syncExecutor) {
+        return new BarrierAwareAsyncTaskConfigurator(
+                asyncExecutor,
+                syncExecutor,
+                barrierContext.getBuilder()
+        );
+    }
+
+    public static BarrierContext barrierFor(final Executor executor) {
+        return new SynchronizedBarrierContext(executor);
+    }
+
+    public static CompletableFuture<Void> build(final ISyncTaskConfigurator configurator) {
+        if (configurator instanceof ICompletableFutureBuilder builder)
+            return builder.build();
+
+        throw new IllegalArgumentException("The configurator is not a completable future builder.");
+    }
+
+    public interface BarrierContext {
+        Executor getBarrierExecutor();
+
+        BarrierAwareAsyncTaskConfigurator.BarrierBuilder getBuilder();
+
+        void start();
+    }
+
+    private static class SynchronizedBarrierContext implements BarrierContext {
+
+        private final Executor barrierOn;
+
+        private final AtomicInteger nextContextId = new AtomicInteger(0);
+        private final List<Integer> expectedContexts = Collections.synchronizedList(new ArrayList<>());
+
+        private final CompletableFuture<Void> initialBarrierTask = new CompletableFuture<>();
+        private final CompletableFuture<Void> primaryBarrierTask = new CompletableFuture<>();
+
+        private SynchronizedBarrierContext(Executor barrierOn) {
+            this.barrierOn = barrierOn;
+        }
+
+        @Override
+        public Executor getBarrierExecutor() {
+            return barrierOn;
+        }
+
+        @Override
+        public BarrierAwareAsyncTaskConfigurator.BarrierBuilder getBuilder() {
+            final int contextId = nextContextId.getAndIncrement();
+            expectedContexts.add(contextId);
+            return new BarrierAwareAsyncTaskConfigurator.BarrierBuilder() {
+                @Override
+                public <T> CompletableFuture<T> stage(T input) {
+                    barrierOn.execute(() -> {
+                        expectedContexts.removeIf(id -> id == contextId);
+                        if (expectedContexts.isEmpty()) {
+                            primaryBarrierTask.complete(null);
+                        }
+
+                    });
+
+                    return primaryBarrierTask.thenApplyAsync((ignored) -> input, barrierOn);
+                }
+
+                @Override
+                public CompletableFuture<Void> initial() {
+                    return initialBarrierTask;
+                }
+            };
+        }
+
+        @Override
+        public void start() {
+            this.initialBarrierTask.completeAsync(() -> null, this.barrierOn);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/task/IAsyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/IAsyncTaskConfigurator.java
@@ -1,0 +1,31 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * A task configurator which can be used to configure task code which needs to run asynchronously first.
+ */
+public interface IAsyncTaskConfigurator extends ISyncTaskConfigurator {
+
+    /**
+     * Configures the task system to run code first asynchronously and then potentially append a synchronous section.
+     *
+     * @param code The code to run asynchronously.
+     * @return The task configurator for configuring synchronous tasks.
+     */
+    ISyncTaskConfigurator async(Runnable code);
+
+    /**
+     * Configures the task system to run code first asynchronously and have it supply the input for the potentially running synchronous section.
+     * @param code The code to run asynchronously.
+     * @param <T> The type of the object returned by the asynchronous code which is then potentially passed to the synchronous code.
+     * @return
+     */
+    <T> ITypedSyncTaskConfigurator<T> async(Supplier<T> code);
+}

--- a/src/main/java/net/minecraftforge/task/ICompletableFutureBuilder.java
+++ b/src/main/java/net/minecraftforge/task/ICompletableFutureBuilder.java
@@ -1,0 +1,13 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import java.util.concurrent.CompletableFuture;
+
+interface ICompletableFutureBuilder {
+
+    CompletableFuture<Void> build();
+}

--- a/src/main/java/net/minecraftforge/task/ISyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/ISyncTaskConfigurator.java
@@ -1,0 +1,18 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+/**
+ * Defines a task configurator which runs a task on the main thread.
+ */
+public interface ISyncTaskConfigurator {
+
+    /**
+     * Configure the code that should be synchronously run on the main thread.
+     * @param runnable The code to run on the main thread.
+     */
+    void sync(Runnable runnable);
+}

--- a/src/main/java/net/minecraftforge/task/ITypedSyncTaskConfigurator.java
+++ b/src/main/java/net/minecraftforge/task/ITypedSyncTaskConfigurator.java
@@ -1,0 +1,21 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.task;
+
+import java.util.function.Consumer;
+
+/**
+ * A configurator for configuring synchronous tasks.
+ * @param <T> The type of the object that the synchronous task consumes.
+ */
+public interface ITypedSyncTaskConfigurator<T> extends ISyncTaskConfigurator {
+
+    /**
+     * Configure the task to run a synchronous which consumes an object of type {@code T}.
+     * @param consumer The executing consumer which consumes the object and runs on the main thread.
+     */
+    void sync(Consumer<T> consumer);
+}

--- a/src/test/java/net/minecraftforge/debug/OnWorldRegistriesLoadedEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/OnWorldRegistriesLoadedEventTest.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.debug;
+
+import com.mojang.logging.LogUtils;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.async.OnWorldRegistriesLoadedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.slf4j.Logger;
+
+/**
+ * Declares a test for the {@link OnWorldRegistriesLoadedEvent} event.
+ * In particular this test verifies its ability to post process task in an async fashion.
+ *
+ * During world load (or creation) the following four lines need to appear in the log:
+ * - Async world registry loaded event without result processing, first task!
+ * - Async world registry loaded event with result processing!
+ * - Async world registry loaded event without result processing, second task!
+ * - Sync world registry loaded event with result processing, result: From Async
+ *
+ * Important here is that the order of the first three lines does not matter, but that the sync line always happens last.
+ */
+@Mod(OnWorldRegistriesLoadedEventTest.MODID)
+public class OnWorldRegistriesLoadedEventTest
+{
+    public static final String MODID = "world_registries_loaded_event";
+    public static final boolean ENABLED = true;
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public OnWorldRegistriesLoadedEventTest() {
+        if (!ENABLED)
+            return;
+
+        MinecraftForge.EVENT_BUS.addListener(this::onWorldRegistriesLoaded);
+    }
+
+    private void onWorldRegistriesLoaded(final OnWorldRegistriesLoadedEvent worldRegistriesLoadedEvent)
+    {
+        worldRegistriesLoadedEvent.withAsyncTask(asyncConfigurator -> asyncConfigurator.async(() -> LOGGER.warn("Async world registry loaded event without result processing, first task!")));
+        worldRegistriesLoadedEvent.withAsyncTask(asyncConfigurator -> asyncConfigurator.async(() -> {
+            LOGGER.warn("Async world registry loaded event with result processing!");
+            return "From Async";
+        })
+        .sync(result -> LOGGER.warn("Sync world registry loaded event with result processing, result: {}", result)));
+        worldRegistriesLoadedEvent.withAsyncTask(asyncConfigurator -> asyncConfigurator.async(() -> LOGGER.warn("Async world registry loaded event without result processing, second task!")));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -213,6 +213,8 @@ license="LGPL v2.1"
 [[mods]]
     modId="hide_neighbor_face_test"
 [[mods]]
+    modId="world_registries_loaded_event"
+[[mods]]
     modId="living_get_projectile_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
### New Subsystems:
- Task system
- Async Events (more on those later, the name is misleading)
- OnWorldRegistriesLoadedEvent (First example of an async event, currently gives access to IO and world Registry in one common place)

#### Task system
This system is designed to work together with executors, and event loops to create a way of processing a set of tasks in one particular place while being able to collect the tasks in another.
The system is designed to feel similar to a `ResourceReloadListener` with support for both an async phase as well as a sync phase. But has an API which is easier to understand.

The system comes with a set of configurators which can be used to configure a single task that is supposed to be executed.

Additionally the system supports barrier based splitting of the phases (if a barrier is not used, then the async and sync parts are executed immediately after each other on the relevant executor, regardless of if there are async parts of other tasks still in the queue), this splitting guarantees that first all async parts are executed on its executor, and once those are all completed the sync parts are executed on their own executor.

#### Async Events
The name is misleading here, but I could not find a better one. An async event is a normal event, fired on a normal synchronous event bus, which then has a post-processing phase which is split in an async and a sync part. This functions then similar to a `ResourceReloadListener` but as a post processing phase to the events firing. (Note if the event is cancelled, then no post-processing is supposed to be executed).

#### OnWorldRegistriesLoadedEvent 
This is the first example of the async event system at play. It is fired when the world registries have been loaded (so after there datapack information is overriden etc) but before the control is handed back to world loading. The event gives a modder access to a common place where both the world specific registries exists and are properly loaded (so Tags can be retrieved) while also the required `ResourceManager` for datapack access is available. Additionally the async post processing allows the IO to be performed asynchronously speeding up the loading of the data if a lot of mods use this endpoint.

### The test mod
The included testmod verifies that the event is properly fired and that the async post processing happens in the correct order.

### Patches:
Both `Minecraft.java` and the server `Main.java` are patched to fired the event.