### PR TITLE
Fix EnumArgument to use enum names for suggestions

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/EnumArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/EnumArgument.java
@@ -43,18 +43,18 @@ public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
         try {
             return Enum.valueOf(enumClass, name);
         } catch (IllegalArgumentException e) {
-            throw INVALID_ENUM.createWithContext(reader, name, Arrays.toString(enumClass.getEnumConstants()));
+            throw INVALID_ENUM.createWithContext(reader, name, Arrays.toString(Arrays.stream(enumClass.getEnumConstants()).map(Enum::name).toArray()));
         }
     }
 
     @Override
     public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
-        return SharedSuggestionProvider.suggest(Stream.of(enumClass.getEnumConstants()).map(Object::toString), builder);
+        return SharedSuggestionProvider.suggest(Stream.of(enumClass.getEnumConstants()).map(Enum::name), builder);
     }
 
     @Override
     public Collection<String> getExamples() {
-        return Stream.of(enumClass.getEnumConstants()).map(Object::toString).collect(Collectors.toList());
+        return Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.toList());
     }
 
     public static class Info<T extends Enum<T>> implements ArgumentTypeInfo<EnumArgument<T>, Info<T>.Template>


### PR DESCRIPTION
This PR fixes #8618 by fixing `EnumArgument`'s suggestions to use the names for enum values via `Enum#name()`, instead of their representations from `Enum#toString()`.

`EnumArgument` uses `Enum#valueOf()` to parse the names of enum values to their actual value instances. By default, the `toString()` of an enum value is the same as its enum name; however, the method may be overriden to return a different string other than their name.

This causes issues with the suggestions from `EnumArgument`, which uses the `toString()` of the enum value rather than their `name()`, when paired with enums which override `toString()` to be different from `name()`, such as `Direction.Axis`. This PR changes the use of `toString()` to `name()`, fixing the problem.

As a potential future enhancement, `EnumArgument` could be taught to recognize `StringRepresentable` enums (which is most of Minecraft's enums) and use the serialized name instead of the enum name. For now, unless requested, I've scoped this PR to fixing the enum argument and leave it to a future contributor (such as myself) to make that enhancement.

As the issue also exists for 1.18, a PR will be made for that version once this PR has been assigned.