### PR TITLE
[1.16.x] Added ways to filter PlayerInteractEvent.LeftClickBlock Actions

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -27,14 +27,14 @@
              BlockState blockstate = this.field_78776_a.field_71441_e.func_180495_p(p_180511_1_);
              this.field_78776_a.func_193032_ao().func_193294_a(this.field_78776_a.field_71441_e, p_180511_1_, blockstate, 1.0F);
              this.func_225324_a(CPlayerDiggingPacket.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_);
-+            if (!net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180511_1_, p_180511_2_).isCanceled())
++            if (!net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180511_1_, p_180511_2_, CPlayerDiggingPacket.Action.START_DESTROY_BLOCK).isCanceled())
              this.func_187103_a(p_180511_1_);
              this.field_78781_i = 5;
           } else if (!this.field_78778_j || !this.func_178893_a(p_180511_1_)) {
              if (this.field_78778_j) {
                 this.func_225324_a(CPlayerDiggingPacket.Action.ABORT_DESTROY_BLOCK, this.field_178895_c, p_180511_2_);
              }
-+            net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180511_1_, p_180511_2_);
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180511_1_, p_180511_2_, CPlayerDiggingPacket.Action.START_DESTROY_BLOCK);
  
              BlockState blockstate1 = this.field_78776_a.field_71441_e.func_180495_p(p_180511_1_);
              this.field_78776_a.func_193032_ao().func_193294_a(this.field_78776_a.field_71441_e, p_180511_1_, blockstate1, 0.0F);
@@ -54,7 +54,7 @@
           BlockState blockstate1 = this.field_78776_a.field_71441_e.func_180495_p(p_180512_1_);
           this.field_78776_a.func_193032_ao().func_193294_a(this.field_78776_a.field_71441_e, p_180512_1_, blockstate1, 1.0F);
           this.func_225324_a(CPlayerDiggingPacket.Action.START_DESTROY_BLOCK, p_180512_1_, p_180512_2_);
