### PR TITLE
[LTS] Fix EnumArgument to use enum names for suggestions

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/EnumArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/EnumArgument.java
@@ -42,18 +42,18 @@ public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
         try {
             return Enum.valueOf(enumClass, name);
         } catch (IllegalArgumentException e) {
-            throw INVALID_ENUM.createWithContext(reader, name, Arrays.toString(enumClass.getEnumConstants()));
+            throw INVALID_ENUM.createWithContext(reader, name, Arrays.toString(Arrays.stream(enumClass.getEnumConstants()).map(Enum::name).toArray()));
         }
     }
 
     @Override
     public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
-        return SharedSuggestionProvider.suggest(Stream.of(enumClass.getEnumConstants()).map(Object::toString), builder);
+        return SharedSuggestionProvider.suggest(Stream.of(enumClass.getEnumConstants()).map(Enum::name), builder);
     }
 
     @Override
     public Collection<String> getExamples() {
-        return Stream.of(enumClass.getEnumConstants()).map(Object::toString).collect(Collectors.toList());
+        return Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.toList());
     }
 
     public static class Serializer implements ArgumentSerializer<EnumArgument<?>>


### PR DESCRIPTION
This PR is an LTS backport of #8728, which fixes #8618 by fixing EnumArgument's suggestions to use the names for enum values via Enum#name(), instead of their representations from Enum#toString(). See the aforementioned PR for more details.