### PR TITLE
Add event for hooking into StructuresBecomeConfiguredFix

### DIFF
--- a/patches/minecraft/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java.patch
+++ b/patches/minecraft/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java.patch
@@ -1,12 +1,13 @@
 --- a/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java
 +++ b/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java
-@@ -93,7 +_,9 @@
+@@ -93,7 +_,10 @@
     private Dynamic<?> m_207723_(Pair<Dynamic<?>, Dynamic<?>> p_207724_, Dynamic<?> p_207725_) {
        String s = p_207724_.getFirst().asString("UNKNOWN").toLowerCase(Locale.ROOT);
        StructuresBecomeConfiguredFix.Conversion structuresbecomeconfiguredfix$conversion = f_207676_.get(s);
 +      if (structuresbecomeconfiguredfix$conversion == null) structuresbecomeconfiguredfix$conversion = net.minecraftforge.common.ForgeHooks.getStructureConversion(s); // Forge: hook for mods to register conversions through RegisterStructureConversionsEvent
        if (structuresbecomeconfiguredfix$conversion == null) {
 +         if (net.minecraftforge.common.ForgeHooks.checkStructureNamespace(s)) return p_207724_.getSecond().createString(s); // Forge: pass-through structure IDs which have a non-"minecraft" namespace
++         if (true) return p_207724_.getSecond().createString("unknown." + s); // Forge: Pass-through with "unknown." prefix, so deserializer logs and ignores rather than fixer throwing an exception and dropping chunk data
           throw new IllegalStateException("Found unknown structure: " + s);
        } else {
           Dynamic<?> dynamic = p_207724_.getSecond();

--- a/patches/minecraft/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java.patch
+++ b/patches/minecraft/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java
++++ b/net/minecraft/util/datafix/fixes/StructuresBecomeConfiguredFix.java
+@@ -93,7 +_,9 @@
+    private Dynamic<?> m_207723_(Pair<Dynamic<?>, Dynamic<?>> p_207724_, Dynamic<?> p_207725_) {
+       String s = p_207724_.getFirst().asString("UNKNOWN").toLowerCase(Locale.ROOT);
+       StructuresBecomeConfiguredFix.Conversion structuresbecomeconfiguredfix$conversion = f_207676_.get(s);
++      if (structuresbecomeconfiguredfix$conversion == null) structuresbecomeconfiguredfix$conversion = net.minecraftforge.common.ForgeHooks.getStructureConversion(s); // Forge: hook for mods to register conversions through RegisterStructureConversionsEvent
+       if (structuresbecomeconfiguredfix$conversion == null) {
++         if (net.minecraftforge.common.ForgeHooks.checkStructureNamespace(s)) return p_207724_.getSecond().createString(s); // Forge: pass-through structure IDs which have a non-"minecraft" namespace
+          throw new IllegalStateException("Found unknown structure: " + s);
+       } else {
+          Dynamic<?> dynamic = p_207724_.getSecond();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1318,7 +1318,7 @@ public class ForgeHooks
         boolean generateBonusChest = wgs.generateBonusChest();
         Registry<LevelStem> originalRegistry = wgs.dimensions();
         Optional<String> legacyCustomOptions = wgs.legacyCustomOptions;
-        
+
         // make a copy of the dimension registry; for dimensions that specify that they should use the server seed instead
         // of the hardcoded json seed, recreate them with the correct seed
         MappedRegistry<LevelStem> seededRegistry = new MappedRegistry<>(Registry.LEVEL_STEM_REGISTRY, Lifecycle.experimental(), (Function<LevelStem, Holder.Reference<LevelStem>>)null);
@@ -1335,10 +1335,10 @@ public class ForgeHooks
                 seededRegistry.register(key, dimension, originalRegistry.lifecycle(dimension));
             }
         }
-        
+
         return new WorldGenSettings(seed, generateFeatures, generateBonusChest, seededRegistry, legacyCustomOptions);
     }
-    
+
     /** Called in the LevelStem codec builder to add extra fields to dimension jsons **/
     public static App<Mu<LevelStem>, LevelStem> expandLevelStemCodec(RecordCodecBuilder.Instance<LevelStem> builder, Supplier<App<Mu<LevelStem>, LevelStem>> vanillaFieldsSupplier)
     {
@@ -1451,7 +1451,7 @@ public class ForgeHooks
             return Lifecycle.deprecated(Integer.parseInt(lifecycle.substring(lifecycle.indexOf('=') + 1)));
         throw new IllegalArgumentException("Unknown lifecycle.");
     }
-  
+
     public static void saveMobEffect(CompoundTag nbt, String key, MobEffect effect)
     {
         var registryName = effect.getRegistryName();
@@ -1491,12 +1491,18 @@ public class ForgeHooks
     });
 
     // DO NOT CALL from within RegisterStructureConversionsEvent, otherwise you'll get a deadlock
