### PR TITLE
Only rewrite datagen cache when needed

### DIFF
--- a/patches/minecraft/net/minecraft/data/HashCache.java.patch
+++ b/patches/minecraft/net/minecraft/data/HashCache.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/data/HashCache.java
 +++ b/net/minecraft/data/HashCache.java
+@@ -92,6 +_,8 @@
+       MutableInt mutableint = new MutableInt();
+       this.f_236083_.forEach((p_236100_, p_236101_) -> {
+          Path path = this.m_236109_(p_236100_);
++         //Forge: Only rewrite the cache file if the version id changed, there are new values, some values were removed, or the cache is missing
++         if (!p_236101_.f_236113_.f_236126_.equals(p_236101_.f_236114_.f_236126_) || p_236101_.f_236115_ > 0 || p_236101_.f_236114_.m_236133_() < p_236101_.f_236113_.m_236133_() || !Files.exists(path))
+          p_236101_.f_236114_.m_236142_(this.f_236079_, path, DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now()) + "\t" + p_236100_.m_6055_());
+          mutableint.add(p_236101_.f_236115_);
+       });
 @@ -231,10 +_,10 @@
                 bufferedwriter.write(p_236145_);
                 bufferedwriter.newLine();

--- a/patches/minecraft/net/minecraft/data/HashCache.java.patch
+++ b/patches/minecraft/net/minecraft/data/HashCache.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/data/HashCache.java
 +++ b/net/minecraft/data/HashCache.java
-@@ -92,6 +_,8 @@
+@@ -92,6 +_,7 @@
        MutableInt mutableint = new MutableInt();
        this.f_236083_.forEach((p_236100_, p_236101_) -> {
           Path path = this.m_236109_(p_236100_);
-+         //Forge: Only rewrite the cache file if the version id changed, there are new values, some values were removed, or the cache is missing
-+         if (!p_236101_.f_236113_.f_236126_.equals(p_236101_.f_236114_.f_236126_) || p_236101_.f_236115_ > 0 || p_236101_.f_236114_.m_236133_() < p_236101_.f_236113_.m_236133_() || !Files.exists(path))
++         if (!p_236101_.f_236114_.equals(p_236101_.f_236113_) || !Files.exists(path))//Forge: Only rewrite the cache file if it changed or is missing
           p_236101_.f_236114_.m_236142_(this.f_236079_, path, DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now()) + "\t" + p_236100_.m_6055_());
           mutableint.add(p_236101_.f_236115_);
        });


### PR DESCRIPTION
This PR fixes datagen caches being rewritten with a different date time every time the datagen is ran even if nothing changed about a file. The reason this is an annoyance/issue is that if you commit your caches so that other people don't have to rewrite all the files to disk when running your datagenerator, then every time to make any change (or even if you make zero changes and just rerun it), the datagen caches would end up being different and either committed extraneously or manually skip committing the ones that only had the header change.