### PR TITLE
Handle modded packets on the network thread

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -72,12 +72,19 @@
     }
  
     private <T> void m_205560_(ResourceKey<? extends Registry<? extends T>> p_205561_, TagNetworkSerialization.NetworkPayload p_205562_) {
-@@ -1843,7 +_,8 @@
+@@ -1646,6 +_,7 @@
+    }
+ 
+    public void m_7413_(ClientboundCustomPayloadPacket p_105004_) {
++      if (!f_104888_.m_18695_() && net.minecraftforge.network.NetworkHooks.onCustomPayload(p_105004_, this.f_104885_)) return;
+       PacketUtils.m_131363_(p_105004_, this, this.f_104888_);
+       ResourceLocation resourcelocation = p_105004_.m_132042_();
+       FriendlyByteBuf friendlybytebuf = null;
+@@ -1843,7 +_,7 @@
              int j5 = friendlybytebuf.m_130242_();
              this.f_104888_.f_91064_.f_173815_.m_173830_(positionsource, j5);
           } else {
 -            f_104883_.warn("Unknown custom packed identifier: {}", (Object)resourcelocation);
-+            if (!net.minecraftforge.network.NetworkHooks.onCustomPayload(p_105004_, this.f_104885_))
 +            f_104883_.warn("Unknown custom packet identifier: {}", (Object)resourcelocation);
           }
        } finally {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -54,11 +54,10 @@
                    } else {
                       ServerGamePacketListenerImpl.this.m_9942_(Component.m_237115_("multiplayer.disconnect.invalid_entity_attacked"));
                       ServerGamePacketListenerImpl.f_9744_.warn("Player {} tried to attack an invalid entity", (Object)ServerGamePacketListenerImpl.this.f_9743_.m_7755_().getString());
-@@ -1596,6 +_,8 @@
+@@ -1596,6 +_,7 @@
     }
  
     public void m_7423_(ServerboundCustomPayloadPacket p_9860_) {
-+      PacketUtils.m_131359_(p_9860_, this, this.f_9743_.m_9236_());
 +      net.minecraftforge.network.NetworkHooks.onCustomPayload(p_9860_, this.f_9742_);
     }
  

