### PR TITLE
Improve TagsUpdatedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -70,7 +70,7 @@
        }
  
        this.f_104888_.m_91171_(SearchRegistry.f_119942_).m_7729_();
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(this.f_104903_));
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(this.f_104903_, true, f_104885_.m_129531_()));
     }
  
     private <T> void m_205560_(ResourceKey<? extends Registry<? extends T>> p_205561_, TagNetworkSerialization.NetworkPayload p_205562_) {

--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -40,7 +40,7 @@
           m_206870_(p_206869_, p_206884_);
        });
        Blocks.m_50758_();
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(p_206869_));
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.TagsUpdatedEvent(p_206869_, false, false));
     }
  
     private static <T> void m_206870_(RegistryAccess p_206871_, TagManager.LoadResult<T> p_206872_) {

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -99,9 +99,12 @@ public class ForgeInternalHandler
     }
 
     @SubscribeEvent
-    public synchronized void tagsUpdated(TagsUpdatedEvent event)
+    public void tagsUpdated(TagsUpdatedEvent event)
     {
-        ForgeHooks.updateBurns();
+        if (event.shouldUpdateStaticData())
+        {
+            ForgeHooks.updateBurns();
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -6,15 +6,33 @@
 package net.minecraftforge.event;
 
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.server.ServerLifecycleHooks;
 
+/**
+ * Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
+ */
 public class TagsUpdatedEvent extends Event
 {
     private final RegistryAccess registries;
+    private final UpdateCause updateCause;
+    private final boolean integratedServer;
 
+    @Deprecated(forRemoval = true, since = "1.18.2")
      public TagsUpdatedEvent(RegistryAccess registries)
      {
          this.registries = registries;
+         this.updateCause = ClientGamePacketListener.class.isAssignableFrom(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass()) ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
+         var currentServer = ServerLifecycleHooks.getCurrentServer();
+         this.integratedServer = currentServer != null && !currentServer.isDedicatedServer();
+     }
+
+     public TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket, boolean isIntegratedServerConnection)
+     {
+         this.registries = registries;
+         this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
+         this.integratedServer = isIntegratedServerConnection;
      }
 
      /**
@@ -24,4 +42,39 @@ public class TagsUpdatedEvent extends Event
      {
          return registries;
      }
+
+    /**
+     * @return the cause for this tag update
+     */
+    public UpdateCause getUpdateCause()
+    {
+        return updateCause;
+    }
+
+    /**
+     * Whether static data (which in single player is shared between server and client thread) should be updated as a
+     * result of this event. Effectively this means that in single player only the server-side updates this data.
+     */
+    public boolean shouldUpdateStaticData()
+    {
+        return updateCause == UpdateCause.SERVER_DATA_LOAD || !integratedServer;
+    }
+
+    /**
+     * Represents the cause for a tag update.
+     */
+    public enum UpdateCause
+    {
+        /**
+         * The tag update is caused by the server loading datapack data. Note that in single player this still happens
+         * on the client thread.
+         */
+        SERVER_DATA_LOAD,
+        /**
+         * The tag update is caused by the client receiving the tag data from the server.
+         */
+        CLIENT_PACKET_RECEIVED
+    }
+
+
 }

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -20,28 +20,28 @@ public class TagsUpdatedEvent extends Event
     private final boolean integratedServer;
 
     @Deprecated(forRemoval = true, since = "1.18.2")
-     public TagsUpdatedEvent(RegistryAccess registries)
-     {
-         this.registries = registries;
-         this.updateCause = ClientGamePacketListener.class.isAssignableFrom(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass()) ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
-         var currentServer = ServerLifecycleHooks.getCurrentServer();
-         this.integratedServer = currentServer != null && !currentServer.isDedicatedServer();
-     }
+    public TagsUpdatedEvent(RegistryAccess registries)
+    {
+        this.registries = registries;
+        this.updateCause = ClientGamePacketListener.class.isAssignableFrom(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass()) ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
+        var currentServer = ServerLifecycleHooks.getCurrentServer();
+        this.integratedServer = currentServer != null && !currentServer.isDedicatedServer();
+    }
 
-     public TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket, boolean isIntegratedServerConnection)
-     {
-         this.registries = registries;
-         this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
-         this.integratedServer = isIntegratedServerConnection;
-     }
+    public TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket, boolean isIntegratedServerConnection)
+    {
+        this.registries = registries;
+        this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
+        this.integratedServer = isIntegratedServerConnection;
+    }
 
-     /**
-      * @return The dynamic registries that have had their tags rebound.
-      */
-     public RegistryAccess getTagManager()
-     {
-         return registries;
-     }
+    /**
+     * @return The dynamic registries that have had their tags rebound.
+     */
+    public RegistryAccess getTagManager()
+    {
+        return registries;
+    }
 
     /**
      * @return the cause for this tag update
@@ -75,6 +75,4 @@ public class TagsUpdatedEvent extends Event
          */
         CLIENT_PACKET_RECEIVED
     }
-
-
 }


### PR DESCRIPTION
- Add UpdateCause information. This tells the user what caused the event.
- Add hint for when static (shared in SP) data should be refreshed. This is now used in Forge to update the burn time map, which previously would refresh twice in SP.