### PR TITLE
[1.19.x] Fix wrong param passed to PlayLevelSoundEvent.AtEntity

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -53,7 +53,7 @@
     }
  
     public void m_213890_(@Nullable Player p_233631_, Entity p_233632_, SoundEvent p_233633_, SoundSource p_233634_, float p_233635_, float p_233636_, long p_233637_) {
-+      net.minecraftforge.event.PlayLevelSoundEvent.AtEntity event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_233631_, p_233633_, p_233634_, p_233635_, p_233636_);
++      net.minecraftforge.event.PlayLevelSoundEvent.AtEntity event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_233632_, p_233633_, p_233634_, p_233635_, p_233636_);
 +      if (event.isCanceled() || event.getSound() == null) return;
 +      p_233633_ = event.getSound();
 +      p_233634_ = event.getSource();


### PR DESCRIPTION
Problem was observed and reported on Forgecord when user used a trident enchanted with riptide, see convo [here](https://discord.com/channels/313125603924639766/313125603924639766/984161525101113355).
This fixes the issue.
Tested a trident with riptide, and the proper entity is now passed to `PlayLevelSoundEvent.AtEntity` instead of the nullable Player one.