### PR TITLE
Implement item hooks for potions and enchantments

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/EnchantedBookItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/EnchantedBookItem.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/item/EnchantedBookItem.java
++++ b/net/minecraft/world/item/EnchantedBookItem.java
+@@ -72,7 +_,7 @@
+    public void m_6787_(CreativeModeTab p_41151_, NonNullList<ItemStack> p_41152_) {
+       if (p_41151_ == CreativeModeTab.f_40754_) {
+          for(Enchantment enchantment : Registry.f_122825_) {
+-            if (enchantment.f_44672_ != null) {
++            if (enchantment.allowedInCreativeTab(this, p_41151_)) {
+                for(int i = enchantment.m_44702_(); i <= enchantment.m_6586_(); ++i) {
+                   p_41152_.add(m_41161_(new EnchantmentInstance(enchantment, i)));
+                }
+@@ -80,7 +_,7 @@
+          }
+       } else if (p_41151_.m_40795_().length != 0) {
+          for(Enchantment enchantment1 : Registry.f_122825_) {
+-            if (p_41151_.m_40776_(enchantment1.f_44672_)) {
++            if (enchantment1.allowedInCreativeTab(this, p_41151_)) {
+                p_41152_.add(m_41161_(new EnchantmentInstance(enchantment1, enchantment1.m_6586_())));
+             }
+          }

--- a/patches/minecraft/net/minecraft/world/item/PotionItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/PotionItem.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/world/item/PotionItem.java
++++ b/net/minecraft/world/item/PotionItem.java
+@@ -127,12 +_,12 @@
+    }
+ 
+    public boolean m_5812_(ItemStack p_42999_) {
+-      return super.m_5812_(p_42999_) || !PotionUtils.m_43547_(p_42999_).isEmpty();
++      return super.m_5812_(p_42999_) || PotionUtils.m_43579_(p_42999_).isFoil(p_42999_);
+    }
+ 
+    public void m_6787_(CreativeModeTab p_42981_, NonNullList<ItemStack> p_42982_) {
+-      if (this.m_220152_(p_42981_)) {
+-         for(Potion potion : Registry.f_122828_) {
++      for(Potion potion : Registry.f_122828_) {
++         if (potion.allowedInCreativeTab(this, p_42981_, this.m_220152_(p_42981_))) {
+             if (potion != Potions.f_43598_) {
+                p_42982_.add(PotionUtils.m_43549_(new ItemStack(this), potion));
+             }

--- a/patches/minecraft/net/minecraft/world/item/TippedArrowItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/TippedArrowItem.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/TippedArrowItem.java
++++ b/net/minecraft/world/item/TippedArrowItem.java
+@@ -20,8 +_,8 @@
+    }
+ 
+    public void m_6787_(CreativeModeTab p_43356_, NonNullList<ItemStack> p_43357_) {
+-      if (this.m_220152_(p_43356_)) {
+-         for(Potion potion : Registry.f_122828_) {
++      for (Potion potion : Registry.f_122828_) {
++         if (potion.allowedInCreativeTab(this, p_43356_, this.m_220152_(p_43356_))) {
+             if (!potion.m_43488_().isEmpty()) {
+                p_43357_.add(PotionUtils.m_43549_(new ItemStack(this), potion));
+             }

--- a/patches/minecraft/net/minecraft/world/item/alchemy/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/alchemy/Potion.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/alchemy/Potion.java
++++ b/net/minecraft/world/item/alchemy/Potion.java
+@@ -7,7 +_,7 @@
+ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.world.effect.MobEffectInstance;
+ 
+-public class Potion {
++public class Potion implements net.minecraftforge.common.extensions.IForgePotion {
+    @Nullable
+    private final String f_43481_;
+    private final ImmutableList<MobEffectInstance> f_43482_;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEnchantment.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEnchantment.java
@@ -28,4 +28,19 @@ public interface IForgeEnchantment
     {
         return self().getDamageBonus(level, mobType);
     }
+
+    /**
+     * Should the book for this enchantment appear in the creative tab
+     * @param book Items.ENCHANTED_BOOK normally, but modded items may also use this hook.
+     * @param tab The creative tab that items are being added to
+     * @return true to put the item variant in the tab.
+     */
+    default boolean allowedInCreativeTab(net.minecraft.world.item.Item book, net.minecraft.world.item.CreativeModeTab tab) {
+        if(!self().isAllowedOnBooks())
+            return false;
+        else if(tab == net.minecraft.world.item.CreativeModeTab.TAB_SEARCH)
+            return self().category != null;
+        else
+            return tab.hasEnchantmentCategory(self().category);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEnchantment.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEnchantment.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.world.entity.MobType;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 
@@ -30,17 +32,24 @@ public interface IForgeEnchantment
     }
 
     /**
-     * Should the book for this enchantment appear in the creative tab
-     * @param book Items.ENCHANTED_BOOK normally, but modded items may also use this hook.
+     * Determines what creative tabs this enchantment's variant of an enchanted book or similar item should appear in.
+     * @param book The item being added to the creative tab
      * @param tab The creative tab that items are being added to
-     * @return true to put the item variant in the tab.
+     * @return whether the given Item's variant for this enchantment should appear in the respective creative tab
      */
-    default boolean allowedInCreativeTab(net.minecraft.world.item.Item book, net.minecraft.world.item.CreativeModeTab tab) {
-        if(!self().isAllowedOnBooks())
+    default boolean allowedInCreativeTab(Item book, CreativeModeTab tab)
+    {
+        if (!self().isAllowedOnBooks())
+        {
             return false;
-        else if(tab == net.minecraft.world.item.CreativeModeTab.TAB_SEARCH)
+        }
+        else if (tab == CreativeModeTab.TAB_SEARCH)
+        {
             return self().category != null;
+        }
         else
+        {
             return tab.hasEnchantmentCategory(self().category);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePotion.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePotion.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.item.alchemy.PotionUtils;
+
+public interface IForgePotion {
+    private Potion self() {
+        return (Potion)this;
+    }
+
+    /**
+     * Determines whether the potion-related item [bottle, tipped arrow, or a modded item] should appear in a creative tab.
+     * 
+     * @param item The item being added to a creative tab
+     * @param tab The tab items are being added to
+     * @param isDefaultTab The tab is the default tab for this item [e.g. Brewing for bottles, Combat for tipped arrows]
+     * @return true to put the item variant in the tab.
+     */
+    default boolean allowedInCreativeTab(Item item, CreativeModeTab tab, boolean isDefaultTab) {
+        return isDefaultTab;
+    }
+
+    /**
+     * Determines whether the potion bottle item should be enchanted.
+     *
+     * Not called for tipped arrows or if the item is already enchanted.
+     *
+     * @param stack The potion bottle
+     * @return true for enchanted appearance
+     */
+    default boolean isFoil(ItemStack stack) {
+        return !PotionUtils.getMobEffects(stack).isEmpty();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePotion.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePotion.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.world.item.CreativeModeTab;
@@ -6,32 +11,33 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionUtils;
 
-public interface IForgePotion {
-    private Potion self() {
-        return (Potion)this;
+public interface IForgePotion
+{
+    private Potion self()
+    {
+        return (Potion) this;
     }
 
     /**
-     * Determines whether the potion-related item [bottle, tipped arrow, or a modded item] should appear in a creative tab.
-     * 
+     * Determines what creative tabs this potion's variant of a potion-related item (e.g. bottles, tipped arrows) should appear in.
      * @param item The item being added to a creative tab
-     * @param tab The tab items are being added to
-     * @param isDefaultTab The tab is the default tab for this item [e.g. Brewing for bottles, Combat for tipped arrows]
-     * @return true to put the item variant in the tab.
+     * @param tab The creative tab that items are being added to
+     * @param isDefaultTab whether the tab is the default tab for this item (e.g. Brewing for bottles, Combat for tipped arrows)
+     * @return whether the given Item's variant for this enchantment should appear in the respective creative tab
      */
-    default boolean allowedInCreativeTab(Item item, CreativeModeTab tab, boolean isDefaultTab) {
+    default boolean allowedInCreativeTab(Item item, CreativeModeTab tab, boolean isDefaultTab)
+    {
         return isDefaultTab;
     }
 
     /**
      * Determines whether the potion bottle item should be enchanted.
-     *
      * Not called for tipped arrows or if the item is already enchanted.
-     *
      * @param stack The potion bottle
-     * @return true for enchanted appearance
+     * @return whether the item should appear enchanted.
      */
-    default boolean isFoil(ItemStack stack) {
+    default boolean isFoil(ItemStack stack)
+    {
         return !PotionUtils.getMobEffects(stack).isEmpty();
     }
 }


### PR DESCRIPTION
Add hooks for enchantments and potions to determine what tabs they go in for creative mode (or whether to appear in creative mode at all), and for potions to control whether the potion bottle has the enchanted 'foil' appearance.