### PR TITLE
Add event for intercepting narration chat messages

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/chat/NarratorChatListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/chat/NarratorChatListener.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/gui/chat/NarratorChatListener.java
++++ b/net/minecraft/client/gui/chat/NarratorChatListener.java
+@@ -30,6 +_,7 @@
+             this.m_168787_(p_93323_.getString());
+          } else {
+             if (narratorstatus == NarratorStatus.ALL || narratorstatus == NarratorStatus.CHAT && p_93322_ == ChatType.CHAT || narratorstatus == NarratorStatus.SYSTEM && p_93322_ == ChatType.SYSTEM) {
++               p_93323_ = net.minecraftforge.client.ForgeHooksClient.onNarratorChat(p_93322_, p_93323_, p_93324_);
+                Component component;
+                if (p_93323_ instanceof TranslatableComponent && "chat.type.text".equals(((TranslatableComponent)p_93323_).m_131328_())) {
+                   component = new TranslatableComponent("chat.type.text.narrate", ((TranslatableComponent)p_93323_).m_131329_());

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -129,6 +129,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.Stack;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1139,5 +1140,12 @@ public class ForgeHooksClient
         }, title, msg, CommonComponents.GUI_PROCEED, CommonComponents.GUI_CANCEL);
 
         Minecraft.getInstance().setScreen(screen);
+    }
+
+    public static Component onNarratorChat(ChatType chatType, Component message, UUID sender)
+    {
+        NarratorChatEvent event = new NarratorChatEvent(chatType, message, sender);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMessage();
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/NarratorChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/NarratorChatEvent.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.client.gui.chat.NarratorChatListener;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
+
+import java.util.UUID;
+
+/**
+ * Fired when {@link NarratorChatListener} receives a chat message for narration. Use {@link #setMessage(Component)} to
+ * modify the message before it is sent to the {@link com.mojang.text2speech.Narrator}.
+ *
+ * <p>This event fires before the hardcoded transformation of translatable components bearing the key
+ * {@code chat.type.text} to they key {@code chat.type.text.narrate}. The transformation will still be done if the
+ * resulting component from this event holds that key.</p>
+ *
+ * <p>This event is not {@linkplain Cancelable cancellable} and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class NarratorChatEvent extends Event
+{
+    private final ChatType chatType;
+    private final UUID sender;
+    private Component message;
+
+    /**
+     * @hidden
+     */
+    public NarratorChatEvent(ChatType chatType, Component message, UUID sender)
+    {
+        this.chatType = chatType;
+        this.message = message;
+        this.sender = sender;
+    }
+
+    /**
+     * {@return the type of the chat message} This will be either {@link ChatType#SYSTEM} or {@link ChatType#GAME_INFO},
+     * as the narrator chat listener does not receive chat messages of type {@link ChatType#GAME_INFO}.
+     */
+    public ChatType getChatType()
+    {
+        return chatType;
+    }
+
+    /**
+     * {@return the UUID of the sender of the chat message.} This can be the {@linkplain net.minecraft.Util#NIL_UUID
+     * nil UUID}, such as for system messages (of type {@link ChatType#SYSTEM}).
+     */
+    public UUID getSender()
+    {
+        return sender;
+    }
+
+    /**
+     * {@return the chat message}
+     *
+     * <p>Any styling in the event in the narration message is discarded, as {@link Component#getString()} is called to
+     * render the message into a regular string for consumption by the narrator.</p>
+     *
+     * @see #setMessage(Component)
+     */
+    public Component getMessage()
+    {
+        return message;
+    }
+
+    /**
+     * Sets the chat message to be used for narration.
+     *
+     * @param message the new chat message
+     * @throws NullPointerException if the chat message is {@code null}
+     * @see #getMessage()
+     */
+    public void setMessage(Component message)
+    {
+        this.message = Preconditions.checkNotNull(message);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/chat/NarratorChatEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/NarratorChatEventTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.chat;
+
+import net.minecraft.client.NarratorStatus;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraftforge.client.event.NarratorChatEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests {@link NarratorChatEvent} by replacing the narration message for chat messages and the single success reply of
+ * {@link net.minecraft.server.commands.EffectCommands /effect}.
+ *
+ * <p>To observe the effects of this test, enable the Narrator using the {@code CTRL + B} keyboard shortcut, or through
+ * the Accessibility sub-menu of the Options screen. Both effects can be observed when the narrator is set to
+ * {@linkplain NarratorStatus#ALL all messages} or the specified narrator setting.</p>
+ *
+ * <p>The first effect requires that the Narrator be able to read chat messages by players ({@link NarratorStatus#CHAT}).
+ * When a player sends any regular chat message, such as the {@code Dev} player saying "Hello", the narrator will read
+ * "The person Dev says Hello".</p>
+ *
+ * <p>The second effect requires that the Narrator be able to read system messages ({@link NarratorStatus#SYSTEM}).
+ * When the {@code /effect} command is ran to apply a single effect to a single target, such as for example the
+ * Wither effect to the single player named {@code Dev} using {@code /effect give Dev minecraft:wither}, the narrator
+ * will read "Blessed someone named Dev with the effect of Wither".</p>
+ */
+@Mod("narrator_chat_event_test")
+public class NarratorChatEventTest
+{
+    static final boolean ENABLED = true;
+
+    public NarratorChatEventTest()
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.addListener(this::onNarratorChat);
+        }
+    }
+
+    public void onNarratorChat(NarratorChatEvent event)
+    {
+        if (event.getMessage() instanceof TranslatableComponent message)
+        {
+            // Checks normal event behavior
+            // commands.effect.give.success.single: Applied effect %s to %s
+            if (message.getKey().equals("commands.effect.give.success.single"))
+            {
+                event.setMessage(new TranslatableComponent("Blessed someone named %2$s with the effect of %1$s", message.getArgs()));
+            }
+
+            // Check that we can change a chat message, overriding Minecraft's hardcoded logic for it
+            // chat.type.text: <%s> %s
+            if (message.getKey().equals("chat.type.text"))
+            {
+                event.setMessage(new TranslatableComponent("The person %s says %s", message.getArgs()));
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -218,5 +218,7 @@ license="LGPL v2.1"
     modId="server_world_creation_test"
 [[mods]]
     modId="valid_railshape_test"
+[[mods]]
+    modId="narrator_chat_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR adds the `NarrationChatEvent` to allow mods to intercept narration chat messages and replace them as needed for a better accessibility experience. This provides a test mod to check and showcase the functionality of the PR.

## Use cases

My usecase for this PR is my mod, Concord, which adds chat messages based on messages from a connected Discord channel. I wish to replicate the functionality that Minecraft hardcodes for regular chat messages for my own chat messages: changing to a more humanized message by replacing the `chat.type.text` key with the `chat.type.text.narrate` key (which contains a more humanized message "%s says %s" for chat messages). 

Other mods may use this in a similar manner, to replace their chat messages with narration-friendly alternatives for the benefit of users who use the narrator functionality.

## Alternatives

It may be possible for a mod to extend `NarratorChatListener`, override its methods to create one's own hook into the chat message functionality, and replace the instance held in `NarratorChatListener#INSTANCE` as well as `Gui#chatListeners`. However, this is disfavored and error-prone for two main reasons:

- A subclass would need to deal with the additional `Narrator` instance constructed by their superclass' constructor, leading to multiple `Narrator` instances. 
	- This could be mitigated with the use of `Unsafe#allocateInstance` to allocate an instance of the subclass without invoking its constructor (and therefore the superclass constructor), but that seems icky to me.
- A subclass would need to deal with the original singleton instance, due to management of the contained `Narrator` within (calls to `#destroy` and such) and due to the possibility of other objects other than `Gui#chatListeners` storing the narrator instance.