### PR TITLE
Fix tags command suggestions to include dynamic registries

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/TagsCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/TagsCommand.java
@@ -24,6 +24,7 @@ import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.chat.HoverEvent;
@@ -232,8 +233,11 @@ class TagsCommand
     private static CompletableFuture<Suggestions> suggestRegistries(final CommandContext<CommandSourceStack> ctx,
             final SuggestionsBuilder builder)
     {
-        ctx.getSource().suggestRegistryElements(Registry.REGISTRY,
-                SharedSuggestionProvider.ElementSuggestionType.ELEMENTS, builder);
+        ctx.getSource().registryAccess().registries()
+                .map(RegistryAccess.RegistryEntry::key)
+                .map(ResourceKey::location)
+                .map(ResourceLocation::toString)
+                .forEach(builder::suggest);
         return builder.buildFuture();
     }
 


### PR DESCRIPTION
This PR fixes #8653 by fixing the suggestions for registry names in the `/forge tags` command to include dynamic registries instead of only static registries.

The issue was caused by the suggestor for registries querying the static registries only rather than querying all registries from the server's `RegistryAccess` (which includes both static registries and dynamic registries). The command still work when manually entering the name of a dynamic registry; this PR only affects the suggestions.

This issue was noticed while testing PR #8630 and using the command to check that the tags for the added dynamic/datapack registries existed.