### PR TITLE
[1.18.x] Add use context and simulate flag to getToolModifiedState

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
@@ -9,9 +9,9 @@
 -      Optional<BlockState> optional2 = Optional.ofNullable(HoneycombItem.f_150864_.get().get(blockstate.m_60734_())).map((p_150694_) -> {
 -         return p_150694_.m_152465_(blockstate);
 -      });
-+      Optional<BlockState> optional = Optional.ofNullable(blockstate.getToolModifiedState(level, blockpos, player, p_40529_.m_43722_(), net.minecraftforge.common.ToolActions.AXE_STRIP));
-+      Optional<BlockState> optional1 = Optional.ofNullable(blockstate.getToolModifiedState(level, blockpos, player, p_40529_.m_43722_(), net.minecraftforge.common.ToolActions.AXE_SCRAPE));
-+      Optional<BlockState> optional2 = Optional.ofNullable(blockstate.getToolModifiedState(level, blockpos, player, p_40529_.m_43722_(), net.minecraftforge.common.ToolActions.AXE_WAX_OFF));
++      Optional<BlockState> optional = Optional.ofNullable(blockstate.getToolModifiedState(p_40529_, net.minecraftforge.common.ToolActions.AXE_STRIP, false));
++      Optional<BlockState> optional1 = optional.isPresent() ? Optional.empty() : Optional.ofNullable(blockstate.getToolModifiedState(p_40529_, net.minecraftforge.common.ToolActions.AXE_SCRAPE, false));
++      Optional<BlockState> optional2 = optional.isPresent() || optional1.isPresent() ? Optional.empty() : Optional.ofNullable(blockstate.getToolModifiedState(p_40529_, net.minecraftforge.common.ToolActions.AXE_WAX_OFF, false));
        ItemStack itemstack = p_40529_.m_43722_();
        Optional<BlockState> optional3 = Optional.empty();
        if (optional.isPresent()) {

--- a/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
@@ -9,7 +9,7 @@
        Level level = p_41341_.m_43725_();
        BlockPos blockpos = p_41341_.m_8083_();
 -      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = f_41332_.get(level.m_8055_(blockpos).m_60734_());
-+      BlockState toolModifiedState = p_41341_.m_43725_().m_8055_(p_41341_.m_8083_()).getToolModifiedState(p_41341_, net.minecraftforge.common.ToolActions.HOE_TILL, false);
++      BlockState toolModifiedState = level.m_8055_(blockpos).getToolModifiedState(p_41341_, net.minecraftforge.common.ToolActions.HOE_TILL, false);
 +      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = toolModifiedState == null ? null : Pair.of(ctx -> true, m_150858_(toolModifiedState));
        if (pair == null) {
           return InteractionResult.PASS;

--- a/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/HoeItem.java
 +++ b/net/minecraft/world/item/HoeItem.java
-@@ -30,6 +_,8 @@
+@@ -30,9 +_,11 @@
     }
  
     public InteractionResult m_6225_(UseOnContext p_41341_) {
@@ -8,7 +8,11 @@
 +      if (hook != 0) return hook > 0 ? InteractionResult.SUCCESS : InteractionResult.FAIL;
        Level level = p_41341_.m_43725_();
        BlockPos blockpos = p_41341_.m_8083_();
-       Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = f_41332_.get(level.m_8055_(blockpos).m_60734_());
+-      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = f_41332_.get(level.m_8055_(blockpos).m_60734_());
++      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = Pair.of(ctx -> ctx.m_43725_().m_8055_(ctx.m_8083_()).getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.HOE_TILL, true) != null, ctx -> ctx.m_43725_().m_8055_(ctx.m_8083_()).getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.HOE_TILL, false));
+       if (pair == null) {
+          return InteractionResult.PASS;
+       } else {
 @@ -72,5 +_,10 @@
  
     public static boolean m_150856_(UseOnContext p_150857_) {

--- a/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/HoeItem.java
 +++ b/net/minecraft/world/item/HoeItem.java
-@@ -30,9 +_,11 @@
+@@ -30,9 +_,12 @@
     }
  
     public InteractionResult m_6225_(UseOnContext p_41341_) {
@@ -9,7 +9,8 @@
        Level level = p_41341_.m_43725_();
        BlockPos blockpos = p_41341_.m_8083_();
 -      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = f_41332_.get(level.m_8055_(blockpos).m_60734_());
-+      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = Pair.of(ctx -> ctx.m_43725_().m_8055_(ctx.m_8083_()).getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.HOE_TILL, true) != null, ctx -> ctx.m_43725_().m_8055_(ctx.m_8083_()).getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.HOE_TILL, false));
++      BlockState toolModifiedState = p_41341_.m_43725_().m_8055_(p_41341_.m_8083_()).getToolModifiedState(p_41341_, net.minecraftforge.common.ToolActions.HOE_TILL, false);
++      Pair<Predicate<UseOnContext>, Consumer<UseOnContext>> pair = toolModifiedState == null ? null : Pair.of(ctx -> true, m_150858_(toolModifiedState));
        if (pair == null) {
           return InteractionResult.PASS;
        } else {

--- a/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/HoeItem.java.patch
@@ -1,5 +1,18 @@
 --- a/net/minecraft/world/item/HoeItem.java
 +++ b/net/minecraft/world/item/HoeItem.java
+@@ -21,6 +_,12 @@
+ import net.minecraft.world.level.block.state.BlockState;
+ 
+ public class HoeItem extends DiggerItem {
++   /**
++    * @deprecated Forge: This map is patched out of vanilla code.
++    * Listen to {@link net.minecraftforge.event.world.BlockEvent.BlockToolModificationEvent}
++    * or override {@link net.minecraftforge.common.extensions.IForgeBlock#getToolModifiedState(BlockState, UseOnContext, net.minecraftforge.common.ToolAction, boolean)}.
++    */
++   @Deprecated
+    protected static final Map<Block, Pair<Predicate<UseOnContext>, Consumer<UseOnContext>>> f_41332_ = Maps.newHashMap(ImmutableMap.of(Blocks.f_50440_, Pair.of(HoeItem::m_150856_, m_150858_(Blocks.f_50093_.m_49966_())), Blocks.f_152481_, Pair.of(HoeItem::m_150856_, m_150858_(Blocks.f_50093_.m_49966_())), Blocks.f_50493_, Pair.of(HoeItem::m_150856_, m_150858_(Blocks.f_50093_.m_49966_())), Blocks.f_50546_, Pair.of(HoeItem::m_150856_, m_150858_(Blocks.f_50493_.m_49966_())), Blocks.f_152549_, Pair.of((p_150861_) -> {
+       return true;
+    }, m_150849_(Blocks.f_50493_.m_49966_(), Items.f_151017_))));
 @@ -30,9 +_,12 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/item/ShovelItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ShovelItem.java.patch
@@ -5,7 +5,7 @@
        } else {
           Player player = p_43119_.m_43723_();
 -         BlockState blockstate1 = f_43110_.get(blockstate.m_60734_());
-+         BlockState blockstate1 = blockstate.getToolModifiedState(level, blockpos, player, p_43119_.m_43722_(), net.minecraftforge.common.ToolActions.SHOVEL_FLATTEN);
++         BlockState blockstate1 = blockstate.getToolModifiedState(p_43119_, net.minecraftforge.common.ToolActions.SHOVEL_FLATTEN, false);
           BlockState blockstate2 = null;
 -         if (blockstate1 != null && level.m_8055_(blockpos.m_7494_()).m_60795_()) {
 +         if (blockstate1 != null && level.m_46859_(blockpos.m_7494_())) {

--- a/src/main/java/net/minecraftforge/common/ToolAction.java
+++ b/src/main/java/net/minecraftforge/common/ToolAction.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("ClassCanBeRecord")
-public class ToolAction
+public final class ToolAction
 {
     private static final Map<String, ToolAction> actions = new ConcurrentHashMap<>();
 

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -31,7 +31,7 @@ public class ToolActions
     public static final ToolAction SHOVEL_DIG = ToolAction.get("shovel_dig");
 
     /**
-     *  Exposed by shovels to allow querying tool behaviours
+     *  Exposed by hoes to allow querying tool behaviours
      */
     public static final ToolAction HOE_DIG = ToolAction.get("hoe_dig");
 
@@ -90,10 +90,10 @@ public class ToolActions
      */
     public static final ToolAction SHEARS_DISARM = ToolAction.get("shears_disarm");
 
-    ///**
-    // *  Passed onto {@link IForgeBlock#getToolModifiedState} when a hoe wants to turn dirt into soil
-    // */
-    // TODO: public static final ToolAction HOE_TILL = ToolAction.get("till");
+    /**
+    *  Passed onto {@link IForgeBlock#getToolModifiedState} when a hoe wants to turn dirt into soil
+    */
+    public static final ToolAction HOE_TILL = ToolAction.get("till");
 
     /**
      * A tool action corresponding to the 'block' action of shields.
@@ -102,7 +102,7 @@ public class ToolActions
 
     // Default actions supported by each tool type
     public static final Set<ToolAction> DEFAULT_AXE_ACTIONS = of(AXE_DIG, AXE_STRIP, AXE_SCRAPE, AXE_WAX_OFF);
-    public static final Set<ToolAction> DEFAULT_HOE_ACTIONS = of(HOE_DIG /* TODO: , HOE_TILL */);
+    public static final Set<ToolAction> DEFAULT_HOE_ACTIONS = of(HOE_DIG, HOE_TILL);
     public static final Set<ToolAction> DEFAULT_SHOVEL_ACTIONS = of(SHOVEL_DIG, SHOVEL_FLATTEN);
     public static final Set<ToolAction> DEFAULT_PICKAXE_ACTIONS = of(PICKAXE_DIG);
     public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = of(SWORD_DIG, SWORD_SWEEP);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -680,7 +680,7 @@ public interface IForgeBlock
         BlockState toolModifiedState = getToolModifiedState(state, context.getLevel(), context.getClickedPos(),
                 context.getPlayer(), context.getItemInHand(), toolAction);
 
-        if (toolModifiedState == null && ToolActions.HOE_TILL == toolAction)
+        if (toolModifiedState == null && ToolActions.HOE_TILL == toolAction && context.getItemInHand().canPerformAction(ToolActions.HOE_TILL))
         {
             // Logic copied from HoeItem#TILLABLES; needs to be kept in sync during updating
             Block block = state.getBlock();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -691,7 +691,7 @@ public interface IForgeBlock
             }
             else if (block == Blocks.ROOTED_DIRT)
             {
-                if (simulate)
+                if (!simulate)
                 {
                     Block.popResourceFromFace(context.getLevel(), context.getClickedPos(), context.getClickedFace(), new ItemStack(Items.HANGING_ROOTS));
                 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -686,7 +686,7 @@ public interface IForgeBlock
             Block block = state.getBlock();
             if (block == Blocks.ROOTED_DIRT)
             {
-                if (!simulate)
+                if (!simulate && !context.getLevel().isClientSide)
                 {
                     Block.popResourceFromFace(context.getLevel(), context.getClickedPos(), context.getClickedFace(), new ItemStack(Items.HANGING_ROOTS));
                 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -703,8 +703,7 @@ public interface IForgeBlock
 
     /**
      * Returns the state that this block should transform into when right-clicked by a tool.
-     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
-     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip} or {@link ToolActions#SHOVEL_FLATTEN a shovel can path}.
      * Returns {@code null} if nothing should happen.
      *
      * @param state The current state

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -22,6 +22,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
@@ -662,9 +663,50 @@ public interface IForgeBlock
     }
 
     /**
-     * Returns the state that this block should transform into when right clicked by a tool.
-     * For example: Used to determine if an axe can strip, a shovel can path, or a hoe can till.
-     * Return null if vanilla behavior should be disabled.
+     * Returns the state that this block should transform into when right-clicked by a tool.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
+     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * Returns {@code null} if nothing should happen.
+     *
+     * @param state The current state
+     * @param context The use on context that the action was performed in
+     * @param toolAction The action being performed by the tool
+     * @param simulate If {@code true}, no actions that modify the world in any way should be performed. If {@code false}, the world may be modified.
+     * @return The resulting state after the action has been performed
+     */
+    @Nullable
+    default BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction, boolean simulate)
+    {
+        BlockState toolModifiedState = getToolModifiedState(state, context.getLevel(), context.getClickedPos(),
+                context.getPlayer(), context.getItemInHand(), toolAction);
+
+        if (toolModifiedState == null && ToolActions.HOE_TILL.equals(toolAction))
+        {
+            // Logic copied from HoeItem#TILLABLES; needs to be kept in sync during updating
+            Block block = state.getBlock();
+            if (context.getLevel().getBlockState(context.getClickedPos().above()).isAir() &&
+                    (block == Blocks.GRASS_BLOCK || block == Blocks.DIRT_PATH || block == Blocks.DIRT || block == Blocks.COARSE_DIRT))
+            {
+                return block == Blocks.COARSE_DIRT ? Blocks.DIRT.defaultBlockState() : Blocks.FARMLAND.defaultBlockState();
+            }
+            else if (block == Blocks.ROOTED_DIRT)
+            {
+                if (simulate)
+                {
+                    Block.popResourceFromFace(context.getLevel(), context.getClickedPos(), context.getClickedFace(), new ItemStack(Items.HANGING_ROOTS));
+                }
+                return Blocks.DIRT.defaultBlockState();
+            }
+        }
+
+        return toolModifiedState;
+    }
+
+    /**
+     * Returns the state that this block should transform into when right-clicked by a tool.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
+     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * Returns {@code null} if nothing should happen.
      *
      * @param state The current state
      * @param level The level
@@ -673,8 +715,11 @@ public interface IForgeBlock
      * @param stack The stack being used by the player
      * @param toolAction The action being performed by the tool
      * @return The resulting state after the action has been performed
+     * @deprecated Override and use {@link #getToolModifiedState(BlockState, UseOnContext, ToolAction, boolean)} instead
      */
     @Nullable
+    // TODO 1.19: Remove this and move the default impl to the newer method in 1.19. Has to stay here to preserve behavior of overrides on this method.
+    @Deprecated(forRemoval = true, since = "1.18.2")
     default BlockState getToolModifiedState(BlockState state, Level level, BlockPos pos, Player player, ItemStack stack, ToolAction toolAction)
     {
         if (!stack.canPerformAction(toolAction)) return null;
@@ -683,7 +728,6 @@ public interface IForgeBlock
         else if(ToolActions.AXE_WAX_OFF.equals(toolAction)) return Optional.ofNullable(HoneycombItem.WAX_OFF_BY_BLOCK.get().get(state.getBlock())).map((p_150694_) -> {
             return p_150694_.withPropertiesOf(state);
         }).orElse(null);
-        //else if(ToolActions.HOE_TILL.equals(toolAction)) return HoeItem.getHoeTillingState(state); //TODO HoeItem bork
         else if (ToolActions.SHOVEL_FLATTEN.equals(toolAction)) return ShovelItem.getShovelPathingState(state);
         return null;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -680,7 +680,7 @@ public interface IForgeBlock
         BlockState toolModifiedState = getToolModifiedState(state, context.getLevel(), context.getClickedPos(),
                 context.getPlayer(), context.getItemInHand(), toolAction);
 
-        if (toolModifiedState == null && ToolActions.HOE_TILL.equals(toolAction))
+        if (toolModifiedState == null && ToolActions.HOE_TILL == toolAction)
         {
             // Logic copied from HoeItem#TILLABLES; needs to be kept in sync during updating
             Block block = state.getBlock();
@@ -723,12 +723,12 @@ public interface IForgeBlock
     default BlockState getToolModifiedState(BlockState state, Level level, BlockPos pos, Player player, ItemStack stack, ToolAction toolAction)
     {
         if (!stack.canPerformAction(toolAction)) return null;
-        if (ToolActions.AXE_STRIP.equals(toolAction)) return AxeItem.getAxeStrippingState(state);
-        else if(ToolActions.AXE_SCRAPE.equals(toolAction)) return WeatheringCopper.getPrevious(state).orElse(null);
-        else if(ToolActions.AXE_WAX_OFF.equals(toolAction)) return Optional.ofNullable(HoneycombItem.WAX_OFF_BY_BLOCK.get().get(state.getBlock())).map((p_150694_) -> {
+        if (ToolActions.AXE_STRIP == toolAction) return AxeItem.getAxeStrippingState(state);
+        else if(ToolActions.AXE_SCRAPE == toolAction) return WeatheringCopper.getPrevious(state).orElse(null);
+        else if(ToolActions.AXE_WAX_OFF == toolAction) return Optional.ofNullable(HoneycombItem.WAX_OFF_BY_BLOCK.get().get(state.getBlock())).map((p_150694_) -> {
             return p_150694_.withPropertiesOf(state);
         }).orElse(null);
-        else if (ToolActions.SHOVEL_FLATTEN.equals(toolAction)) return ShovelItem.getShovelPathingState(state);
+        else if (ToolActions.SHOVEL_FLATTEN == toolAction) return ShovelItem.getShovelPathingState(state);
         return null;
     }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -684,18 +684,17 @@ public interface IForgeBlock
         {
             // Logic copied from HoeItem#TILLABLES; needs to be kept in sync during updating
             Block block = state.getBlock();
-            if (context.getLevel().getBlockState(context.getClickedPos().above()).isAir() &&
-                    (block == Blocks.GRASS_BLOCK || block == Blocks.DIRT_PATH || block == Blocks.DIRT || block == Blocks.COARSE_DIRT))
-            {
-                return block == Blocks.COARSE_DIRT ? Blocks.DIRT.defaultBlockState() : Blocks.FARMLAND.defaultBlockState();
-            }
-            else if (block == Blocks.ROOTED_DIRT)
+            if (block == Blocks.ROOTED_DIRT)
             {
                 if (!simulate)
                 {
                     Block.popResourceFromFace(context.getLevel(), context.getClickedPos(), context.getClickedFace(), new ItemStack(Items.HANGING_ROOTS));
                 }
                 return Blocks.DIRT.defaultBlockState();
+            } else if ((block == Blocks.GRASS_BLOCK || block == Blocks.DIRT_PATH || block == Blocks.DIRT || block == Blocks.COARSE_DIRT) &&
+                    context.getLevel().getBlockState(context.getClickedPos().above()).isAir())
+            {
+                return block == Blocks.COARSE_DIRT ? Blocks.DIRT.defaultBlockState() : Blocks.FARMLAND.defaultBlockState();
             }
         }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -624,8 +624,7 @@ public interface IForgeBlockState
 
     /**
      * Returns the state that this block should transform into when right-clicked by a tool.
-     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
-     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip} or {@link ToolActions#SHOVEL_FLATTEN a shovel can path}.
      * Returns {@code null} if nothing should happen.
      *
      * @param level The level

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
@@ -37,6 +38,7 @@ import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
 
 public interface IForgeBlockState
 {
@@ -603,9 +605,28 @@ public interface IForgeBlockState
     }
 
     /**
-     * Returns the state that this block should transform into when right clicked by a tool.
-     * For example: Used to determine if an axe can strip, a shovel can path, or a hoe can till.
-     * Return null if vanilla behavior should be disabled.
+     * Returns the state that this block should transform into when right-clicked by a tool.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
+     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * Returns {@code null} if nothing should happen.
+     *
+     * @param context The use on context that the action was performed in
+     * @param toolAction The action being performed by the tool
+     * @param simulate If {@code true}, no actions that modify the world in any way should be performed. If {@code false}, the world may be modified.
+     * @return The resulting state after the action has been performed
+     */
+    @Nullable
+    default BlockState getToolModifiedState(UseOnContext context, ToolAction toolAction, boolean simulate)
+    {
+        BlockState eventState = net.minecraftforge.event.ForgeEventFactory.onToolUse(self(), context, toolAction, simulate);
+        return eventState != self() ? eventState : self().getBlock().getToolModifiedState(self(), context, toolAction, simulate);
+    }
+
+    /**
+     * Returns the state that this block should transform into when right-clicked by a tool.
+     * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
+     * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
+     * Returns {@code null} if nothing should happen.
      *
      * @param level The level
      * @param pos The block position in level
@@ -613,8 +634,11 @@ public interface IForgeBlockState
      * @param stack The stack being used by the player
      * @param toolAction The tool type to be considered when performing the action
      * @return The resulting state after the action has been performed
+     * @deprecated Use {@link #getToolModifiedState(UseOnContext, ToolAction, boolean)} instead
      */
     @Nullable
+    // TODO 1.19: Remove
+    @Deprecated(forRemoval = true, since = "1.18.2")
     default BlockState getToolModifiedState(Level level, BlockPos pos, Player player, ItemStack stack, ToolAction toolAction)
     {
         BlockState eventState = net.minecraftforge.event.ForgeEventFactory.onToolUse(self(), level, pos, player, stack, toolAction);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -125,7 +125,7 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
-import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEventNew;
+import net.minecraftforge.event.world.BlockEvent.BlockToolModificationEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.EntityMultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.EntityPlaceEvent;
@@ -363,8 +363,9 @@ public class ForgeEventFactory
     @Nullable
     public static BlockState onToolUse(BlockState originalState, UseOnContext context, ToolAction toolAction, boolean simulate)
     {
-        BlockToolInteractEventNew event = simulate
-                ? new BlockToolInteractEventNew(originalState, context, toolAction, true)
+        // TODO 1.19: Remove ternary and just use BlockToolModificationEvent constructor with simulate parameter passed in
+        BlockToolModificationEvent event = simulate
+                ? new BlockToolModificationEvent(originalState, context, toolAction, true)
                 : new BlockToolInteractEvent(originalState, context, toolAction);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getFinalState();
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -125,6 +125,7 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
+import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEventNew;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.EntityMultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.EntityPlaceEvent;
@@ -362,7 +363,9 @@ public class ForgeEventFactory
     @Nullable
     public static BlockState onToolUse(BlockState originalState, UseOnContext context, ToolAction toolAction, boolean simulate)
     {
-        BlockToolInteractEvent event = new BlockToolInteractEvent(originalState, context, toolAction, simulate);
+        BlockToolInteractEventNew event = simulate
+                ? new BlockToolInteractEventNew(originalState, context, toolAction, true)
+                : new BlockToolInteractEvent(originalState, context, toolAction);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getFinalState();
     }
 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -345,8 +345,8 @@ public class ForgeEventFactory
         return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
     }
 
-    //TODO: 1.17 Remove
-    @Deprecated
+    //TODO 1.19: Remove
+    @Deprecated(forRemoval = true, since = "1.18.2")
     public static int onHoeUse(UseOnContext context)
     {
         UseHoeEvent event = new UseHoeEvent(context);
@@ -360,6 +360,18 @@ public class ForgeEventFactory
     }
 
     @Nullable
+    public static BlockState onToolUse(BlockState originalState, UseOnContext context, ToolAction toolAction, boolean simulate)
+    {
+        BlockToolInteractEvent event = new BlockToolInteractEvent(originalState, context, toolAction, simulate);
+        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getFinalState();
+    }
+
+    /**
+     * @deprecated Use {@link #onToolUse(BlockState, UseOnContext, ToolAction, boolean)} instead.
+     */
+    @Nullable
+    // TODO 1.19: Remove
+    @Deprecated(forRemoval = true, since = "1.18.2")
     public static BlockState onToolUse(BlockState originalState, Level level, BlockPos pos, Player player, ItemStack stack, ToolAction toolAction)
     {
         BlockToolInteractEvent event = new BlockToolInteractEvent(level, pos, originalState, player, stack, toolAction);

--- a/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
@@ -19,12 +19,11 @@ import javax.annotation.Nonnull;
  * and damage the hoe.
  *
  * setResult(ALLOW) is the same as the old setHandled();
- * 
- * TODO: 1.17 Remove
  */
 @Cancelable
 @HasResult
-@Deprecated
+// TODO 1.19: Remove
+@Deprecated(forRemoval = true, since = "1.18.2")
 public class UseHoeEvent extends PlayerEvent
 {
     private final UseOnContext context;;

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -422,17 +422,16 @@ public class BlockEvent extends Event
      * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
      * <p>
      * This deprecated subclass event is <i>only</i> fired when {@link #isSimulate()} is false.
-     * To receive simulated events, use {@link BlockToolInteractEventNew}.
+     * To receive simulated events, use {@link BlockToolModificationEvent}.
      * <p>
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      *
-     * @deprecated Use {@link BlockToolInteractEventNew} and put world-modifying actions behind <code>if (!event.isSimulate())</code>.
-     * This event will be removed in 1.19, and BlockToolInteractEventNew will be renamed to BlockToolInteractEvent.
+     * @deprecated Use {@link BlockToolModificationEvent} and put world-modifying actions behind <code>if (!event.isSimulate())</code>.
      */
     @Cancelable
     @Deprecated(forRemoval = true, since = "1.18.2")
-    public static class BlockToolInteractEvent extends BlockToolInteractEventNew
+    public static class BlockToolInteractEvent extends BlockToolModificationEvent
     {
         private final Player player;
         private final ItemStack stack;
@@ -472,15 +471,14 @@ public class BlockEvent extends Event
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      */
-    // TODO 1.19: Merge with BlockToolInteractEvent
-    public static class BlockToolInteractEventNew extends BlockEvent
+    public static class BlockToolModificationEvent extends BlockEvent
     {
         private final UseOnContext context;
         private final ToolAction toolAction;
         private final boolean simulate;
         private BlockState state;
 
-        public BlockToolInteractEventNew(BlockState originalState, @Nonnull UseOnContext context, ToolAction toolAction, boolean simulate)
+        public BlockToolModificationEvent(BlockState originalState, @Nonnull UseOnContext context, ToolAction toolAction, boolean simulate)
         {
             super(context.getLevel(), context.getClickedPos(), originalState);
             this.context = context;
@@ -490,7 +488,7 @@ public class BlockEvent extends Event
         }
 
         // TODO 1.19: Remove
-        BlockToolInteractEventNew(LevelAccessor level, BlockPos pos, BlockState originalState, ToolAction toolAction)
+        BlockToolModificationEvent(LevelAccessor level, BlockPos pos, BlockState originalState, ToolAction toolAction)
         {
             super(level, pos, originalState);
             this.context = null;

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -421,13 +421,13 @@ public class BlockEvent extends Event
      * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
      * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
      * <p>
-     * This deprecated subclass event is <i>only</i> fired when {@link #isSimulate()} is false.
+     * This deprecated subclass event is <i>only</i> fired when {@link #isSimulated()} is false.
      * To receive simulated events, use {@link BlockToolModificationEvent}.
      * <p>
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      *
-     * @deprecated Use {@link BlockToolModificationEvent} and put world-modifying actions behind <code>if (!event.isSimulate())</code>.
+     * @deprecated Use {@link BlockToolModificationEvent} and put world-modifying actions behind <code>if (!event.isSimulated())</code>.
      */
     @Cancelable
     @Deprecated(forRemoval = true, since = "1.18.2")
@@ -466,7 +466,7 @@ public class BlockEvent extends Event
      * For example: Used to determine if {@link ToolActions#AXE_STRIP an axe can strip},
      * {@link ToolActions#SHOVEL_FLATTEN a shovel can path}, or {@link ToolActions#HOE_TILL a hoe can till}.
      * <p>
-     * Care must be taken to ensure world-modifying events are only performed if {@link #isSimulate()} returns {@code true}.
+     * Care must be taken to ensure world-modifying events are only performed if {@link #isSimulated()} returns {@code true}.
      * <p>
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
@@ -528,7 +528,7 @@ public class BlockEvent extends Event
          * @return {@code true} if this event should not perform any actions that modify the world.
          * If {@code false}, then world-modifying actions can be performed.
          */
-        public boolean isSimulate()
+        public boolean isSimulated()
         {
             return this.simulate;
         }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -450,6 +450,10 @@ public class BlockEvent extends Event
             this.stack = stack;
         }
 
+        /**
+         * @return the player using the tool, never null
+         */
+        @Nonnull
         public Player getPlayer()
         {
             return this.player;
@@ -498,8 +502,10 @@ public class BlockEvent extends Event
         }
 
         /**
-         * @return the player using the tool
+         * @return the player using the tool.
+         * May be null based on what was provided by {@link #getContext() the use on context}.
          */
+        @Nullable
         public Player getPlayer()
         {
             return this.context.getPlayer();

--- a/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEvent;
+import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEventNew;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod("tool_interact_test")
@@ -17,13 +17,13 @@ public class ToolInteractTest
 {
 
     private static final Logger LOGGER = LogManager.getLogger();
-	
+
     public ToolInteractTest()
     {
         MinecraftForge.EVENT_BUS.addListener(this::onToolInteraction);
     }
-	
-    private void onToolInteraction(final BlockToolInteractEvent event)
+
+    private void onToolInteraction(final BlockToolInteractEventNew event)
     {
         //Test 1: No Changes, just test if event is called. State and Final State should be the same
         LOGGER.info("BlockState {} is modified to {} at position {} by {} with {}", event.getState(), event.getFinalState(), event.getPos(), event.getPlayer(), event.getHeldItemStack());

--- a/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.BlockEvent.BlockToolInteractEventNew;
+import net.minecraftforge.event.world.BlockEvent.BlockToolModificationEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod("tool_interact_test")
@@ -23,7 +23,7 @@ public class ToolInteractTest
         MinecraftForge.EVENT_BUS.addListener(this::onToolInteraction);
     }
 
-    private void onToolInteraction(final BlockToolInteractEventNew event)
+    private void onToolInteraction(final BlockToolModificationEvent event)
     {
         //Test 1: No Changes, just test if event is called. State and Final State should be the same
         LOGGER.info("BlockState {} is modified to {} at position {} by {} with {}", event.getState(), event.getFinalState(), event.getPos(), event.getPlayer(), event.getHeldItemStack());

--- a/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
@@ -26,7 +26,7 @@ public class ToolInteractTest
     private void onToolInteraction(final BlockToolModificationEvent event)
     {
         //Test 1: No Changes, just test if event is called. State and Final State should be the same
-        LOGGER.info("BlockState {} is modified to {} at position {} by {} with {}", event.getState(), event.getFinalState(), event.getPos(), event.getPlayer(), event.getHeldItemStack());
+        LOGGER.info("BlockState {} is modified to {} at position {} by {} with {} simulated={}", event.getState(), event.getFinalState(), event.getPos(), event.getPlayer(), event.getHeldItemStack(), event.isSimulated());
 
         //Test 2: Canceling, nothing in game should change
         /*event.setCanceled(true);

--- a/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomShieldTest.java
@@ -64,7 +64,7 @@ public class CustomShieldTest
         @Override
         public boolean canPerformAction(ItemStack stack, ToolAction toolAction)
         {
-            return toolAction.equals(ToolActions.SHIELD_BLOCK);
+            return toolAction == ToolActions.SHIELD_BLOCK;
         }
     }
 }


### PR DESCRIPTION
This is a different approach to the problem faced in #8503.
Hoes have been fixed to call `getToolModifiedState` when tilling with an appropriate patch.
A new overload of `getToolModifiedState` has been introduced which takes a `UseOnContext` and `simulate` boolean flag.
The old overload has been deprecated for removal in 1.19.
To preserve mods that do world-modifying actions from `BlockToolInteractEvent`, a new event called `BlockToolModificationEvent` has been made.
When `getToolModifiedState` is called with simulate as true, then `BlockToolModificationEvent` will be fired.
Otherwise, `BlockToolInteractEvent` will be fired.
`BlockToolInteractEvent` is a subclass of `BlockToolModificationEvent`.
This means that listeners of `BlockToolModificationEvent` will receive both simulate = true and simulate = false events, while older listeners of the now-deprecated `BlockToolInteractEvent` will only receive the old behavior of simulate = false.
Appropriate deprecation annotations and `// TODO`s have been added to `BlockToolInteractEvent` and `BlockToolModificationEvent` for 1.19 when the former can be removed.