### PR TITLE
Implement PlayerNegotiationEvent

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerNegotiationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerNegotiationEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.network.Connection;
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * This event is fired when a connection has started the Forge Handshake.<br>
+ * Forge will wait for all enqueued work to be completed before proceeding further with the login process.
+ */
+public class PlayerNegotiationEvent extends Event
+{
+
+    private final Connection connection;
+    private final GameProfile profile;
+    private final List<Future<Void>> futures;
+
+    public PlayerNegotiationEvent(Connection connection, GameProfile profile, List<Future<Void>> futures)
+    {
+        this.connection = connection;
+        this.profile = profile;
+        this.futures = futures;
+    }
+
+    /**
+     * Enqueue work to be completed asynchronously before the login proceeds.
+     */
+    public void enqueueWork(Runnable runnable)
+    {
+        enqueueWork(CompletableFuture.runAsync(runnable));
+    }
+
+    /**
+     * Enqueue work to be completed asynchronously before the login proceeds.
+     */
+    public void enqueueWork(Future<Void> future)
+    {
+        futures.add(future);
+    }
+
+    public Connection getConnection()
+    {
+        return connection;
+    }
+
+    public GameProfile getProfile()
+    {
+        return profile;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerNegotiationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerNegotiationEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.player;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.network.Connection;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
 import java.util.List;
@@ -14,8 +15,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 /**
- * This event is fired when a connection has started the Forge Handshake.<br>
+ * This event is fired on the server when a connection has started the Forge handshake,
  * Forge will wait for all enqueued work to be completed before proceeding further with the login process.
+ * <br>
+ * This event can be used to delay the player login until any necessary work such as preloading user data has completed.
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 public class PlayerNegotiationEvent extends Event
 {

--- a/src/main/java/net/minecraftforge/network/HandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeHandler.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.network;
 
 import com.google.common.collect.Multimap;
+import com.mojang.authlib.GameProfile;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
 import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
@@ -13,7 +14,9 @@ import net.minecraft.network.protocol.login.ServerboundCustomQueryPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.LogMessageAdapter;
+import net.minecraftforge.event.entity.player.PlayerNegotiationEvent;
 import net.minecraftforge.network.simple.SimpleChannel;
 import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.GameData;
@@ -25,7 +28,10 @@ import org.apache.logging.log4j.MarkerManager;
 import com.google.common.collect.Maps;
 
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.IntSupplier;
@@ -99,6 +105,8 @@ public class HandshakeHandler
     private Map<ResourceLocation, ForgeRegistry.Snapshot> registrySnapshots;
     private Set<ResourceLocation> registriesToReceive;
     private Map<ResourceLocation, String> registryHashes;
+    private boolean negotiationStarted;
+    private final List<Future<Void>> pendingFutures = new ArrayList<>();
 
     private HandshakeHandler(Connection networkManager, NetworkDirection side)
     {
@@ -281,6 +289,13 @@ public class HandshakeHandler
      */
     public boolean tickServer()
     {
+        if (!negotiationStarted) {
+            GameProfile profile = ((ServerLoginPacketListenerImpl) manager.getPacketListener()).gameProfile;
+            PlayerNegotiationEvent event = new PlayerNegotiationEvent(manager, profile, pendingFutures);
+            MinecraftForge.EVENT_BUS.post(event);
+            negotiationStarted = true;
+        }
+
         if (packetPosition < messageList.size()) {
             NetworkRegistry.LoginPayload message = messageList.get(packetPosition);
 
@@ -290,8 +305,24 @@ public class HandshakeHandler
             packetPosition++;
         }
 
+        pendingFutures.removeIf(future -> {
+            if (!future.isDone()) {
+                return false;
+            }
+
+            try {
+                future.get();
+            } catch (ExecutionException ex) {
+                LOGGER.error(FMLHSMARKER, "Error during negotiation", ex.getCause());
+            } catch (CancellationException | InterruptedException ex) {
+                // no-op
+            }
+
+            return true;
+        });
+
         // we're done when sentMessages is empty
-        if (sentMessages.isEmpty() && packetPosition >= messageList.size()-1) {
+        if (sentMessages.isEmpty() && packetPosition >= messageList.size()-1 && pendingFutures.isEmpty()) {
             // clear ourselves - we're done!
             this.manager.channel().attr(NetworkConstants.FML_HANDSHAKE_HANDLER).set(null);
             LOGGER.debug(FMLHSMARKER, "Handshake complete!");

--- a/src/main/java/net/minecraftforge/network/HandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeHandler.java
@@ -313,7 +313,7 @@ public class HandshakeHandler
             try {
                 future.get();
             } catch (ExecutionException ex) {
-                LOGGER.error(FMLHSMARKER, "Error during negotiation", ex.getCause());
+                LOGGER.error("Error during negotiation", ex.getCause());
             } catch (CancellationException | InterruptedException ex) {
                 // no-op
             }

--- a/src/main/java/net/minecraftforge/network/HandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeHandler.java
@@ -105,7 +105,7 @@ public class HandshakeHandler
     private Map<ResourceLocation, ForgeRegistry.Snapshot> registrySnapshots;
     private Set<ResourceLocation> registriesToReceive;
     private Map<ResourceLocation, String> registryHashes;
-    private boolean negotiationStarted;
+    private boolean negotiationStarted = false;
     private final List<Future<Void>> pendingFutures = new ArrayList<>();
 
     private HandshakeHandler(Connection networkManager, NetworkDirection side)

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -271,6 +271,7 @@ public net.minecraft.server.level.ServerLevel m_142646_()Lnet/minecraft/world/le
 public net.minecraft.server.level.ServerPlayer f_8940_ # containerCounter
 public net.minecraft.server.level.ServerPlayer m_143399_(Lnet/minecraft/world/inventory/AbstractContainerMenu;)V # initMenu
 public net.minecraft.server.level.ServerPlayer m_9217_()V # nextContainerCounter
+public net.minecraft.server.network.ServerLoginPacketListenerImpl f_10021_ # gameProfile
 public net.minecraft.server.packs.AbstractPackResources f_10203_ # file
 public net.minecraft.server.packs.resources.FallbackResourceManager f_10599_ # fallbacks
 public net.minecraft.tags.Tag$BuilderEntry <init>(Lnet/minecraft/tags/Tag$Entry;Ljava/lang/String;)V # constructor

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraftforge.event.entity.player.PlayerNegotiationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("player_negotiation_event_test")
+@Mod.EventBusSubscriber()
+public class PlayerNegotiationEventTest
+{
+    private static final boolean ENABLE = true;
+    private static final Logger LOGGER = LogManager.getLogger(PlayerNegotiationEventTest.class);
+
+    @SubscribeEvent
+    public static void onPlayerNegotiation(PlayerNegotiationEvent event)
+    {
+        if (!ENABLE) return;
+        LOGGER.info("{}[{}] started negotiation", event.getProfile().getName(), event.getConnection().getRemoteAddress());
+        event.enqueueWork(() -> {
+            LOGGER.info("Hello from {}", Thread.currentThread().getName());
+        });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
@@ -11,6 +11,10 @@ import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Tests {@link PlayerNegotiationEvent} by listening for and then enqueuing work to be done asynchronously,
+ * details regarding the work execution is printed out and exceptions are thrown to ensure proper handling.
+ */
 @Mod("player_negotiation_event_test")
 @Mod.EventBusSubscriber()
 public class PlayerNegotiationEventTest
@@ -24,9 +28,11 @@ public class PlayerNegotiationEventTest
         if (!ENABLE) return;
         LOGGER.info("{} ({})[{}] started negotiation", event.getProfile().getName(), event.getProfile().getId(), event.getConnection().getRemoteAddress());
         event.enqueueWork(() -> {
+            // This log message should be printed on the fork-join-pool.
             LOGGER.info("Hello from {}", Thread.currentThread().getName());
         });
         event.enqueueWork(() -> {
+            // This exception should be logged by Forge.
             throw new RuntimeException("Test Exception from PlayerNegotiationEventTest");
         });
     }

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNegotiationEventTest.java
@@ -15,16 +15,19 @@ import org.apache.logging.log4j.Logger;
 @Mod.EventBusSubscriber()
 public class PlayerNegotiationEventTest
 {
-    private static final boolean ENABLE = true;
+    private static final boolean ENABLE = false;
     private static final Logger LOGGER = LogManager.getLogger(PlayerNegotiationEventTest.class);
 
     @SubscribeEvent
     public static void onPlayerNegotiation(PlayerNegotiationEvent event)
     {
         if (!ENABLE) return;
-        LOGGER.info("{}[{}] started negotiation", event.getProfile().getName(), event.getConnection().getRemoteAddress());
+        LOGGER.info("{} ({})[{}] started negotiation", event.getProfile().getName(), event.getProfile().getId(), event.getConnection().getRemoteAddress());
         event.enqueueWork(() -> {
             LOGGER.info("Hello from {}", Thread.currentThread().getName());
+        });
+        event.enqueueWork(() -> {
+            throw new RuntimeException("Test Exception from PlayerNegotiationEventTest");
         });
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -218,5 +218,7 @@ license="LGPL v2.1"
     modId="server_world_creation_test"
 [[mods]]
     modId="valid_railshape_test"
+[[mods]]
+    modId="player_negotiation_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
I'm currently attempting to add Forge support to LuckPerms (https://github.com/LuckPerms/LuckPerms/pull/3262) however there are some shortcomings in Forge that @lucko would rather me address directly in Forge instead of attempting to work around them.

The earliest event currently available is the `PlayerLoggedInEvent`, however, this is too late for LuckPerms as block/claim protection mods (GriefDefender / GriefPrevention) or other mods that wish to block player actions upon logging in, won't be able to perform permission checks until LuckPerms has finished loading the user data. To reduce the likelihood of login timeouts on slow connections and unnecessary stalls on the Server Thread (affecting TPS), LuckPerms must load the user data as early as possible, due to the various supported storage providers taking an undetermined amount of time to load.

This PR adds the `PlayerNegotiationEvent` which is posted on the first tick of [`HandshakeHandler.tickServer`](https://github.com/LXGaming/MinecraftForge/blob/efccafe3a9c74efae2d9fc56df1b2c8699a74c02/src/main/java/net/minecraftforge/network/HandshakeHandler.java#L295). This event facilitates the ability for mods to enqueue work that must be completed before the login can proceed.

This functionality already exists in the following platforms and providing it here in Forge would allow plugins traditionally targeting these platforms, such as LuckPerms, to exist on Forge:
- Bukkit [AsyncPlayerPreLoginEvent](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java)
- Fabric [LoginSynchronizer](https://github.com/FabricMC/fabric/blob/1d2d03ecd5a4508d14d4bf0647324afef1b8d2bd/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerLoginNetworking.java#L159) and [Impl](https://github.com/FabricMC/fabric/blob/1d2d03ecd5a4508d14d4bf0647324afef1b8d2bd/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerLoginNetworkAddon.java#L70-L111)
- Sponge [ServerSideConnectionEvent.Auth](https://github.com/SpongePowered/SpongeAPI/blob/44f1788068a046618636856858cab8d30dc4d257/src/main/java/org/spongepowered/api/event/network/ServerSideConnectionEvent.java#L86), [Hook](https://github.com/SpongePowered/Sponge/blob/api-8/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImpl_1Mixin.java) and [Impl](https://github.com/SpongePowered/Sponge/blob/47d863402e6145daca63d6f426c313d3a45bfbcf/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java#L200)
- Velocity [PreLoginEvent](https://github.com/PaperMC/Velocity/blob/aa38d3e561862d92c1a62f296cfdb6cdf983871a/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java#L32)