### PR TITLE
Fix return value of Recipe#isIncomplete being inaccurate for empty tags

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/Recipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Recipe.java.patch
@@ -13,3 +13,12 @@
           }
        }
  
+@@ -55,7 +_,7 @@
+    default boolean m_142505_() {
+       NonNullList<Ingredient> nonnulllist = this.m_7527_();
+       return nonnulllist.isEmpty() || nonnulllist.stream().anyMatch((p_151268_) -> {
+-         return p_151268_.m_43908_().length == 0;
++         return net.minecraftforge.common.ForgeHooks.hasNoElements(p_151268_);
+       });
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -43,6 +43,15 @@
     static NonNullList<Ingredient> m_44202_(String[] p_44203_, Map<String, Ingredient> p_44204_, int p_44205_, int p_44206_) {
        NonNullList<Ingredient> nonnulllist = NonNullList.m_122780_(p_44205_ * p_44206_, Ingredient.f_43901_);
        Set<String> set = Sets.newHashSet(p_44204_.keySet());
+@@ -180,7 +_,7 @@
+       return nonnulllist.isEmpty() || nonnulllist.stream().filter((p_151277_) -> {
+          return !p_151277_.m_43947_();
+       }).anyMatch((p_151273_) -> {
+-         return p_151273_.m_43908_().length == 0;
++         return net.minecraftforge.common.ForgeHooks.hasNoElements(p_151273_);
+       });
+    }
+ 
 @@ -202,15 +_,15 @@
  
     static String[] m_44196_(JsonArray p_44197_) {

--- a/patches/minecraft/net/minecraft/world/item/crafting/UpgradeRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/UpgradeRecipe.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/world/item/crafting/UpgradeRecipe.java
 +++ b/net/minecraft/world/item/crafting/UpgradeRecipe.java
-@@ -72,7 +_,7 @@
+@@ -68,11 +_,11 @@
+ 
+    public boolean m_142505_() {
+       return Stream.of(this.f_44518_, this.f_44519_).anyMatch((p_151284_) -> {
+-         return p_151284_.m_43908_().length == 0;
++         return net.minecraftforge.common.ForgeHooks.hasNoElements(p_151284_);
        });
     }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -58,6 +58,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.*;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -1091,6 +1092,19 @@ public class ForgeHooks
     public static int canEntitySpawn(Mob entity, LevelAccessor world, double x, double y, double z, BaseSpawner spawner, MobSpawnType spawnReason) {
         Result res = ForgeEventFactory.canEntitySpawn(entity, world, x, y, z, null, spawnReason);
         return res == Result.DEFAULT ? 0 : res == Result.DENY ? -1 : 1;
+    }
+
+    public static boolean hasNoElements(Ingredient ingredient)
+    {
+        ItemStack[] items = ingredient.getItems();
+        if (items.length == 0) return true;
+        if (items.length == 1 && !ForgeConfig.SERVER.treatEmptyTagsAsAir.get())
+        {
+            //If we potentially added a barrier due to the ingredient being an empty tag, try and check if it is the stack we added
+            ItemStack item = items[0];
+            return item.getItem() == Items.BARRIER && item.getHoverName() instanceof TextComponent hoverName && hoverName.getText().startsWith("Empty Tag: ");
+        }
+        return false;
     }
 
     public static <T> void deserializeTagAdditions(List<Tag.Entry> list, JsonObject json, List<Tag.BuilderEntry> allList)


### PR DESCRIPTION
Forge adds barriers to the output items for empty tags to fix issues with how vanilla does recipe matching. This adjusts vanilla's code that checks for if a recipe is incomplete and should be added to the recipe book to properly ignore this added item.

Eventually hopefully mojang will make `Recipe#isIncomplete` also be used as a precheck sort of thing before matching recipes, but until then as it would be a lot of spots for forge to patch and potentially might cause the method to be used in a way mojang doesn't intend, this is a simpler and less intrusive fix.