### PR TITLE
[1.19.x] Use stack sensitive translation key by default

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -212,7 +212,7 @@ public class FluidAttributes
      */
     public Component getDisplayName(FluidStack stack)
     {
-        return Component.translatable(getTranslationKey());
+        return Component.translatable(getTranslationKey(stack));
     }
 
     /**


### PR DESCRIPTION
This is a 1.19 port of #8674
<hr>

Utilizes the stack sensitive `getTranslationKey` method, inside the `getDisplayName` method, for the `FluidAttributes`.