### PR TITLE
[1.18.x] Fix ContextNbtProvider serializing wrong name

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/loot/LootContext.java.patch
@@ -66,12 +66,13 @@
              }
           }
        }
-@@ -230,6 +_,10 @@
+@@ -230,6 +_,11 @@
  
        public LootContextParam<? extends Entity> m_79003_() {
           return this.f_78995_;
 +      }
 +
++      // Forge: This method is patched in to expose the same name used in getByName so that ContextNbtProvider#forEntity serializes it properly
 +      public String getName() {
 +         return this.f_78994_;
        }

--- a/patches/minecraft/net/minecraft/world/level/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/loot/LootContext.java.patch
@@ -66,3 +66,14 @@
              }
           }
        }
+@@ -230,6 +_,10 @@
+ 
+       public LootContextParam<? extends Entity> m_79003_() {
+          return this.f_78995_;
++      }
++
++      public String getName() {
++         return this.f_78994_;
+       }
+ 
+       public static LootContext.EntityTarget m_79006_(String p_79007_) {

--- a/patches/minecraft/net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider.java
++++ b/net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider.java
+@@ -46,7 +_,7 @@
+          }
+ 
+          public String m_142016_() {
+-            return p_165578_.name();
++            return p_165578_.getName();
+          }
+ 
+          public Set<LootContextParam<?>> m_142524_() {


### PR DESCRIPTION
In vanilla, ContextNbtProvider serializes `LootContext.EntityTarget` using `Enum#name`. This leads to serializing with `"THIS"`, `"KILLER"`, `"DIRECT_KILLER"`, or `"KILLER_PLAYER"`. However, deserializing through `ContextNbtProvider#createFromContext` uses `LootContext.EntityTarget#getByName`. This does not use the enum name, but rather a private field named `name` which is in lowercase. This leads to issues when trying to datagen a `ContextNbtProvider` made for an entity target, as the serialization will be invalid since the datagen produced invalid results. This PR fixes the issue by changing `getId()` to use a new patched `getName()` method on EntityTarget, since the `name` field is private. Testing from @Tslat would be appreciated as he was the user to experience this issue.