### PR TITLE
[1.18] Let BaseRailBlocks decide if the calculated RailShape for placement or connection to neighbors is valid

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/RailState.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/RailState.java.patch
@@ -37,6 +37,17 @@
           if (BaseRailBlock.m_49364_(this.f_55414_, blockpos3.m_7494_())) {
              railshape = RailShape.ASCENDING_EAST;
           }
+@@ -203,6 +_,10 @@
+          railshape = RailShape.NORTH_SOUTH;
+       }
+ 
++      if (!this.f_55416_.isValidRailShape(railshape)) { // Forge: allow rail block to decide if the new shape is valid
++         this.f_55419_.remove(p_55442_.f_55415_);
++         return;
++      }
+       this.f_55417_ = this.f_55417_.m_61124_(this.f_55416_.m_7978_(), railshape);
+       this.f_55414_.m_7731_(this.f_55415_, this.f_55417_, 3);
+    }
 @@ -305,7 +_,7 @@
           }
        }
@@ -55,3 +66,12 @@
           if (BaseRailBlock.m_49364_(this.f_55414_, blockpos3.m_7494_())) {
              railshape = RailShape.ASCENDING_EAST;
           }
+@@ -325,7 +_,7 @@
+          }
+       }
+ 
+-      if (railshape == null) {
++      if (railshape == null || !this.f_55416_.isValidRailShape(railshape)) { // Forge: allow rail block to decide if the new shape is valid
+          railshape = p_55434_;
+       }
+ 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBaseRailBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBaseRailBlock.java
@@ -72,4 +72,17 @@ public interface IForgeBaseRailBlock
       * @param pos Block's position in level
       */
     default void onMinecartPass(BlockState state, Level level, BlockPos pos, AbstractMinecart cart){}
+
+    /**
+     * Returns true if the given {@link RailShape} is valid for this rail block.
+     * This is called when the RailShape for the initial placement of this block is calculated or
+     * when another rail block tries to connect to this block and this block's RailState calculates
+     * the new RailShape for its current neigbors.
+     * @param shape The new RailShape
+     * @return True when the given RailShape is valid
+     */
+    default boolean isValidRailShape(RailShape shape)
+    {
+        return true;
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/block/ValidRailShapeTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ValidRailShapeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.*;
+import net.minecraft.world.level.material.*;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.*;
+
+@Mod(ValidRailShapeTest.MOD_ID)
+public class ValidRailShapeTest
+{
+    public static final String MOD_ID = "valid_railshape_test";
+    public static final boolean ENABLED = true;
+
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MOD_ID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+
+    private static final RegistryObject<Block> RAIL_SLOPE_BLOCK = BLOCKS.register("rail_slope", RailSlopeBlock::new);
+    private static final RegistryObject<Item> RAIL_SLOPE_ITEM = ITEMS.register("rail_slope", () -> new BlockItem(RAIL_SLOPE_BLOCK.get(), new Item.Properties()));
+
+    public ValidRailShapeTest()
+    {
+        if (ENABLED)
+        {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            BLOCKS.register(bus);
+            ITEMS.register(bus);
+        }
+    }
+
+    private static class RailSlopeBlock extends BaseRailBlock
+    {
+        private static final EnumProperty<RailShape> ASCENDING_RAIL_SHAPE = EnumProperty.create("shape", RailShape.class, RailShape::isAscending);
+
+        protected RailSlopeBlock()
+        {
+            super(true, Properties.of(Material.DECORATION).noCollission().strength(0.7F).sound(SoundType.METAL));
+        }
+
+        @Override
+        protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
+        {
+            builder.add(ASCENDING_RAIL_SHAPE, BaseRailBlock.WATERLOGGED);
+        }
+
+        @Override
+        public BlockState getStateForPlacement(BlockPlaceContext context)
+        {
+            RailShape shape = switch (context.getHorizontalDirection())
+            {
+                case NORTH -> RailShape.ASCENDING_NORTH;
+                case EAST -> RailShape.ASCENDING_EAST;
+                case SOUTH -> RailShape.ASCENDING_SOUTH;
+                case WEST -> RailShape.ASCENDING_WEST;
+                default -> throw new IllegalArgumentException("Invalid facing " + context.getHorizontalDirection());
+            };
+
+            FluidState fluid = context.getLevel().getFluidState(context.getClickedPos());
+
+            return defaultBlockState()
+                    .setValue(ASCENDING_RAIL_SHAPE, shape)
+                    .setValue(BaseRailBlock.WATERLOGGED, fluid.getType() == Fluids.WATER);
+        }
+
+        @Override
+        public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos)
+        {
+            RailShape shape = state.getValue(ASCENDING_RAIL_SHAPE);
+            Direction dir = switch (shape)
+            {
+                case ASCENDING_NORTH -> Direction.NORTH;
+                case ASCENDING_EAST -> Direction.EAST;
+                case ASCENDING_SOUTH -> Direction.SOUTH;
+                case ASCENDING_WEST -> Direction.WEST;
+                default -> throw new IllegalArgumentException("Invalid shape " + shape);
+            };
+
+            if (!canSupportRigidBlock(level, pos.relative(dir)))
+            {
+                return false;
+            }
+
+            return super.canSurvive(state, level, pos);
+        }
+
+        @Override
+        public boolean isValidRailShape(RailShape shape)
+        {
+            return shape.isAscending();
+        }
+
+        @Override
+        public Property<RailShape> getShapeProperty()
+        {
+            return ASCENDING_RAIL_SHAPE;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -216,5 +216,7 @@ license="LGPL v2.1"
     modId="living_get_projectile_event_test"
 [[mods]]
     modId="server_world_creation_test"
+[[mods]]
+    modId="valid_railshape_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/assets/valid_railshape_test/blockstates/rail_slope.json
+++ b/src/test/resources/assets/valid_railshape_test/blockstates/rail_slope.json
@@ -1,0 +1,18 @@
+{
+  "variants": {
+    "shape=ascending_east": {
+      "model": "minecraft:block/rail_raised_ne",
+      "y": 90
+    },
+    "shape=ascending_north": {
+      "model": "minecraft:block/rail_raised_ne"
+    },
+    "shape=ascending_south": {
+      "model": "minecraft:block/rail_raised_sw"
+    },
+    "shape=ascending_west": {
+      "model": "minecraft:block/rail_raised_sw",
+      "y": 90
+    }
+  }
+}

--- a/src/test/resources/assets/valid_railshape_test/models/item/rail_slope.json
+++ b/src/test/resources/assets/valid_railshape_test/models/item/rail_slope.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "minecraft:block/rail"
+    }
+}

--- a/src/test/resources/data/minecraft/tags/blocks/rails.json
+++ b/src/test/resources/data/minecraft/tags/blocks/rails.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "valid_railshape_test:rail_slope"
+  ]
+}

--- a/src/test/resources/data/valid_railshape_test/loot_tables/blocks/rail_slope.json
+++ b/src/test/resources/data/valid_railshape_test/loot_tables/blocks/rail_slope.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "valid_railshape_test:rail_slope"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a method in `IForgeBaseRailBlock` that allows modded rail blocks to decide whether the new `RailShape` calculated for block placement in `RailState#place()` or for neighbor connection in `RailState#connectTo()` is valid for this block.
This allows mods to add rail blocks where the `BlockState` property that is returned from `BaseRailBlock#getShapeProperty()` has limitations that are not covered by the existing checks (`IForgeBaseRailBlock#isFlexibleRail()` for allowing corners and `IForgeBaseRailBlock#canMakeSlopes()` for allowing slopes).
This has no influence on the behaviour of existing (vanilla) rails that do not use this new method.

My usecase is a rail block that can only have a ramp shape (essentially an underfilled rail ramp), which currently causes an exception and server-side log spam when another rail block is placed at the high end of the ramp on the y level of the lower end and tries to modify the shape of the ramp to be flat.