### PR TITLE
Call isEdible on stack in hand than on current item instance

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -31,11 +31,15 @@
     public void m_5929_(Level p_41428_, LivingEntity p_41429_, ItemStack p_41430_, int p_41431_) {
     }
  
-@@ -134,7 +_,7 @@
+@@ -132,9 +_,9 @@
+    }
+ 
     public InteractionResultHolder<ItemStack> m_7203_(Level p_41432_, Player p_41433_, InteractionHand p_41434_) {
-       if (this.m_41472_()) {
-          ItemStack itemstack = p_41433_.m_21120_(p_41434_);
+-      if (this.m_41472_()) {
+-         ItemStack itemstack = p_41433_.m_21120_(p_41434_);
 -         if (p_41433_.m_36391_(this.m_41473_().m_38747_())) {
++      ItemStack itemstack = p_41433_.m_21120_(p_41434_);
++      if (itemstack.m_41614_()) {
 +         if (p_41433_.m_36391_(itemstack.getFoodProperties(p_41433_).m_38747_())) {
              p_41433_.m_6672_(p_41434_);
              return InteractionResultHolder.m_19096_(itemstack);


### PR DESCRIPTION
This PR fixes #8602 by changing the receiver of the `#isEdible` call from the current item instance to the stack in hand (which necessitates moving the `#getItemInHand` call to before the `if` expression).

Before the addition of `IForgeItem#getFoodProperties`, `Item#isEdible` and the regular `Item#getFoodProperties` were called on the current item instance (`this`). However, after the addition of the `ItemStack`-sensitive `getFoodPropertiers`, it is now possible that `Item#isEdible` is called on a different item instance than the one in the stack which `IForgeItem#getFoodProperties` is called on.

In the linked issue, this happens as the `Item#use` method is called on an edible item (`this.isEdible() == true`) while the stack in the player's hand is not edible, which means the food properties of that stack is absent/`null` (`player.getItemInHand(stack).getFoodProperties(player) == null`).

This fixes that issue by calling `#isEdible` on the stack in hand rather than the current item instance, thus matching the stack that `IForgeItem#getFoodProperties` is called on.