### PR TITLE
[1.19] Allow safely registering RenderType predicates at any time

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -1,9 +1,11 @@
 --- a/net/minecraft/client/renderer/ItemBlockRenderTypes.java
 +++ b/net/minecraft/client/renderer/ItemBlockRenderTypes.java
-@@ -19,6 +_,7 @@
+@@ -18,7 +_,8 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
  
  @OnlyIn(Dist.CLIENT)
- public class ItemBlockRenderTypes {
+-public class ItemBlockRenderTypes {
++public class ItemBlockRenderTypes extends net.minecraftforge.client.extensions.ForgeItemBlockRenderTypes {
 +   @Deprecated
     private static final Map<Block, RenderType> f_109275_ = Util.m_137469_(Maps.newHashMap(), (p_109296_) -> {
        RenderType rendertype = RenderType.m_110503_();
@@ -42,7 +44,7 @@
           if (!Minecraft.m_91085_()) {
              return Sheets.m_110792_();
           } else {
-@@ -350,9 +_,103 @@
+@@ -350,10 +_,68 @@
        }
     }
  
@@ -50,25 +52,9 @@
     public static RenderType m_109287_(FluidState p_109288_) {
        RenderType rendertype = f_109276_.get(p_109288_.m_76152_());
        return rendertype != null ? rendertype : RenderType.m_110451_();
-+   }
+    }
 +
 +   // FORGE START
-+
-+   private static final java.util.function.Predicate<RenderType> SOLID_PREDICATE = type -> type == RenderType.m_110451_();
-+   private static final Object LOCK = new Object();
-+   private static final Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> blockRenderChecks = createRenderCheckMap(net.minecraftforge.registries.ForgeRegistries.BLOCKS, f_109275_);
-+   private static final Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecks = createRenderCheckMap(net.minecraftforge.registries.ForgeRegistries.FLUIDS, f_109276_);
-+   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> blockRenderChecksReadOnly = null;
-+   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecksReadOnly = null;
-+
-+   private static <T> Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> createRenderCheckMap(net.minecraftforge.registries.IForgeRegistry<T> registry, Map<T, RenderType> vanillaMap) {
-+      return Util.m_137469_(new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(vanillaMap.size(), 0.5F), map -> {
-+         map.defaultReturnValue(SOLID_PREDICATE);
-+         for(Map.Entry<T, RenderType> entry : vanillaMap.entrySet()) {
-+            map.put(registry.getDelegateOrThrow(entry.getKey()), createMatchingLayerPredicate(entry.getValue()));
-+         }
-+      });
-+   }
 +
 +   public static boolean canRenderInLayer(BlockState state, RenderType type) {
 +      Block block = state.m_60734_();
@@ -84,65 +70,46 @@
 +   }
 +
 +   public static void setRenderLayer(Block block, RenderType type) {
-+      setRenderLayer(block, createMatchingLayerPredicate(type));
++      java.util.Objects.requireNonNull(type);
++      setRenderLayer(block, t -> t == type);
 +   }
 +
 +   public static void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
-+      synchronized (LOCK) {
-+         blockRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), predicate);
-+         blockRenderChecksReadOnly = null;
-+      }
++      net.minecraftforge.client.extensions.ForgeItemBlockRenderTypes.setRenderLayer(block, predicate);
 +   }
 +
 +   public static void setRenderLayer(Fluid fluid, RenderType type) {
-+      setRenderLayer(fluid, createMatchingLayerPredicate(type));
++      java.util.Objects.requireNonNull(type);
++      setRenderLayer(fluid, t -> t == type);
 +   }
 +
 +   public static void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
-+      synchronized (LOCK) {
-+            fluidRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid), predicate);
-+            fluidRenderChecksReadOnly = null;
-+      }
++      net.minecraftforge.client.extensions.ForgeItemBlockRenderTypes.setRenderLayer(fluid, predicate);
 +   }
 +
++   /**
++    * Returns an unmodifiable view of the current block -> render type predicate map.
++    * The returned view should not be cached, as its backing map will become outdated as soon as
++    * something registers a new render type predicate
++    */
 +   public static Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicatesView() {
 +      return java.util.Collections.unmodifiableMap(getBlockLayerPredicates());
 +   }
 +
-+   private static Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicates() {
-+      Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> map = blockRenderChecksReadOnly;
-+      if (map == null) {
-+         synchronized (LOCK) {
-+            blockRenderChecksReadOnly = map = copy(blockRenderChecks);
-+         }
-+      }
-+      return map;
-+   }
-+
-+
++   /**
++    * Returns an unmodifiable view of the current fluid -> render type predicate map.
++    * The returned view should not be cached, as its backing map will become outdated as soon as
++    * something registers a new render type predicate
++    */
 +   public static Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicatesView() {
 +      return java.util.Collections.unmodifiableMap(getFluidLayerPredicates());
 +   }
 +
