### PR TITLE
Fix attack cooldown bar showing improperly

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/client/gui/Gui.java
 +++ b/net/minecraft/client/gui/Gui.java
+@@ -411,6 +_,7 @@
+                   if (this.f_92986_.f_91076_ != null && this.f_92986_.f_91076_ instanceof LivingEntity && f >= 1.0F) {
+                      flag = this.f_92986_.f_91074_.m_36333_() > 5.0F;
+                      flag &= this.f_92986_.f_91076_.m_6084_();
++                     flag &= this.f_92986_.f_91074_.canHit(this.f_92986_.f_91076_, 0);
+                   }
+ 
+                   int j = this.f_92978_ / 2 - 7 + 16;
 @@ -463,6 +_,10 @@
  
           for(MobEffectInstance mobeffectinstance : Ordering.natural().reverse().sortedCopy(collection)) {

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -95,20 +95,23 @@ public class ForgeMod
     public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
 
     /**
-     * Reach Distance represents the distance at which a player may interact with the world.  The default is 4.5 blocks.  Players in creative mode have an additional 0.5 blocks of reach distance.<br>
-     * See {@link IForgePlayer#getReachDistance} and {@link IForgePlayer#canInteractWith}
+     * Reach Distance represents the distance at which a player may interact with the world.  The default is 4.5 blocks.  Players in creative mode have an additional 0.5 blocks of reach distance.
+     * @see IForgePlayer#getReachDistance()
+     * @see IForgePlayer#canInteractWith(BlockPos, double)
+     * @see IForgePlayer#canInteractWith(Entity, double)
      */
     public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("generic.reachDistance", 4.5D, 0.0D, 1024.0D).setSyncable(true));
 
     /**
-     * Attack Range represents the distance at which a player may attack an entity.  The default is 3 blocks.  Players in creative mode have an additional 3 blocks of attack reach.<br>
-     * See {@link IForgePlayer#getAttackRange} and {@link IForgePlayer#canHit}
+     * Attack Range represents the distance at which a player may attack an entity.  The default is 3 blocks.  Players in creative mode have an additional 3 blocks of attack reach.
+     * @see IForgePlayer#getAttackRange()
+     * @see IForgePlayer#canHit(Entity, double)
      */
     public static final RegistryObject<Attribute> ATTACK_RANGE = ATTRIBUTES.register("attack_range", () -> new RangedAttribute("generic.attack_range", 3.0D, 0.0D, 1024.0D).setSyncable(true));
 
     /**
-     * Step Height Addition modifies the amount of blocks an entity may walk up without jumping.<br>
-     * See {@link IForgeEntity#getStepHeight}
+     * Step Height Addition modifies the amount of blocks an entity may walk up without jumping.
+     * @see IForgeEntity#getStepHeight()
      */
     public static final RegistryObject<Attribute> STEP_HEIGHT_ADDITION = ATTRIBUTES.register("step_height_addition", () -> new RangedAttribute("forge.stepHeight", 0.0D, -512.0D, 512.0D).setSyncable(true));
 

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -23,6 +23,8 @@ import net.minecraftforge.common.crafting.DifferenceIngredient;
 import net.minecraftforge.common.crafting.IntersectionIngredient;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.ForgeFluidTagsProvider;
+import net.minecraftforge.common.extensions.IForgeEntity;
+import net.minecraftforge.common.extensions.IForgePlayer;
 import net.minecraftforge.common.loot.CanToolPerformAction;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.loot.LootTableIdCondition;
@@ -93,14 +95,21 @@ public class ForgeMod
     public static final RegistryObject<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("forge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
 
     /**
-     * Reach Distance represents the distance at which a player may interact with the world.  The default is 4.5 blocks.  Players in creative mode have an additional 0.5 blocks of reach distance.
+     * Reach Distance represents the distance at which a player may interact with the world.  The default is 4.5 blocks.  Players in creative mode have an additional 0.5 blocks of reach distance.<br>
+     * See {@link IForgePlayer#getReachDistance} and {@link IForgePlayer#canInteractWith}
      */
     public static final RegistryObject<Attribute> REACH_DISTANCE = ATTRIBUTES.register("reach_distance", () -> new RangedAttribute("generic.reachDistance", 4.5D, 0.0D, 1024.0D).setSyncable(true));
 
     /**
-     * Attack Range represents the distance at which a player may attack an entity.  The default is 3 blocks.  Players in creative mode have an additional 3 blocks of attack reach.
+     * Attack Range represents the distance at which a player may attack an entity.  The default is 3 blocks.  Players in creative mode have an additional 3 blocks of attack reach.<br>
+     * See {@link IForgePlayer#getAttackRange} and {@link IForgePlayer#canHit}
      */
     public static final RegistryObject<Attribute> ATTACK_RANGE = ATTRIBUTES.register("attack_range", () -> new RangedAttribute("generic.attack_range", 3.0D, 0.0D, 1024.0D).setSyncable(true));
+
+    /**
+     * Step Height Addition modifies the amount of blocks an entity may walk up without jumping.<br>
+     * See {@link IForgeEntity#getStepHeight}
+     */
     public static final RegistryObject<Attribute> STEP_HEIGHT_ADDITION = ATTRIBUTES.register("step_height_addition", () -> new RangedAttribute("forge.stepHeight", 0.0D, -512.0D, 512.0D).setSyncable(true));
 
 


### PR DESCRIPTION
Closes #8639

Fixes the attack cooldown bar showing even when the attack range is reduced and the entity cannot be attacked.
Also has minor javadoc updates so modders find the correct methods for interfacing with these attributes.