### PR TITLE
Fix incorrect method used in getStream

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/sounds/SoundInstance.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/sounds/SoundInstance.java.patch
@@ -8,6 +8,6 @@
 +   /*================================ FORGE START ================================================*/
 +
 +   default java.util.concurrent.CompletableFuture<net.minecraft.client.sounds.AudioStream> getStream(net.minecraft.client.sounds.SoundBufferLibrary soundBuffers, Sound sound, boolean looping) {
-+      return soundBuffers.m_120204_(sound.m_119787_(), looping);
++      return soundBuffers.m_120204_(sound.m_119790_(), looping);
 +   }
  }


### PR DESCRIPTION
This PR fixes #8531 by changing the method used in the Forge-added method `SoundInstance#getStream` from `Sound#getLocation` (which is the location/idenfitier of the sound itself) to the correct `Sound#getPath` (which is the resource location to the sound OGG resource).