-+   private static Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicates() {
-+      Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> map = fluidRenderChecksReadOnly;
-+      if (map == null) {
-+         synchronized (LOCK) {
-+            fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
-+         }
-+      }
-+      return map;
++   static {
++      net.minecraftforge.client.extensions.ForgeItemBlockRenderTypes.initFromVanillaMaps(f_109275_, f_109276_);
 +   }
 +
-+   private static <T> Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> copy(Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> map) {
-+      var newMap = new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(map);
-+      newMap.defaultReturnValue(SOLID_PREDICATE);
-+      return newMap;
-+   }
-+
-+   private static java.util.function.Predicate<RenderType> createMatchingLayerPredicate(RenderType type) {
-+      java.util.Objects.requireNonNull(type);
-+      return type::equals;
-    }
++   // FORGE END
  
     public static void m_109291_(boolean p_109292_) {
+       f_109277_ = p_109292_;

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -42,7 +42,7 @@
           if (!Minecraft.m_91085_()) {
              return Sheets.m_110792_();
           } else {
-@@ -350,9 +_,68 @@
+@@ -350,9 +_,103 @@
        }
     }
  
@@ -55,8 +55,11 @@
 +   // FORGE START
 +
 +   private static final java.util.function.Predicate<RenderType> SOLID_PREDICATE = type -> type == RenderType.m_110451_();
++   private static final Object LOCK = new Object();
 +   private static final Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> blockRenderChecks = createRenderCheckMap(net.minecraftforge.registries.ForgeRegistries.BLOCKS, f_109275_);
 +   private static final Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecks = createRenderCheckMap(net.minecraftforge.registries.ForgeRegistries.FLUIDS, f_109276_);
++   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> blockRenderChecksReadOnly = null;
++   @org.jetbrains.annotations.Nullable private static volatile Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> fluidRenderChecksReadOnly = null;
 +
 +   private static <T> Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> createRenderCheckMap(net.minecraftforge.registries.IForgeRegistry<T> registry, Map<T, RenderType> vanillaMap) {
 +      return Util.m_137469_(new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(vanillaMap.size(), 0.5F), map -> {
@@ -72,37 +75,69 @@
 +      if (block instanceof LeavesBlock) {
 +         return f_109277_ ? type == RenderType.m_110457_() : type == RenderType.m_110451_();
 +      } else {
-+         return blockRenderChecks.get(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block)).test(type);
++         return getBlockLayerPredicates().get(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block)).test(type);
 +      }
 +   }
 +
 +   public static boolean canRenderInLayer(FluidState fluid, RenderType type) {
-+      return fluidRenderChecks.get(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid.m_76152_())).test(type);
++      return getFluidLayerPredicates().get(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid.m_76152_())).test(type);
 +   }
 +
 +   public static void setRenderLayer(Block block, RenderType type) {
 +      setRenderLayer(block, createMatchingLayerPredicate(type));
 +   }
 +
-+   public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
-+      checkClientLoading();
-+      blockRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), predicate);
++   public static void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
++      synchronized (LOCK) {
++         blockRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), predicate);
++         blockRenderChecksReadOnly = null;
++      }
 +   }
 +
 +   public static void setRenderLayer(Fluid fluid, RenderType type) {
 +      setRenderLayer(fluid, createMatchingLayerPredicate(type));
 +   }
 +
-+   public static synchronized void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
-+      checkClientLoading();
-+      fluidRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid), predicate);
++   public static void setRenderLayer(Fluid fluid, java.util.function.Predicate<RenderType> predicate) {
++      synchronized (LOCK) {
++            fluidRenderChecks.put(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid), predicate);
++            fluidRenderChecksReadOnly = null;
++      }
 +   }
 +
