### PR TITLE
Add method with pre/post wrap to allow setting/clearing mod context. …

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -282,6 +284,17 @@ public class ModLoader
             return;
         }
         ModList.get().forEachModContainer((id, mc) -> mc.acceptEvent(e));
+    }
+    public <T extends Event & IModBusEvent> void postEventWithWrap(T e, BiConsumer<ModContainer, T> pre, BiConsumer<ModContainer, T> post) {
+        if (!loadingStateValid) {
+            LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
+            return;
+        }
+        ModList.get().forEachModContainer((id, mc) -> {
+            pre.accept(mc, e);
+            mc.acceptEvent(e);
+            post.accept(mc, e);
+        });
     }
 
     public List<ModLoadingWarning> getWarnings()

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -39,6 +39,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.util.LogMessageAdapter;
 import net.minecraftforge.common.world.ForgeWorldPreset;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.StartupMessageManager;
@@ -322,7 +323,7 @@ public class GameData
                 if (forgeRegistry != null)
                     forgeRegistry.unfreeze();
 
-                ModLoader.get().postEvent(registerEvent);
+                ModLoader.get().postEventWithWrap(registerEvent, (mc, e) -> ModLoadingContext.get().setActiveContainer(mc), (mc, e)-> ModLoadingContext.get().setActiveContainer(null));
 
                 if (forgeRegistry != null)
                     forgeRegistry.freeze();

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -24,6 +24,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.Registry;
 import net.minecraftforge.fml.ModLoader;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.network.HandshakeMessages;
 import net.minecraftforge.registries.ForgeRegistry.Snapshot;
 import org.apache.commons.lang3.tuple.Pair;
@@ -152,7 +153,7 @@ public class RegistryManager
         NewRegistryEvent event = new NewRegistryEvent();
         vanillaRegistryKeys = Set.copyOf(Registry.REGISTRY.keySet());
 
-        ModLoader.get().postEvent(event);
+        ModLoader.get().postEventWithWrap(event, (mc, e) -> ModLoadingContext.get().setActiveContainer(mc), (mc, e) -> ModLoadingContext.get().setActiveContainer(null));
 
         event.fill();
     }


### PR DESCRIPTION
…Fixes ActiveContainer in ModContext not being present in registry events.