### PR TITLE
A potential approach to registering order-dependent objects

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ObjectRegisteredEvent.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectRegisteredEvent.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.registries;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.event.IModBusEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public class ObjectRegisteredEvent extends Event implements IModBusEvent
+{
+    @NotNull
+    private final RegisterEvent registerEvent;
+    @NotNull
+    private final ResourceLocation location;
+    public ObjectRegisteredEvent(RegisterEvent registerEvent, ResourceLocation location)
+    {
+        this.registerEvent = registerEvent;
+        this.location = location;
+    }
+
+    public @NotNull RegisterEvent getRegisterEvent() {
+        return registerEvent;
+    }
+
+    public @NotNull ResourceLocation getLocation() {
+        return location;
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/ObjectRegisteredEvent.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectRegisteredEvent.java
@@ -14,17 +14,27 @@ public class ObjectRegisteredEvent extends Event implements IModBusEvent
     private final RegisterEvent registerEvent;
     @NotNull
     private final ResourceLocation location;
-    public ObjectRegisteredEvent(RegisterEvent registerEvent, ResourceLocation location)
+    private final Object value;
+
+    public ObjectRegisteredEvent(RegisterEvent registerEvent, ResourceLocation location, Object value)
     {
         this.registerEvent = registerEvent;
         this.location = location;
+        this.value = value;
     }
 
-    public @NotNull RegisterEvent getRegisterEvent() {
+    public @NotNull RegisterEvent getRegisterEvent()
+    {
         return registerEvent;
     }
 
-    public @NotNull ResourceLocation getLocation() {
+    public @NotNull ResourceLocation getLocation()
+    {
         return location;
+    }
+
+    public @NotNull Object getValue()
+    {
+        return value;
     }
 }

--- a/src/main/java/net/minecraftforge/registries/RegisterEvent.java
+++ b/src/main/java/net/minecraftforge/registries/RegisterEvent.java
@@ -62,11 +62,15 @@ public class RegisterEvent extends Event implements IModBusEvent
         {
             if (!protectedEntries.contains(name)) {
                 protectedEntries.add(name);
-                if (this.forgeRegistry != null)
-                    ((IForgeRegistry) this.forgeRegistry).register(name, valueSupplier.get());
-                else if (this.vanillaRegistry != null)
-                    Registry.register((Registry) this.vanillaRegistry, name, valueSupplier.get());
-                ObjectRegisteredEvent objectRegisteredEvent = new ObjectRegisteredEvent(this, name);
+                T value = null;
+                if (this.forgeRegistry != null) {
+                    value = valueSupplier.get();
+                    ((IForgeRegistry) this.forgeRegistry).register(name, value);
+                } else if (this.vanillaRegistry != null) {
+                    value = valueSupplier.get();
+                    Registry.register((Registry) this.vanillaRegistry, name, value);
+                }
+                ObjectRegisteredEvent objectRegisteredEvent = new ObjectRegisteredEvent(this, name, value);
                 ModLoader.get().postEventWithWrap(objectRegisteredEvent, (mc, e) -> ModLoadingContext.get().setActiveContainer(mc), (mc, e)-> ModLoadingContext.get().setActiveContainer(null));
                 protectedEntries.remove(name);
             } else


### PR DESCRIPTION
This is a draft of a possible approach to solving an issue I've had come up in my own mods, that requires a very hacky solution at present.

An example of the issue: Blocks need certain things (blockstate properties) to be defined prior to the constructor call, and other pieces (block properties) are extremely difficult to fully change after the constructor call. If you are registering a block that depends on the properties of another block, from a (possibly unknown at compile-time) different mod you have no control over, then it is necessary to ensure that your block registers after the other block in question. At present, this is extremely difficult to do. I have put together a first attempt at making this a bit easier - this PR simply provides a single ObjectRegisteredEvent, which is fired after an object is registered in a RegisterEvent and includes a reference to the ResourceLocation, the object in question, and the RegisterEvent it was registered in. There are definitely some aspects I'd like to clean up (for isntance, the object registered is currently a raw `Object`), but I figured I'd place it here as a draft PR so that I don't put too much time into this if it isn't going anywhere.