### PR TITLE
[1.18.x] Allow safely registering RenderType predicates at any time

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -42,7 +42,7 @@
           if (!Minecraft.m_91085_()) {
              return Sheets.m_110792_();
           } else {
-@@ -340,9 +_,70 @@
+@@ -340,9 +_,106 @@
        }
     }
  
@@ -55,8 +55,12 @@
 +   // FORGE START
 +
 +   private static final java.util.function.Predicate<RenderType> SOLID_PREDICATE = type -> type == RenderType.m_110451_();
++   private static final Object LOCK = new Object();
++   // Access to the two following editable maps is guarded by synchronization and they are lazily copied to the "readonly" maps on first read after modification
 +   private static final Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> blockRenderChecks = createRenderCheckMap(f_109275_);
 +   private static final Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecks = createRenderCheckMap(f_109276_);
++   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> blockRenderChecksReadOnly = null;
++   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecksReadOnly = null;
 +
 +   private static <T extends net.minecraftforge.registries.ForgeRegistryEntry<T>> Map<net.minecraftforge.registries.IRegistryDelegate<T>, java.util.function.Predicate<RenderType>> createRenderCheckMap(
 +           Map<T, RenderType> vanillaMap
@@ -74,37 +78,69 @@
 +      if (block instanceof LeavesBlock) {
 +         return f_109277_ ? type == RenderType.m_110457_() : type == RenderType.m_110451_();
 +      } else {
-+         return blockRenderChecks.get(block.delegate).test(type);
++         return getBlockLayerPredicates().get(block.delegate).test(type);
 +      }
 +   }
 +
 +   public static boolean canRenderInLayer(FluidState fluid, RenderType type) {
-+      return fluidRenderChecks.get(fluid.m_76152_().delegate).test(type);
++      return getFluidLayerPredicates().get(fluid.m_76152_().delegate).test(type);
 +   }
 +
 +   public static void setRenderLayer(Block block, RenderType type) {
 +      setRenderLayer(block, createMatchingLayerPredicate(type));
 +   }
 +
-+   public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
-+      checkClientLoading();
-+      blockRenderChecks.put(block.delegate, predicate);
++   public static void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
++      synchronized (LOCK) {
++         blockRenderChecks.put(block.delegate, predicate);
++         blockRenderChecksReadOnly = null;
++      }
 +   }
 +
 +   public static void setRenderLayer(Fluid fluid, RenderType type) {
 +      setRenderLayer(fluid, createMatchingLayerPredicate(type));
 +   }
 +
-+   public static synchronized void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
-+      checkClientLoading();
-+      fluidRenderChecks.put(fluid.delegate, predicate);
++   public static void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
++      synchronized (LOCK) {
++         fluidRenderChecks.put(fluid.delegate, predicate);
++         fluidRenderChecksReadOnly = null;
++      }
 +   }
 +
-+   private static void checkClientLoading() {
-+      com.google.common.base.Preconditions.checkState(net.minecraftforge.client.loading.ClientModLoader.isLoading(),
-+              "Render layers can only be set during client loading! " +
-+                      "This might ideally be done from `FMLClientSetupEvent`."
-+      );
++   public static Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicatesView() {
++      return java.util.Collections.unmodifiableMap(getBlockLayerPredicates());
++   }
++
++   private static Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicates() {
++      Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> map = blockRenderChecksReadOnly;
++      if (map == null) {
++         synchronized (LOCK) {
++            blockRenderChecksReadOnly = map = copy(blockRenderChecks);
++         }
++      }
++      return map;
++   }
++
++
++   public static Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicatesView() {
++      return java.util.Collections.unmodifiableMap(getFluidLayerPredicates());
++   }
++
++   private static Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicates() {
++      Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> map = fluidRenderChecksReadOnly;
++      if (map == null) {
++         synchronized (LOCK) {
++            fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
++         }
++      }
++      return map;
++   }
++
++   private static <T> Map<net.minecraftforge.registries.IRegistryDelegate<T>, java.util.function.Predicate<RenderType>> copy(Map<net.minecraftforge.registries.IRegistryDelegate<T>, java.util.function.Predicate<RenderType>> map) {
++      var newMap = new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(map);
++      newMap.defaultReturnValue(SOLID_PREDICATE);
++      return newMap;
 +   }
 +
 +   private static java.util.function.Predicate<RenderType> createMatchingLayerPredicate(RenderType type) {

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -42,7 +42,7 @@
           if (!Minecraft.m_91085_()) {
              return Sheets.m_110792_();
           } else {
-@@ -340,9 +_,106 @@
+@@ -340,9 +_,111 @@
        }
     }
  
@@ -55,7 +55,6 @@
 +   // FORGE START
 +
 +   private static final java.util.function.Predicate<RenderType> SOLID_PREDICATE = type -> type == RenderType.m_110451_();
-+   private static final Object LOCK = new Object();
 +   // Access to the two following editable maps is guarded by synchronization and they are lazily copied to the "readonly" maps on first read after modification
 +   private static final Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> blockRenderChecks = createRenderCheckMap(f_109275_);
 +   private static final Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecks = createRenderCheckMap(f_109276_);
@@ -91,7 +90,7 @@
 +   }
 +
 +   public static void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
-+      synchronized (LOCK) {
++      synchronized (blockRenderChecks) {
 +         blockRenderChecks.put(block.delegate, predicate);
 +         blockRenderChecksReadOnly = null;
 +      }
@@ -102,7 +101,7 @@
 +   }
 +
 +   public static void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
-+      synchronized (LOCK) {
++      synchronized (fluidRenderChecks) {
 +         fluidRenderChecks.put(fluid.delegate, predicate);
 +         fluidRenderChecksReadOnly = null;
 +      }
@@ -115,8 +114,11 @@
 +   private static Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicates() {
 +      Map<net.minecraftforge.registries.IRegistryDelegate<Block>, java.util.function.Predicate<RenderType>> map = blockRenderChecksReadOnly;
 +      if (map == null) {
-+         synchronized (LOCK) {
-+            blockRenderChecksReadOnly = map = copy(blockRenderChecks);
++         synchronized (blockRenderChecks) {
++            map = blockRenderChecksReadOnly;
++            if (map == null) {
++               blockRenderChecksReadOnly = map = copy(blockRenderChecks);
++            }
 +         }
 +      }
 +      return map;
@@ -130,8 +132,11 @@
 +   private static Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicates() {
 +      Map<net.minecraftforge.registries.IRegistryDelegate<Fluid>, java.util.function.Predicate<RenderType>> map = fluidRenderChecksReadOnly;
 +      if (map == null) {
-+         synchronized (LOCK) {
-+            fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
++         synchronized (fluidRenderChecks) {
++            map = fluidRenderChecksReadOnly;
++            if (map == null) {
++               fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
++            }
 +         }
 +      }
 +      return map;


### PR DESCRIPTION
This PR effectively supersedes #8664 by providing a solution that keeps the performance benefit of the initial change in #8476 while avoiding breaking mods that need access to the predicate map, such as CTM.
This is done by using a lazy "copy-on-write" implementation where the map is only actually copied on the first read access after modification.
The PR also adds getters to allow mods like CTM to access an unmodifiable view of the maps instead of accessing internals via reflection.

Quote of the description of #8664 for completeness:
> This PR reverts to an earlier approach from #8476 which is less likely to cause any breakage for mods. Instead of erroring on registration from outside of client setup, a copy-on-write map is used. This maintains the intent of the previous PR by not requiring synchronisation, but also resolves a crash in the case where a mod registers render type checks outside of client setup. For example, some mods such as CTM are registering render type checks from resource reload.