### PR TITLE
[1.19.x] Fix experimental confirmation screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1192,7 +1192,7 @@ project(':forge') {
 
     def baseForgeVersion = System.getProperty("forge.compatibility_check_version")
     if (baseForgeVersion == null)
-        baseForgeVersion = "${MC_VERSION}-${GIT_INFO.tag}.0"
+        baseForgeVersion = "1.19-41.0.1" // "${MC_VERSION}-${GIT_INFO.tag}.0"
     if (baseForgeVersion == "null")
         baseForgeVersion = null // Allow disabling from system property if not wanted
     def baseForgeUniversal = null
@@ -1228,7 +1228,7 @@ project(':forge') {
             }.toArray(Dependency[]::new))
 
             baseJar = project.tasks.applyBaseCompatibilityJarBinPatches.output
-            baseLibraries.from(baseForgeUniversal)
+            baseLibraries.from(project.configurations.detachedConfiguration(baseForgeUniversal))
             baseLibraries.from(project.tasks.createJoinedSRG.output)
             baseLibraries.from(fmlLibs)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1192,6 +1192,7 @@ project(':forge') {
 
     def baseForgeVersion = System.getProperty("forge.compatibility_check_version")
     if (baseForgeVersion == null)
+        // FIXME: Restore commented out portion when next tagged (41.1 or 42.0), assuming that a .0 build is published
         baseForgeVersion = "1.19-41.0.1" // "${MC_VERSION}-${GIT_INFO.tag}.0"
     if (baseForgeVersion == "null")
         baseForgeVersion = null // Allow disabling from system property if not wanted

--- a/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
@@ -1,13 +1,29 @@
 --- a/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java
 +++ b/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java
-@@ -138,6 +_,7 @@
+@@ -132,13 +_,23 @@
+    }
+ 
+    private void m_233145_(Screen p_233146_, String p_233147_, boolean p_233148_, boolean p_233149_) {
++      // FORGE: Patch in overload to reduce further patching
++      this.doLoadLevel(p_233146_, p_233147_, p_233148_, p_233149_, false);
++   }
++
++   // FORGE: Patch in confirmExperimentalWarning which confirms the experimental warning when true
++   private void doLoadLevel(Screen p_233146_, String p_233147_, boolean p_233148_, boolean p_233149_, boolean confirmExperimentalWarning) {
+       LevelStorageSource.LevelStorageAccess levelstoragesource$levelstorageaccess = this.m_233155_(p_233147_);
+       if (levelstoragesource$levelstorageaccess != null) {
+          PackRepository packrepository = m_233105_(levelstoragesource$levelstorageaccess);
  
           WorldStem worldstem;
           try {
 +            levelstoragesource$levelstorageaccess.readAdditionalLevelSaveData(); // Read extra (e.g. modded) data from the world before creating it
              worldstem = this.m_233122_(levelstoragesource$levelstorageaccess, p_233148_, packrepository);
++            if (confirmExperimentalWarning && worldstem.f_206895_() instanceof PrimaryLevelData pld) {
++               pld.withConfirmedWarning(true);
++            }
           } catch (Exception exception) {
              f_233088_.warn("Failed to load datapacks, can't proceed with server load", (Throwable)exception);
+             this.f_233089_.m_91152_(new DatapackLoadFailureScreen(() -> {
 @@ -151,7 +_,9 @@
           WorldData worlddata = worldstem.f_206895_();
           boolean flag = worlddata.m_5961_().m_64670_();
@@ -27,7 +43,7 @@
              this.m_233140_(p_233146_, p_233147_, flag, () -> {
                 this.m_233145_(p_233146_, p_233147_, p_233148_, false);
              });
-+            else net.minecraftforge.client.ForgeHooksClient.createWorldConfirmationScreen(p_233147_, levelstoragesource$levelstorageaccess, packrepository, worldstem);
++            else net.minecraftforge.client.ForgeHooksClient.createWorldConfirmationScreen(() -> this.doLoadLevel(p_233146_, p_233147_, p_233148_, false, true));
              worldstem.close();
              m_233116_(levelstoragesource$levelstorageaccess, p_233147_);
           }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -28,8 +28,6 @@ import net.minecraft.locale.Language;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.*;
 import net.minecraft.network.protocol.status.ServerStatus;
-import net.minecraft.server.WorldStem;
-import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -78,8 +76,6 @@ import net.minecraft.client.player.Input;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.material.FogType;
-import net.minecraft.world.level.storage.LevelStorageSource;
-import net.minecraft.world.level.storage.PrimaryLevelData;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -1059,9 +1055,7 @@ public class ForgeHooksClient
         return ItemBlockRenderTypes.canRenderInLayer(state, RenderType.solid());
     }
 
-    public static void createWorldConfirmationScreen(
-            String worldName, LevelStorageSource.LevelStorageAccess levelStorageAccess,
-            PackRepository packRepository, WorldStem worldStem)
+    public static void createWorldConfirmationScreen(Runnable doConfirmedWorldLoad)
     {
         Component title = Component.translatable("selectWorld.backupQuestion.experimental");
         Component msg = Component.translatable("selectWorld.backupWarning.experimental")
@@ -1072,11 +1066,7 @@ public class ForgeHooksClient
         {
             if (confirmed)
             {
-                if (worldStem.worldData() instanceof PrimaryLevelData pld)
-                {
-                    pld.withConfirmedWarning(true);
-                }
-                Minecraft.getInstance().doWorldLoad(worldName, levelStorageAccess, packRepository, worldStem);
+                doConfirmedWorldLoad.run();
             }
             else
             {

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -1,5 +1,6 @@
 net/minecraft/advancements/Advancement$Builder.fromJson(Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;Lnet/minecraftforge/common/crafting/conditions/ICondition$IContext;)Lnet/minecraft/advancements/Advancement$Builder;=|p_138381_,p_138382_,context
 net/minecraft/client/gui/screens/MenuScreens.getScreenFactory(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/Minecraft;ILnet/minecraft/network/chat/Component;)Ljava/util/Optional;=|p_96202_,p_96203_,p_96204_,p_96205_
+net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.doLoadLevel(Lnet/minecraft/client/gui/screens/Screen;Ljava/lang/String;ZZZ)V=|p_233146_,p_233147_,p_233148_,p_233149_,confirmExperimentalWarning
 net/minecraft/client/renderer/ScreenEffectRenderer.getOverlayBlock(Lnet/minecraft/world/entity/player/Player;)Lorg/apache/commons/lang3/tuple/Pair;=|p_110717_
 net/minecraft/client/renderer/ShaderInstance.<init>(Lnet/minecraft/server/packs/resources/ResourceProvider;Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;)V=|p_173336_,shaderLocation,p_173338_
 net/minecraft/client/renderer/block/BlockModelShaper.getTexture(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;=|p_110883_,level,pos


### PR DESCRIPTION
A porting error (by me) led to the wrong method being used in `ForgeHooksClient#createWorldConfirmationScreen` when the user confirmed that they wanted to proceed on loading the experimental world.
This is due to the fact that the directory lock is closed directly after `createWorldConfirmationScreen` is invoked.
However, the same directory lock instance is reused without being reopened once the user confirms.
This is incorrect and leads to a crash 100% of the time. Instead, the proper fix is to use `WorldOpenFlows#doLoadLevel` (which has similar method contexts to what was used in 1.18.2 inside `ForgeHooksClient#createWorldConfirmationScreen`).
We must now patch this method to be able to set `PrimaryLevelData#withConfirmedWarning` to true, as there is no way to get the world stem inside `createWorldCreationScreen`.
Simple fix, oopsie on my part.

Also unrelated is an inclusion which fixes checkJarCompatibility, which I also broke during the 1.19 update.
So that people can run it locally, and (potentially) during CI.
Didn't make a separate PR for this cuz it's minor and a waste of a build imo.

Fixes #8713.
Can be reproduced with the datapack provided on the original issue [here](https://github.com/MinecraftForge/MinecraftForge/issues/8713#issuecomment-1152347183).
Without the PR -> game crashes after clicking proceed on an existing world w/ experimental settings.
With the PR -> world proceeds to load after clicking proceed on an existing world w/ experimental settings.