+    /**
+     * @hidden For internal use only.
+     */
     @Nullable
     public static StructuresBecomeConfiguredFix.Conversion getStructureConversion(String originalBiome)
     {
         return FORGE_CONVERSION_MAP.get().get(originalBiome);
     }
 
+    /**
+     * @hidden For internal use only.
+     */
     public static boolean checkStructureNamespace(String biome)
     {
         @Nullable ResourceLocation biomeLocation = ResourceLocation.tryParse(biome);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -26,6 +25,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Queues;
@@ -35,7 +35,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.mojang.datafixers.kinds.App;
-import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Lifecycle;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -50,6 +49,7 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.core.*;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -97,10 +97,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.*;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldGenSettings;
-import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -118,6 +115,7 @@ import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.loot.LootModifierManager;
 import net.minecraftforge.common.loot.LootTableIdCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
 import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
 import net.minecraftforge.common.world.ForgeWorldPreset;
@@ -127,6 +125,7 @@ import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ItemAttributeModifierEvent;
 import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.RegisterStructureConversionsEvent;
 import net.minecraftforge.event.VanillaGameEvent;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
@@ -1485,4 +1484,22 @@ public class ForgeHooks
         return mask.isEnderMask(player, enderMan) || MinecraftForge.EVENT_BUS.post(new EnderManAngerEvent(enderMan, player));
     }
 
