### PR TITLE
Revert "[1.18.x] Enable "Experimental Forge Light Pipeline" by default"

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -39,7 +39,7 @@ public class ForgeBlockModelRenderer extends ModelBlockRenderer
     @Override
     public boolean tesselateWithoutAO(BlockAndTintGetter level, BakedModel model, BlockState state, BlockPos pos, PoseStack poseStack, VertexConsumer buffer, boolean checkSides, Random rand, long seed, int packedOverlay, IModelData modelData)
     {
-        if(ForgeConfig.CLIENT.forgeLightPipelineEnabled.get())
+        if(ForgeConfig.CLIENT.experimentalForgeLightPipelineEnabled.get())
         {
             VertexBufferConsumer consumer = consumerFlat.get();
             consumer.setBuffer(buffer);
@@ -59,7 +59,7 @@ public class ForgeBlockModelRenderer extends ModelBlockRenderer
     @Override
     public boolean tesselateWithAO(BlockAndTintGetter level, BakedModel model, BlockState state, BlockPos pos, PoseStack poseStack, VertexConsumer buffer, boolean checkSides, Random rand, long seed, int packedOverlay, IModelData modelData)
     {
-        if(ForgeConfig.CLIENT.forgeLightPipelineEnabled.get())
+        if(ForgeConfig.CLIENT.experimentalForgeLightPipelineEnabled.get())
         {
             VertexBufferConsumer consumer = consumerSmooth.get();
             consumer.setBuffer(buffer);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -120,9 +120,6 @@ public class ForgeConfig {
     public static class Client {
         public final BooleanValue alwaysSetupTerrainOffThread;
 
-        public final BooleanValue forgeLightPipelineEnabled;
-
-        @Deprecated(forRemoval = true, since = "1.18.2")
         public final BooleanValue experimentalForgeLightPipelineEnabled;
 
         public final BooleanValue showLoadWarnings;
@@ -141,11 +138,6 @@ public class ForgeConfig {
                         "Not recommended for computers without a significant number of cores available.")
                 .translation("forge.configgui.alwaysSetupTerrainOffThread")
                 .define("alwaysSetupTerrainOffThread", false);
-
-            forgeLightPipelineEnabled = builder
-                    .comment("Enable the Forge block rendering pipeline - fixes the lighting of custom models.")
-                    .translation("forge.configgui.forgeLightPipelineEnabled")
-                    .define("forgeLightPipelineEnabled", true);
 
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")


### PR DESCRIPTION
As it turns out there are a few mods that can't handle the Forge light pipeline being enabled. As such it was decided to revert the change for now.