### PR TITLE
[1.18] Use stack sensitive translation key by default

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -213,7 +213,7 @@ public class FluidAttributes
      */
     public Component getDisplayName(FluidStack stack)
     {
-        return new TranslatableComponent(getTranslationKey());
+        return new TranslatableComponent(getTranslationKey(stack));
     }
 
     /**


### PR DESCRIPTION
This fixes #8646, by using the stack sensitive `getTranslationKey` method, inside the `getDisplayName` method.