### PR TITLE
Fix Reach Distance / Attack Range being clamped at 6.0

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -1,16 +1,18 @@
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -124,6 +_,10 @@
+@@ -124,7 +_,11 @@
     }
  
     public void m_214168_(BlockPos p_215120_, ServerboundPlayerActionPacket.Action p_215121_, Direction p_215122_, int p_215123_, int p_215124_) {
+-      if (this.f_9245_.m_146892_().m_82557_(Vec3.m_82512_(p_215120_)) > ServerGamePacketListenerImpl.f_215198_) {
 +      net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(f_9245_, p_215120_, p_215122_);
 +      if (event.isCanceled() || (!this.m_9295_() && event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY)) {
 +         return;
 +      }
-       if (this.f_9245_.m_146892_().m_82557_(Vec3.m_82512_(p_215120_)) > ServerGamePacketListenerImpl.f_215198_) {
++      if (!this.f_9245_.canInteractWith(p_215120_, 1)) {
           this.m_215125_(p_215120_, false, p_215124_, "too far");
        } else if (p_215120_.m_123342_() >= p_215123_) {
+          this.f_9245_.f_8906_.m_9829_(new ClientboundBlockUpdatePacket(p_215120_, this.f_9244_.m_8055_(p_215120_)));
 @@ -152,6 +_,7 @@
              float f = 1.0F;
              BlockState blockstate = this.f_9244_.m_8055_(p_215120_);

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -171,6 +_,7 @@
+ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, ServerGamePacketListener {
+    static final Logger f_9744_ = LogUtils.getLogger();
+    private static final int f_143608_ = 15000;
++   @Deprecated // Forge: See Reach Distance / Attack Range attributes.
+    public static final double f_215198_ = Mth.m_144952_(6.0D);
+    private static final int f_215199_ = -1;
+    public final Connection f_9742_;
 @@ -413,9 +_,11 @@
              }
  
@@ -21,12 +29,21 @@
     }
  
     public void m_7376_(ServerboundAcceptTeleportationPacket p_9835_) {
+@@ -1004,7 +_,7 @@
+       Vec3 vec3 = blockhitresult.m_82450_();
+       BlockPos blockpos = blockhitresult.m_82425_();
+       Vec3 vec31 = Vec3.m_82512_(blockpos);
+-      if (!(this.f_9743_.m_146892_().m_82557_(vec31) > f_215198_)) {
++      if (this.f_9743_.canInteractWith(blockpos, 3)) {
+          Vec3 vec32 = vec3.m_82546_(vec31);
+          double d0 = 1.0000001D;
+          if (Math.abs(vec32.m_7096_()) < 1.0000001D && Math.abs(vec32.m_7098_()) < 1.0000001D && Math.abs(vec32.m_7094_()) < 1.0000001D) {
 @@ -1012,7 +_,7 @@
              this.f_9743_.m_9243_();
              int i = this.f_9743_.f_19853_.m_151558_();
              if (blockpos.m_123342_() < i) {
 -               if (this.f_9766_ == null && this.f_9743_.m_20275_((double)blockpos.m_123341_() + 0.5D, (double)blockpos.m_123342_() + 0.5D, (double)blockpos.m_123343_() + 0.5D) < 64.0D && serverlevel.m_7966_(this.f_9743_, blockpos)) {
-+               if (this.f_9766_ == null && this.f_9743_.canInteractWith(blockpos, 3) && serverlevel.m_7966_(this.f_9743_, blockpos)) {
++               if (this.f_9766_ == null && serverlevel.m_7966_(this.f_9743_, blockpos)) {
                    InteractionResult interactionresult = this.f_9743_.f_8941_.m_7179_(this.f_9743_, serverlevel, itemstack, interactionhand, blockhitresult);
                    if (direction == Direction.UP && !interactionresult.m_19077_() && blockpos.m_123342_() >= i - 1 && m_9790_(this.f_9743_, itemstack)) {
                       Component component = Component.m_237110_("build.tooHigh", i - 1).m_130940_(ChatFormatting.RED);

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,10 +1,15 @@
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -171,6 +_,7 @@
+@@ -171,6 +_,12 @@
  public class ServerGamePacketListenerImpl implements ServerPlayerConnection, ServerGamePacketListener {
     static final Logger f_9744_ = LogUtils.getLogger();
     private static final int f_143608_ = 15000;
-+   @Deprecated // Forge: See Reach Distance / Attack Range attributes.
++   /**
++    * Forge: Deprecated in favor of range/reach attributes.
++    * @see net.minecraftforge.common.ForgeMod#REACH_DISTANCE
++    * @see net.minecraftforge.common.ForgeMod#ATTACK_RANGE
++    */
++   @Deprecated
     public static final double f_215198_ = Mth.m_144952_(6.0D);
     private static final int f_215199_ = -1;
     public final Connection f_9742_;


### PR DESCRIPTION
In 1.19 mojang added `ServerGamePacketListenerImpl.MAX_INTERACTION_DISTANCE` and added checks against it that need to be removed to support extended reach/range.  This PR removes the checks and deprecates the field.

Fixes #8689