### PR TITLE
[1.18.x] Expose `getHolder()` method on RegistryObject

### DIFF
--- a/patches/minecraft/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/minecraft/net/minecraft/core/MappedRegistry.java.patch
@@ -1,17 +1,27 @@
 --- a/net/minecraft/core/MappedRegistry.java
 +++ b/net/minecraft/core/MappedRegistry.java
-@@ -279,6 +_,14 @@
-       return this.f_205842_.containsKey(p_175392_);
-    }
+@@ -90,7 +_,8 @@
+       this.f_122672_.size(Math.max(this.f_122672_.size(), p_205858_ + 1));
+       this.f_122673_.put(p_205860_, p_205858_);
+       this.f_211051_ = null;
+-      if (p_205862_ && this.f_205842_.containsKey(p_205859_)) {
++      // Forge: Fix bug where a key is considered a duplicate if getOrCreateHolder was called before the entry was registered
++      if (p_205862_ && this.f_205842_.containsKey(p_205859_) && this.f_205842_.get(p_205859_).m_203633_()) {
+          Util.m_143785_("Adding duplicate key '" + p_205859_ + "' to registry");
+       }
  
+@@ -277,6 +_,14 @@
+ 
+    public boolean m_142003_(ResourceKey<T> p_175392_) {
+       return this.f_205842_.containsKey(p_175392_);
++   }
++
 +   /** @deprecated Forge: For internal use only. Use the Register events when registering values. */
 +   @Deprecated
 +   public void unfreeze() {
 +      this.f_205845_ = false;
 +      if (this.f_205846_ != null && this.f_205847_ == null)
 +         this.f_205847_ = new IdentityHashMap<>();
-+   }
-+
+    }
+ 
     public Registry<T> m_203521_() {
-       this.f_205845_ = true;
-       List<ResourceLocation> list = this.f_205842_.entrySet().stream().filter((p_211055_) -> {

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -578,6 +578,19 @@ public final class RegistryObject<T> implements Supplier<T>
         }
     }
 
+    /**
+     * Returns an optional {@link Holder} instance pointing to this RegistryObject's name and value.
+     * <p>
+     * This should <b>only</b> be used in cases where vanilla code requires passing in a Holder.
+     * Mod-written code should rely on RegistryObjects or Suppliers instead.
+     * <p>
+     * The returned optional will be empty if the registry does not exist
+     * or if the deprecated factories {@link #of(ResourceLocation, Class, String)}
+     * or {@link #of(ResourceLocation, Supplier)} are used.
+     * Otherwise, the optional Holder will be present even if {@link #isPresent()} returns false.
+     *
+     * @return an optional {@link Holder} instance pointing to this RegistryObject's name and value
+     */
     @SuppressWarnings("unchecked")
     @NotNull
     public Optional<Holder<T>> getHolder()

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -396,6 +396,18 @@ public final class RegistryObject<T> implements Supplier<T>
         return this.name;
     }
 
+    /**
+     * Returns the resource key that points to the registry and name of this registry object.
+     * Nullable only when the deprecated functions {@link #of(ResourceLocation, Class, String)} or {@link #of(ResourceLocation, Supplier)} are used.
+     *
+     * @return the resource key that points to the registry and name of this registry object
+     */
+    @Nullable
+    public ResourceKey<T> getKey()
+    {
+        return this.key;
+    }
+
     public Stream<T> stream() {
         return isPresent() ? Stream.of(get()) : Stream.of();
     }

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -404,7 +404,7 @@ public final class RegistryObject<T> implements Supplier<T>
 
     /**
      * Returns the resource key that points to the registry and name of this registry object.
-     * Nullable only when the deprecated functions {@link #of(ResourceLocation, Class, String)} or {@link #of(ResourceLocation, Supplier)} are used.
+     * Nullable only when the deprecated factories {@link #of(ResourceLocation, Class, String)} or {@link #of(ResourceLocation, Supplier)} are used.
      *
      * @return the resource key that points to the registry and name of this registry object
      */

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -351,7 +351,7 @@ public final class RegistryObject<T> implements Supplier<T>
             this.value = registry.get(this.name);
             if (this.key == null)
                 this.key = (ResourceKey<T>) ResourceKey.create(registry.key(), this.name);
-            this.holder = ((Registry<T>) registry).getHolder(ResourceKey.create((ResourceKey<? extends Registry<T>>) registry.key(), this.name)).orElse(null);
+            this.holder = ((Registry<T>) registry).getHolder(this.key).orElse(null);
         }
         else
         {

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -198,7 +198,7 @@ public final class RegistryObject<T> implements Supplier<T>
         return new RegistryObject<>(name, registryName, modid, true);
     }
 
