### PR TITLE
Shears played no breaking sound after mob interaction

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ShearsItem.java.patch
@@ -17,7 +17,7 @@
 +               net.minecraft.world.entity.item.ItemEntity ent = entity.m_5552_(d, 1.0F);
 +               ent.m_20256_(ent.m_20184_().m_82520_((double)((rand.nextFloat() - rand.nextFloat()) * 0.1F), (double)(rand.nextFloat() * 0.05F), (double)((rand.nextFloat() - rand.nextFloat()) * 0.1F)));
 +            });
-+            stack.m_41622_(1, entity, e -> e.m_21190_(hand));
++            stack.m_41622_(1, playerIn, e -> e.m_21190_(hand));
 +         }
 +         return net.minecraft.world.InteractionResult.SUCCESS;
 +      }


### PR DESCRIPTION
This is a small bugfix which affects the issue that no breaking sound was played when breaking shears by shearing an entity (sheep, mooshroom, snow golem). 

You can test it when you give you shears with only one durability

    /give @s minecraft:shears{Damage:237}

and rightclicking with them on a sheep. (in survival mode)

The shears are breaking without a breaking sound. 

In the `interactLivingEntity` of the `ShearsItem` the second parameter of the `hurtAndBreak` call was wrong. I changed it from the sheared entity to the acting player. After this, a breaking sound is played. :)