### PR TITLE
[1.18.x] Fix wrong position in LevelAccessor#hasChunk() call in IForgeBlockGetter

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockGetter.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockGetter.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -29,7 +30,7 @@ public interface IForgeBlockGetter
     {
         if (this instanceof Level level)
         {
-            if (!level.hasChunk(pos.getX(), pos.getZ()))
+            if (!level.hasChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())))
             {
                 return null;
             }


### PR DESCRIPTION
This PR fixes a mistake in the current implementation of `IForgeBlockGetter#getExistingBlockEntity()` where it directly uses the block position for the chunk check instead of converting it to a chunk position first, which is what `LevelAccessor#hasChunk()` expects.