-+         if (!net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180512_1_, p_180512_2_).isCanceled())
++         if (!net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180512_1_, p_180512_2_, CPlayerDiggingPacket.Action.START_DESTROY_BLOCK).isCanceled())
           this.func_187103_a(p_180512_1_);
           return true;
        } else if (this.func_178893_a(p_180512_1_)) {
@@ -73,7 +73,7 @@
  
              ++this.field_78780_h;
              this.field_78776_a.func_193032_ao().func_193294_a(this.field_78776_a.field_71441_e, p_180512_1_, blockstate, MathHelper.func_76131_a(this.field_78770_f, 0.0F, 1.0F));
-+            if (net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180512_1_, p_180512_2_).getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return true;
++            if (net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180512_1_, p_180512_2_, CPlayerDiggingPacket.Action.START_DESTROY_BLOCK).getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return true;
              if (this.field_78770_f >= 1.0F) {
                 this.field_78778_j = false;
                 this.func_225324_a(CPlayerDiggingPacket.Action.STOP_DESTROY_BLOCK, p_180512_1_, p_180512_2_);

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -24,7 +24,7 @@
        double d3 = d0 * d0 + d1 * d1 + d2 * d2;
 -      if (d3 > 36.0D) {
 +      double dist = field_73090_b.func_110148_a(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).func_111126_e() + 1;
-+      net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(field_73090_b, p_225416_1_, p_225416_3_);
++      net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(field_73090_b, p_225416_1_, p_225416_3_, p_225416_2_);
 +      if (event.isCanceled() || (!this.func_73083_d() && event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY)) { // Restore block and te data
 +         field_73090_b.field_71135_a.func_147359_a(new SPlayerDiggingPacket(p_225416_1_, field_73092_a.func_180495_p(p_225416_1_), p_225416_2_, false, "mod canceled"));
 +         field_73092_a.func_184138_a(p_225416_1_, field_73092_a.func_180495_p(p_225416_1_), field_73092_a.func_180495_p(p_225416_1_), 3);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -86,6 +86,7 @@ import net.minecraft.item.TippedArrowItem;
 import net.minecraft.item.ItemUseContext;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
+import net.minecraft.network.play.client.CPlayerDiggingPacket;
 import net.minecraft.network.play.ServerPlayNetHandler;
 import net.minecraft.network.IPacket;
 import net.minecraft.network.datasync.IDataSerializer;
@@ -803,9 +804,9 @@ public class ForgeHooks
         return evt.isCanceled() ? evt.getCancellationResult() : null;
     }
 
-    public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(PlayerEntity player, BlockPos pos, Direction face)
+    public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(PlayerEntity player, BlockPos pos, Direction face, CPlayerDiggingPacket.Action blockAction)
     {
-        PlayerInteractEvent.LeftClickBlock evt = new PlayerInteractEvent.LeftClickBlock(player, pos, face);
+        PlayerInteractEvent.LeftClickBlock evt = new PlayerInteractEvent.LeftClickBlock(player, pos, face, blockAction);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -129,7 +129,7 @@ public class PlayerInteractEvent extends PlayerEvent
      * If result equals {@link ActionResultType#PASS}, we proceed to {@link RightClickItem}.  <br>
      * <br>
      * There are various results to this event, see the getters below.  <br>
-     * Note that handling things differently on the client vs server may cause desynchronizations! 
+     * Note that handling things differently on the client vs server may cause desynchronizations!
      */
     @Cancelable
     public static class RightClickBlock extends PlayerInteractEvent
@@ -251,13 +251,13 @@ public class PlayerInteractEvent extends PlayerEvent
     {
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
-        private Action blockAction;
-        
+        private CPlayerDiggingPacket.Action blockAction;
+
         public LeftClickBlock(PlayerEntity player, BlockPos pos, Direction face, CPlayerDiggingPacket.Action blockAction)
         {
             super(player, Hand.MAIN_HAND, pos, face);
             this.blockAction = blockAction;
-            
+
         }
 
         /**
@@ -276,11 +276,11 @@ public class PlayerInteractEvent extends PlayerEvent
             return useItem;
         }
 
-        public CPlayerDiggingPacket.Action getAction() 
+        public CPlayerDiggingPacket.Action getAction()
         {
             return blockAction;
         }
-        
+
         public void setUseBlock(Result triggerBlock)
         {
             this.useBlock = triggerBlock;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.CPlayerDiggingPacket;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
@@ -251,7 +252,6 @@ public class PlayerInteractEvent extends PlayerEvent
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
         private Action blockAction;
-        
         
         public LeftClickBlock(PlayerEntity player, BlockPos pos, Direction face, CPlayerDiggingPacket.Action blockAction)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -250,10 +250,14 @@ public class PlayerInteractEvent extends PlayerEvent
     {
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
-
-        public LeftClickBlock(PlayerEntity player, BlockPos pos, Direction face)
+        private Action blockAction;
+        
+        
+        public LeftClickBlock(PlayerEntity player, BlockPos pos, Direction face, CPlayerDiggingPacket.Action blockAction)
         {
             super(player, Hand.MAIN_HAND, pos, face);
+            this.blockAction = blockAction;
+            
         }
 
         /**
@@ -272,6 +276,11 @@ public class PlayerInteractEvent extends PlayerEvent
             return useItem;
         }
 
+        public CPlayerDiggingPacket.Action getAction() 
+        {
+            return blockAction;
+        }
+        
         public void setUseBlock(Result triggerBlock)
         {
             this.useBlock = triggerBlock;


### PR DESCRIPTION
A quick and simple fix for how PlayerInteractEvent.LeftClickBlock fires on unfiltered on all 3 actions (https://github.com/MinecraftForge/MinecraftForge/issues/8643).

This is an implementation of the solution proposed by KnightMiner (https://github.com/MinecraftForge/MinecraftForge/issues/8643#issuecomment-1143084781).