### PR TITLE
Make CapabilityProvider#serializeCaps public

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -119,7 +119,7 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
         }
     }
 
-    protected final @Nullable CompoundTag serializeCaps()
+    public final @Nullable CompoundTag serializeCaps()
     {
         if (isLazy && !initialized)
         {


### PR DESCRIPTION
This is useful for mods that wish to also hash caps when hashing `ItemStack`s (Mekanism, AE2 at least), or use another representation of `ItemStack`s (AE2's `AEItemKey` for example, and RS2 will have a similar need with its `ItemResource`).

Currently, I have the following hack in AE2, and I'd like to get rid of it:

```java
    private static final MethodHandle SERIALIZE_CAPS_HANDLE;
    static {
        try {
            var method = CapabilityProvider.class.getDeclaredMethod("serializeCaps");
            method.setAccessible(true);
            SERIALIZE_CAPS_HANDLE = MethodHandles.lookup().unreflect(method);
        } catch (Exception exception) {
            throw new RuntimeException("Failed to create serializeCaps method handle", exception);
        }
    }

    @Nullable
    private static CompoundTag serializeStackCaps(ItemStack stack) {
        try {
            var caps = (CompoundTag) SERIALIZE_CAPS_HANDLE.invokeExact((CapabilityProvider) stack);
            // Ensure stacks with no serializable cap providers are treated the same as stacks with no caps!
            return caps == null || caps.isEmpty() ? null : caps;
        } catch (Throwable ex) {
            throw new RuntimeException("Failed to call serializeCaps", ex);
        }
    }
```