### PR TITLE
Expose ICondition$IContext to modded reload listeners.

### DIFF
--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -44,21 +44,20 @@
     }
  
     private static <T> void m_206870_(RegistryAccess p_206871_, TagManager.LoadResult<T> p_206872_) {
-@@ -96,5 +_,17 @@
+@@ -96,5 +_,16 @@
           return p_206874_.getValue().m_6497_();
        }));
        p_206871_.m_175515_(resourcekey).m_203652_(map);
 +   }
 +
-+   private final net.minecraftforge.common.crafting.conditions.ConditionContext context;
++   private final net.minecraftforge.common.crafting.conditions.ICondition.IContext context;
 +
 +   /**
-+    * Exposes the currently staged TagManager wrapped in an IContext so that mods can use<br>
-+    * tags in their custom reload listeners.<br>
-+    * This is only useful for reload listeners who need the currently staged tag values.<br>
-+    * @return A ConditionContext with access to the current TagManager.
++    * Exposes the current condition context for usage in other reload listeners.<br>
++    * This is not useful outside the reloading stage.
++    * @return The condition context for the currently active reload.
 +    */
-+   public net.minecraftforge.common.crafting.conditions.ConditionContext getTagContext() {
++   public net.minecraftforge.common.crafting.conditions.ICondition.IContext getConditionContext() {
 +      return this.context;
     }
  }

--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -18,8 +18,8 @@
        this.f_206849_ = new TagManager(p_206857_);
        this.f_206847_ = new Commands(p_206858_);
        this.f_206854_ = new ServerFunctionLibrary(p_206859_, this.f_206847_.m_82094_());
-+      // Forge: pass condition context too
-+      var context = new net.minecraftforge.common.crafting.conditions.ConditionContext(this.f_206849_);
++      // Forge: Create context object and pass it to the recipe manager.
++      this.context = new net.minecraftforge.common.crafting.conditions.ConditionContext(this.f_206849_);
 +      this.f_206848_ = new RecipeManager(context);
 +      this.f_206853_ = new ServerAdvancementManager(this.f_206850_, context);
     }
@@ -44,3 +44,21 @@
     }
  
     private static <T> void m_206870_(RegistryAccess p_206871_, TagManager.LoadResult<T> p_206872_) {
+@@ -96,5 +_,17 @@
+          return p_206874_.getValue().m_6497_();
+       }));
+       p_206871_.m_175515_(resourcekey).m_203652_(map);
++   }
++
++   private final net.minecraftforge.common.crafting.conditions.ConditionContext context;
++
++   /**
++    * Exposes the currently staged TagManager wrapped in an IContext so that mods can use<br>
++    * tags in their custom reload listeners.<br>
++    * This is only useful for reload listeners who need the currently staged tag values.<br>
++    * @return A ConditionContext with access to the current TagManager.
++    */
++   public net.minecraftforge.common.crafting.conditions.ConditionContext getTagContext() {
++      return this.context;
+    }
+ }

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -49,7 +49,7 @@ public class AddReloadListenerEvent extends Event
     }
 
     /**
-     * For access to the currently-staged tags, see {@link ReloadableServerResources#getTagContext()}
+     * For additional context, see {@link ReloadableServerResources#getConditionContext()}
      * @return The ReloableServerResources being reloaded.
      */
     public ReloadableServerResources getServerResources()

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -11,6 +11,7 @@ import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModLoader;
 
@@ -49,12 +50,20 @@ public class AddReloadListenerEvent extends Event
     }
 
     /**
-     * For additional context, see {@link ReloadableServerResources#getConditionContext()}
      * @return The ReloableServerResources being reloaded.
      */
     public ReloadableServerResources getServerResources()
     {
         return serverResources;
+    }
+
+    /**
+     * This context object holds data relevant to the current reload, such as staged tags.
+     * @return The condition context for the currently active reload.
+     */
+    public ICondition.IContext getConditionContext()
+    {
+        return serverResources.getConditionContext();
     }
 
     private static class WrappedStateAwareListener implements PreparableReloadListener {

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -48,6 +48,10 @@ public class AddReloadListenerEvent extends Event
        return ImmutableList.copyOf(listeners);
     }
 
+    /**
+     * For access to the currently-staged tags, see {@link ReloadableServerResources#getTagContext()}
+     * @return The ReloableServerResources being reloaded.
+     */
     public ReloadableServerResources getServerResources()
     {
         return serverResources;


### PR DESCRIPTION
Currently the ConditionContext is only available for recipes.  This change makes it available to all reload listeners, so modded reload listeners can perform actions that require this information (such as loading conditions with support for `forge:tag_empty`).