### PR TITLE
Make fishing rods use tool actions for relevant logic

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/FishingHookRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/FishingHookRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/entity/FishingHookRenderer.java
++++ b/net/minecraft/client/renderer/entity/FishingHookRenderer.java
+@@ -49,7 +_,7 @@
+          p_114708_.m_85849_();
+          int i = player.m_5737_() == HumanoidArm.RIGHT ? 1 : -1;
+          ItemStack itemstack = player.m_21205_();
+-         if (!itemstack.m_150930_(Items.f_42523_)) {
++         if (!itemstack.canPerformAction(net.minecraftforge.common.ToolActions.FISHING_ROD_CAST)) {
+             i = -i;
+          }
+ 

--- a/patches/minecraft/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/net/minecraft/world/entity/projectile/FishingHook.java
+@@ -228,8 +_,8 @@
+    private boolean m_37136_(Player p_37137_) {
+       ItemStack itemstack = p_37137_.m_21205_();
+       ItemStack itemstack1 = p_37137_.m_21206_();
+-      boolean flag = itemstack.m_150930_(Items.f_42523_);
+-      boolean flag1 = itemstack1.m_150930_(Items.f_42523_);
++      boolean flag = itemstack.canPerformAction(net.minecraftforge.common.ToolActions.FISHING_ROD_CAST);
++      boolean flag1 = itemstack1.canPerformAction(net.minecraftforge.common.ToolActions.FISHING_ROD_CAST);
+       if (!p_37137_.m_213877_() && p_37137_.m_6084_() && (flag || flag1) && !(this.m_20280_(p_37137_) > 1024.0D)) {
+          return false;
+       } else {
 @@ -240,7 +_,7 @@
  
     private void m_37171_() {

--- a/patches/minecraft/net/minecraft/world/item/FishingRodItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/FishingRodItem.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/item/FishingRodItem.java
++++ b/net/minecraft/world/item/FishingRodItem.java
+@@ -46,4 +_,11 @@
+    public int m_6473_() {
+       return 1;
+    }
++
++    /* ******************** FORGE START ******************** */
++
++    @Override
++   public boolean canPerformAction(ItemStack stack, net.minecraftforge.common.ToolAction toolAction) {
++      return net.minecraftforge.common.ToolActions.DEFAULT_FISHING_ROD_ACTIONS.contains(toolAction);
++   }
+ }

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -100,6 +100,11 @@ public class ToolActions
      */
     public static final ToolAction SHIELD_BLOCK = ToolAction.get("shield_block");
 
+    /**
+     * This action corresponds to right-clicking the fishing rod.
+     */
+    public static final ToolAction FISHING_ROD_CAST = ToolAction.get("fishing_rod_cast");
+
     // Default actions supported by each tool type
     public static final Set<ToolAction> DEFAULT_AXE_ACTIONS = of(AXE_DIG, AXE_STRIP, AXE_SCRAPE, AXE_WAX_OFF);
     public static final Set<ToolAction> DEFAULT_HOE_ACTIONS = of(HOE_DIG, HOE_TILL);
@@ -108,6 +113,7 @@ public class ToolActions
     public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = of(SWORD_DIG, SWORD_SWEEP);
     public static final Set<ToolAction> DEFAULT_SHEARS_ACTIONS = of(SHEARS_DIG, SHEARS_HARVEST, SHEARS_CARVE, SHEARS_DISARM);
     public static final Set<ToolAction> DEFAULT_SHIELD_ACTIONS = of(SHIELD_BLOCK);
+    public static final Set<ToolAction> DEFAULT_FISHING_ROD_ACTIONS = of(FISHING_ROD_CAST);
 
     private static Set<ToolAction> of(ToolAction... actions) {
         return Stream.of(actions).collect(Collectors.toCollection(Sets::newIdentityHashSet));


### PR DESCRIPTION
This is a 1.19 port of #8424 which is a port of #8168. There is not much more to be said about this PR that has not been said in the previous conversations. To summarize, this removes hardcoded references to `Items.FISHING_ROD` in a couple places that make life harder for modders.