### PR TITLE
[1.18] Fix EntityEvent.Size not being fired

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -372,7 +372,7 @@
  
     }
  
-@@ -3061,6 +_,89 @@
+@@ -3061,6 +_,76 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -442,19 +442,6 @@
 +    */
 +   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
-+   }
-+
-+   public EntityDimensions getDimensionsForge(Pose pose) {
-+      EntityDimensions size = this.m_6972_(pose);
-+      float eyeHeight = this.m_6380_(pose, size);
-+      net.minecraftforge.event.entity.EntityEvent.Size e = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, size, eyeHeight);
-+      return e.getNewSize();
-+   }
-+
-+   protected float getEyeHeightForge(Pose pose, EntityDimensions size) {
-+      float eyeHeight = this.m_6380_(pose, size);
-+      net.minecraftforge.event.entity.EntityEvent.Size e = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, size, eyeHeight);
-+      return e.getNewEyeHeight();
 +   }
 +
 +   /* ================================== Forge End =====================================*/

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -285,6 +285,24 @@
           }
        } else {
           return null;
+@@ -2300,7 +_,7 @@
+                   vec3 = new Vec3(0.5D, 0.0D, 0.0D);
+                }
+ 
+-               return PortalShape.m_77699_(p_19923_, p_185941_, direction$axis, vec3, this.m_6972_(this.m_20089_()), this.m_20184_(), this.m_146908_(), this.m_146909_());
++               return PortalShape.m_77699_(p_19923_, p_185941_, direction$axis, vec3, this.getDimensionsForge(this.m_20089_()), this.m_20184_(), this.m_146908_(), this.m_146909_());
+             }).orElse((PortalInfo)null);
+          }
+       } else {
+@@ -2316,7 +_,7 @@
+    }
+ 
+    protected Vec3 m_7643_(Direction.Axis p_20045_, BlockUtil.FoundRectangle p_20046_) {
+-      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.m_6972_(this.m_20089_()));
++      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.getDimensionsForge(this.m_20089_()));
+    }
+ 
+    protected Optional<BlockUtil.FoundRectangle> m_183318_(ServerLevel p_185935_, BlockPos p_185936_, boolean p_185937_, WorldBorder p_185938_) {
 @@ -2463,8 +_,10 @@
        EntityDimensions entitydimensions = this.f_19815_;
        Pose pose = this.m_20089_();
@@ -308,6 +326,44 @@
           });
        }
  
+@@ -2504,7 +_,7 @@
+    }
+ 
+    protected AABB m_20217_(Pose p_20218_) {
+-      EntityDimensions entitydimensions = this.m_6972_(p_20218_);
++      EntityDimensions entitydimensions = this.getDimensionsForge(p_20218_);
+       float f = entitydimensions.f_20377_ / 2.0F;
+       Vec3 vec3 = new Vec3(this.m_20185_() - (double)f, this.m_20186_(), this.m_20189_() - (double)f);
+       Vec3 vec31 = new Vec3(this.m_20185_() + (double)f, this.m_20186_() + (double)entitydimensions.f_20378_, this.m_20189_() + (double)f);
+@@ -2515,12 +_,16 @@
+       this.f_19828_ = p_20012_;
+    }
+ 
++   /**
++    * @deprecated Can be overridden but call {@link #getEyeHeightForge(Pose, EntitySize)} instead.
++    */
++   @Deprecated
+    protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {
+       return p_19977_.f_20378_ * 0.85F;
+    }
+ 
+    public float m_20236_(Pose p_20237_) {
+-      return this.m_6380_(p_20237_, this.m_6972_(p_20237_));
++      return this.getEyeHeightForge(p_20237_, this.getDimensionsForge(p_20237_));
+    }
+ 
+    public final float m_20192_() {
+@@ -2838,6 +_,10 @@
+ 
+    public abstract Packet<?> m_5654_();
+ 
++   /**
++    * @deprecated Can be overridden but call {@link #getDimensionsForge(Pose)} instead.
++    */
++   @Deprecated
+    public EntityDimensions m_6972_(Pose p_19975_) {
+       return this.f_19847_.m_20680_();
+    }
 @@ -2950,6 +_,7 @@
              gameeventlistenerregistrar.m_157862_(this.f_19853_);
           }
@@ -316,7 +372,7 @@
  
     }
  
-@@ -3061,6 +_,76 @@
+@@ -3061,6 +_,89 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -386,6 +442,19 @@
 +    */
 +   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
++   }
++
++   public EntityDimensions getDimensionsForge(Pose pose) {
++      EntityDimensions size = this.m_6972_(pose);
++      float eyeHeight = this.m_6380_(pose, size);
++      net.minecraftforge.event.entity.EntityEvent.Size e = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, size, eyeHeight);
++      return e.getNewSize();
++   }
++
++   protected float getEyeHeightForge(Pose pose, EntityDimensions size) {
++      float eyeHeight = this.m_6380_(pose, size);
++      net.minecraftforge.event.entity.EntityEvent.Size e = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, size, eyeHeight);
++      return e.getNewEyeHeight();
 +   }
 +
 +   /* ================================== Forge End =====================================*/

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -14,7 +14,9 @@ import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.world.item.ItemStack;
@@ -25,6 +27,8 @@ import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.entity.PartEntity;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.EntityEvent;
 
 public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
 {
@@ -211,5 +215,20 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
             }
         }
         return vanillaStep;
+    }
+
+    default EntityDimensions getDimensionsForge(Pose pose)
+    {
+        EntityDimensions size = self().getDimensions(pose);
+        float eyeHeight = self().getEyeHeightAccess(pose, size);
+        EntityEvent.Size e = ForgeEventFactory.getEntitySizeForge(self(), pose, size, eyeHeight);
+        return e.getNewSize();
+    }
+
+    default float getEyeHeightForge(Pose pose, EntityDimensions size)
+    {
+        float eyeHeight = self().getEyeHeightAccess(pose, size);
+        EntityEvent.Size e = ForgeEventFactory.getEntitySizeForge(self(), pose, size, eyeHeight);
+        return e.getNewEyeHeight();
     }
 }


### PR DESCRIPTION
`EntityEvent.Size` is only fired in the entity constructor and in `refreshDimensions`. But the event should be fired whenever `getDimensions(Pose)` or `getEyeHeight(Pose, EntitySize)` is called.

For example creating an event listener that just scales the player size by 0.5 will result in the player only being 0.9 blocks high. But when going into a one block gap the player still starts crawling.

Firing the event inside the two methods is problematic because already in vanilla the methods are overridden by several subclasses.
Firing the event whenever the methods are called is also not ideal because the methods get called at several locations in vanilla.
That's why the vanilla methods are now marked as deprecated and forge versions of these methods were added which just call the vanilla method and fire the event.

### Problems and Future
The `refreshDimensions` method wasn't changed and still uses the vanilla `getDimensions` and `getEyeHeight` methods and fires the event manually. The reason for not changing the method is that the event here also gets the old dimensions and old eye height of the entity.
Also `getEyeHeight(Pose)` is called the event gets fired twice because `getEyeHeightForge` and `getDimensionsForge` is called.

In the future I would split the event into `Dimensions` and `EyeHeight` and also change the `oldSize` and `oldEyeHeight` fields of the event to just hold the size and eyeheight when the event was created. This would make things a lot cleaner but splitting the event would be a breaking change and changing the old fields is a logical change (or however you would call this then).