-    private static RegistryObject<?> EMPTY = new RegistryObject<>();
+    private static final RegistryObject<?> EMPTY = new RegistryObject<>();
 
     private static <T> RegistryObject<T> empty() {
         @SuppressWarnings("unchecked")
@@ -325,6 +325,8 @@ public final class RegistryObject<T> implements Supplier<T>
     @Deprecated(since = "1.18.1") // TODO: make package-private
     public void updateReference(IForgeRegistry<? extends T> registry)
     {
+        if (this.name == null)
+            return;
         if (registry.containsKey(this.name))
         {
             this.value = registry.getValue(this.name);
@@ -342,6 +344,8 @@ public final class RegistryObject<T> implements Supplier<T>
     @SuppressWarnings("unchecked")
     void updateReference(Registry<? extends T> registry)
     {
+        if (this.name == null)
+            return;
         if (registry.containsKey(this.name))
         {
             this.value = registry.get(this.name);
@@ -359,6 +363,8 @@ public final class RegistryObject<T> implements Supplier<T>
     @SuppressWarnings("unchecked")
     void updateReference(ResourceLocation registryName)
     {
+        if (this.name == null)
+            return;
         IForgeRegistry<? extends T> forgeRegistry = RegistryManager.ACTIVE.getRegistry(registryName);
         if (forgeRegistry != null)
         {

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -5,13 +5,13 @@
 
 package net.minecraftforge.registries;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -23,10 +23,15 @@ import java.util.stream.Stream;
 
 public final class RegistryObject<T> implements Supplier<T>
 {
+    @Nullable
     private final ResourceLocation name;
+    @Nullable
+    private ResourceKey<T> key;
     private final boolean optionalRegistry;
     @Nullable
     private T value;
+    @Nullable
+    private Holder<T> holder;
 
     /**
      * @deprecated The uniqueness of registry super types will not be guaranteed starting in 1.19.
@@ -268,6 +273,7 @@ public final class RegistryObject<T> implements Supplier<T>
     private RegistryObject(final ResourceLocation name, final ResourceLocation registryName, final String modid, boolean optionalRegistry)
     {
         this.name = name;
+        this.key = ResourceKey.create(ResourceKey.createRegistryKey(registryName), name);
         this.optionalRegistry = optionalRegistry;
         final Throwable callerStack = new Throwable("Calling Site from mod: " + modid);
         ObjectHolderRegistry.addHandler(new Consumer<>()
@@ -297,11 +303,17 @@ public final class RegistryObject<T> implements Supplier<T>
     }
 
     /**
-     * Directly retrieves the wrapped Registry Object. This value will automatically be updated when the backing registry is updated.
-     * Will throw NPE if the value is null, use isPresent to check first. Or use any of the other guarded functions.
+     * Retrieves the wrapped object in the registry.
+     * This value will automatically be updated when the backing registry is updated.
+     *
+     * @throws NullPointerException If the value is null. Use {@link #isPresent()} to check if the value exists first.
+     * @see #isPresent()
+     * @see #orElse(Object)
+     * @see #orElseGet(Supplier)
+     * @see #orElseThrow(Supplier)
      */
+    @NotNull
     @Override
-    @Nonnull
     public T get()
     {
         T ret = this.value;
@@ -309,15 +321,39 @@ public final class RegistryObject<T> implements Supplier<T>
         return ret;
     }
 
+    @SuppressWarnings("unchecked")
     @Deprecated(since = "1.18.1") // TODO: make package-private
     public void updateReference(IForgeRegistry<? extends T> registry)
     {
-        this.value = registry.containsKey(this.name) ? registry.getValue(this.name) : null;
+        if (registry.containsKey(this.name))
+        {
+            this.value = registry.getValue(this.name);
+            if (this.key == null)
+                this.key = (ResourceKey<T>) ResourceKey.create(registry.getRegistryKey(), this.name);
+            this.holder = (Holder<T>) registry.getHolder(this.name).orElse(null);
+        }
+        else
+        {
+            this.value = null;
+            this.holder = null;
+        }
     }
 
+    @SuppressWarnings("unchecked")
     void updateReference(Registry<? extends T> registry)
     {
-        this.value = registry.containsKey(this.name) ? registry.get(this.name) : null;
+        if (registry.containsKey(this.name))
+        {
+            this.value = registry.get(this.name);
+            if (this.key == null)
+                this.key = (ResourceKey<T>) ResourceKey.create(registry.key(), this.name);
+            this.holder = ((Registry<T>) registry).getHolder(ResourceKey.create((ResourceKey<? extends Registry<T>>) registry.key(), this.name)).orElse(null);
+        }
+        else
+        {
+            this.value = null;
+            this.holder = null;
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -345,6 +381,7 @@ public final class RegistryObject<T> implements Supplier<T>
         }
 
         this.value = null;
+        this.holder = null;
     }
 
     private static boolean registryExists(ResourceLocation registryName)
@@ -521,6 +558,24 @@ public final class RegistryObject<T> implements Supplier<T>
         } else {
             throw exceptionSupplier.get();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    public Optional<Holder<T>> getHolder()
+    {
+        if (this.holder == null && this.key != null && registryExists(this.key.registry()))
+        {
+            ResourceLocation registryName = this.key.registry();
+            Registry<T> registry = (Registry<T>) Registry.REGISTRY.get(registryName);
+            if (registry == null)
+                registry = (Registry<T>) BuiltinRegistries.REGISTRY.get(registryName);
+
+            if (registry != null)
+                this.holder = registry.getOrCreateHolder(this.key);
+        }
+
+        return Optional.ofNullable(this.holder);
     }
 
     @Override


### PR DESCRIPTION
This PR exposes a `getHolder()` method on RegistryObject which returns an `Optional<Holder<T>>` to provide better compatibility with vanilla code that requires the use of a Holder, especially worldgen (see `FeatureUtils#simpleRandomPatchConfiguration`, `BiomeGenerationSettings#addFeature`, `WeightedPlacedFeature#<init>`, `RandomBooleanFeatureConfiguration#<init>` for some examples).