### PR TITLE
[1.19.x] Affect ItemEntity Motion in Custom Fluids

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -32,7 +32,7 @@
           Vec3 vec3 = this.m_20184_();
           float f = this.m_20192_() - 0.11111111F;
 +         net.minecraftforge.fluids.FluidType fluidType = this.getMaxHeightFluidType();
-+         if (!fluidType.isAir() && !fluidType.isVanilla() && this.getFluidTypeHeight(fluidType) > (double)f) fluidType.setItemMovement(this);
++         if (!fluidType.isAir() && !fluidType.isVanilla() && this.getFluidTypeHeight(fluidType) > (double)f) fluidType.setItemMovement(this); else
           if (this.m_20069_() && this.m_204036_(FluidTags.f_13131_) > (double)f) {
              this.m_32067_();
           } else if (this.m_20077_() && this.m_204036_(FluidTags.f_13132_) > (double)f) {

--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -27,12 +27,13 @@
        if (this.m_32055_().m_41619_()) {
           this.m_146870_();
        } else {
-@@ -100,6 +_,8 @@
+@@ -100,6 +_,9 @@
           this.f_19856_ = this.m_20189_();
           Vec3 vec3 = this.m_20184_();
           float f = this.m_20192_() - 0.11111111F;
 +         net.minecraftforge.fluids.FluidType fluidType = this.getMaxHeightFluidType();
-+         if (!fluidType.isAir() && !fluidType.isVanilla() && this.getFluidTypeHeight(fluidType) > (double)f) fluidType.setItemMovement(this); else
++         if (!fluidType.isAir() && !fluidType.isVanilla() && this.getFluidTypeHeight(fluidType) > (double)f) fluidType.setItemMovement(this);
++         else
           if (this.m_20069_() && this.m_204036_(FluidTags.f_13131_) > (double)f) {
              this.m_32067_();
           } else if (this.m_20077_() && this.m_204036_(FluidTags.f_13132_) > (double)f) {


### PR DESCRIPTION
Readds an accidental patch removal when reducing patch sizes allowing custom fluids to affect item entity motion.