### PR TITLE
displayTest option in mods.toml

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
@@ -93,5 +93,7 @@ public interface IExtensionPoint<T extends Record>
      * @see net.minecraftforge.client.ForgeHooksClient#processForgeListPingData(net.minecraft.network.protocol.status.ServerStatus, net.minecraft.client.multiplayer.ServerData)
      */
     @SuppressWarnings("JavadocReference") // reference to NetworkConstants, ForgeHooksClient
-    record DisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) implements IExtensionPoint<DisplayTest> {}
+    record DisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) implements IExtensionPoint<DisplayTest> {
+        public static final String IGNORESERVERONLY = "OHNOES\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31";
+    }
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -57,19 +57,23 @@ public abstract class ModContainer
         this.modInfo = info;
         this.modLoadingStage = ModLoadingStage.CONSTRUCT;
 
-        final String displayTestString = info.getConfig().<String>getConfigElement("displayTest").orElse("DEFAULT"); // missing defaults to DEFAULT type
+        final String displayTestString = info.getConfig().<String>getConfigElement("displayTest").orElse("MATCH_VERSION"); // missing defaults to DEFAULT type
         Supplier<IExtensionPoint.DisplayTest> displayTestSupplier = switch (displayTestString) {
-            case "DEFAULT" -> // default displaytest checks for version string match
-                    ()->new IExtensionPoint.DisplayTest(()->this.modInfo.getVersion().toString(),
-                        (incoming, isNetwork)->Objects.equals(incoming, this.modInfo.getVersion().toString()));
-            case "SERVERONLY" -> // server only displaytest returns special IGNORESERVERONLY value and accepts anything
-                    ()->new IExtensionPoint.DisplayTest(()->IExtensionPoint.DisplayTest.IGNORESERVERONLY, (incoming, isNetwork)->true);
-            case "CLIENTONLY" -> // client only displaytest sends empty string and accepts anything
-                    ()->new IExtensionPoint.DisplayTest(()->"", (incoming, isNetwork)->true);
+            case "MATCH_VERSION" -> // default displaytest checks for version string match
+                    () -> new IExtensionPoint.DisplayTest(() -> this.modInfo.getVersion().toString(),
+                        (incoming, isNetwork) -> Objects.equals(incoming, this.modInfo.getVersion().toString()));
+            case "IGNORE_SERVER_VERSION" -> // Ignores any version information coming from the server - use for server only mods
+                    () -> new IExtensionPoint.DisplayTest(() -> IExtensionPoint.DisplayTest.IGNORESERVERONLY, (incoming, isNetwork) -> true);
+            case "IGNORE_ALL_VERSION" -> // Ignores all information and provides no information
+                    () -> new IExtensionPoint.DisplayTest(() -> "", (incoming, isNetwork) -> true);
+            case "NONE" -> null; // NO display test at all - use this if you're going to do your own display test
             default -> // any other value throws an exception
                     throw new IllegalArgumentException("Invalid displayTest value supplied in mods.toml");
         };
-        registerExtensionPoint(IExtensionPoint.DisplayTest.class, displayTestSupplier);
+        if (displayTestSupplier != null)
+            registerExtensionPoint(IExtensionPoint.DisplayTest.class, displayTestSupplier);
+        else
+            extensionPoints.remove(IExtensionPoint.DisplayTest.class);
     }
 
     /**

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -32,6 +32,14 @@ logoFile="examplemod.png" #optional
 credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
 authors="Love, Cheese and small house plants" #optional
+# Display Test controls the display for your mod in the server connection screen
+# MATCH_VERSION means that your mod will cause a red X if the versions on client and server differ. This is the default behaviour and should be what you choose if you have server and client elements to your mod.
+# IGNORE_SERVER_VERSION means that your mod will not cause a red X if it's present on the server but not on the client. This is what you should use if you're a server only mod.
+# IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
+# NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
+# IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
+#displayTest="MATCH_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
+
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 This is a long form description of the mod. You can write whatever you want here

--- a/src/main/java/net/minecraftforge/network/NetworkConstants.java
+++ b/src/main/java/net/minecraftforge/network/NetworkConstants.java
@@ -7,6 +7,7 @@ package net.minecraftforge.network;
 
 import io.netty.util.AttributeKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
 import net.minecraftforge.network.ConnectionData.ModMismatchData;
 import net.minecraftforge.network.HandshakeMessages.S2CModList;
@@ -45,7 +46,7 @@ public class NetworkConstants
     /**
      * Return this value in your {@link DisplayTest} function to be ignored.
      */
-    public static final String IGNORESERVERONLY = "OHNOES\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31";
+    public static final String IGNORESERVERONLY = DisplayTest.IGNORESERVERONLY;
 
     public static String init() {
         return NetworkConstants.NETVERSION;


### PR DESCRIPTION
* "DEFAULT" (or none) is existing match version string behaviour
* "CLIENTONLY" accepts anything and sends an empty string
* "SERVERONLY" accepts anything and sends special SERVERONLY string

Signed-off-by: cpw <cpw+github@weeksfamily.ca>