### PR TITLE
[1.18.x] Fix ForgeHooks.canEntityDestroy causing lag if a pos is not loaded

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1161,6 +1161,8 @@ public class ForgeHooks
 
     public static boolean canEntityDestroy(Level level, BlockPos pos, LivingEntity entity)
     {
+        if (!level.isLoaded(pos))
+            return false;
         BlockState state = level.getBlockState(pos);
         return ForgeEventFactory.getMobGriefingEvent(level, entity) && state.canEntityDestroy(level, pos, entity) && ForgeEventFactory.onEntityDestroyBlock(entity, pos, state);
     }


### PR DESCRIPTION
When `ForgeHooks.canEntityDestroy` is called, it does not do a check for if the position is actually loaded. This can cause a significant amount of server lag for entities that call this regularly, such as zombified piglins and zombies searching for turtle eggs at the default position (0, 0, 0), which has no guarantee of being loaded.

Screenshot comparing TPS in The End at (0, 0, 10,000) with a zombie searching for turtle eggs.
![2022-04-24_01 10 56](https://user-images.githubusercontent.com/15661705/164957955-984d6fe2-51a6-452e-ae8e-fcdd727d9a14.png)

Note: The lag not happen in vanilla since they don't run `level.getBlockState` during the gamerule check in `RemoveBlockGoal`, but Forge does since `ForgeHooks.canEntityDestroy` has additional checks.