### PR TITLE
[1.18.x] Add checkJarCompatibility task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:[5.1.26,)'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:[5.1.39,)'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap
 import net.minecraftforge.forge.tasks.*
 import static net.minecraftforge.forge.tasks.Util.*
 import net.minecraftforge.gradle.common.tasks.ApplyBinPatches
+import net.minecraftforge.gradle.common.tasks.CheckJarCompatibility
 import net.minecraftforge.gradle.common.tasks.DownloadMavenArtifact
 import net.minecraftforge.gradle.common.tasks.ExtractInheritance
 import net.minecraftforge.gradle.common.tasks.SignJar
@@ -69,6 +70,7 @@ ext {
     JAR_SPLITTER = 'net.minecraftforge:jarsplitter:1.1.4'
     FART = 'net.minecraftforge:ForgeAutoRenamingTool:0.1.22:all'
     MIN_TAG_FOR_CHANGELOG = "39.0"
+    LAST_RB = GIT_INFO.tag.rsplit('.', 1)[1] as int >= 1 ? GIT_INFO.tag + '.0' : null
 }
 
 println('Version: ' + VERSION +
@@ -486,7 +488,7 @@ def sharedFmlonlyForge = { Project prj ->
             IGNORE_LIST: Util.getArtifacts(prj, prj.configurations.moduleonly, false).values().collect{it.downloads.artifact.path.rsplit('/', 1)[1]}.join(','),
             MODULES: 'ALL-MODULE-PATH'
     ]
-    
+
     prj.task([dependsOn: rootProject.downloadServerRaw], 'makeClasspathFiles') {
         doLast {
             def CLASS_PATH = Util.getArtifacts(prj, prj.configurations.installer, false).values().collect{"libraries/${it.downloads.artifact.path}"} +
@@ -845,7 +847,7 @@ project(':fmlonly') {
     }
 
     // Since we need the modules in the bootstrap, we need to make sure they are compiled before we do each run
-    afterEvaluate { prepareRuns.dependsOn(':fmlcore:jar', ':fmlloader:jar', ':javafmllanguage:jar', ':mclanguage:jar') }
+    afterEvaluate { prepareRuns.dependsOn(PACKED_DEPS) }
 }
 
 project(':forge') {
@@ -1173,6 +1175,54 @@ project(':forge') {
         finalizedBy checkPatches
         autoHeader true
         lineEnding = '\n'
+    }
+
+    def baseForgeVersion = LAST_RB == null ? null : "${MC_VERSION}-${LAST_RB}"
+
+    task downloadBaseCompatibilityBinPatches(type: DownloadBaseCompatibilityBinPatches) {
+        inputVersion = baseForgeVersion
+    }
+
+    task applyBaseCompatibilityJarBinPatches(type: ApplyBinPatches) {
+        group = 'jar compatibility'
+        onlyIf {
+            baseForgeVersion != null
+        }
+        inputs.property 'baseForgeVersion', baseForgeVersion
+
+        clean = createJoinedSRG.output
+        patch = downloadBaseCompatibilityBinPatches.output
+        output = project.layout.buildDirectory.dir(name).map { it.file('output.jar') }
+    }
+
+    task checkJarCompatibility(type: CheckJarCompatibility) {
+        group = 'jar compatibility'
+        onlyIf {
+            baseForgeVersion != null
+        }
+        inputs.property 'baseForgeVersion', baseForgeVersion
+
+        if (baseForgeVersion != null) {
+            def baseForgeUniversal = project.configurations.detachedConfiguration(project.dependencies.create("net.minecraftforge:forge:${baseForgeVersion}:universal"))
+            def fmlLibs = project.configurations.detachedConfiguration(PACKED_DEPS.collect {
+                def artifactId = it.split(':')[1]
+                return project.dependencies.create("net.minecraftforge:${artifactId}:${baseForgeVersion}")
+            }.toArray(Dependency[]::new))
+
+            baseJar = project.tasks.applyBaseCompatibilityJarBinPatches.output
+            baseLibraries.from(project.file(project.provider {
+                baseForgeUniversal.resolve().iterator().next()
+            }))
+            baseLibraries.from(project.tasks.createJoinedSRG.output)
+            baseLibraries.from(fmlLibs)
+
+            inputJar = project.tasks.reobfJar.output
+            concreteLibraries.from(PACKED_DEPS.collect { rootProject.tasks.getByPath(it).archiveFile })
+
+            commonLibraries.from(project.configurations.minecraftImplementation)
+            commonLibraries.from(project.configurations.installer)
+            commonLibraries.from(project.configurations.moduleonly)
+        }
     }
 
     task launcherJson(type: LauncherJson) {
@@ -1538,7 +1588,7 @@ project(':forge') {
         }
     }
     // Since we need the modules in the bootstrap, we need to make sure they are compiled before we do each run
-    afterEvaluate { prepareRuns.dependsOn(':fmlcore:jar', ':fmlloader:jar', ':javafmllanguage:jar', ':mclanguage:jar') }
+    afterEvaluate { prepareRuns.dependsOn(PACKED_DEPS) }
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/DownloadBaseCompatibilityBinPatches.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/DownloadBaseCompatibilityBinPatches.groovy
@@ -1,0 +1,39 @@
+package net.minecraftforge.forge.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+import java.nio.file.Files
+
+abstract class DownloadBaseCompatibilityBinPatches extends DefaultTask {
+    DownloadBaseCompatibilityBinPatches() {
+        group = 'jar compatibility'
+        onlyIf {
+            inputVersion.getOrNull() != null
+        }
+
+        output.convention(project.layout.buildDirectory.dir(name).map { it.file('joined.lzma') })
+    }
+
+    @TaskAction
+    void run() {
+        def dep = project.dependencies.create("net.minecraftforge:forge:${inputVersion.get()}:userdev")
+        def baseForgeUserdev = project.configurations.detachedConfiguration(dep).resolve().iterator().next()
+
+        def joinedLzma = project.zipTree(baseForgeUserdev).matching { it.include('joined.lzma') }.singleFile
+
+        Files.copy(joinedLzma.toPath(), output.get().asFile.toPath())
+    }
+
+    @Input
+    @Optional
+    abstract Property<String> getInputVersion()
+
+    @OutputFile
+    abstract RegularFileProperty getOutput()
+}


### PR DESCRIPTION
Utilizes the newest version of ForgeGradle, `5.1.39`, to implement a `checkJarCompatibility` test.
By default, this will use the value of `LAST_RB` as the base Forge version/jar. If there is no LAST_RB, then it will default to null and attempting to run the `checkJarCompatibility` task will skip.
If there are errors, they will be logged to the gradle console and the task will fail due to a non-zero exit value.
If there are warnings, they will still be logged to the gradle console but not count towards the error count / exit value.
This can be used both by PR authors to check their feature/patches do not break compatibility, and also can be added as an additional check during PRs (cc @OrionDevelopment).