### PR TITLE
Fire ChunkWatchEvents after sending packets

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -31,14 +31,14 @@
              this.m_63502_(chunkpos, compoundtag);
              this.m_140229_(chunkpos, chunkstatus.m_62494_());
              return true;
-@@ -848,6 +_,7 @@
+@@ -862,6 +_,7 @@
  
-    protected void m_183754_(ServerPlayer p_183755_, ChunkPos p_183756_, MutableObject<ClientboundLevelChunkWithLightPacket> p_183757_, boolean p_183758_, boolean p_183759_) {
-       if (p_183755_.f_19853_ == this.f_140133_) {
-+         net.minecraftforge.event.ForgeEventFactory.fireChunkWatch(p_183758_, p_183759_, p_183755_, p_183756_, this.f_140133_);
-          if (p_183759_ && !p_183758_) {
-             ChunkHolder chunkholder = this.m_140327_(p_183756_.m_45588_());
-             if (chunkholder != null) {
+          if (!p_183759_ && p_183758_) {
+             p_183755_.m_9088_(p_183756_);
++            net.minecraftforge.event.ForgeEventFactory.fireChunkUnWatch(p_183755_, p_183756_, this.f_140133_);
+          }
+ 
+       }
 @@ -1104,7 +_,7 @@
     }
  
@@ -48,3 +48,11 @@
           EntityType<?> entitytype = p_140200_.m_6095_();
           int i = entitytype.m_20681_() * 16;
           if (i != 0) {
+@@ -1230,6 +_,7 @@
+          }
+       }
+ 
++      net.minecraftforge.event.ForgeEventFactory.fireChunkWatch(p_183761_, p_183763_, this.f_140133_);
+    }
+ 
+    protected PoiManager m_140424_() {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -21,6 +21,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
@@ -624,18 +625,14 @@ public class ForgeEventFactory
         return event.getResult() != Result.DENY;
     }
 
-    public static void fireChunkWatch(boolean watch, ServerPlayer entity, ChunkPos chunkpos, ServerLevel level)
+    public static void fireChunkWatch(ServerPlayer entity, LevelChunk chunk, ServerLevel level)
     {
-        if (watch)
-            MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.Watch(entity, chunkpos, level));
-        else
-            MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, level));
+        MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.Watch(entity, chunk, level));
     }
 