--- a/src/main/java/net/minecraftforge/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInitialization.java
@@ -26,7 +26,7 @@ class NetworkInitialization {
                 loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
                 decoder(HandshakeMessages.C2SAcknowledge::decode).
                 encoder(HandshakeMessages.C2SAcknowledge::encode).
-                consumer(HandshakeHandler.indexFirst(HandshakeHandler::handleClientAck)).
+                consumerNetworkThread(HandshakeHandler.indexFirst(HandshakeHandler::handleClientAck)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.S2CModData.class, 5, NetworkDirection.LOGIN_TO_CLIENT).
@@ -35,7 +35,7 @@ class NetworkInitialization {
                 encoder(HandshakeMessages.S2CModData::encode).
                 markAsLoginPacket().
                 noResponse().
-                consumer(HandshakeHandler.biConsumerFor(HandshakeHandler::handleModData)).
+                consumerNetworkThread(HandshakeHandler.biConsumerFor(HandshakeHandler::handleModData)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.S2CModList.class, 1, NetworkDirection.LOGIN_TO_CLIENT).
@@ -43,14 +43,14 @@ class NetworkInitialization {
                 decoder(HandshakeMessages.S2CModList::decode).
                 encoder(HandshakeMessages.S2CModList::encode).
                 markAsLoginPacket().
-                consumer(HandshakeHandler.biConsumerFor(HandshakeHandler::handleServerModListOnClient)).
+                consumerNetworkThread(HandshakeHandler.biConsumerFor(HandshakeHandler::handleServerModListOnClient)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.C2SModListReply.class, 2, NetworkDirection.LOGIN_TO_SERVER).
                 loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
                 decoder(HandshakeMessages.C2SModListReply::decode).
                 encoder(HandshakeMessages.C2SModListReply::encode).
-                consumer(HandshakeHandler.indexFirst(HandshakeHandler::handleClientModListOnServer)).
+                consumerNetworkThread(HandshakeHandler.indexFirst(HandshakeHandler::handleClientModListOnServer)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.S2CRegistry.class, 3, NetworkDirection.LOGIN_TO_CLIENT).
@@ -58,7 +58,7 @@ class NetworkInitialization {
                 decoder(HandshakeMessages.S2CRegistry::decode).
                 encoder(HandshakeMessages.S2CRegistry::encode).
                 buildLoginPacketList(RegistryManager::generateRegistryPackets). //TODO: Make this non-static, and store a cache on the client.
-                consumer(HandshakeHandler.biConsumerFor(HandshakeHandler::handleRegistryMessage)).
+                consumerNetworkThread(HandshakeHandler.biConsumerFor(HandshakeHandler::handleRegistryMessage)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.S2CConfigData.class, 4, NetworkDirection.LOGIN_TO_CLIENT).
@@ -66,14 +66,14 @@ class NetworkInitialization {
                 decoder(HandshakeMessages.S2CConfigData::decode).
                 encoder(HandshakeMessages.S2CConfigData::encode).
                 buildLoginPacketList(ConfigSync.INSTANCE::syncConfigs).
-                consumer(HandshakeHandler.biConsumerFor(HandshakeHandler::handleConfigSync)).
+                consumerNetworkThread(HandshakeHandler.biConsumerFor(HandshakeHandler::handleConfigSync)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.S2CChannelMismatchData.class, 6, NetworkDirection.LOGIN_TO_CLIENT).
                 loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
                 decoder(HandshakeMessages.S2CChannelMismatchData::decode).
                 encoder(HandshakeMessages.S2CChannelMismatchData::encode).
-                consumer(HandshakeHandler.biConsumerFor(HandshakeHandler::handleModMismatchData)).
+                consumerNetworkThread(HandshakeHandler.biConsumerFor(HandshakeHandler::handleModMismatchData)).
                 add();
 
         return handshakeChannel;
@@ -90,13 +90,13 @@ class NetworkInitialization {
         playChannel.messageBuilder(PlayMessages.SpawnEntity.class, 0).
                 decoder(PlayMessages.SpawnEntity::decode).
                 encoder(PlayMessages.SpawnEntity::encode).
-                consumer(PlayMessages.SpawnEntity::handle).
+                consumerNetworkThread(PlayMessages.SpawnEntity::handle).
                 add();
 
         playChannel.messageBuilder(PlayMessages.OpenContainer.class,1).
                 decoder(PlayMessages.OpenContainer::decode).
                 encoder(PlayMessages.OpenContainer::encode).
-                consumer(PlayMessages.OpenContainer::handle).
+                consumerNetworkThread(PlayMessages.OpenContainer::handle).
                 add();
 
         return playChannel;

--- a/src/main/java/net/minecraftforge/network/event/EventNetworkChannel.java
+++ b/src/main/java/net/minecraftforge/network/event/EventNetworkChannel.java
@@ -6,11 +6,25 @@
 package net.minecraftforge.network.event;
 
 import net.minecraft.network.Connection;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkInstance;
+import net.minecraftforge.network.NetworkRegistry;
 
 import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
+/**
+ * An event-bus like object on which {@link NetworkEvent}s are posted.
+ *
+ * These events are fired from the network thread, and so should not interact with most game state by default.
+ * {@link NetworkEvent.Context#enqueueWork(Runnable)} can be used to handle the message on the main server or client
+ * thread.
+ *
+ * @see NetworkRegistry#newEventChannel(ResourceLocation, Supplier, Predicate, Predicate)
+ * @see NetworkRegistry.ChannelBuilder#newEventChannel(ResourceLocation, Supplier, Predicate, Predicate)
+ */
 public class EventNetworkChannel
 {
     private final NetworkInstance instance;

--- a/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
@@ -8,25 +8,16 @@ package net.minecraftforge.network.simple;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.Connection;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.Packet;
 import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkInstance;
 import net.minecraftforge.network.PacketDistributor;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.IntSupplier;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class SimpleChannel
@@ -252,7 +243,7 @@ public class SimpleChannel
          * @return The message builder, for chaining.
          * @deprecated Use {@link #consumerMainThread(BiConsumer)} or {@link #consumerNetworkThread(BiConsumer)}.
          */
-        @Deprecated(forRemoval = true)
+        @Deprecated(forRemoval = true, since = "1.19")
         public MessageBuilder<MSG> consumer(BiConsumer<MSG, Supplier<NetworkEvent.Context>> consumer) {
             consumerMainThread(consumer);
             return this;
@@ -320,6 +311,7 @@ public class SimpleChannel
          * @return The message builder, for chaining.
          * @deprecated Use {@link #consumerMainThread(BiConsumer)} or {@link #consumerNetworkThread(BiConsumer)}.
          */
+        @Deprecated(forRemoval = true, since = "1.19")
         public MessageBuilder<MSG> consumer(ToBooleanBiFunction<MSG, Supplier<NetworkEvent.Context>> handler) {
             consumerMainThread(handler::applyAsBool);
             return this;

--- a/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
@@ -183,11 +183,11 @@ public class SimpleChannel
 
         /**
          * Set the message encoder, which writes this message to a {@link FriendlyByteBuf}.
-         *
-         * The encoder is called <em>immediately</em> {@link #send(PacketDistributor.PacketTarget, Object) when the
+         * <p>
+         * The encoder is called <em>immediately</em> {@linkplain #send(PacketDistributor.PacketTarget, Object) when the
          * packet is sent}. This means encoding typically occurs on the main server/client thread rather than on the
          * network thread.
-         *
+         * <p>
          * However, this behaviour should not be relied on, and the encoder should try to be thread-safe and not
          * interact with the current game state.
          *
@@ -201,10 +201,10 @@ public class SimpleChannel
 
         /**
          * Set the message decoder, which reads the message from a {@link FriendlyByteBuf}.
-         *
+         * <p>
          * The decoder is called when the message is received on the network thread. The decoder should not attempt to
-         * access or mutate any game state, deferring that until the {@link #consumer(ToBooleanBiFunction) the message
-         * is handled}.
+         * access or mutate any game state, deferring that until the {@linkplain #consumer(ToBooleanBiFunction) the
+         * message is handled}.
          *
          * @param decoder The message decoder.
          * @return The message builder, for chaining.
@@ -249,7 +249,7 @@ public class SimpleChannel
         /**
          * Set the message consumer, which is called once a message has been decoded. This accepts the decoded message
          * object and the message's context.
-         *
+         * <p>
          * The consumer is called on the network thread, and so should not interact with most game state by default.
          * {@link NetworkEvent.Context#enqueueWork(Runnable)} can be used to handle the message on the main server or
          * client thread.

--- a/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/network/simple/SimpleChannel.java
@@ -247,6 +247,18 @@ public class SimpleChannel
         }
 
         /**
+         * Set the message consumer, which is called once a message has been decoded.
+         * @param consumer The message consumer.
+         * @return The message builder, for chaining.
+         * @deprecated Use {@link #consumerMainThread(BiConsumer)} or {@link #consumerNetworkThread(BiConsumer)}.
+         */
+        @Deprecated(forRemoval = true)
+        public MessageBuilder<MSG> consumer(BiConsumer<MSG, Supplier<NetworkEvent.Context>> consumer) {
+            consumerMainThread(consumer);
+            return this;
+        }
+
+        /**
          * Set the message consumer, which is called once a message has been decoded. This accepts the decoded message
          * object and the message's context.
          * <p>
@@ -299,6 +311,17 @@ public class SimpleChannel
                 boolean handled = handler.applyAsBool(msg, ctx);
                 ctx.get().setPacketHandled(handled);
             };
+            return this;
+        }
+
+        /**
+         * Set the message consumer, which is called once a message has been decoded.
+         * @param handler The message consumer.
+         * @return The message builder, for chaining.
+         * @deprecated Use {@link #consumerMainThread(BiConsumer)} or {@link #consumerNetworkThread(BiConsumer)}.
+         */
+        public MessageBuilder<MSG> consumer(ToBooleanBiFunction<MSG, Supplier<NetworkEvent.Context>> handler) {
+            consumerMainThread(handler::applyAsBool);
             return this;
         }
 


### PR DESCRIPTION
Fixes #8642. This ensures custom modded packets are both read and handled on the network thread by default, rather than the main server/client thread.

Tested on both single player and a server, with Netty's Advanced leak detection enabled. Custom packets work as expected (tested with [a mod of mine](https://github.com/cc-tweaked/CC-Tweaked)), and it does not appear to introduce any `ByteBuf` leaks.

I did also look at changing the custom packets to write their contents on the network thread (they are currently written when the packet is created instead), but this would require a more invasive change, and I wasn't comfortable doing that without further discussion.