-+   private static void checkClientLoading() {
-+      com.google.common.base.Preconditions.checkState(net.minecraftforge.client.loading.ClientModLoader.isLoading(),
-+              "Render layers can only be set during client loading! " +
-+                      "This might ideally be done from `FMLClientSetupEvent`."
-+      );
++   public static Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicatesView() {
++      return java.util.Collections.unmodifiableMap(getBlockLayerPredicates());
++   }
++
++   private static Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> getBlockLayerPredicates() {
++      Map<net.minecraft.core.Holder.Reference<Block>, java.util.function.Predicate<RenderType>> map = blockRenderChecksReadOnly;
++      if (map == null) {
++         synchronized (LOCK) {
++            blockRenderChecksReadOnly = map = copy(blockRenderChecks);
++         }
++      }
++      return map;
++   }
++
++
++   public static Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicatesView() {
++      return java.util.Collections.unmodifiableMap(getFluidLayerPredicates());
++   }
++
++   private static Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> getFluidLayerPredicates() {
++      Map<net.minecraft.core.Holder.Reference<Fluid>, java.util.function.Predicate<RenderType>> map = fluidRenderChecksReadOnly;
++      if (map == null) {
++         synchronized (LOCK) {
++            fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
++         }
++      }
++      return map;
++   }
++
++   private static <T> Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> copy(Map<net.minecraft.core.Holder.Reference<T>, java.util.function.Predicate<RenderType>> map) {
++      var newMap = new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(map);
++      newMap.defaultReturnValue(SOLID_PREDICATE);
++      return newMap;
 +   }
 +
 +   private static java.util.function.Predicate<RenderType> createMatchingLayerPredicate(RenderType type) {

--- a/src/main/java/net/minecraftforge/client/extensions/ForgeItemBlockRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/extensions/ForgeItemBlockRenderTypes.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.extensions;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class ForgeItemBlockRenderTypes
+{
+    private static final Predicate<RenderType> SOLID_PREDICATE = type -> type == RenderType.solid();
+    private static final Object LOCK = new Object();
+
+    private static final Map<Holder.Reference<Block>, Predicate<RenderType>> blockRenderChecks = createMap();
+    private static final Map<Holder.Reference<Fluid>, Predicate<RenderType>> fluidRenderChecks = createMap();
+
+    @Nullable
+    private static volatile Map<Holder.Reference<Block>, Predicate<RenderType>> blockRenderChecksReadOnly = null;
+    @Nullable
+    private static volatile Map<Holder.Reference<Fluid>, Predicate<RenderType>> fluidRenderChecksReadOnly = null;
+
+    public static void setRenderLayer(Block block, Predicate<RenderType> predicate)
+    {
+        Objects.requireNonNull(predicate);
+        synchronized (LOCK)
+        {
+            blockRenderChecks.put(ForgeRegistries.BLOCKS.getDelegateOrThrow(block), predicate);
+            blockRenderChecksReadOnly = null;
+        }
+    }
+
+    public static void setRenderLayer(Fluid fluid, Predicate<RenderType> predicate)
+    {
+        Objects.requireNonNull(predicate);
+        synchronized (LOCK)
+        {
+            fluidRenderChecks.put(ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid), predicate);
+            fluidRenderChecksReadOnly = null;
+        }
+    }
+
+    protected static Map<Holder.Reference<Block>, Predicate<RenderType>> getBlockLayerPredicates()
+    {
+        Map<Holder.Reference<Block>, Predicate<RenderType>> map = blockRenderChecksReadOnly;
+        if (map == null)
+        {
+            synchronized (LOCK)
+            {
+                blockRenderChecksReadOnly = map = copy(blockRenderChecks);
+            }
+        }
+        return map;
+    }
+
+    protected static Map<Holder.Reference<Fluid>, Predicate<RenderType>> getFluidLayerPredicates()
+    {
+        Map<Holder.Reference<Fluid>, Predicate<RenderType>> map = fluidRenderChecksReadOnly;
+        if (map == null)
+        {
+            synchronized (LOCK)
+            {
+                fluidRenderChecksReadOnly = map = copy(fluidRenderChecks);
+            }
+        }
+        return map;
+    }
+
+    private static <T> Map<Holder.Reference<T>, Predicate<RenderType>> copy(Map<Holder.Reference<T>, Predicate<RenderType>> map)
+    {
+        var newMap = new Object2ObjectOpenHashMap<>(map);
+        newMap.defaultReturnValue(SOLID_PREDICATE);
+        return newMap;
+    }
+
+    private static <T> Map<Holder.Reference<T>, Predicate<RenderType>> createMap()
+    {
+        Object2ObjectMap<Holder.Reference<T>, Predicate<RenderType>> map = new Object2ObjectOpenHashMap<>(
+                Object2ObjectOpenHashMap.DEFAULT_INITIAL_SIZE, .75F
+        );
+        map.defaultReturnValue(SOLID_PREDICATE);
+        return map;
+    }
+
+    protected static void initFromVanillaMaps(Map<Block, RenderType> typeByBlock, Map<Fluid, RenderType> typeByFluid)
+    {
+        for (Map.Entry<Block, RenderType> entry : typeByBlock.entrySet())
+        {
+            RenderType type = entry.getValue();
+            blockRenderChecks.put(ForgeRegistries.BLOCKS.getDelegateOrThrow(entry.getKey()), t -> t == type);
+        }
+
+        for (Map.Entry<Fluid, RenderType> entry : typeByFluid.entrySet())
+        {
+            RenderType type = entry.getValue();
+            fluidRenderChecks.put(ForgeRegistries.FLUIDS.getDelegateOrThrow(entry.getKey()), t -> t == type);
+        }
+    }
+}


### PR DESCRIPTION
This PR is the 1.19 port of #8671.

This PR effectively supersedes https://github.com/MinecraftForge/MinecraftForge/pull/8664 by providing a solution that keeps the performance benefit of the initial change in https://github.com/MinecraftForge/MinecraftForge/pull/8476 while still allowing mods to register render type predicates at any point in time.
This is done by using a lazy "copy-on-write" implementation where the map is only actually copied on the first read access after modification.
The PR also adds getters to allow mods like CTM to access an unmodifiable view of the maps instead of accessing internals via reflection.

Quote of the description of https://github.com/MinecraftForge/MinecraftForge/pull/8664 for completeness:

> This PR reverts to an earlier approach from https://github.com/MinecraftForge/MinecraftForge/pull/8476 which is less likely to cause any breakage for mods. Instead of erroring on registration from outside of client setup, a copy-on-write map is used. This maintains the intent of the previous PR by not requiring synchronisation, but also resolves a crash in the case where a mod registers render type checks outside of client setup. For example, some mods such as CTM are registering render type checks from resource reload.