### PR TITLE
[1.18.x] Enable "Experimental Forge Light Pipeline" by default

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -39,7 +39,7 @@ public class ForgeBlockModelRenderer extends ModelBlockRenderer
     @Override
     public boolean tesselateWithoutAO(BlockAndTintGetter level, BakedModel model, BlockState state, BlockPos pos, PoseStack poseStack, VertexConsumer buffer, boolean checkSides, Random rand, long seed, int packedOverlay, IModelData modelData)
     {
-        if(ForgeConfig.CLIENT.experimentalForgeLightPipelineEnabled.get())
+        if(ForgeConfig.CLIENT.forgeLightPipelineEnabled.get())
         {
             VertexBufferConsumer consumer = consumerFlat.get();
             consumer.setBuffer(buffer);
@@ -59,7 +59,7 @@ public class ForgeBlockModelRenderer extends ModelBlockRenderer
     @Override
     public boolean tesselateWithAO(BlockAndTintGetter level, BakedModel model, BlockState state, BlockPos pos, PoseStack poseStack, VertexConsumer buffer, boolean checkSides, Random rand, long seed, int packedOverlay, IModelData modelData)
     {
-        if(ForgeConfig.CLIENT.experimentalForgeLightPipelineEnabled.get())
+        if(ForgeConfig.CLIENT.forgeLightPipelineEnabled.get())
         {
             VertexBufferConsumer consumer = consumerSmooth.get();
             consumer.setBuffer(buffer);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -134,7 +134,7 @@ public class ForgeConfig {
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
                 .translation("forge.configgui.forgeLightPipelineEnabled")
-                .define("experimentalForgeLightPipelineEnabled", false);
+                .define("experimentalForgeLightPipelineEnabled", true);
 
             showLoadWarnings = builder
                 .comment("When enabled, Forge will show any warnings that occurred during loading.")

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -112,6 +112,9 @@ public class ForgeConfig {
     public static class Client {
         public final BooleanValue alwaysSetupTerrainOffThread;
 
+        public final BooleanValue forgeLightPipelineEnabled;
+
+        @Deprecated(forRemoval = true, since = "1.18.2")
         public final BooleanValue experimentalForgeLightPipelineEnabled;
 
         public final BooleanValue showLoadWarnings;
@@ -131,10 +134,15 @@ public class ForgeConfig {
                 .translation("forge.configgui.alwaysSetupTerrainOffThread")
                 .define("alwaysSetupTerrainOffThread", false);
 
+            forgeLightPipelineEnabled = builder
+                    .comment("Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
+                    .translation("forge.configgui.forgeLightPipelineEnabled")
+                    .define("forgeLightPipelineEnabled", true);
+
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
                 .translation("forge.configgui.forgeLightPipelineEnabled")
-                .define("experimentalForgeLightPipelineEnabled", true);
+                .define("experimentalForgeLightPipelineEnabled", false);
 
             showLoadWarnings = builder
                 .comment("When enabled, Forge will show any warnings that occurred during loading.")


### PR DESCRIPTION
This PR enables the "Experimental Forge Light Pipeline" by default, as requested by @sciwhiz12.
The experimental Forge light pipeline is a vital feature for a lot of mods with more intricate block models that are not lit properly with the vanilla light pipeline.

To quote @TheCurle on Forgecord:
> It's been in incubation for a few years, but since it's now fixing more problems than it's causing, it's now default on for 1.19. [...] And will probably be made default on for 1.18 in a few days.