### PR TITLE
Add missing patches for not lowering mipmap level for small textures

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/MipmapGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/MipmapGenerator.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/client/renderer/texture/MipmapGenerator.java
++++ b/net/minecraft/client/renderer/texture/MipmapGenerator.java
+@@ -34,9 +_,12 @@
+             }
+          }
+ 
++         int maxMipmapLevel = net.minecraftforge.client.ForgeHooksClient.getMaxMipmapLevel(p_118055_.m_84982_(), p_118055_.m_85084_());
+          for(int k1 = 1; k1 <= p_118056_; ++k1) {
+             NativeImage nativeimage1 = anativeimage[k1 - 1];
+-            NativeImage nativeimage = new NativeImage(nativeimage1.m_84982_() >> 1, nativeimage1.m_85084_() >> 1, false);
++            // Forge: guard against invalid texture size, because we allow generating mipmaps regardless of texture sizes
++            NativeImage nativeimage = new NativeImage(Math.max(1, nativeimage1.m_84982_() >> 1), Math.max(1, nativeimage1.m_85084_() >> 1), false);
++            if (k1 <= maxMipmapLevel) {
+             int k = nativeimage.m_84982_();
+             int l = nativeimage.m_85084_();
+ 
+@@ -44,6 +_,7 @@
+                for(int j1 = 0; j1 < l; ++j1) {
+                   nativeimage.m_84988_(i1, j1, m_118048_(nativeimage1.m_84985_(i1 * 2 + 0, j1 * 2 + 0), nativeimage1.m_84985_(i1 * 2 + 1, j1 * 2 + 0), nativeimage1.m_84985_(i1 * 2 + 0, j1 * 2 + 1), nativeimage1.m_84985_(i1 * 2 + 1, j1 * 2 + 1), flag));
+                }
++            }
+             }
+ 
+             anativeimage[k1] = nativeimage;

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
@@ -8,6 +8,25 @@
           p_118378_[i].m_85003_(i, this.f_118349_ >> i, this.f_118350_ >> i, p_118376_ >> i, p_118377_ >> i, this.f_174723_ >> i, this.f_174724_ >> i, this.f_118342_.length > 1, false);
        }
  
+@@ -389,7 +_,8 @@
+             int j = p_118446_.f_118423_ >> i;
+             int k = p_118446_.f_118424_ >> i;
+             if (this.f_118443_[i] == null) {
+-               this.f_118443_[i] = new NativeImage(j, k, false);
++               // Forge: guard against invalid texture size, because we allow generating mipmaps regardless of texture sizes
++               this.f_118443_[i] = new NativeImage(Math.max(1, j), Math.max(1, k), false);
+             }
+          }
+ 
+@@ -404,6 +_,8 @@
+             for(int k = 0; k < this.f_118443_.length; ++k) {
+                int l = TextureAtlasSprite.this.f_174723_ >> k;
+                int i1 = TextureAtlasSprite.this.f_174724_ >> k;
++               // Forge: guard against invalid texture size, because we allow generating mipmaps regardless of texture sizes
++               if (l == 0 || i1 == 0) continue;
+ 
+                for(int j1 = 0; j1 < i1; ++j1) {
+                   for(int k1 = 0; k1 < l; ++k1) {
 @@ -438,5 +_,15 @@
           }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1145,8 +1145,8 @@ public class ForgeHooksClient
     public static int getMaxMipmapLevel(int width, int height)
     {
         return Math.min(
-                Mth.log2(Math.max(1, width >> 1)),
-                Mth.log2(Math.max(1, height >> 1))
+                Mth.log2(Math.max(1, width)),
+                Mth.log2(Math.max(1, height))
         );
     }
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -30,6 +30,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.chat.*;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.server.WorldStem;
+import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
@@ -1139,5 +1140,13 @@ public class ForgeHooksClient
         }, title, msg, CommonComponents.GUI_PROCEED, CommonComponents.GUI_CANCEL);
 
         Minecraft.getInstance().setScreen(screen);
+    }
+
+    public static int getMaxMipmapLevel(int width, int height)
+    {
+        return Math.min(
+                Mth.log2(Math.max(1, width >> 1)),
+                Mth.log2(Math.max(1, height >> 1))
+        );
     }
 }


### PR DESCRIPTION
Fixes #8094.

This only prevents crashes and textures that fail to load. If the textures are too small for the selected mipmap level, they will produce strange mipmaps.