### PR TITLE
add an option for OBJ Loder to load .obj file with same part name

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
@@ -48,10 +48,11 @@ public class OBJLoader implements IModelLoader<OBJModel>
         boolean diffuseLighting = GsonHelper.getAsBoolean(modelContents, "diffuseLighting", false);
         boolean flipV = GsonHelper.getAsBoolean(modelContents, "flip-v", false);
         boolean ambientToFullbright = GsonHelper.getAsBoolean(modelContents, "ambientToFullbright", true);
+        boolean allowHomonymObjectName = GsonHelper.getAsBoolean(modelContents,"allowHomonymObjectName",false);
         @Nullable
         String materialLibraryOverrideLocation = modelContents.has("materialLibraryOverride") ? GsonHelper.getAsString(modelContents, "materialLibraryOverride") : null;
 
-        return loadModel(new OBJModel.ModelSettings(new ResourceLocation(modelLocation), detectCullableFaces, diffuseLighting, flipV, ambientToFullbright, materialLibraryOverrideLocation));
+        return loadModel(new OBJModel.ModelSettings(new ResourceLocation(modelLocation), detectCullableFaces, diffuseLighting, flipV, ambientToFullbright, materialLibraryOverrideLocation, allowHomonymObjectName));
     }
 
     public OBJModel loadModel(OBJModel.ModelSettings settings)

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -249,6 +249,35 @@ public class OBJModel implements IMultipartModelGeometry<OBJModel>
                 case "o":
                 {
                     String name = line[1];
+                    if (settings.allowHomonymObjectName)
+                    {
+                        if (parts.containsKey(name))
+                        {
+                            int index = name.length();
+                            char c;
+                            do
+                            {
+                                c = name.charAt(--index);
+                            }
+                            while (index > 0 || ( c >= '0' && c <= '9'));
+                            if (index != name.length() - 1)
+                            {
+                                String strName = name.substring(0,index);
+                                int num = Integer.parseInt(name.substring(index + 1));
+                                String renamed;
+                                do
+                                {
+                                    renamed = strName + (num++);
+                                }
+                                while (!parts.containsKey(renamed));
+                                name = renamed;
+                            }
+                            else
+                            {
+                                name+=1;
+                            }
+                        }
+                    }
                     if (objAboveGroup || currentGroup == null)
                     {
                         objAboveGroup = true;
@@ -662,6 +691,7 @@ public class OBJModel implements IMultipartModelGeometry<OBJModel>
 
     public record ModelSettings(@Nonnull ResourceLocation modelLocation,
                                 boolean detectCullableFaces, boolean diffuseLighting, boolean flipV,
-                                boolean ambientToFullbright, @Nullable String materialLibraryOverrideLocation)
+                                boolean ambientToFullbright, @Nullable String materialLibraryOverrideLocation,
+                                boolean allowHomonymObjectName)
     {}
 }

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -249,34 +249,17 @@ public class OBJModel implements IMultipartModelGeometry<OBJModel>
                 case "o":
                 {
                     String name = line[1];
-                    if (settings.allowHomonymObjectName)
+                    if (settings.allowHomonymObjectName && parts.containsKey(name))
                     {
-                        if (parts.containsKey(name))
+                        int suffixNum = 0;
+                        String trueName = name + '_';
+                        String renamed;
+                        do
                         {
-                            int index = name.length();
-                            char c;
-                            do
-                            {
-                                c = name.charAt(--index);
-                            }
-                            while (index > 0 || ( c >= '0' && c <= '9'));
-                            if (index != name.length() - 1)
-                            {
-                                String strName = name.substring(0,index);
-                                int num = Integer.parseInt(name.substring(index + 1));
-                                String renamed;
-                                do
-                                {
-                                    renamed = strName + (num++);
-                                }
-                                while (!parts.containsKey(renamed));
-                                name = renamed;
-                            }
-                            else
-                            {
-                                name+=1;
-                            }
+                            renamed = trueName + (suffixNum++);
                         }
+                        while (parts.containsKey(renamed));
+                        name = renamed;
                     }
                     if (objAboveGroup || currentGroup == null)
                     {

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderableTest.java
@@ -88,7 +88,8 @@ public class RenderableTest
                             true,
                             true,
                             false,
-                            null
+                            null,
+                            false
                     );
                     return OBJLoader.INSTANCE.loadModel(settings);
                 }


### PR DESCRIPTION
This PR adds the ability for the OBJ Loder to load .obj file with same part name  

# Why need this?

Some modeling software such as BlockBench , which allows homonym cube names .  When its model is exported as an .obj model file . The name subsequents to  .obj format command/keyworld `o` will duplicate

Due to the current OBJ Loader implementation , the collection of the parts is a `Map<String, ModelGroup>` , so the later will override the former. As a reuslt , only the last part will remain

# Implementation

add an option bool for OBJModel.Setting called `allowHomonymObjectName`  which is false by default in order to keep forward compatibility

when the option is true ,  we will check weather the same part name occours before , if it is , we re-name it by adding a positive growth after the origin name until no repeat occour
The similar way as another modeling software called Blender , it can correctly load .obj file with homonym object name

re-name only works on the `o` .obj command/keyword now

# Maybe a problem

```java
    public Optional<? extends IModelGeometryPart> getPart(String name)
    {
        return Optional.ofNullable(parts.get(name));
    }
```

after re-name , the getter method may fail to get the correct named part 
but if your model has homonym part name , you can't expect to get it by this way
you should name the needed part yourself or you could call this method  
 `public Collection<? extends IModelGeometryPart> getParts()`
and filter according to its keys by methods such as startWith to group them