### PR TITLE
[1.19] Fix data-gen output path of custom data-pack registries

### DIFF
--- a/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
+++ b/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/info/WorldgenRegistryDumpReport.java
++++ b/net/minecraft/data/info/WorldgenRegistryDumpReport.java
+@@ -37,7 +_,7 @@
+    private <T> void m_236204_(CachedOutput p_236205_, RegistryAccess p_236206_, DynamicOps<JsonElement> p_236207_, RegistryAccess.RegistryData<T> p_236208_) {
+       ResourceKey<? extends Registry<T>> resourcekey = p_236208_.f_123101_();
+       Registry<T> registry = p_236206_.m_206191_(resourcekey);
+-      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135815_());
++      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135827_().equals("minecraft") ? resourcekey.m_135782_().m_135815_() : resourcekey.m_135782_().m_135827_() + resourcekey.m_135782_().m_135815_());// FORGE: Custom data-pack registries are prefixed with their namespace
+ 
+       for(Map.Entry<ResourceKey<T>, T> entry : registry.m_6579_()) {
+          m_236209_(datagenerator$pathprovider.m_236048_(entry.getKey().m_135782_()), p_236205_, p_236207_, p_236208_.f_123102_(), entry.getValue());

--- a/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
+++ b/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
@@ -5,7 +5,7 @@
        ResourceKey<? extends Registry<T>> resourcekey = p_236208_.f_123101_();
        Registry<T> registry = p_236206_.m_206191_(resourcekey);
 -      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135815_());
