### PR TITLE
Deprecate patched-in Style methods for removal

### DIFF
--- a/patches/minecraft/net/minecraft/network/chat/Style.java.patch
+++ b/patches/minecraft/net/minecraft/network/chat/Style.java.patch
@@ -1,17 +1,29 @@
 --- a/net/minecraft/network/chat/Style.java
 +++ b/net/minecraft/network/chat/Style.java
-@@ -133,6 +_,18 @@
+@@ -133,6 +_,30 @@
        return new Style(this.f_131101_, this.f_131102_, this.f_131103_, this.f_131104_, this.f_131105_, p_178525_, this.f_131107_, this.f_131108_, this.f_131109_, this.f_131110_);
     }
  
++   /**
++    * @deprecated Use {@link #withUnderlined(Boolean)} instead.
++    */
++   @Deprecated(forRemoval = true, since = "1.18.2")
 +   public Style setUnderlined(@Nullable Boolean underlined) {
 +      return new Style(this.f_131101_, this.f_131102_, this.f_131103_, underlined, this.f_131105_, this.f_131106_, this.f_131107_, this.f_131108_, this.f_131109_, this.f_131110_);
 +   }
 +
++   /**
++    * @deprecated Use {@link #withStrikethrough(Boolean)} instead.
++    */
++   @Deprecated(forRemoval = true, since = "1.18.2")
 +   public Style setStrikethrough(@Nullable Boolean strikethrough) {
 +      return new Style(this.f_131101_, this.f_131102_, this.f_131103_, this.f_131104_, strikethrough, this.f_131106_, this.f_131107_, this.f_131108_, this.f_131109_, this.f_131110_);
 +   }
 +
++   /**
++    * @deprecated Use {@link #withObfuscated(Boolean)} instead.
++    */
++   @Deprecated(forRemoval = true, since = "1.18.2")
 +   public Style setObfuscated(@Nullable Boolean obfuscated) {
 +      return new Style(this.f_131101_, this.f_131102_, this.f_131103_, this.f_131104_, this.f_131105_, obfuscated, this.f_131107_, this.f_131108_, this.f_131109_, this.f_131110_);
 +   }


### PR DESCRIPTION
This PR implements and closes #8457 by deprecating for removal the patched-in `setUnderlined`, `setStrikethrough`, and `setObfuscated` methods in `Style`. 1.17's disabling of the code stripper means the original Mojang methods of `withUnderlined`, `withStrikethrough`, and `withObfuscated` are now present and accessbile, making our patched-in methods redundant.

By deprecating these methods, we signal to mod developers to switch to the Mojang-added methods and signal to the 1.19 patchers in the future to remove these methods.