### PR TITLE
[1.19.x] Add CommandBuildContext to Register Command Events

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -48,11 +48,14 @@
  
           if (p_205557_ instanceof CommandBlockEntity && this.f_104888_.f_91080_ instanceof CommandBlockEditScreen) {
              ((CommandBlockEditScreen)this.f_104888_.f_91080_).m_98398_();
-@@ -1185,6 +_,7 @@
+@@ -1184,7 +_,9 @@
+ 
     public void m_7443_(ClientboundCommandsPacket p_104990_) {
        PacketUtils.m_131363_(p_104990_, this, this.f_104888_);
-       this.f_104899_ = new CommandDispatcher<>(p_104990_.m_237624_(new CommandBuildContext(this.f_104903_)));
-+      this.f_104899_ = net.minecraftforge.client.ClientCommandHandler.mergeServerCommands(this.f_104899_);
+-      this.f_104899_ = new CommandDispatcher<>(p_104990_.m_237624_(new CommandBuildContext(this.f_104903_)));
++      var context = new CommandBuildContext(this.f_104903_);
++      this.f_104899_ = new CommandDispatcher<>(p_104990_.m_237624_(context));
++      this.f_104899_ = net.minecraftforge.client.ClientCommandHandler.mergeServerCommands(this.f_104899_, context);
     }
  
     public void m_7183_(ClientboundStopSoundPacket p_105116_) {

--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -13,7 +13,7 @@
        if (p_230943_.f_82144_) {
           PublishCommand.m_138184_(this.f_82090_);
        }
-+      net.minecraftforge.event.ForgeEventFactory.onCommandRegister(this.f_82090_, p_230943_);
++      net.minecraftforge.event.ForgeEventFactory.onCommandRegister(this.f_82090_, p_230943_, p_230944_);
  
        this.f_82090_.setConsumer((p_230954_, p_230955_, p_230956_) -> {
           p_230954_.getSource().m_81342_(p_230954_, p_230955_, p_230956_);

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -17,6 +17,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandRuntimeException;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
@@ -45,7 +46,7 @@ public class ClientCommandHandler
     private static void handleClientPlayerLogin(ClientPlayerNetworkEvent.LoggedInEvent event)
     {
         // some custom server implementations do not send ClientboundCommandsPacket, provide a fallback
-        var suggestionDispatcher = mergeServerCommands(new CommandDispatcher<>());
+        var suggestionDispatcher = mergeServerCommands(new CommandDispatcher<>(), new CommandBuildContext(event.getPlayer().connection.registryAccess()));
         if (event.getConnection().getPacketListener() instanceof ClientPacketListener listener)
         {
             // Must set this, so that suggestions for client-only commands work, if server never sends commands packet
@@ -59,10 +60,10 @@ public class ClientCommandHandler
      * Merges command dispatcher use for suggestions to the command dispatcher used for client commands so they can be sent to the server, and vice versa so client commands appear
      * with server commands in suggestions
      */
-    public static CommandDispatcher<SharedSuggestionProvider> mergeServerCommands(CommandDispatcher<SharedSuggestionProvider> serverCommands)
+    public static CommandDispatcher<SharedSuggestionProvider> mergeServerCommands(CommandDispatcher<SharedSuggestionProvider> serverCommands, CommandBuildContext buildContext)
     {
         CommandDispatcher<CommandSourceStack> commandsTemp = new CommandDispatcher<>();
-        MinecraftForge.EVENT_BUS.post(new RegisterClientCommandsEvent(commandsTemp));
+        MinecraftForge.EVENT_BUS.post(new RegisterClientCommandsEvent(commandsTemp, buildContext));
 
         // Copies the client commands into another RootCommandNode so that redirects can't be used with server commands
         commands = new CommandDispatcher<>();

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.client.event;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.ObjectiveArgument;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
@@ -36,14 +37,16 @@ public class RegisterClientCommandsEvent extends Event
 {
 
     private final CommandDispatcher<CommandSourceStack> dispatcher;
+    private final CommandBuildContext context;
 
     /**
      * @hidden
-     * @see net.minecraftforge.client.ClientCommandHandler#mergeServerCommands(CommandDispatcher)
+     * @see net.minecraftforge.client.ClientCommandHandler#mergeServerCommands(CommandDispatcher, CommandBuildContext)
      */
-    public RegisterClientCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher)
+    public RegisterClientCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context)
     {
         this.dispatcher = dispatcher;
+        this.context = context;
     }
 
     /**
@@ -52,5 +55,13 @@ public class RegisterClientCommandsEvent extends Event
     public CommandDispatcher<CommandSourceStack> getDispatcher()
     {
         return dispatcher;
+    }
+
+    /**
+     * @return the context to build the commands for
+     */
+    public CommandBuildContext getContext()
+    {
+        return context;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -58,9 +58,9 @@ public class RegisterClientCommandsEvent extends Event
     }
 
     /**
-     * @return the context to build the commands for
+     * {@return the context to build the commands for}
      */
-    public CommandBuildContext getContext()
+    public CommandBuildContext getBuildContext()
     {
         return context;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 import com.mojang.authlib.GameProfile;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.network.chat.ChatSender;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.players.PlayerList;
@@ -661,9 +662,9 @@ public class ForgeEventFactory
         return event.getListeners();
     }
 
-    public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment)
+    public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context)
     {
-        RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment);
+        RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment, context);
         MinecraftForge.EVENT_BUS.post(event);
     }
 

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
@@ -24,11 +25,13 @@ public class RegisterCommandsEvent extends Event
 {
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final Commands.CommandSelection environment;
+    private final CommandBuildContext context;
     
-    public RegisterCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment)
+    public RegisterCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context)
     {
         this.dispatcher = dispatcher;
         this.environment = environment;
+        this.context = context;
     }
     
     public CommandDispatcher<CommandSourceStack> getDispatcher()
@@ -39,5 +42,10 @@ public class RegisterCommandsEvent extends Event
     public Commands.CommandSelection getEnvironment()
     {
         return environment;
+    }
+
+    public CommandBuildContext getContext()
+    {
+        return context;
     }
 }

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -33,18 +33,27 @@ public class RegisterCommandsEvent extends Event
         this.environment = environment;
         this.context = context;
     }
-    
+
+    /**
+     * {@return the command dispatcher for registering commands to be executed on the client}
+     */
     public CommandDispatcher<CommandSourceStack> getDispatcher()
     {
         return dispatcher;
     }
-    
+
+    /**
+     * {@return the environment the command is being registered for}
+     */
     public Commands.CommandSelection getEnvironment()
     {
         return environment;
     }
 
-    public CommandBuildContext getContext()
+    /**
+     * {@return the context to build the commands for}
+     */
+    public CommandBuildContext getBuildContext()
     {
         return context;
     }


### PR DESCRIPTION
This expands `RegisterCommandsEvent` and `RegisterClientCommandsEvent` to accept a `CommandBuildContext` for holder lookups.