### PR TITLE
Fix entity parts being ignored when collecting entities in an AABB

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/client/multiplayer/ClientLevel.java
 +++ b/net/minecraft/client/multiplayer/ClientLevel.java
+@@ -117,6 +_,7 @@
+    private final Deque<Runnable> f_194122_ = Queues.newArrayDeque();
+    private int f_194123_;
+    private static final Set<Item> f_194124_ = Set.of(Items.f_42127_, Items.f_151033_);
++   private final it.unimi.dsi.fastutil.ints.Int2ObjectMap<net.minecraftforge.entity.PartEntity<?>> partEntities = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>();
+ 
+    public ClientLevel(ClientPacketListener p_205505_, ClientLevel.ClientLevelData p_205506_, ResourceKey<Level> p_205507_, Holder<DimensionType> p_205508_, int p_205509_, int p_205510_, Supplier<ProfilerFiller> p_205511_, LevelRenderer p_205512_, boolean p_205513_, long p_205514_) {
+       super(p_205506_, p_205507_, p_205508_, p_205511_, true, p_205513_, p_205514_);
 @@ -129,6 +_,8 @@
        this.f_194123_ = p_205510_;
        this.m_46465_();
@@ -60,13 +68,34 @@
           this.f_104840_ = p_104852_;
        }
  
-@@ -912,6 +_,9 @@
+@@ -907,11 +_,30 @@
+             ClientLevel.this.f_104566_.add((AbstractClientPlayer)p_171712_);
+          }
+ 
++         if (p_171712_.isMultipartEntity()) {
++            for (net.minecraftforge.entity.PartEntity<?> part : p_171712_.getParts()) {
++               ClientLevel.this.partEntities.put(part.m_142049_(), part);
++            }
++         }
+       }
+ 
        public void m_141981_(Entity p_171716_) {
           p_171716_.m_19877_();
           ClientLevel.this.f_104566_.remove(p_171716_);
 +
 +          p_171716_.onRemovedFromWorld();
 +          net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_171716_, ClientLevel.this));
++
++         if (p_171716_.isMultipartEntity()) {
++            for (net.minecraftforge.entity.PartEntity<?> part : p_171716_.getParts()) {
++               ClientLevel.this.partEntities.remove(part.m_142049_());
++            }
++         }
        }
++   }
++
++   @Override
++   public java.util.Collection<net.minecraftforge.entity.PartEntity<?>> getPartEntities() {
++      return this.partEntities.values();
     }
  }

--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -260,12 +260,17 @@
                 ServerLevel.this.f_143247_.remove(enderdragonpart.m_142049_());
              }
           }
-@@ -1538,6 +_,8 @@
+@@ -1538,6 +_,13 @@
              gameeventlistenerregistrar.m_157854_(p_143375_.f_19853_);
           }
  
 +         p_143375_.onRemovedFromWorld();
 +         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_143375_, ServerLevel.this));
        }
++   }
++
++   @Override
++   public java.util.Collection<net.minecraftforge.entity.PartEntity<?>> getPartEntities() {
++      return this.f_143247_.values();
     }
  }

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -172,30 +172,48 @@
     }
  
     public boolean m_46749_(BlockPos p_46750_) {
-@@ -538,8 +_,8 @@
+@@ -538,6 +_,7 @@
              list.add(p_151522_);
           }
  
--         if (p_151522_ instanceof EnderDragon) {
--            for(EnderDragonPart enderdragonpart : ((EnderDragon)p_151522_).m_31156_()) {
-+         if (p_151522_.isMultipartEntity()) {
-+            for(net.minecraftforge.entity.PartEntity<?> enderdragonpart : p_151522_.getParts()) {
++         if (false)
+          if (p_151522_ instanceof EnderDragon) {
+             for(EnderDragonPart enderdragonpart : ((EnderDragon)p_151522_).m_31156_()) {
                 if (p_151522_ != p_46536_ && p_46538_.test(enderdragonpart)) {
-                   list.add(enderdragonpart);
-                }
-@@ -558,10 +_,8 @@
+@@ -547,6 +_,11 @@
+          }
+ 
+       });
++      for (net.minecraftforge.entity.PartEntity<?> p : this.getPartEntities()) {
++         if (p != p_46536_ && p.m_142469_().m_82381_(p_46537_) && p_46538_.test(p)) {
++            list.add(p);
++         }
++      }
+       return list;
+    }
+ 
+@@ -558,6 +_,8 @@
              list.add(p_151539_);
           }
  
--         if (p_151539_ instanceof EnderDragon) {
--            EnderDragon enderdragon = (EnderDragon)p_151539_;
--
--            for(EnderDragonPart enderdragonpart : enderdragon.m_31156_()) {
-+         if (p_151539_.isMultipartEntity()) {
-+            for(net.minecraftforge.entity.PartEntity<?> enderdragonpart : p_151539_.getParts()) {
-                T t = p_151528_.m_141992_(enderdragonpart);
-                if (t != null && p_151530_.test(t)) {
-                   list.add(t);
++
++         if (false)
+          if (p_151539_ instanceof EnderDragon) {
+             EnderDragon enderdragon = (EnderDragon)p_151539_;
+ 
+@@ -570,6 +_,12 @@
+          }
+ 
+       });
++      for (net.minecraftforge.entity.PartEntity<?> p : this.getPartEntities()) {
++         T t = p_151528_.m_141992_(p);
++         if (t != null && t.m_142469_().m_82381_(p_151529_) && p_151530_.test(t)) {
++            list.add(t);
++         }
++      }
+       return list;
+    }
+ 
 @@ -581,6 +_,7 @@
           this.m_46745_(p_151544_).m_8092_(true);
        }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLevel.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLevel.java
@@ -5,7 +5,11 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.entity.PartEntity;
 
 public interface IForgeLevel extends ICapabilityProvider
 {
@@ -22,4 +26,12 @@ public interface IForgeLevel extends ICapabilityProvider
      * @return The new max radius
      */
     public double increaseMaxEntityRadius(double value);
+    /**
+     * All part entities in this world. Used when collecting entities in an AABB to fix parts being
+     * ignored whose parent entity is in a chunk that does not intersect with the AABB.
+     */
+    public default Collection<PartEntity<?>> getPartEntities()
+    {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
Currently entity parts are only taken into consideration when the parent entity is in a chunk that intersects with the AABB. This PR fixes that issue.

This issue is part of [MC-158205](https://bugs.mojang.com/browse/MC-158205).

Another solution to this problem would be to reimplement `MAX_ENTITY_RADIUS` and replace the hardcoded `2.0D` in the `forEachAccessibleNonEmptySection` method in the `EntitySectionStorage` class. But this has two problems:
1. Performance: The ender dragon is the largest entity with a width of 16 which means passing small AABB to `forEachAccessibleNonEmptySection` will result in at least 3x3x3=27 sections being checked.
2. This only works when the bounding box of the parent entity contains all part entities at all time. This is definitely not the case for all modded multipart entities.