### PR TITLE
Grindstone event

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -1,5 +1,45 @@
 --- a/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/net/minecraft/world/inventory/GrindstoneMenu.java
+@@ -35,6 +_,7 @@
+       }
+    };
+    private final ContainerLevelAccess f_39561_;
++   private int xp = -1;
+ 
+    public GrindstoneMenu(int p_39563_, Inventory p_39564_) {
+       this(p_39563_, p_39564_, ContainerLevelAccess.f_39287_);
+@@ -45,12 +_,12 @@
+       this.f_39561_ = p_39568_;
+       this.m_38897_(new Slot(this.f_39560_, 0, 49, 19) {
+          public boolean m_5857_(ItemStack p_39607_) {
+-            return p_39607_.m_41763_() || p_39607_.m_150930_(Items.f_42690_) || p_39607_.m_41793_();
++            return true;
+          }
+       });
+       this.m_38897_(new Slot(this.f_39560_, 1, 49, 40) {
+          public boolean m_5857_(ItemStack p_39616_) {
+-            return p_39616_.m_41763_() || p_39616_.m_150930_(Items.f_42690_) || p_39616_.m_41793_();
++            return true;
+          }
+       });
+       this.m_38897_(new Slot(this.f_39559_, 2, 129, 34) {
+@@ -71,6 +_,7 @@
+          }
+ 
+          private int m_39631_(Level p_39632_) {
++            if (xp > -1) return xp;
+             int l = 0;
+             l += this.m_39636_(GrindstoneMenu.this.f_39560_.m_8020_(0));
+             l += this.m_39636_(GrindstoneMenu.this.f_39560_.m_8020_(1));
+@@ -123,6 +_,8 @@
+       ItemStack itemstack1 = this.f_39560_.m_8020_(1);
+       boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
+       boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
++      this.xp = -1;
++      if (!net.minecraftforge.common.ForgeHooks.onGrindstoneChange(this, itemstack, itemstack1, f_39559_, xp)) return;
+       if (!flag) {
+          this.f_39559_.m_6836_(0, ItemStack.f_41583_);
+       } else {
 @@ -144,12 +_,13 @@
              }
  

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -35,8 +35,8 @@
        ItemStack itemstack1 = this.f_39560_.m_8020_(1);
        boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
        boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
-+      this.xp = -1;
-+      if (!net.minecraftforge.common.ForgeHooks.onGrindstoneChange(this, itemstack, itemstack1, f_39559_, xp)) return;
++      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(this, itemstack, itemstack1, f_39559_);
++      if (this.xp != Integer.MIN_VALUE) return;
        if (!flag) {
           this.f_39559_.m_6836_(0, ItemStack.f_41583_);
        } else {

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -23,7 +23,13 @@
           }
        });
        this.m_38897_(new Slot(this.f_39559_, 2, 129, 34) {
-@@ -71,6 +_,7 @@
+@@ -66,11 +_,13 @@
+ 
+                p_39634_.m_46796_(1042, p_39635_, 0);
+             });
++            if (!net.minecraftforge.common.ForgeHooks.onGrindstoneTake(GrindstoneMenu.this.f_39560_.m_8020_(0), GrindstoneMenu.this.f_39560_.m_8020_(1),  GrindstoneMenu.this.f_39560_)) return;
+             GrindstoneMenu.this.f_39560_.m_6836_(0, ItemStack.f_41583_);
+             GrindstoneMenu.this.f_39560_.m_6836_(1, ItemStack.f_41583_);
           }
  
           private int m_39631_(Level p_39632_) {
@@ -35,7 +41,7 @@
        ItemStack itemstack1 = this.f_39560_.m_8020_(1);
        boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
        boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
-+      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(this, itemstack, itemstack1, f_39559_);
++      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, f_39559_);
 +      if (this.xp != Integer.MIN_VALUE) return;
        if (!flag) {
           this.f_39559_.m_6836_(0, ItemStack.f_41583_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -35,6 +35,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.mojang.datafixers.kinds.App;
+import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Lifecycle;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -83,6 +84,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.GrindstoneMenu;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.nbt.CompoundTag;
@@ -123,6 +125,7 @@ import net.minecraftforge.common.world.MobSpawnSettingsBuilder;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.GrindstoneUpdateEvent;
 import net.minecraftforge.event.ItemAttributeModifierEvent;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.RegisterStructureConversionsEvent;
@@ -673,6 +676,24 @@ public class ForgeHooks
         AnvilRepairEvent e = new AnvilRepairEvent(player, left, right, output);
         MinecraftForge.EVENT_BUS.post(e);
         return e.getBreakChance();
+    }
+    
+    public static boolean onGrindstoneChange(GrindstoneMenu container, @Nonnull ItemStack top, @Nonnull ItemStack bottem, Container outputSlot, int xp)
+    {
+        GrindstoneUpdateEvent e = new GrindstoneUpdateEvent(top, bottem);
+        if (MinecraftForge.EVENT_BUS.post(e))
+        {
+            xp = e.getXp();
+            return false;
+        }
+        if (e.getOutput().isEmpty()) 
+        {
+            return true;
+        }
+
+        outputSlot.setItem(0, e.getOutput());
+        xp = e.getXp();
+        return false;
     }
 
     private static ThreadLocal<Player> craftingPlayer = new ThreadLocal<Player>();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -678,22 +678,20 @@ public class ForgeHooks
         return e.getBreakChance();
     }
     
