### PR TITLE
Fix issues with custom forge ingredients causing sub ingredients to be prematurely and invalidly cached

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -56,3 +56,12 @@
           } else {
              ItemStack itemstack = ShapedRecipe.m_151274_(GsonHelper.m_13930_(p_44291_, "result"));
              return new ShapelessRecipe(p_44290_, s, itemstack, nonnulllist);
+@@ -88,7 +_,7 @@
+ 
+          for(int i = 0; i < p_44276_.size(); ++i) {
+             Ingredient ingredient = Ingredient.m_43917_(p_44276_.get(i));
+-            if (!ingredient.m_43947_()) {
++            if (net.minecraftforge.common.ForgeConfig.SERVER.skipEmptyShapelessCheck.get() || !ingredient.m_43947_()) {
+                nonnulllist.add(ingredient);
+             }
+          }

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -27,6 +27,7 @@ public class ForgeConfig {
         public final DoubleValue zombieBabyChance;
 
         public final BooleanValue treatEmptyTagsAsAir;
+        public final BooleanValue skipEmptyShapelessCheck;
 
         public final BooleanValue fixAdvancementLoading;
 
@@ -64,6 +65,11 @@ public class ForgeConfig {
                     .comment("Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.")
                     .translation("forge.configgui.treatEmptyTagsAsAir")
                     .define("treatEmptyTagsAsAir", false);
+
+            skipEmptyShapelessCheck = builder
+                  .comment("Skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early.")
+                  .translation("forge.configgui.skipEmptyShapelessCheck")
+                  .define("skipEmptyShapelessCheck", true);
 
             fixAdvancementLoading = builder
                     .comment("Fix advancement loading to use a proper topological sort. This may have visibility side-effects and can thus be turned off if needed for data-pack compatibility.")

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -156,7 +156,7 @@ public class CompoundIngredient extends AbstractIngredient
     @Override
     public boolean isEmpty()
     {
-        return getItems().length == 0;
+        return children.stream().allMatch(Ingredient::isEmpty);
     }
 
     public static class Serializer implements IIngredientSerializer<CompoundIngredient>

--- a/src/main/java/net/minecraftforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/DifferenceIngredient.java
@@ -64,7 +64,7 @@ public class DifferenceIngredient extends AbstractIngredient
     @Override
     public boolean isEmpty()
     {
-        return getItems().length == 0;
+        return base.isEmpty();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IntersectionIngredient.java
@@ -91,7 +91,7 @@ public class IntersectionIngredient extends AbstractIngredient
     @Override
     public boolean isEmpty()
     {
-        return getItems().length == 0;
+        return children.stream().anyMatch(Ingredient::isEmpty);
     }
 
     @Override

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -153,6 +153,8 @@
   "forge.configgui.clumpingThreshold": "Packet Clumping Threshold",
   "forge.configgui.treatEmptyTagsAsAir.tooltip": "Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.",
   "forge.configgui.treatEmptyTagsAsAir": "Treat empty tags as air",
+  "forge.configgui.skipEmptyShapelessCheck.tooltip": "Skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early.",
+  "forge.configgui.skipEmptyShapelessCheck":  "Skip checking for empty ingredients in Shapeless Recipe Deserialization",
   "forge.configgui.forceSystemNanoTime.tooltip": "Force the use of System.nanoTime instead of glfwGetTime as the main client Time provider.",
   "forge.configgui.forceSystemNanoTime": "Force System.nanoTime",
 


### PR DESCRIPTION
This PR fixes an issue I ran into when trying to use the `DifferenceIngredient` in a `ShapelessRecipe` as part of the deserialization logic for `ShapelessRecipe`s checks if the ingredient is empty. Vanilla's default empty implementation seems to be: `if no values and hasn't been initialized then it is empty`, so I went ahead and added empty checks in a semi similar way based on what my intuition tells me is right (this should definitely be validated to see if it makes sense though):
- Compound Ingredient: If all child ingredients are empty the compound is empty
- Intersection Ingredient: If any child ingredient is empty the intersection is empty. This doesn't necessarily return it being empty for non intersecting sets, but as vanilla in many places uses `getItems().length == 0` to check if the ingredient has no elements, I believe this is a reasonable implementation.
- Difference Ingredient: If the base ingredient is empty the difference is empty. I ignore the `subtracted` ingredient as if it is empty then the ingredient will just be equal to the `base` ingredient.

To prevent similar issues I also made a [commit](https://github.com/pupnewfster/MinecraftForge/commit/2f838577b928190e90018f518f49c040ea566681) on another branch that in theory would fix any issues like this where modders may accidentally initialize an ingredients' item cache during resource reloading (when tags are invalid) by invalidating all ingredients when tags update on the server (as client side there is no issue as the server doesn't tell the client the ingredient is a tag). I didn't include that commit in this PR for now as I am not quite sure if this extra safety handling is something that forge wants to do as it will add a tiny bit of overhead each time `getItems` or `test` is ran on ingredients to check if the ingredient's cache is valid. Additionally ensuring it is valid like that and updating it then would likely end up masking bugs in mods that then would never be discovered. Though if this is something that is decided is worthwhile to have I can add that commit to this PR.