+    private static final Lazy<Map<String, StructuresBecomeConfiguredFix.Conversion>> FORGE_CONVERSION_MAP = Lazy.concurrentOf(() -> {
+        Map<String, StructuresBecomeConfiguredFix.Conversion> map = new HashMap<>();
+        MinecraftForge.EVENT_BUS.post(new RegisterStructureConversionsEvent(map));
+        return ImmutableMap.copyOf(map);
+    });
+
+    // DO NOT CALL from within RegisterStructureConversionsEvent, otherwise you'll get a deadlock
+    @Nullable
+    public static StructuresBecomeConfiguredFix.Conversion getStructureConversion(String originalBiome)
+    {
+        return FORGE_CONVERSION_MAP.get().get(originalBiome);
+    }
+
+    public static boolean checkStructureNamespace(String biome)
+    {
+        @Nullable ResourceLocation biomeLocation = ResourceLocation.tryParse(biome);
+        return biomeLocation != null && !biomeLocation.getNamespace().equals(ResourceLocation.DEFAULT_NAMESPACE);
+    }
 }

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Fired for registering structure conversions for pre-1.18.2 worlds. This is used by {@link StructuresBecomeConfiguredFix}
+ * for converting old structure IDs in pre-1.18.2 worlds to their new equivalents, which can be differentiated per biome.
+ *
+ * <p>By default, structures whose old ID has a namespace which is not equal to {@value ResourceLocation#DEFAULT_NAMESPACE}
+ * will be assumed to belong to a modded structure and will be used as the new ID. Mods may choose to register structure
+ * conversions for their structures, if they wish to override this default behavior.</p>
+ *
+ * <p>This event will only fire if {@link StructuresBecomeConfiguredFix} is used, as a result of converting a
+ * pre-1.18.2 world to the current version.</p>
+ *
+ * <p>This event is not {@linkplain Cancelable cancelable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}. </p>
+ *
+ * @see StructuresBecomeConfiguredFix
+ * @see #register(String, StructuresBecomeConfiguredFix.Conversion)
+ */
+public class RegisterStructureConversionsEvent extends Event
+{
+    private final Map<String, StructuresBecomeConfiguredFix.Conversion> map;
+
+    /**
+     * @hidden For internal use only.
+     */
+    public RegisterStructureConversionsEvent(Map<String, StructuresBecomeConfiguredFix.Conversion> map)
+    {
+        this.map = map;
+    }
+
+    /**
+     * Registers a conversion for a structure.
+     *
+     * <p>A structure conversion can be of two kinds:</p>
+     * <ul>
+     *     <li>A <em>trivial</em> conversion, created using {@link StructuresBecomeConfiguredFix.Conversion#trivial(String)},
+     *     contains only the new structure ID and simply converts all mentions of the old structure ID to the new
+     *     structure ID.</li>
+     *     <li>A <em>biome-mapped</em> conversion, created using {@link
+     *     StructuresBecomeConfiguredFix.Conversion#biomeMapped(Map, String)}, contains a fallback structure ID, and a
+     *     biome-specific conversion map. Each entry in the map is composed of a list of biome IDs and the new structure
+     *     ID.
+     *
+     *     <p>If a structure is in a biome which exists in the map, the
+     *     structure ID in the corresponding entry is used as the new structure ID. If there is no such biome found,
+     *     the new structure ID will be the fallback structure ID.</p>
+     *
+     *     <p>For example, the following registers a biome-mapped conversion for {@code "xampleStructure} with the
+     *     following logic:</p>
+     *     <ul>
+     *         <li>If the structure is within either a {@code minecraft:desert} or a {@code minecraft:jungle} biome,
+     *         it is mapped to {@code examplemod:deserted_structure}.</li>
+     *         <li>If the structure is within a {@code "minecraft:ocean"} biome, it is mapped to
+     *         {@code examplemod:flooded_structure}.</li>
+     *         <li>Otherwise, the structure is mapped to {@code examplemod:structure}</li>
+     *     </ul>
+     *     <pre>{@code
+     * event.register("exampleStructure", StructuresBecomeConfiguredFix.Conversion.biomeMapped(Map.of(
+     *     List.of("minecraft:desert", "minecraft:jungle"), "examplemod:deserted_structure",
+     *     List.of("minecraft:ocean"), "examplemod:flooded_structure"
+     * ), "examplemod:structure"));
+     *     }</pre>
+     *     </li>
+     * </ul>
+     *
+     * @param oldStructureID the old structure ID, in all lowercase
+     * @param conversion     the conversion data
+     * @throws NullPointerException     if the old structure ID, the conversion data, or the fallback structure ID in
+     *                                  the conversion data is null
+     * @throws IllegalArgumentException if the old structure ID is not in full lowercase, or if a conversion for that
+     *                                  structure ID has already been registered previously
+     */
+    public void register(String oldStructureID, StructuresBecomeConfiguredFix.Conversion conversion)
+    {
+        checkNotNull(oldStructureID, "Original structure ID must not be null");
+        checkArgument(oldStructureID.toLowerCase(Locale.ROOT).equals(oldStructureID),
+                "Original structure ID should be in all lowercase");
+        checkNotNull(conversion, "Structure conversion must not be null");
+        checkNotNull(conversion.fallback(), "Fallback structure ID in structure conversion must not be null");
+        if (map.putIfAbsent(oldStructureID.toLowerCase(Locale.ROOT), conversion) != null)
+        {
+            throw new IllegalArgumentException("Conversion has already been registered for structure " + oldStructureID);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -65,7 +65,7 @@ public class RegisterStructureConversionsEvent extends Event
      *     structure ID in the corresponding entry is used as the new structure ID. If there is no such biome found,
      *     the new structure ID will be the fallback structure ID.</p>
      *
-     *     <p>For example, the following registers a biome-mapped conversion for {@code "xampleStructure} with the
+     *     <p>For example, the following registers a biome-mapped conversion for {@code "exampleStructure} with the
      *     following logic:</p>
      *     <ul>
      *         <li>If the structure is within either a {@code minecraft:desert} or a {@code minecraft:jungle} biome,

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -72,7 +72,7 @@ public class RegisterStructureConversionsEvent extends Event
      *         it is mapped to {@code examplemod:deserted_structure}.</li>
      *         <li>If the structure is within a {@code minecraft:ocean} biome, it is mapped to
      *         {@code examplemod:flooded_structure}.</li>
-     *         <li>Otherwise, the structure is mapped to {@code examplemod:structure}</li>
+     *         <li>Otherwise, the structure is mapped to {@code examplemod:structure}.</li>
      *     </ul>
      *     <pre>{@code
      * event.register("exampleStructure", StructuresBecomeConfiguredFix.Conversion.biomeMapped(Map.of(

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -65,12 +65,12 @@ public class RegisterStructureConversionsEvent extends Event
      *     structure ID in the corresponding entry is used as the new structure ID. If there is no such biome found,
      *     the new structure ID will be the fallback structure ID.</p>
      *
-     *     <p>For example, the following registers a biome-mapped conversion for {@code "exampleStructure} with the
+     *     <p>For example, the following registers a biome-mapped conversion for {@code exampleStructure} with the
      *     following logic:</p>
      *     <ul>
      *         <li>If the structure is within either a {@code minecraft:desert} or a {@code minecraft:jungle} biome,
      *         it is mapped to {@code examplemod:deserted_structure}.</li>
-     *         <li>If the structure is within a {@code "minecraft:ocean"} biome, it is mapped to
+     *         <li>If the structure is within a {@code minecraft:ocean} biome, it is mapped to
      *         {@code examplemod:flooded_structure}.</li>
      *         <li>Otherwise, the structure is mapped to {@code examplemod:structure}</li>
      *     </ul>

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -278,6 +278,7 @@ public net.minecraft.tags.Tag$ElementEntry
 public net.minecraft.tags.Tag$OptionalElementEntry
 public net.minecraft.tags.Tag$OptionalTagEntry
 public net.minecraft.tags.Tag$TagEntry
+public net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix$Conversion
 public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # submitAsync
 #group public net.minecraft.world.damagesource.DamageSource *() #All methods public, most are already
 public net.minecraft.world.damagesource.DamageSource <init>(Ljava/lang/String;)V # constructor


### PR DESCRIPTION
This PR fixes #8505 by implementing options 1 and 3 as described in https://github.com/MinecraftForge/MinecraftForge/issues/8505#issuecomment-1062676787: old structure IDs which are namespaced are passed along as the new structure IDs, and a new `RegisterStructureConversionsEvent` is added for registering structure conversions.

The new event has been documented thoroughly for the benefit of consumers. I've not implemented a test mod, mostly because testing this event will require manual work on behalf of the tester (creating the world in an older version with a strucuture datapack/mod, loading the same world on this version with the same structure datapack/mod).

I've tested this PR using the same setup I used to confirm the linked issue, and it does work as expected. I request people to test this PR out locally, especially in using the new event for converting old structure IDs to new ones based on biomes.

<details>
<summary>Screenshot of the PR in action -- using the same pre-1.18.2 world from the linked issue, loaded on a production installation of my PR</summary>

![image](https://user-images.githubusercontent.com/21304337/163530224-f4d0148e-2353-443c-80a6-948aaf7656b3.png)

</details>