### PR TITLE
Fix shears passing on a client when interacting with a shearable entity

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ShearsItem.java.patch
@@ -1,14 +1,13 @@
 --- a/net/minecraft/world/item/ShearsItem.java
 +++ b/net/minecraft/world/item/ShearsItem.java
-@@ -48,6 +_,32 @@
+@@ -48,6 +_,31 @@
        }
     }
  
 +   @Override
 +   public net.minecraft.world.InteractionResult m_6880_(ItemStack stack, net.minecraft.world.entity.player.Player playerIn, LivingEntity entity, net.minecraft.world.InteractionHand hand) {
-+      if (entity.f_19853_.f_46443_) return net.minecraft.world.InteractionResult.PASS;
-+      if (entity instanceof net.minecraftforge.common.IForgeShearable) {
-+          net.minecraftforge.common.IForgeShearable target = (net.minecraftforge.common.IForgeShearable)entity;
++      if (entity instanceof net.minecraftforge.common.IForgeShearable target) {
++         if (entity.f_19853_.f_46443_) return net.minecraft.world.InteractionResult.SUCCESS;
 +         BlockPos pos = new BlockPos(entity.m_20185_(), entity.m_20186_(), entity.m_20189_());
 +         if (target.isShearable(stack, entity.f_19853_, pos)) {
 +            java.util.List<ItemStack> drops = target.onSheared(playerIn, stack, entity.f_19853_, pos,


### PR DESCRIPTION
Forge replaces the default shear logic with logic that supports `IShearableEntity`, how ever the current code causes it to pass on the client. This leads to both hands interacting with the entity, as the main hand passing falls back to the client. To see this bug with just forge, put shears in your main hand, and a renamed name tag in your offhand. Shearing a sheep will also immediately rename it.

Fix is pretty straight forward, just return success on the client if the entity is shearable (so move the check after the instance of check)