-+      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, net.minecraftforge.registries.DataPackRegistriesHooks.prefixNamespace(resourcekey.m_135782_())); // FORGE: Custom data-pack registries are prefixed with their namespace
++      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, net.minecraftforge.common.ForgeHooks.prefixNamespace(resourcekey.m_135782_())); // FORGE: Custom data-pack registries are prefixed with their namespace
  
        for(Map.Entry<ResourceKey<T>, T> entry : registry.m_6579_()) {
           m_236209_(datagenerator$pathprovider.m_236048_(entry.getKey().m_135782_()), p_236205_, p_236207_, p_236208_.f_123102_(), entry.getValue());

--- a/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
+++ b/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
@@ -1,11 +1,19 @@
 --- a/net/minecraft/data/info/WorldgenRegistryDumpReport.java
 +++ b/net/minecraft/data/info/WorldgenRegistryDumpReport.java
+@@ -16,6 +_,7 @@
+ import net.minecraft.data.DataProvider;
+ import net.minecraft.resources.RegistryOps;
+ import net.minecraft.resources.ResourceKey;
++import net.minecraftforge.registries.DataPackRegistriesHooks;
+ import org.slf4j.Logger;
+ 
+ public class WorldgenRegistryDumpReport implements DataProvider {
 @@ -37,7 +_,7 @@
     private <T> void m_236204_(CachedOutput p_236205_, RegistryAccess p_236206_, DynamicOps<JsonElement> p_236207_, RegistryAccess.RegistryData<T> p_236208_) {
        ResourceKey<? extends Registry<T>> resourcekey = p_236208_.f_123101_();
        Registry<T> registry = p_236206_.m_206191_(resourcekey);
 -      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135815_());
-+      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135827_().equals("minecraft") ? resourcekey.m_135782_().m_135815_() : resourcekey.m_135782_().m_135827_() + resourcekey.m_135782_().m_135815_());// FORGE: Custom data-pack registries are prefixed with their namespace
++      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, DataPackRegistriesHooks.prefixNamespace(resourcekey.m_135782_()));// FORGE: Custom data-pack registries are prefixed with their namespace
  
        for(Map.Entry<ResourceKey<T>, T> entry : registry.m_6579_()) {
           m_236209_(datagenerator$pathprovider.m_236048_(entry.getKey().m_135782_()), p_236205_, p_236207_, p_236208_.f_123102_(), entry.getValue());

--- a/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
+++ b/patches/minecraft/net/minecraft/data/info/WorldgenRegistryDumpReport.java.patch
@@ -1,19 +1,11 @@
 --- a/net/minecraft/data/info/WorldgenRegistryDumpReport.java
 +++ b/net/minecraft/data/info/WorldgenRegistryDumpReport.java
-@@ -16,6 +_,7 @@
- import net.minecraft.data.DataProvider;
- import net.minecraft.resources.RegistryOps;
- import net.minecraft.resources.ResourceKey;
-+import net.minecraftforge.registries.DataPackRegistriesHooks;
- import org.slf4j.Logger;
- 
- public class WorldgenRegistryDumpReport implements DataProvider {
 @@ -37,7 +_,7 @@
     private <T> void m_236204_(CachedOutput p_236205_, RegistryAccess p_236206_, DynamicOps<JsonElement> p_236207_, RegistryAccess.RegistryData<T> p_236208_) {
        ResourceKey<? extends Registry<T>> resourcekey = p_236208_.f_123101_();
        Registry<T> registry = p_236206_.m_206191_(resourcekey);
 -      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, resourcekey.m_135782_().m_135815_());
-+      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, DataPackRegistriesHooks.prefixNamespace(resourcekey.m_135782_()));// FORGE: Custom data-pack registries are prefixed with their namespace
++      DataGenerator.PathProvider datagenerator$pathprovider = this.f_194676_.m_236036_(DataGenerator.Target.REPORTS, net.minecraftforge.registries.DataPackRegistriesHooks.prefixNamespace(resourcekey.m_135782_())); // FORGE: Custom data-pack registries are prefixed with their namespace
  
        for(Map.Entry<ResourceKey<T>, T> entry : registry.m_6579_()) {
           m_236209_(datagenerator$pathprovider.m_236048_(entry.getKey().m_135782_()), p_236205_, p_236207_, p_236208_.f_123102_(), entry.getValue());

--- a/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/resources/RegistryResourceAccess.java
 +++ b/net/minecraft/resources/RegistryResourceAccess.java
-@@ -21,6 +_,7 @@
- import net.minecraft.core.Registry;
- import net.minecraft.core.RegistryAccess;
- import net.minecraft.server.packs.resources.ResourceManager;
-+import net.minecraftforge.registries.DataPackRegistriesHooks;
- import org.slf4j.Logger;
- 
- public interface RegistryResourceAccess {
 @@ -47,7 +_,7 @@
  
                       DataResult dataresult;
@@ -39,7 +31,7 @@
  
           private static String m_214239_(ResourceLocation p_214240_) {
 -            return p_214240_.m_135815_();
-+            return DataPackRegistriesHooks.prefixNamespace(p_214240_);// FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
++            return net.minecraftforge.registries.DataPackRegistriesHooks.prefixNamespace(p_214240_); // FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
           }
  
           private static <E> ResourceLocation m_214268_(ResourceKey<E> p_214269_) {

--- a/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/resources/RegistryResourceAccess.java
 +++ b/net/minecraft/resources/RegistryResourceAccess.java
+@@ -21,6 +_,7 @@
+ import net.minecraft.core.Registry;
+ import net.minecraft.core.RegistryAccess;
+ import net.minecraft.server.packs.resources.ResourceManager;
++import net.minecraftforge.registries.DataPackRegistriesHooks;
+ import org.slf4j.Logger;
+ 
+ public interface RegistryResourceAccess {
 @@ -47,7 +_,7 @@
  
                       DataResult dataresult;
@@ -18,7 +26,7 @@
                       } catch (Throwable throwable1) {
                          if (reader != null) {
                             try {
-@@ -107,12 +_,15 @@
+@@ -107,13 +_,14 @@
              });
           }
  
@@ -30,8 +38,8 @@
           }
  
           private static String m_214239_(ResourceLocation p_214240_) {
-+            if (net.minecraftforge.registries.RegistryManager.FROZEN.getRegistry(p_214240_) != null && !(p_214240_.m_135827_().equals("minecraft")))
-+               return p_214240_.m_135827_() + "/" + p_214240_.m_135815_(); // FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
-             return p_214240_.m_135815_();
+-            return p_214240_.m_135815_();
++            return DataPackRegistriesHooks.prefixNamespace(p_214240_);// FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
           }
  
+          private static <E> ResourceLocation m_214268_(ResourceKey<E> p_214269_) {

--- a/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryResourceAccess.java.patch
@@ -31,7 +31,7 @@
  
           private static String m_214239_(ResourceLocation p_214240_) {
 -            return p_214240_.m_135815_();
-+            return net.minecraftforge.registries.DataPackRegistriesHooks.prefixNamespace(p_214240_); // FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
++            return net.minecraftforge.common.ForgeHooks.prefixNamespace(p_214240_); // FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
           }
  
           private static <E> ResourceLocation m_214268_(ResourceKey<E> p_214269_) {

--- a/patches/minecraft/net/minecraft/tags/TagManager.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagManager.java.patch
@@ -1,12 +1,11 @@
 --- a/net/minecraft/tags/TagManager.java
 +++ b/net/minecraft/tags/TagManager.java
-@@ -30,7 +_,8 @@
+@@ -30,7 +_,7 @@
  
     public static String m_203918_(ResourceKey<? extends Registry<?>> p_203919_) {
        String s = f_203902_.get(p_203919_);
 -      return s != null ? s : "tags/" + p_203919_.m_135782_().m_135815_();
-+      ResourceLocation registryName = p_203919_.m_135782_();
-+      return s != null ? s : "tags/" + (registryName.m_135827_().equals("minecraft") ? "" : registryName.m_135827_() + "/") + registryName.m_135815_();
++      return s != null ? s : "tags/" + net.minecraftforge.common.ForgeHooks.prefixNamespace(p_203919_.m_135782_());
     }
  
     public CompletableFuture<Void> m_5540_(PreparableReloadListener.PreparationBarrier p_13482_, ResourceManager p_13483_, ProfilerFiller p_13484_, ProfilerFiller p_13485_, Executor p_13486_, Executor p_13487_) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1424,4 +1424,28 @@ public class ForgeHooks
 
         return map.buildOrThrow();
     }
+
+    /**
+     * <p>
+     *    This method is used to prefix the path, where elements of the associated registry are stored, with their namespace, if it is not minecraft
+     * </p>
+     * <p>
+     *    This rules conflicts with equal paths out. If for example the mod {@code fancy_cheese} adds a registry named {@code cheeses},
+     *    but the mod {@code awesome_cheese} also adds a registry called {@code cheeses},
+     *    they are going to have the same path {@code cheeses}, just with different namespaces.
+     *    If {@code additional_cheese} wants to add additional cheese to {@code awesome_cheese}, but not {@code fancy_cheese},
+     *    it can not differentiate both. Both paths will look like {@code data/additional_cheese/cheeses}.
+     * </p>
+     * <p>
+     *    The fix, which is applied here prefixes the path of the registry with the namespace,
+     *    so {@code fancy_cheese}'s registry stores its elements in {@code data/<namespace>/fancy_cheese/cheeses}
+     *    and {@code awesome_cheese}'s registry stores its elements in {@code data/namespace/awesome_cheese/cheeses}
+     * </p>
+     *
+     * @param registryKey key of the registry
+     * @return path of the registry key. Prefixed with the namespace if it is not "minecraft"
+     */
+    public static String prefixNamespace(ResourceLocation registryKey) {
+        return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();
+    }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1445,7 +1445,8 @@ public class ForgeHooks
      * @param registryKey key of the registry
      * @return path of the registry key. Prefixed with the namespace if it is not "minecraft"
      */
-    public static String prefixNamespace(ResourceLocation registryKey) {
+    public static String prefixNamespace(ResourceLocation registryKey)
+    {
         return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();
     }
 }

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,5 +57,14 @@ public final class DataPackRegistriesHooks
     public static Set<ResourceKey<? extends Registry<?>>> getSyncedCustomRegistries()
     {
         return SYNCED_CUSTOM_REGISTRIES_VIEW;
+    }
+
+    /**
+     *  FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
+     * @param registryKey original registry key
+     * @return path of the registry key. Prefixed with the modid if it wasn't minecraft
+     */
+    public static String prefixNamespace(ResourceLocation registryKey) {
+        return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();
     }
 }

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -60,9 +60,27 @@ public final class DataPackRegistriesHooks
     }
 
     /**
-     *  FORGE: add non-vanilla registry namespace to loader directory, same format as tag directory (see net.minecraft.tags.TagManager#getTagDir(ResourceKey))
-     * @param registryKey original registry key
-     * @return path of the registry key. Prefixed with the modid if it wasn't minecraft
+     * <p>
+     *    This method is used to prefix the path, where elements of the associated registry are stored, with their namespace, if it is not minecraft
+     * </p>
+     * <p>
+     *    This rules conflicts with equal paths out. If for example the mod {@code fancy_cheese} adds a registry named {@code cheeses},
+     *    but the mod {@code awesome_cheese} also adds a registry called {@code cheeses},
+     *    they are going to have the same path {@code cheeses}, just with different namespaces.
+     *    If {@code additional_cheese} wants to add additional cheese to {@code awesome_cheese}, but not {@code fancy_cheese},
+     *    it can not differentiate both. Both paths will look like {@code data/additional_cheese/cheeses}.
+     * </p>
+     * <p>
+     *    The fix, which is applied here prefixes the path of the registry with the namespace,
+     *    so {@code fancy_cheese}'s registry stores its elements in {@code data/<namespace>/fancy_cheese/cheeses}
+     *    and {@code awesome_cheese}'s registry stores its elements in {@code data/namespace/awesome_cheese/cheeses}
+     * </p>
+     * <p>
+     *    This is the same format as tag directory (see {@link net.minecraft.tags.TagManager#getTagDir(ResourceKey)})
+     * </p>
+     *
+     * @param registryKey key of the registry
+     * @return path of the registry key. Prefixed with the namespace if it is not "minecraft"
      */
     public static String prefixNamespace(ResourceLocation registryKey) {
         return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -57,32 +56,5 @@ public final class DataPackRegistriesHooks
     public static Set<ResourceKey<? extends Registry<?>>> getSyncedCustomRegistries()
     {
         return SYNCED_CUSTOM_REGISTRIES_VIEW;
-    }
-
-    /**
-     * <p>
-     *    This method is used to prefix the path, where elements of the associated registry are stored, with their namespace, if it is not minecraft
-     * </p>
-     * <p>
-     *    This rules conflicts with equal paths out. If for example the mod {@code fancy_cheese} adds a registry named {@code cheeses},
-     *    but the mod {@code awesome_cheese} also adds a registry called {@code cheeses},
-     *    they are going to have the same path {@code cheeses}, just with different namespaces.
-     *    If {@code additional_cheese} wants to add additional cheese to {@code awesome_cheese}, but not {@code fancy_cheese},
-     *    it can not differentiate both. Both paths will look like {@code data/additional_cheese/cheeses}.
-     * </p>
-     * <p>
-     *    The fix, which is applied here prefixes the path of the registry with the namespace,
-     *    so {@code fancy_cheese}'s registry stores its elements in {@code data/<namespace>/fancy_cheese/cheeses}
-     *    and {@code awesome_cheese}'s registry stores its elements in {@code data/namespace/awesome_cheese/cheeses}
-     * </p>
-     * <p>
-     *    This is the same format as tag directory (see {@link net.minecraft.tags.TagManager#getTagDir(ResourceKey)})
-     * </p>
-     *
-     * @param registryKey key of the registry
-     * @return path of the registry key. Prefixed with the namespace if it is not "minecraft"
-     */
-    public static String prefixNamespace(ResourceLocation registryKey) {
-        return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();
     }
 }


### PR DESCRIPTION
This aims to fix output path of custom data-pack registries for datagen.

In #8630, there was a discussion about prefixing the resource key with the namespace or just prefix it on usage. It was decided to go for option two, but one usage was missed. Here is a fix to align registry dump report output path with the path it reads from.

### Patches:
- Patch WorldgenRegistryDumpReport to prefix the output path with the namespace if it's not "minecraft"