### PR TITLE
Fixes setPos to syncPacketPositionCodec

### DIFF
--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -142,6 +142,10 @@ public class PlayMessages
                     return;
                 }
 
+                /*
+	            * Sets the postiion on the client, Mirrors what
+	            * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
+	            */
                 e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
                 e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
                 e.setYHeadRot((msg.headYaw * 360) / 256.0F);

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -143,9 +143,9 @@ public class PlayMessages
                 }
 
                 /*
-	            * Sets the postiion on the client, Mirrors what
-	            * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
-	            */
+	        * Sets the postiion on the client, Mirrors what
+	        * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
+	        */
                 e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
                 e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
                 e.setYHeadRot((msg.headYaw * 360) / 256.0F);

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -143,9 +143,9 @@ public class PlayMessages
                 }
 
                 /*
-	        * Sets the postiion on the client, Mirrors what
-	        * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
-	        */
+                 * Sets the postiion on the client, Mirrors what
+                 * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
+                 */
                 e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
                 e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
                 e.setYHeadRot((msg.headYaw * 360) / 256.0F);

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -142,7 +142,7 @@ public class PlayMessages
                     return;
                 }
 
-                e.setPos(msg.posX, msg.posY, msg.posZ);
+                e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
                 e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
                 e.setYHeadRot((msg.headYaw * 360) / 256.0F);
                 e.setYBodyRot((msg.headYaw * 360) / 256.0F);


### PR DESCRIPTION
This is a fix for #8701 where modded projectiles will spawn at 0,0,0 instead of where they suppose to. 