### PR TITLE
[1.18.x] Fix #8530 (Banner Pattern) NPE

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1485,9 +1485,13 @@ public class ForgeHooks
         }
     }
   
-    private static BannerPattern[] nonPatternItems= Arrays.stream(BannerPattern.values()).filter(p -> !p.hasPatternItem).toArray(BannerPattern[]::new);
-    private static int totalPatternRows = (nonPatternItems.length + 2) / 4;
+    private static BannerPattern[] nonPatternItems;
+    private static int totalPatternRows;
 
+    static
+    {
+        refreshBannerPatternData();
+    }
     public static void refreshBannerPatternData()
     {
         nonPatternItems = Arrays.stream(BannerPattern.values())

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1485,8 +1485,8 @@ public class ForgeHooks
         }
     }
   
-    private static BannerPattern[] nonPatternItems;
-    private static int totalPatternRows;
+    private static BannerPattern[] nonPatternItems= Arrays.stream(BannerPattern.values()).filter(p -> !p.hasPatternItem).toArray(BannerPattern[]::new);
+    private static int totalPatternRows = (nonPatternItems.length + 2) / 4;
 
     public static void refreshBannerPatternData()
     {


### PR DESCRIPTION
This fixes #8530 by providing a default for the uninitialized static variables if no patterns are extensibly registered.