### PR TITLE
Allow Exception passed through CommandEvent to propagate

### DIFF
--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -17,7 +17,7 @@
  
        this.f_82090_.findAmbiguities((p_82108_, p_82109_, p_82110_, p_82111_) -> {
           f_82089_.warn("Ambiguity between arguments {} and {} with inputs: {}", this.f_82090_.getPath(p_82109_), this.f_82090_.getPath(p_82110_), p_82111_);
-@@ -220,7 +_,15 @@
+@@ -220,7 +_,17 @@
  
        try {
           try {
@@ -25,7 +25,9 @@
 +            ParseResults<CommandSourceStack> parse = this.f_82090_.parse(stringreader, p_82118_);
 +            net.minecraftforge.event.CommandEvent event = new net.minecraftforge.event.CommandEvent(parse);
 +            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) {
-+               if (event.getException() != null) {
++               if (event.getException() instanceof Exception) {
++                  throw (Exception) event.getException();
++               } else if (event.getException() != null) {
 +                  com.google.common.base.Throwables.throwIfUnchecked(event.getException());
 +               }
 +               return 1;

--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -25,8 +25,8 @@
 +            ParseResults<CommandSourceStack> parse = this.f_82090_.parse(stringreader, p_82118_);
 +            net.minecraftforge.event.CommandEvent event = new net.minecraftforge.event.CommandEvent(parse);
 +            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) {
-+               if (event.getException() instanceof Exception) {
-+                  throw (Exception) event.getException();
++               if (event.getException() instanceof Exception exception) {
++                  throw exception;
 +               } else if (event.getException() != null) {
 +                  com.google.common.base.Throwables.throwIfUnchecked(event.getException());
 +               }


### PR DESCRIPTION
I want to throw a `CommandSyntaxException` through the `CommandEvent` so that the client is notified of the error, currently Forge is ignoring it as it's a checked exception (only unchecked exceptions are being re-thrown). Because the surrounding try-catch is handling `Exception` I've added a re-throw for it as it can/should be handled instead of being ignored.

Example Event Handler:
```java
@SubscribeEvent
public void onCommand(CommandEvent event) {
    event.setException(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(event.getParseResults().getReader()));
    event.setCanceled(true);
}
```