### PR TITLE
Re-add hook for EntityTravelToDimensionEvent in Entity

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -241,7 +241,7 @@
     }
  
     public boolean m_7306_(Entity p_20356_) {
-@@ -2237,14 +_,19 @@
+@@ -2237,14 +_,20 @@
  
     @Nullable
     public Entity m_5489_(ServerLevel p_20118_) {
@@ -249,6 +249,7 @@
 +   }
 +   @Nullable
 +   public Entity changeDimension(ServerLevel p_20118_, net.minecraftforge.common.util.ITeleporter teleporter) {
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_20118_.m_46472_())) return null;
        if (this.f_19853_ instanceof ServerLevel && !this.m_146910_()) {
           this.f_19853_.m_46473_().m_6180_("changeDimension");
           this.m_19877_();


### PR DESCRIPTION
This PR fixes #8520 by re-adding the hook for `EntityTravelToDimensionEvent` in `Entity#changeDimension`.

The hook is [present in 1.15][1.15]. It was then removed during the initial update and patch cycle for 1.16 alongside the `ITeleporter` patches and was not re-added in PR #6886 which reimplemented the `ITeleporter` patches in 1.16.

As this issue is present in 1.16, an LTS backport PR will be opened once this is assigned or merged.

[1.15]: https://github.com/MinecraftForge/MinecraftForge/blob/a3d50ff54554096674458d3724dbc984390d203b/patches/minecraft/net/minecraft/entity/Entity.java.patch#L233