-    public static void fireChunkWatch(boolean wasLoaded, boolean load, ServerPlayer entity, ChunkPos chunkpos, ServerLevel level)
+    public static void fireChunkUnWatch(ServerPlayer entity, ChunkPos chunkpos, ServerLevel level)
     {
-        if (wasLoaded != load)
-            fireChunkWatch(load, entity, chunkpos, level);
+        MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, level));
     }
 
     public static boolean onPistonMovePre(Level level, BlockPos pos, Direction direction, boolean extending)

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -14,18 +14,19 @@ import net.minecraftforge.eventbus.api.Event;
 import org.apache.commons.lang3.mutable.MutableObject;
 
 /**
- * ChunkWatchEvent is fired when an event involving a chunk being watched occurs.<br>
+ * ChunkWatchEvent is fired when an event involving a chunk being watched occurs.
+ * <p>
  * If a method utilizes this {@link Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
+ * receive every child event of this class.
+ * <p>
  * {@link #pos} contains the ChunkPos of the Chunk this event is affecting.<br>
  * {@link #world} contains the World of the Chunk this event is affecting.<br>
- * {@link #player} contains the EntityPlayer that is involved with this chunk being watched. <br>
- * <br>
+ * {@link #player} contains the {@link ServerPlayer} that is involved with this chunk being watched.
+ * <p>
  * The {@link #player}'s world may not be the same as the world of the chunk
- * when the player is teleporting to another dimension.<br>
- * <br>
- * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * when the player is teleporting to another dimension.
+ * <p>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class ChunkWatchEvent extends Event
 {
@@ -56,15 +57,16 @@ public class ChunkWatchEvent extends Event
     }
 
     /**
-     * ChunkWatchEvent.Watch is fired when an EntityPlayer begins watching a chunk.<br>
-     * This event is fired when a chunk is added to the watched chunks of an EntityPlayer and sent to the player in
-     * {@code net.minecraft.server.level.ChunkMap#playerLoadedChunk(ServerPlayer, MutableObject, LevelChunk)}. <br>
-     * <br>
-     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult} <br>
-     * <br>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * ChunkWatchEvent.Watch is fired when a {@link ServerPlayer} begins watching a chunk.
+     * <p>
+     * This event is fired when a chunk is added to the watched chunks of a {@link ServerPlayer}
+     * and the chunk's data is sent to the client (see
+     * {@code net.minecraft.server.level.ChunkMap#playerLoadedChunk(ServerPlayer, MutableObject, LevelChunk)}).
+     * <p>
+     * This event may be used to send additional chunk-related data to the client.
+     * <p>
+     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable} and
+     * {@link HasResult does not have a result}.
      **/
     public static class Watch extends ChunkWatchEvent
     {
@@ -83,15 +85,13 @@ public class ChunkWatchEvent extends Event
     }
 
     /**
-     * ChunkWatchEvent.UnWatch is fired when an EntityPlayer stops watching a chunk.<br>
-     * This event is fired when a chunk is removed from the watched chunks of an EntityPlayer in
-     * {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}. <br>
-     * <br>
-     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult} <br>
-     * <br>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     * ChunkWatchEvent.UnWatch is fired when a {@link ServerPlayer} stops watching a chunk.
+     * <p>
+     * This event is fired when a chunk is removed from the watched chunks of an {@link ServerPlayer}
+     * in {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}.
+     * <p>
+     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable} and
+     * {@link HasResult does not have a result}.
      **/
     public static class UnWatch extends ChunkWatchEvent
     {

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -8,8 +8,10 @@ package net.minecraftforge.event.world;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
+import org.apache.commons.lang3.mutable.MutableObject;
 
 /**
  * ChunkWatchEvent is fired when an event involving a chunk being watched occurs.<br>
@@ -55,8 +57,8 @@ public class ChunkWatchEvent extends Event
 
     /**
      * ChunkWatchEvent.Watch is fired when an EntityPlayer begins watching a chunk.<br>
-     * This event is fired when a chunk is added to the watched chunks of an EntityPlayer in
-     * {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}. <br>
+     * This event is fired when a chunk is added to the watched chunks of an EntityPlayer and sent to the player in
+     * {@code net.minecraft.server.level.ChunkMap#playerLoadedChunk(ServerPlayer, MutableObject, LevelChunk)}. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>
@@ -66,7 +68,18 @@ public class ChunkWatchEvent extends Event
      **/
     public static class Watch extends ChunkWatchEvent
     {
-        public Watch(ServerPlayer player, ChunkPos pos, ServerLevel world) {super(player, pos, world);}
+        private final LevelChunk chunk;
+
+        public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel world)
+        {
+            super(player, chunk.getPos(), world);
+            this.chunk = chunk;
+        }
+
+        public LevelChunk getChunk()
+        {
+            return this.chunk;
+        }
     }
 
     /**


### PR DESCRIPTION
Sorry for submitting this breaking change so close to the deadline!

A common use-case for the `ChunkWatchEvent.Watch` event is to sync chunk-relevant data to the client. However, since Mojang's various rewrites of chunk loading, it's much more awkward to achieve this.

Currently, `ChunkWatchEvent.Watch` is fired when the player starts watching a chunk but before the chunk is actually loaded or sent to the client. This means mods either schedule a task next tick to sync their additional data or (incorrectly) forcibly load the chunk while handling the event (which defeats the whole point of async chunk loading!).

This change moves where the `ChunkWatchEvent`s events are fired from:
 - `ChunkWatchEvent.Watch` is now fired just after the chunk data is sent to the client.
 - `ChunkWatchEvent.UnWatch` is now fired after `ClientboundForgetLevelChunkPacket` is sent to the client.

For what it's worth, this matches the original semantics of this event - though I realise chunk loading has changed a lot since then so those behaviours may not be entirely desirable.

---

I'm also happy to keep the current events as is and add a new one which fires after chunk data is sent, if that's preferred?