### PR TITLE
Fire registry events in the order vanilla registers to registries

### DIFF
--- a/patches/minecraft/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/minecraft/net/minecraft/core/MappedRegistry.java.patch
@@ -1,6 +1,22 @@
 --- a/net/minecraft/core/MappedRegistry.java
 +++ b/net/minecraft/core/MappedRegistry.java
-@@ -90,7 +_,8 @@
+@@ -83,14 +_,24 @@
+       return this.m_205857_(p_205853_, p_205854_, p_205855_, p_205856_, true);
+    }
+ 
++   private static final Set<ResourceLocation> KNOWN = new java.util.LinkedHashSet<>();
++   public static Set<ResourceLocation> getKnownRegistries() {
++      return java.util.Collections.unmodifiableSet(KNOWN);
++   }
++   protected final void markKnown() {
++      KNOWN.add(m_123023_().m_135782_());
++   }
++
+    private Holder<T> m_205857_(int p_205858_, ResourceKey<T> p_205859_, T p_205860_, Lifecycle p_205861_, boolean p_205862_) {
++      markKnown();
+       this.m_205921_(p_205859_);
+       Validate.notNull(p_205859_);
+       Validate.notNull(p_205860_);
        this.f_122672_.size(Math.max(this.f_122672_.size(), p_205858_ + 1));
        this.f_122673_.put(p_205860_, p_205858_);
        this.f_211051_ = null;

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -142,7 +142,7 @@ public class ForgeRegistries
         public static final ResourceKey<Registry<Biome>> BIOMES = key("worldgen/biome");
 
         // Forge
-        public static final ResourceKey<Registry<EntityDataSerializer<?>>> DATA_SERIALIZERS = key("data_serializers");
+        public static final ResourceKey<Registry<EntityDataSerializer<?>>> DATA_SERIALIZERS = key("forge:data_serializers");
         public static final ResourceKey<Registry<GlobalLootModifierSerializer<?>>> LOOT_MODIFIER_SERIALIZERS = key("forge:loot_modifier_serializers");
         public static final ResourceKey<Registry<ForgeWorldPreset>> WORLD_TYPES = key("forge:world_types");
         public static final ResourceKey<Registry<Codec<? extends BiomeModifier>>> BIOME_MODIFIER_SERIALIZERS = key("forge:biome_modifier_serializers");

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -12,7 +12,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.mojang.serialization.Lifecycle;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import net.minecraft.core.DefaultedRegistry;
 import net.minecraft.core.IdMapper;
 import net.minecraft.core.MappedRegistry;
@@ -298,14 +298,9 @@ public class GameData
         keySet.addAll(RegistryManager.getVanillaRegistryKeys());
         keySet.addAll(BuiltinRegistries.REGISTRY.keySet());
 
-        List<ResourceLocation> ordered = new ArrayList<>();
-        MappedRegistry.getKnownRegistries().forEach(k -> {
-            if (keySet.remove(k))
-                ordered.add(k);
-        });
-        ordered.addAll(keySet.stream()
-              .sorted((o1, o2) -> String.valueOf(o1).compareToIgnoreCase(String.valueOf(o2)))
-              .toList());
+        Set<ResourceLocation> ordered = new LinkedHashSet<>(MappedRegistry.getKnownRegistries());
+        ordered.retainAll(keySet);
+        ordered.addAll(keySet.stream().sorted(ResourceLocation::compareNamespaced).toList());
 
         RuntimeException aggregate = new RuntimeException();
 

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -293,12 +293,15 @@ public class GameData
     @SuppressWarnings("deprecation")
     public static void postRegisterEvents()
     {
+        Comparator<ResourceLocation> alphabetical = (o1, o2) -> String.valueOf(o1).compareToIgnoreCase(String.valueOf(o2));
         Set<ResourceLocation> keySet = new HashSet<>(RegistryManager.ACTIVE.registries.keySet());
         keySet.addAll(RegistryManager.getVanillaRegistryKeys());
-        keySet.addAll(BuiltinRegistries.REGISTRY.keySet());
         List<ResourceLocation> keys = keySet.stream()
-                .sorted((o1, o2) -> String.valueOf(o1).compareToIgnoreCase(String.valueOf(o2)))
+                .sorted(alphabetical)
                 .collect(Collectors.toList());
+        keys.addAll(BuiltinRegistries.REGISTRY.keySet().stream()
+              .sorted(alphabetical)
+              .toList());
 
         //Move Blocks to first, and Items to second.
         keys.remove(BLOCKS.location());

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -52,6 +52,7 @@ class NamespacedDefaultedWrapper<T> extends DefaultedRegistry<T> implements ILoc
             throw new IllegalStateException("Can not register to a locked registry. Modder should use Forge Register methods.");
 
         Validate.notNull(value);
+        markKnown();
         this.elementsLifecycle = this.elementsLifecycle.add(lifecycle);
 
         T oldValue = this.delegate.getRaw(key.location());

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -55,6 +55,7 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
             throw new IllegalStateException("Can not register to a locked registry. Modder should use Forge Register methods.");
 
         Validate.notNull(value);
+        markKnown();
         this.elementsLifecycle = this.elementsLifecycle.add(lifecycle);
 
         T oldValue = get(key);


### PR DESCRIPTION
Fixes issues where things like Features, Placements and the like could not be registered before ConfiguredFeatures and PlacedFeatures as required.

This makes it so registry events fire in the order that vanilla populates registries, and then for any custom ones in alphabetical order. For the current registries that makes the new order be: https://gist.github.com/pupnewfster/ea38cf3744f23d6b65d67e6f279d5942 One subtle change is that blocks and items are not the *first* two register events fired.

This PR also moves the entity data serializer registry to the forge namespace as it is early in the breaking changes window, only used for networking, and was only in vanilla's namespace for legacy reasons.