### PR TITLE
implement a server starter jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,8 +486,20 @@ def sharedFmlonlyForge = { Project prj ->
             IGNORE_LIST: Util.getArtifacts(prj, prj.configurations.moduleonly, false).values().collect{it.downloads.artifact.path.rsplit('/', 1)[1]}.join(','),
             MODULES: 'ALL-MODULE-PATH'
     ]
+
+    def makeLauncherScriptJar = prj.tasks.register('makeLauncherScriptJar', Zip) {
+        dependsOn ':launcherscript:jar'
+
+        from(zipTree(project(':launcherscript').tasks.jar.outputs.files.singleFile)) {
+            exclude("maven_path.txt")
+        }
+        from(zipTree(project(':launcherscript').tasks.jar.outputs.files.singleFile)) {
+            include("maven_path.txt")
+            filter(ReplaceTokens, tokens: tokens)
+        }
+    }
     
-    prj.task([dependsOn: rootProject.downloadServerRaw], 'makeClasspathFiles') {
+    prj.task([dependsOn: [rootProject.downloadServerRaw, makeLauncherScriptJar]], 'makeClasspathFiles') {
         doLast {
             def CLASS_PATH = Util.getArtifacts(prj, prj.configurations.installer, false).values().collect{"libraries/${it.downloads.artifact.path}"} +
             [
@@ -509,6 +521,9 @@ def sharedFmlonlyForge = { Project prj ->
                 from(rootProject.file('server_files/args.txt')) {
                     filter(ReplaceTokens, tokens: tokens + [MODULE_PATH: MODULE_PATH.join(':'), CLASS_PATH: CLASS_PATH.join(':')])
                     rename { 'data/unix_args.txt' }
+                }
+                from(makeLauncherScriptJar) {
+                    rename { 'data/start_server.jar' }
                 }
             }
         }
@@ -717,6 +732,10 @@ project(':fmlonly') {
                             '--to',   '{ROOT}/run.bat',
                             //'--from', 'data/run_fml_${VERSION.replace('-', '_').bat',
                             //'--to',   '{ROOT}/run_fml_${VERSION.replace('-', '_').bat',
+
+                            '--from', 'data/start_server.jar',
+                            '--to',   '{ROOT}/start_server.jar',
+                            '--exec', '{ROOT}/start_server.jar', // executable bit allows double-clicking in Linux Desktop
 
                             '--from',     'data/user_jvm_args.txt',
                             '--to',       '{ROOT}/user_jvm_args.txt',
@@ -1305,6 +1324,10 @@ project(':forge') {
                             '--to',   '{ROOT}/run.bat',
                             //'--from', 'data/run_forge_${VERSION.replace('-', '_').bat',
                             //'--to',   '{ROOT}/run_forge_${VERSION.replace('-', '_').bat',
+
+                            '--from', 'data/start_server.jar',
+                            '--to',   '{ROOT}/start_server.jar',
+                            '--exec', '{ROOT}/start_server.jar', // executable bit allows double-clicking in Linux Desktop
 
                             '--from',     'data/user_jvm_args.txt',
                             '--to',       '{ROOT}/user_jvm_args.txt',

--- a/launcherscript/build.gradle
+++ b/launcherscript/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'java'
+}
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'net.minecraftforge.launcherscript.LauncherScript'
+        )
+    }
+}

--- a/launcherscript/src/main/java/net/minecraftforge/launcherscript/LauncherScript.java
+++ b/launcherscript/src/main/java/net/minecraftforge/launcherscript/LauncherScript.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.launcherscript;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class LauncherScript
+{
+
+    public static void main(String[] args) throws Exception
+    {
+
+        List<String> command = new ArrayList<>();
+        Collections.addAll(command, findJavaBinary(), "@user_jvm_args.txt");
+
+        command.add(String.format(Locale.ROOT, "@libraries/%s/%s_args.txt", loadMavenPath(), isWindows() ? "win" : "unix"));
+        Collections.addAll(command, args);
+        new ProcessBuilder(command)
+                .directory(null)
+                .inheritIO()
+                .start().waitFor();
+    }
+
+    private static String findJavaBinary() {
+        return ProcessHandle.current().info().command().orElse("java");
+    }
+
+    private static boolean isWindows()
+    {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private static String loadMavenPath() throws IOException
+    {
+        var stream = LauncherScript.class.getClassLoader().getResourceAsStream("maven_path.txt");
+        if (stream == null)
+        {
+            throw new IOException("Missing maven_path.txt");
+        }
+        try (var reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
+        {
+            return Objects.requireNonNull(reader.readLine(), "maven_path.txt empty");
+        }
+    }
+
+}

--- a/launcherscript/src/main/java/net/minecraftforge/launcherscript/LauncherScript.java
+++ b/launcherscript/src/main/java/net/minecraftforge/launcherscript/LauncherScript.java
@@ -1,10 +1,19 @@
+/*
+ * Minecraft Forge - Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.launcherscript;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 public class LauncherScript
 {

--- a/launcherscript/src/main/resources/maven_path.txt
+++ b/launcherscript/src/main/resources/maven_path.txt
@@ -1,0 +1,1 @@
+@MAVEN_PATH@

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include ':mcp'
 include ':clean'
 include ':fmlonly'
 include ':forge'
+include ':launcherscript'
 
 project(":mcp").projectDir = file("projects/mcp")
 project(":clean").projectDir = file("projects/clean")


### PR DESCRIPTION
Adds a `server_starter.jar` generated by the installer. Allows starting the server via `java -jar start_server.jar`.

~~So far only tested in a Linux console, marked as Draft until further testing (Windows, possibly server hosting consoles) has been done.~~