### PR TITLE
[1.18.x] Allow Brewing Stand to Properly Handle Stacked Items in Bottle Slots

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/BrewingStandMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/BrewingStandMenu.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/inventory/BrewingStandMenu.java
 +++ b/net/minecraft/world/inventory/BrewingStandMenu.java
+@@ -75,7 +_,7 @@
+                if (!this.m_38903_(itemstack1, 3, 4, false)) {
+                   return ItemStack.f_41583_;
+                }
+-            } else if (BrewingStandMenu.PotionSlot.m_39133_(itemstack) && itemstack.m_41613_() == 1) {
++            } else if (BrewingStandMenu.PotionSlot.m_39133_(itemstack)) {
+                if (!this.m_38903_(itemstack1, 0, 3, false)) {
+                   return ItemStack.f_41583_;
+                }
 @@ -146,7 +_,7 @@
        }
  

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -137,8 +137,6 @@ public class BrewingRecipeRegistry {
      */
     public static boolean isValidInput(ItemStack stack)
     {
-        if (stack.getCount() != 1) return false;
-
         for (IBrewingRecipe recipe : recipes)
         {
             if (recipe.isInput(stack))


### PR DESCRIPTION
Closes #8521.

Removes the count checks from the brewing menu and registry to allow stacked items to be properly handled. This has no adverse effects since the menu handles all splitting logic normally without issue.