### PR TITLE
Remove bad patch for AbstractFurnaceBlockEntity

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -34,7 +34,7 @@
        ContainerHelper.m_18973_(p_187452_, this.f_58310_);
        CompoundTag compoundtag = new CompoundTag();
        this.f_58320_.forEach((p_187449_, p_187450_) -> {
-@@ -240,34 +_,35 @@
+@@ -240,30 +_,32 @@
  
        ItemStack itemstack = p_155017_.f_58310_.get(1);
        if (p_155017_.m_58425_() || !itemstack.m_41619_() && !p_155017_.f_58310_.get(0).m_41619_()) {
@@ -73,10 +73,6 @@
                    p_155017_.m_6029_(recipe);
                 }
  
--               flag1 = true;
-             }
-          } else {
-             p_155017_.f_58318_ = 0;
 @@ -288,9 +_,9 @@
  
     }


### PR DESCRIPTION
This bad patch was accidentally introduced in the 1.18 update and patch cycle, and prevented the block entity from being marked as changed when an item finished smelting. (Credits to @SizableShrimp for pointing this out.)

https://github.com/MinecraftForge/MinecraftForge/commit/40a174310d9eaf31e089f18b66a26d45c96d5587#diff-ff8896e0334590ab16251db3baa8ef3446a1ab83d4bdc880bc648efbc7287211
![image](https://user-images.githubusercontent.com/21304337/162606744-aa01d386-b51a-4c62-b60a-d345e71ea08d.png)
