### PR TITLE
[1.18.x] Simplfy default behavior of isSimple

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/crafting/Ingredient.java
 +++ b/net/minecraft/world/item/crafting/Ingredient.java
-@@ -29,17 +_,26 @@
+@@ -29,12 +_,19 @@
  import net.minecraft.world.level.ItemLike;
  
  public class Ingredient implements Predicate<ItemStack> {
@@ -17,16 +17,9 @@
     @Nullable
     private IntList f_43904_;
 +   private int invalidationCounter;
-+   private final boolean isSimple;
  
     protected Ingredient(Stream<? extends Ingredient.Value> p_43907_) {
        this.f_43902_ = p_43907_.toArray((p_43933_) -> {
-          return new Ingredient.Value[p_43933_];
-       });
-+      this.isSimple = !net.minecraftforge.data.loading.DatagenModLoader.isRunningDataGen() && !Arrays.stream(f_43902_).anyMatch(list -> list.m_6223_().stream().anyMatch(stack -> stack.m_41720_().isDamageable(stack)));
-    }
- 
-    public ItemStack[] m_43908_() {
 @@ -78,7 +_,8 @@
     }
  
@@ -71,7 +64,7 @@
 +   }
 +
 +   public boolean isSimple() {
-+      return isSimple || this == f_43901_;
++      return true;
 +   }
 +
 +   private final boolean isVanilla = this.getClass() == Ingredient.class;


### PR DESCRIPTION
isSimple should only return true if the ingredient is not NBT sensitive. Simply matching against a pickaxe or another damagable tool is not NBT sensitive so it should still be considered simple

Also prevents fetching tag values too early, as tags are not ready during the ingredient constructor.