-    public static boolean onGrindstoneChange(GrindstoneMenu container, @Nonnull ItemStack top, @Nonnull ItemStack bottem, Container outputSlot, int xp)
+    public static int onGrindstoneChange(GrindstoneMenu container, @Nonnull ItemStack top, @Nonnull ItemStack bottem, Container outputSlot)
     {
         GrindstoneUpdateEvent e = new GrindstoneUpdateEvent(top, bottem);
         if (MinecraftForge.EVENT_BUS.post(e))
         {
-            xp = e.getXp();
-            return false;
+            return e.getXp();
         }
         if (e.getOutput().isEmpty()) 
         {
-            return true;
+            return Integer.MIN_VALUE;
         }
 
         outputSlot.setItem(0, e.getOutput());
-        xp = e.getXp();
-        return false;
+        return e.getXp();
     }
 
     private static ThreadLocal<Player> craftingPlayer = new ThreadLocal<Player>();

--- a/src/main/java/net/minecraftforge/event/GrindstoneResultEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneResultEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * 
+ * GrindstoneResultEvent is fired when the before the result stack is taken from a grindstone. <br> 
+ * It is called from {@link GrindstoneMenu#GrindstoneMenu(...).new Slot() {...}.onTake(Player, ItemStack)}. <br>
+ * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
+ * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
+ * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
+ * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
+ */
+@Cancelable
+public class GrindstoneResultEvent extends Event
+{
+	private final ItemStack top;
+    private final ItemStack bottom;
+    private ItemStack newTop;
+    private ItemStack newBottom;
+    
+    public GrindstoneResultEvent(ItemStack top, ItemStack bottom) 
+    {
+        this.top = top;
+        this.bottom = bottom;
+        this.newTop = ItemStack.EMPTY;
+        this.newBottom = ItemStack.EMPTY;
+    }
+    
+    /**
+     * @return The item in the top input grindstone slot. <br>
+     */
+    public ItemStack getTop()
+    {
+        return top;
+    }
+    
+    /**
+     * @return The item in the top input grindstone slot. <br>
+     */
+    public ItemStack getnewTop()
+    {
+        return newTop;
+    }
+    
+    /**
+     * Sets the itemstack in the top slot
+     * @param top
+     */
+    public void setnewTop(ItemStack top)
+    {
+        this.newTop = top;
+    }
+    
+    /**
+     * @return The item in the bottom input grindstone slot. <br>
+     */
+    public ItemStack getBottom() 
+    {
+        return bottom;
+    }
+    
+    /**
+     * @return The item in the bottom input grindstone slot. <br>
+     */
+    public ItemStack getnewBottom() 
+    {
+        return newBottom;
+    }
+    
+    /**
+     * Sets the itemstack in the bottom slot
+     * @param top
+     */
+    public void setnewBottom(ItemStack bottom)
+    {
+        this.newBottom = bottom;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/GrindstoneUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneUpdateEvent.java
@@ -23,14 +23,14 @@ public class GrindstoneUpdateEvent extends Event
 {
 	
     private final ItemStack top;
-    private final ItemStack bottem;
+    private final ItemStack bottom;
     private ItemStack output;
     private int xp;
     
-    public GrindstoneUpdateEvent(ItemStack top, ItemStack bottem) 
+    public GrindstoneUpdateEvent(ItemStack top, ItemStack bottom) 
     {
         this.top = top;
-        this.bottem = bottem;
+        this.bottom = bottom;
         this.output = ItemStack.EMPTY;
         this.xp = 0;
     }
@@ -48,7 +48,7 @@ public class GrindstoneUpdateEvent extends Event
      */
     public ItemStack getBottom() 
     {
-        return bottem;
+        return bottom;
     }
     
     /**
@@ -75,7 +75,7 @@ public class GrindstoneUpdateEvent extends Event
     /**
      * This is the experience amount determined by the event, not the vanilla behavior. <br>
      * If you are the first receiver of this event, it is guaranteed to be 0. <br>
-     * if the value is lower than 0, the vanilla behavior for calculating experience will run. <br>
+     * if the value is equal to -1, the vanilla behavior for calculating experience will run. <br>
      * @return The experience amount given to the player.
      */
     public int getXp()
@@ -91,5 +91,4 @@ public class GrindstoneUpdateEvent extends Event
     {
         this.xp = xp;
     }
-
 }

--- a/src/main/java/net/minecraftforge/event/GrindstoneUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneUpdateEvent.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * 
+ * GrindstoneUpdateEvent is fired when the inputs to a grindstone are changed. <br> 
+ * It is called from {@link GrindstoneMenu#createResult()}. <br>
+ * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
+ * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
+ * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
+ * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
+ */
+@Cancelable
+public class GrindstoneUpdateEvent extends Event
+{
+	
+    private final ItemStack top;
+    private final ItemStack bottem;
+    private ItemStack output;
+    private int xp;
+    
+    public GrindstoneUpdateEvent(ItemStack top, ItemStack bottem) 
+    {
+        this.top = top;
+        this.bottem = bottem;
+        this.output = ItemStack.EMPTY;
+        this.xp = 0;
+    }
+    
+    /**
+     * @return The item in the top input grindstone slot. <br>
+     */
+    public ItemStack getTop()
+    {
+        return top;
+    }
+    
+    /**
+     * @return The item in the bottom input grindstone slot. <br>
+     */
+    public ItemStack getBottom() 
+    {
+        return bottem;
+    }
+    
+    /**
+     * This is the output as determined by the event, not by the vanilla behavior between these two items. <br>
+     * If you are the first receiver of this event, it is guaranteed to be empty. <br>
+     * It will only be non-empty if changed by an event handler. <br>
+     * If this event is cancelled, this output stack is discarded. <br>
+     * @return The item to set in the output grindstone slot.
+     */
+    public ItemStack getOutput()
+    {
+        return output;
+    }
+    
+    /**
+     * Sets the output slot to a specific itemstack.
+     * @param output The stack to change the output to.
+     */
+    public void setOutput(ItemStack output)
+    {
+        this.output = output;
+    }
+    
+    /**
+     * This is the experience amount determined by the event, not the vanilla behavior. <br>
+     * If you are the first receiver of this event, it is guaranteed to be 0. <br>
+     * if the value is lower than 0, the vanilla behavior for calculating experience will run. <br>
+     * @return The experience amount given to the player.
+     */
+    public int getXp()
+    {
+        return xp;
+    }
+    
+    /**
+     * Sets the experience amount.
+     * @param xp The experience amount given to the player.
+     */
+    public void setXp(int xp)
+    {
+        this.xp = xp;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
@@ -3,6 +3,7 @@ package net.minecraftforge.debug;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.GrindstoneResultEvent;
 import net.minecraftforge.event.GrindstoneUpdateEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -43,4 +44,16 @@ public class GrindstoneEventTest {
         }
     }
 	
+    @SubscribeEvent
+    public static void onGrindstoneResult(GrindstoneResultEvent event) {
+        if (event.getTop().is(Items.LAPIS_LAZULI) && event.getBottom().is(Items.NETHERITE_INGOT))
+	    {
+	        ItemStack top = event.getTop().copy();
+	        ItemStack bottom = event.getBottom().copy();
+	        bottom.shrink(1);
+	        top.shrink(1);
+			event.setnewBottom(bottom);
+            event.setnewTop(top);
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.GrindstoneUpdateEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("grindstone_event_test")
+@Mod.EventBusSubscriber
+public class GrindstoneEventTest {
+
+	@SubscribeEvent
+    public static void onGrindstoneUpdate(GrindstoneUpdateEvent event)
+    {
+        if (event.getTop().is(Items.LAPIS_LAZULI) && event.getBottom().is(Items.NETHERITE_INGOT))
+        {
+        	event.setOutput(new ItemStack(Items.DIAMOND, 1));
+        	event.setXp(5);
+        }
+        
+        if (event.getTop().is(Items.IRON_ORE) && event.getBottom().is(Items.FLINT))
+        {
+        	event.setOutput(new ItemStack(Items.RAW_IRON, 3));
+        	event.setXp(0);
+        }
+        
+        if (event.getTop().is(Items.IRON_AXE) && event.getBottom().is(Items.AIR))
+        {
+        	event.setOutput(event.getTop().copy());
+        	event.setXp(-1);
+        }
+        
+        if (event.getTop().is(Items.IRON_SWORD) && event.getBottom().is(Items.AIR))
+        {
+        	event.setCanceled(true);
+        }
+    }
+	
+}

--- a/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/GrindstoneEventTest.java
@@ -32,6 +32,11 @@ public class GrindstoneEventTest {
         	event.setXp(-1);
         }
         
+        if (event.getTop().is(Items.IRON_SHOVEL) && event.getBottom().is(Items.AIR))
+        {
+        	event.setOutput(ItemStack.EMPTY);
+        }
+        
         if (event.getTop().is(Items.IRON_SWORD) && event.getBottom().is(Items.AIR))
         {
         	event.setCanceled(true);

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -213,6 +213,8 @@ license="LGPL v2.1"
 [[mods]]
     modId="hide_neighbor_face_test"
 [[mods]]
+    modId="grindstone_event_test"
+[[mods]]
     modId="living_get_projectile_event_test"
 [[mods]]
     modId="server_world_creation_test"


### PR DESCRIPTION
An event implementation for the grindstone. This is heavily based on the anvil event. I've made this implementation based on the talks in the discord chat, so any comments/remarks are certainly welcome if I've missed something.

A quick question: similar to the anvil events, these events do not handle changes in the input items. Would another event (or a "post" type event) be good to achieve this? Currently the vanilla behavior is to set the slots to empty, deleting whatever was in them, even if it was a full stack.