### PR TITLE
[1.19.x] Support Mob-Specific Behavior in Custom Fluids

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/AxolotlModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/AxolotlModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/AxolotlModel.java
++++ b/net/minecraft/client/model/AxolotlModel.java
+@@ -81,7 +_,7 @@
+          this.m_170388_(p_170395_);
+       } else {
+          boolean flag = p_170395_.m_20184_().m_165925_() > 1.0E-7D || p_170395_.m_146909_() != p_170395_.f_19860_ || p_170395_.m_146908_() != p_170395_.f_19859_ || p_170395_.f_19790_ != p_170395_.m_20185_() || p_170395_.f_19792_ != p_170395_.m_20189_();
+-         if (p_170395_.m_20072_()) {
++         if (p_170395_.m_20072_() || p_170395_.isInFluidType((fluidType, height) -> p_170395_.canSwimInFluidType(fluidType))) {
+             if (flag) {
+                this.m_170422_(p_170398_, p_170400_);
+             } else {

--- a/patches/minecraft/net/minecraft/client/model/CodModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/CodModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/CodModel.java
++++ b/net/minecraft/client/model/CodModel.java
+@@ -41,7 +_,7 @@
+ 
+    public void m_6973_(T p_102409_, float p_102410_, float p_102411_, float p_102412_, float p_102413_, float p_102414_) {
+       float f = 1.0F;
+-      if (!p_102409_.m_20069_()) {
++      if (!(p_102409_.m_20069_() || p_102409_.isInFluidType((fluidType, height) -> p_102409_.canSwimInFluidType(fluidType)))) {
+          f = 1.5F;
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/model/SalmonModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/SalmonModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/SalmonModel.java
++++ b/net/minecraft/client/model/SalmonModel.java
+@@ -45,7 +_,7 @@
+    public void m_6973_(T p_103640_, float p_103641_, float p_103642_, float p_103643_, float p_103644_, float p_103645_) {
+       float f = 1.0F;
+       float f1 = 1.0F;
+-      if (!p_103640_.m_20069_()) {
++      if (!(p_103640_.m_20069_() || p_103640_.isInFluidType((fluidType, height) -> p_103640_.canSwimInFluidType(fluidType)))) {
+          f = 1.3F;
+          f1 = 1.7F;
+       }

--- a/patches/minecraft/net/minecraft/client/model/TadpoleModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/TadpoleModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/TadpoleModel.java
++++ b/net/minecraft/client/model/TadpoleModel.java
+@@ -43,7 +_,7 @@
+    }
+ 
+    public void m_6973_(T p_233453_, float p_233454_, float p_233455_, float p_233456_, float p_233457_, float p_233458_) {
+-      float f = p_233453_.m_20069_() ? 1.0F : 1.5F;
++      float f = p_233453_.m_20069_() || p_233453_.isInFluidType((fluidType, height) -> p_233453_.canSwimInFluidType(fluidType)) ? 1.0F : 1.5F;
+       this.f_233441_.f_104204_ = -f * 0.25F * Mth.m_14031_(0.3F * p_233456_);
+    }
+ }

--- a/patches/minecraft/net/minecraft/client/model/TropicalFishModelA.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/TropicalFishModelA.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/TropicalFishModelA.java
++++ b/net/minecraft/client/model/TropicalFishModelA.java
+@@ -40,7 +_,7 @@
+ 
+    public void m_6973_(T p_103961_, float p_103962_, float p_103963_, float p_103964_, float p_103965_, float p_103966_) {
+       float f = 1.0F;
+-      if (!p_103961_.m_20069_()) {
++      if (!(p_103961_.m_20069_() || p_103961_.isInFluidType((fluidType, height) -> p_103961_.canSwimInFluidType(fluidType)))) {
+          f = 1.5F;
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/model/TropicalFishModelB.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/TropicalFishModelB.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/TropicalFishModelB.java
++++ b/net/minecraft/client/model/TropicalFishModelB.java
+@@ -41,7 +_,7 @@
+ 
+    public void m_6973_(T p_103977_, float p_103978_, float p_103979_, float p_103980_, float p_103981_, float p_103982_) {
+       float f = 1.0F;
+-      if (!p_103977_.m_20069_()) {
++      if (!(p_103977_.m_20069_() || p_103977_.isInFluidType((fluidType, height) -> p_103977_.canSwimInFluidType(fluidType)))) {
+          f = 1.5F;
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/model/TurtleModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/TurtleModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/model/TurtleModel.java
++++ b/net/minecraft/client/model/TurtleModel.java
+@@ -55,7 +_,7 @@
+       this.f_170855_.f_104204_ = 0.0F;
+       this.f_170852_.f_104204_ = 0.0F;
+       this.f_170853_.f_104204_ = 0.0F;
+-      if (!p_103994_.m_20069_() && p_103994_.m_20096_()) {
++      if (!(p_103994_.m_20069_() || p_103994_.isInFluidType((fluidType, height) -> p_103994_.canSwimInFluidType(fluidType))) && p_103994_.m_20096_()) {
+          float f = p_103994_.m_30206_() ? 4.0F : 1.0F;
+          float f1 = p_103994_.m_30206_() ? 2.0F : 1.0F;
+          float f2 = 5.0F;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/CodRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/CodRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/entity/CodRenderer.java
++++ b/net/minecraft/client/renderer/entity/CodRenderer.java
+@@ -26,7 +_,7 @@
+       super.m_7523_(p_114017_, p_114018_, p_114019_, p_114020_, p_114021_);
+       float f = 4.3F * Mth.m_14031_(0.6F * p_114019_);
+       p_114018_.m_85845_(Vector3f.f_122225_.m_122240_(f));
+-      if (!p_114017_.m_20069_()) {
++      if (!(p_114017_.m_20069_() || p_114017_.isInFluidType((fluidType, height) -> p_114017_.canSwimInFluidType(fluidType)))) {
+          p_114018_.m_85837_((double)0.1F, (double)0.1F, (double)-0.1F);
+          p_114018_.m_85845_(Vector3f.f_122227_.m_122240_(90.0F));
+       }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/SalmonRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/SalmonRenderer.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/renderer/entity/SalmonRenderer.java
++++ b/net/minecraft/client/renderer/entity/SalmonRenderer.java
+@@ -26,7 +_,7 @@
+       super.m_7523_(p_115828_, p_115829_, p_115830_, p_115831_, p_115832_);
+       float f = 1.0F;
+       float f1 = 1.0F;
+-      if (!p_115828_.m_20069_()) {
++      if (!(p_115828_.m_20069_() || p_115828_.isInFluidType((fluidType, height) -> p_115828_.canSwimInFluidType(fluidType)))) {
+          f = 1.3F;
+          f1 = 1.7F;
+       }
+@@ -34,7 +_,7 @@
+       float f2 = f * 4.3F * Mth.m_14031_(f1 * 0.6F * p_115830_);
+       p_115829_.m_85845_(Vector3f.f_122225_.m_122240_(f2));
+       p_115829_.m_85837_(0.0D, 0.0D, (double)-0.4F);
+-      if (!p_115828_.m_20069_()) {
++      if (!(p_115828_.m_20069_() || p_115828_.isInFluidType((fluidType, height) -> p_115828_.canSwimInFluidType(fluidType)))) {
+          p_115829_.m_85837_((double)0.2F, (double)0.1F, 0.0D);
+          p_115829_.m_85845_(Vector3f.f_122227_.m_122240_(90.0F));
+       }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/TropicalFishRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/TropicalFishRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/entity/TropicalFishRenderer.java
++++ b/net/minecraft/client/renderer/entity/TropicalFishRenderer.java
+@@ -42,7 +_,7 @@
+       super.m_7523_(p_116226_, p_116227_, p_116228_, p_116229_, p_116230_);
+       float f = 4.3F * Mth.m_14031_(0.6F * p_116228_);
+       p_116227_.m_85845_(Vector3f.f_122225_.m_122240_(f));
+-      if (!p_116226_.m_20069_()) {
++      if (!(p_116226_.m_20069_() || p_116226_.isInFluidType((fluidType, height) -> p_116226_.canSwimInFluidType(fluidType)))) {
+          p_116227_.m_85837_((double)0.2F, (double)0.1F, 0.0D);
+          p_116227_.m_85845_(Vector3f.f_122227_.m_122240_(90.0F));
+       }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -480,12 +480,13 @@
              if (map == null) {
                 map = Maps.newEnumMap(EquipmentSlot.class);
              }
-@@ -2502,6 +_,8 @@
+@@ -2502,6 +_,9 @@
        this.f_19853_.m_46473_().m_6180_("jump");
        if (this.f_20899_ && this.m_6129_()) {
           double d7;
 +         net.minecraftforge.fluids.FluidType fluidType = this.getMaxHeightFluidType();
 +         if (!fluidType.isAir()) d7 = this.getFluidTypeHeight(fluidType);
++         else
           if (this.m_20077_()) {
              d7 = this.m_204036_(FluidTags.f_13132_);
           } else {

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/RandomSwim.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/RandomSwim.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/behavior/RandomSwim.java
++++ b/net/minecraft/world/entity/ai/behavior/RandomSwim.java
+@@ -14,7 +_,7 @@
+    }
+ 
+    protected boolean m_6114_(ServerLevel p_147858_, PathfinderMob p_147859_) {
+-      return p_147859_.m_20072_();
++      return p_147859_.m_20072_() || p_147859_.isInFluidType((fluidType, height) -> p_147859_.canSwimInFluidType(fluidType));
+    }
+ 
+    @Nullable

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindLand.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindLand.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/ai/behavior/TryFindLand.java
++++ b/net/minecraft/world/entity/ai/behavior/TryFindLand.java
+@@ -29,7 +_,7 @@
+    }
+ 
+    protected boolean m_6114_(ServerLevel p_217428_, PathfinderMob p_217429_) {
+-      return p_217429_.f_19853_.m_6425_(p_217429_.m_20183_()).m_205070_(FluidTags.f_13131_);
++      return p_217429_.canSwimInFluidType(p_217429_.f_19853_.m_6425_(p_217429_.m_20183_()).getFluidType());
+    }
+ 
+    protected void m_6735_(ServerLevel p_217435_, PathfinderMob p_217436_, long p_217437_) {
+@@ -42,7 +_,7 @@
+             if (blockpos1.m_123341_() != blockpos.m_123341_() || blockpos1.m_123343_() != blockpos.m_123343_()) {
+                BlockState blockstate = p_217435_.m_8055_(blockpos1);
+                BlockState blockstate1 = p_217435_.m_8055_(blockpos$mutableblockpos.m_122159_(blockpos1, Direction.DOWN));
+-               if (!blockstate.m_60713_(Blocks.f_49990_) && p_217435_.m_6425_(blockpos1).m_76178_() && blockstate.m_60742_(p_217435_, blockpos1, collisioncontext).m_83281_() && blockstate1.m_60783_(p_217435_, blockpos$mutableblockpos, Direction.UP)) {
++               if (p_217435_.m_6425_(blockpos1).m_76178_() && blockstate.m_60742_(p_217435_, blockpos1, collisioncontext).m_83281_() && blockstate1.m_60783_(p_217435_, blockpos$mutableblockpos, Direction.UP)) {
+                   this.f_217416_ = p_217437_ + 60L;
+                   BehaviorUtils.m_22617_(p_217436_, blockpos1.m_7949_(), this.f_217415_, 1);
+                   return;

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindLandNearWater.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindLandNearWater.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/ai/behavior/TryFindLandNearWater.java
++++ b/net/minecraft/world/entity/ai/behavior/TryFindLandNearWater.java
+@@ -27,7 +_,7 @@
+    }
+ 
+    protected boolean m_6114_(ServerLevel p_217456_, PathfinderMob p_217457_) {
+-      return !p_217457_.f_19853_.m_6425_(p_217457_.m_20183_()).m_205070_(FluidTags.f_13131_);
++      return !p_217457_.canSwimInFluidType(p_217457_.f_19853_.m_6425_(p_217457_.m_20183_()).getFluidType());
+    }
+ 
+    protected void m_6735_(ServerLevel p_217463_, PathfinderMob p_217464_, long p_217465_) {
+@@ -40,7 +_,7 @@
+             if ((blockpos1.m_123341_() != blockpos.m_123341_() || blockpos1.m_123343_() != blockpos.m_123343_()) && p_217463_.m_8055_(blockpos1).m_60742_(p_217463_, blockpos1, collisioncontext).m_83281_() && !p_217463_.m_8055_(blockpos$mutableblockpos.m_122159_(blockpos1, Direction.DOWN)).m_60742_(p_217463_, blockpos1, collisioncontext).m_83281_()) {
+                for(Direction direction : Direction.Plane.HORIZONTAL) {
+                   blockpos$mutableblockpos.m_122159_(blockpos1, direction);
+-                  if (p_217463_.m_8055_(blockpos$mutableblockpos).m_60795_() && p_217463_.m_8055_(blockpos$mutableblockpos.m_122173_(Direction.DOWN)).m_60713_(Blocks.f_49990_)) {
++                  if (p_217463_.m_8055_(blockpos$mutableblockpos).m_60795_() && p_217464_.canSwimInFluidType(p_217463_.m_8055_(blockpos$mutableblockpos.m_122173_(Direction.DOWN)).m_60819_().getFluidType())) {
+                      this.f_217444_ = p_217465_ + 40L;
+                      BehaviorUtils.m_22617_(p_217464_, blockpos1, this.f_217443_, 0);
+                      return;

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindWater.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryFindWater.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/ai/behavior/TryFindWater.java
++++ b/net/minecraft/world/entity/ai/behavior/TryFindWater.java
+@@ -26,7 +_,7 @@
+    }
+ 
+    protected boolean m_6114_(ServerLevel p_148012_, PathfinderMob p_148013_) {
+-      return !p_148013_.f_19853_.m_6425_(p_148013_.m_20183_()).m_205070_(FluidTags.f_13131_);
++      return !p_148013_.canSwimInFluidType(p_148013_.f_19853_.m_6425_(p_148013_.m_20183_()).getFluidType());
+    }
+ 
+    protected void m_6735_(ServerLevel p_148019_, PathfinderMob p_148020_, long p_148021_) {
+@@ -39,7 +_,7 @@
+             if (blockpos3.m_123341_() != blockpos2.m_123341_() || blockpos3.m_123343_() != blockpos2.m_123343_()) {
+                BlockState blockstate = p_148020_.f_19853_.m_8055_(blockpos3.m_7494_());
+                BlockState blockstate1 = p_148020_.f_19853_.m_8055_(blockpos3);
+-               if (blockstate1.m_60713_(Blocks.f_49990_)) {
++               if (p_148020_.canSwimInFluidType(blockstate1.m_60819_().getFluidType())) {
+                   if (blockstate.m_60795_()) {
+                      blockpos = blockpos3.m_7949_();
+                      break;

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java
++++ b/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java
+@@ -24,7 +_,7 @@
+    }
+ 
+    protected boolean m_6114_(ServerLevel p_217483_, Frog p_217484_) {
+-      return !p_217484_.m_20069_() && p_217484_.m_20096_();
++      return !(p_217484_.m_20069_() || p_217484_.isInFluidType((fluidType, height) -> p_217484_.canSwimInFluidType(fluidType))) && p_217484_.m_20096_();
+    }
+ 
+    protected void m_6735_(ServerLevel p_217486_, Frog p_217487_, long p_217488_) {
+@@ -32,7 +_,7 @@
+ 
+       for(Direction direction : Direction.Plane.HORIZONTAL) {
+          BlockPos blockpos1 = blockpos.m_121945_(direction);
+-         if (p_217486_.m_8055_(blockpos1).m_60713_(Blocks.f_49990_)) {
++         if (p_217487_.canSwimInFluidType(p_217486_.m_8055_(blockpos1).m_60819_().getFluidType())) {
+             BlockPos blockpos2 = blockpos1.m_7494_();
+             if (p_217486_.m_8055_(blockpos2).m_60795_()) {
+                p_217486_.m_7731_(blockpos2, this.f_217470_.m_49966_(), 3);

--- a/patches/minecraft/net/minecraft/world/entity/ai/control/SmoothSwimmingMoveControl.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/control/SmoothSwimmingMoveControl.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/ai/control/SmoothSwimmingMoveControl.java
++++ b/net/minecraft/world/entity/ai/control/SmoothSwimmingMoveControl.java
+@@ -21,7 +_,7 @@
+    }
+ 
+    public void m_8126_() {
+-      if (this.f_148068_ && this.f_24974_.m_20069_()) {
++      if (this.f_148068_ && (this.f_24974_.m_20069_() || this.f_24974_.isInFluidType((fluidType, height) -> this.f_24974_.canSwimInFluidType(fluidType)))) {
+          this.f_24974_.m_20256_(this.f_24974_.m_20184_().m_82520_(0.0D, 0.005D, 0.0D));
+       }
+ 
+@@ -38,7 +_,7 @@
+             this.f_24974_.f_20883_ = this.f_24974_.m_146908_();
+             this.f_24974_.f_20885_ = this.f_24974_.m_146908_();
+             float f1 = (float)(this.f_24978_ * this.f_24974_.m_21133_(Attributes.f_22279_));
+-            if (this.f_24974_.m_20069_()) {
++            if (this.f_24974_.m_20069_() || this.f_24974_.isInFluidType((fluidType, height) -> this.f_24974_.canSwimInFluidType(fluidType))) {
+                this.f_24974_.m_7910_(f1 * this.f_148066_);
+                double d4 = Math.sqrt(d0 * d0 + d2 * d2);
+                if (Math.abs(d1) > (double)1.0E-5F || Math.abs(d4) > (double)1.0E-5F) {

--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/DolphinJumpGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/DolphinJumpGoal.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/ai/goal/DolphinJumpGoal.java
++++ b/net/minecraft/world/entity/ai/goal/DolphinJumpGoal.java
+@@ -41,7 +_,7 @@
+ 
+    private boolean m_25172_(BlockPos p_25173_, int p_25174_, int p_25175_, int p_25176_) {
+       BlockPos blockpos = p_25173_.m_7918_(p_25174_ * p_25176_, 0, p_25175_ * p_25176_);
+-      return this.f_25163_.f_19853_.m_6425_(blockpos).m_205070_(FluidTags.f_13131_) && !this.f_25163_.f_19853_.m_8055_(blockpos).m_60767_().m_76334_();
++      return this.f_25163_.canSwimInFluidType(this.f_25163_.f_19853_.m_6425_(blockpos).getFluidType()) && !this.f_25163_.f_19853_.m_8055_(blockpos).m_60767_().m_76334_();
+    }
+ 
+    private boolean m_25178_(BlockPos p_25179_, int p_25180_, int p_25181_, int p_25182_) {
+@@ -50,7 +_,7 @@
+ 
+    public boolean m_8045_() {
+       double d0 = this.f_25163_.m_20184_().f_82480_;
+-      return (!(d0 * d0 < (double)0.03F) || this.f_25163_.m_146909_() == 0.0F || !(Math.abs(this.f_25163_.m_146909_()) < 10.0F) || !this.f_25163_.m_20069_()) && !this.f_25163_.m_20096_();
++      return (!(d0 * d0 < (double)0.03F) || this.f_25163_.m_146909_() == 0.0F || !(Math.abs(this.f_25163_.m_146909_()) < 10.0F) || !(this.f_25163_.m_20069_() || this.f_25163_.isInFluidType((fluidType, height) -> this.f_25163_.canSwimInFluidType(fluidType)))) && !this.f_25163_.m_20096_();
+    }
+ 
+    public boolean m_6767_() {
+@@ -71,7 +_,7 @@
+       boolean flag = this.f_25165_;
+       if (!flag) {
+          FluidState fluidstate = this.f_25163_.f_19853_.m_6425_(this.f_25163_.m_20183_());
+-         this.f_25165_ = fluidstate.m_205070_(FluidTags.f_13131_);
++         this.f_25165_ = this.f_25163_.canSwimInFluidType(fluidstate.getFluidType());
+       }
+ 
+       if (this.f_25165_ && !flag) {

--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/PanicGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/PanicGoal.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/goal/PanicGoal.java
++++ b/net/minecraft/world/entity/ai/goal/PanicGoal.java
+@@ -80,7 +_,7 @@
+    protected BlockPos m_198172_(BlockGetter p_198173_, Entity p_198174_, int p_198175_) {
+       BlockPos blockpos = p_198174_.m_20183_();
+       return !p_198173_.m_8055_(blockpos).m_60812_(p_198173_, blockpos).m_83281_() ? null : BlockPos.m_121930_(p_198174_.m_20183_(), p_198175_, 1, (p_196649_) -> {
+-         return p_198173_.m_6425_(p_196649_).m_205070_(FluidTags.f_13131_);
++         return p_198174_.canSwimInFluidType(p_198173_.m_6425_(p_196649_).getFluidType());
+       }).orElse((BlockPos)null);
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/TryFindWaterGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/TryFindWaterGoal.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/entity/ai/goal/TryFindWaterGoal.java
++++ b/net/minecraft/world/entity/ai/goal/TryFindWaterGoal.java
+@@ -13,14 +_,14 @@
+    }
+ 
+    public boolean m_8036_() {
+-      return this.f_25962_.m_20096_() && !this.f_25962_.f_19853_.m_6425_(this.f_25962_.m_20183_()).m_205070_(FluidTags.f_13131_);
++      return this.f_25962_.m_20096_() && !this.f_25962_.canSwimInFluidType(this.f_25962_.f_19853_.m_6425_(this.f_25962_.m_20183_()).getFluidType());
+    }
+ 
+    public void m_8056_() {
+       BlockPos blockpos = null;
+ 
+       for(BlockPos blockpos1 : BlockPos.m_121976_(Mth.m_14107_(this.f_25962_.m_20185_() - 2.0D), Mth.m_14107_(this.f_25962_.m_20186_() - 2.0D), Mth.m_14107_(this.f_25962_.m_20189_() - 2.0D), Mth.m_14107_(this.f_25962_.m_20185_() + 2.0D), this.f_25962_.m_146904_(), Mth.m_14107_(this.f_25962_.m_20189_() + 2.0D))) {
+-         if (this.f_25962_.f_19853_.m_6425_(blockpos1).m_205070_(FluidTags.f_13131_)) {
++         if (this.f_25962_.canSwimInFluidType(this.f_25962_.f_19853_.m_6425_(blockpos1).getFluidType())) {
+             blockpos = blockpos1;
+             break;
+          }

--- a/patches/minecraft/net/minecraft/world/entity/ai/navigation/PathNavigation.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/navigation/PathNavigation.java.patch
@@ -14,3 +14,12 @@
        if (flag || this.f_26494_.m_21481_(this.f_26496_.m_77401_().f_77282_) && this.m_26559_(vec3)) {
           this.f_26496_.m_77374_();
        }
+@@ -317,7 +_,7 @@
+    protected abstract boolean m_7632_();
+ 
+    protected boolean m_26574_() {
+-      return this.f_26494_.m_20072_() || this.f_26494_.m_20077_();
++      return this.f_26494_.m_20072_() || this.f_26494_.m_20077_() || this.f_26494_.isInFluidType((fluidType, height) -> this.f_26494_.canSwimInFluidType(fluidType));
+    }
+ 
+    protected void m_6804_() {

--- a/patches/minecraft/net/minecraft/world/entity/ai/sensing/IsInWaterSensor.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/sensing/IsInWaterSensor.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/sensing/IsInWaterSensor.java
++++ b/net/minecraft/world/entity/ai/sensing/IsInWaterSensor.java
+@@ -13,7 +_,7 @@
+    }
+ 
+    protected void m_5578_(ServerLevel p_217816_, LivingEntity p_217817_) {
+-      if (p_217817_.m_20069_()) {
++      if (p_217817_.m_20069_() || p_217817_.isInFluidType((fluidType, height) -> p_217817_.canSwimInFluidType(fluidType))) {
+          p_217817_.m_6274_().m_21879_(MemoryModuleType.f_217766_, Unit.INSTANCE);
+       } else {
+          p_217817_.m_6274_().m_21936_(MemoryModuleType.f_217766_);

--- a/patches/minecraft/net/minecraft/world/entity/animal/AbstractFish.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/AbstractFish.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/animal/AbstractFish.java
++++ b/net/minecraft/world/entity/animal/AbstractFish.java
+@@ -94,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_27490_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(0.01F, p_27490_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));
+@@ -108,7 +_,7 @@
+    }
+ 
+    public void m_8107_() {
+-      if (!this.m_20069_() && this.f_19861_ && this.f_19863_) {
++      if (!(this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) && this.f_19861_ && this.f_19863_) {
+          this.m_20256_(this.m_20184_().m_82520_((double)((this.f_19796_.m_188501_() * 2.0F - 1.0F) * 0.05F), (double)0.4F, (double)((this.f_19796_.m_188501_() * 2.0F - 1.0F) * 0.05F)));
+          this.f_19861_ = false;
+          this.f_19812_ = true;
+@@ -156,7 +_,7 @@
+       }
+ 
+       public void m_8126_() {
+-         if (this.f_27499_.m_204029_(FluidTags.f_13131_)) {
++         if (this.f_27499_.canSwimInFluidType(this.f_27499_.getEyeInFluidType())) {
+             this.f_27499_.m_20256_(this.f_27499_.m_20184_().m_82520_(0.0D, 0.005D, 0.0D));
+          }
+ 

--- a/patches/minecraft/net/minecraft/world/entity/animal/Bee.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Bee.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/Bee.java
 +++ b/net/minecraft/world/entity/animal/Bee.java
+@@ -340,7 +_,7 @@
+ 
+    protected void m_8024_() {
+       boolean flag = this.m_27857_();
+-      if (this.m_20072_()) {
++      if (this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType))) {
+          ++this.f_27702_;
+       } else {
+          this.f_27702_ = 0;
 @@ -472,7 +_,7 @@
           return false;
        } else {

--- a/patches/minecraft/net/minecraft/world/entity/animal/Dolphin.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Dolphin.java.patch
@@ -1,0 +1,71 @@
+--- a/net/minecraft/world/entity/animal/Dolphin.java
++++ b/net/minecraft/world/entity/animal/Dolphin.java
+@@ -68,6 +_,7 @@
+    static final TargetingConditions f_28311_ = TargetingConditions.m_148353_().m_26883_(10.0D).m_148355_();
+    public static final int f_148892_ = 4800;
+    private static final int f_148893_ = 2400;
++   @Deprecated // FORGE: Use ForgeHooks#dolphinAllowedItems instead
+    public static final Predicate<ItemEntity> f_28309_ = (p_28369_) -> {
+       return !p_28369_.m_32063_() && p_28369_.m_6084_() && p_28369_.m_20069_();
+    };
+@@ -229,7 +_,7 @@
+       if (this.m_21525_()) {
+          this.m_20301_(this.m_6062_());
+       } else {
+-         if (this.m_20071_()) {
++         if (this.m_20071_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) {
+             this.m_28343_(2400);
+          } else {
+             this.m_28343_(this.m_28378_() - 1);
+@@ -245,7 +_,7 @@
+             }
+          }
+ 
+-         if (this.f_19853_.f_46443_ && this.m_20069_() && this.m_20184_().m_82556_() > 0.03D) {
++         if (this.f_19853_.f_46443_ && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) && this.m_20184_().m_82556_() > 0.03D) {
+             Vec3 vec3 = this.m_20252_(0.0F);
+             float f = Mth.m_14089_(this.m_146908_() * ((float)Math.PI / 180F)) * 0.3F;
+             float f1 = Mth.m_14031_(this.m_146908_() * ((float)Math.PI / 180F)) * 0.3F;
+@@ -325,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_28383_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(this.m_6113_(), p_28383_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));
+@@ -399,7 +_,7 @@
+ 
+             if (vec31 != null) {
+                BlockPos blockpos = new BlockPos(vec31);
+-               if (!level.m_6425_(blockpos).m_205070_(FluidTags.f_13131_) || !level.m_8055_(blockpos).m_60647_(level, blockpos, PathComputationType.WATER)) {
++               if (!this.f_28399_.canSwimInFluidType(level.m_6425_(blockpos).getFluidType()) || !level.m_8055_(blockpos).m_60647_(level, blockpos, PathComputationType.WATER)) {
+                   vec31 = DefaultRandomPos.m_148412_(this.f_28399_, 8, 5, vec3, (double)((float)Math.PI / 2F));
+                }
+             }
+@@ -475,13 +_,13 @@
+          if (this.f_28421_ > Dolphin.this.f_19797_) {
+             return false;
+          } else {
+-            List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), Dolphin.f_28309_);
++            List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), net.minecraftforge.common.ForgeHooks.dolphinAllowedItems(Dolphin.this));
+             return !list.isEmpty() || !Dolphin.this.m_6844_(EquipmentSlot.MAINHAND).m_41619_();
+          }
+       }
+ 
+       public void m_8056_() {
+-         List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), Dolphin.f_28309_);
++         List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), net.minecraftforge.common.ForgeHooks.dolphinAllowedItems(Dolphin.this));
+          if (!list.isEmpty()) {
+             Dolphin.this.m_21573_().m_5624_(list.get(0), (double)1.2F);
+             Dolphin.this.m_5496_(SoundEvents.f_11806_, 1.0F, 1.0F);
+@@ -501,7 +_,7 @@
+       }
+ 
+       public void m_8037_() {
+-         List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), Dolphin.f_28309_);
++         List<ItemEntity> list = Dolphin.this.f_19853_.m_6443_(ItemEntity.class, Dolphin.this.m_20191_().m_82377_(8.0D, 8.0D, 8.0D), net.minecraftforge.common.ForgeHooks.dolphinAllowedItems(Dolphin.this));
+          ItemStack itemstack = Dolphin.this.m_6844_(EquipmentSlot.MAINHAND);
+          if (!itemstack.m_41619_()) {
+             this.m_28428_(itemstack);

--- a/patches/minecraft/net/minecraft/world/entity/animal/Squid.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Squid.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/world/entity/animal/Squid.java
++++ b/net/minecraft/world/entity/animal/Squid.java
+@@ -109,7 +_,7 @@
+          }
+       }
+ 
+-      if (this.m_20072_()) {
++      if (this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) {
+          if (this.f_29940_ < (float)Math.PI) {
+             float f = this.f_29940_ / (float)Math.PI;
+             this.f_29942_ = Mth.m_14031_(f * f * (float)Math.PI) * (float)Math.PI * 0.25F;
+@@ -217,7 +_,7 @@
+ 
+       public boolean m_8036_() {
+          LivingEntity livingentity = Squid.this.m_21188_();
+-         if (Squid.this.m_20069_() && livingentity != null) {
++         if ((Squid.this.m_20069_() || Squid.this.isInFluidType((fluidType, height) -> Squid.this.canSwimInFluidType(fluidType))) && livingentity != null) {
+             return Squid.this.m_20280_(livingentity) < 100.0D;
+          } else {
+             return false;
+@@ -239,7 +_,7 @@
+             Vec3 vec3 = new Vec3(Squid.this.m_20185_() - livingentity.m_20185_(), Squid.this.m_20186_() - livingentity.m_20186_(), Squid.this.m_20189_() - livingentity.m_20189_());
+             BlockState blockstate = Squid.this.f_19853_.m_8055_(new BlockPos(Squid.this.m_20185_() + vec3.f_82479_, Squid.this.m_20186_() + vec3.f_82480_, Squid.this.m_20189_() + vec3.f_82481_));
+             FluidState fluidstate = Squid.this.f_19853_.m_6425_(new BlockPos(Squid.this.m_20185_() + vec3.f_82479_, Squid.this.m_20186_() + vec3.f_82480_, Squid.this.m_20189_() + vec3.f_82481_));
+-            if (fluidstate.m_205070_(FluidTags.f_13131_) || blockstate.m_60795_()) {
++            if (Squid.this.canSwimInFluidType(fluidstate.getFluidType()) || blockstate.m_60795_()) {
+                double d0 = vec3.m_82553_();
+                if (d0 > 0.0D) {
+                   vec3.m_82541_();
+@@ -283,7 +_,7 @@
+          int i = this.f_30001_.m_21216_();
+          if (i > 100) {
+             this.f_30001_.m_29958_(0.0F, 0.0F, 0.0F);
+-         } else if (this.f_30001_.m_217043_().m_188503_(m_186073_(50)) == 0 || !this.f_30001_.f_19798_ || !this.f_30001_.m_29981_()) {
++         } else if (this.f_30001_.m_217043_().m_188503_(m_186073_(50)) == 0 || !(this.f_30001_.f_19798_ || this.f_30001_.isInFluidType((fluidType, height) -> this.f_30001_.canSwimInFluidType(fluidType))) || !this.f_30001_.m_29981_()) {
+             float f = this.f_30001_.m_217043_().m_188501_() * ((float)Math.PI * 2F);
+             float f1 = Mth.m_14089_(f) * 0.2F;
+             float f2 = -0.1F + this.f_30001_.m_217043_().m_188501_() * 0.2F;

--- a/patches/minecraft/net/minecraft/world/entity/animal/Turtle.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Turtle.java.patch
@@ -1,0 +1,109 @@
+--- a/net/minecraft/world/entity/animal/Turtle.java
++++ b/net/minecraft/world/entity/animal/Turtle.java
+@@ -68,7 +_,7 @@
+    public static final Ingredient f_149066_ = Ingredient.m_43929_(Blocks.f_50037_.m_5456_());
+    int f_30129_;
+    public static final Predicate<LivingEntity> f_30122_ = (p_30226_) -> {
+-      return p_30226_.m_6162_() && !p_30226_.m_20069_();
++      return p_30226_.m_6162_() && !(p_30226_.m_20069_() || p_30226_.isInFluidType((fluidType, height) -> p_30226_.canSwimInFluidType(fluidType)));
+    };
+ 
+    public Turtle(EntityType<? extends Turtle> p_30132_, Level p_30133_) {
+@@ -261,7 +_,7 @@
+    }
+ 
+    public float m_5610_(BlockPos p_30159_, LevelReader p_30160_) {
+-      if (!this.m_30211_() && p_30160_.m_6425_(p_30159_).m_205070_(FluidTags.f_13131_)) {
++      if (!this.m_30211_() && this.canSwimInFluidType(p_30160_.m_6425_(p_30159_).getFluidType())) {
+          return 10.0F;
+       } else {
+          return TurtleEggBlock.m_57762_(p_30160_, p_30159_) ? 10.0F : p_30160_.m_220419_(p_30159_);
+@@ -288,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_30218_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(0.1F, p_30218_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));
+@@ -395,7 +_,7 @@
+                vec31 = DefaultRandomPos.m_148412_(this.f_30248_, 8, 7, vec3, (double)((float)Math.PI / 2F));
+             }
+ 
+-            if (vec31 != null && !flag && !this.f_30248_.f_19853_.m_8055_(new BlockPos(vec31)).m_60713_(Blocks.f_49990_)) {
++            if (vec31 != null && !flag && !this.f_30248_.canSwimInFluidType(this.f_30248_.f_19853_.m_8055_(new BlockPos(vec31)).m_60819_().getFluidType())) {
+                vec31 = DefaultRandomPos.m_148412_(this.f_30248_, 16, 5, vec3, (double)((float)Math.PI / 2F));
+             }
+ 
+@@ -421,14 +_,14 @@
+       }
+ 
+       public boolean m_8045_() {
+-         return !this.f_30260_.m_20069_() && this.f_25601_ <= 1200 && this.m_6465_(this.f_30260_.f_19853_, this.f_25602_);
++         return !(this.f_30260_.m_20069_() || this.f_30260_.isInFluidType((fluidType, height) -> this.f_30260_.canSwimInFluidType(fluidType))) && this.f_25601_ <= 1200 && this.m_6465_(this.f_30260_.f_19853_, this.f_25602_);
+       }
+ 
+       public boolean m_8036_() {
+          if (this.f_30260_.m_6162_() && !this.f_30260_.m_20069_()) {
+             return super.m_8036_();
+          } else {
+-            return !this.f_30260_.m_30211_() && !this.f_30260_.m_20069_() && !this.f_30260_.m_30205_() ? super.m_8036_() : false;
++            return !this.f_30260_.m_30211_() && !(this.f_30260_.m_20069_() || this.f_30260_.isInFluidType((fluidType, height) -> this.f_30260_.canSwimInFluidType(fluidType))) && !this.f_30260_.m_30205_() ? super.m_8036_() : false;
+          }
+       }
+ 
+@@ -437,7 +_,7 @@
+       }
+ 
+       protected boolean m_6465_(LevelReader p_30270_, BlockPos p_30271_) {
+-         return p_30270_.m_8055_(p_30271_).m_60713_(Blocks.f_49990_);
++         return this.f_30260_.canSwimInFluidType(p_30270_.m_8055_(p_30271_).m_60819_().getFluidType());
+       }
+    }
+ 
+@@ -460,7 +_,7 @@
+       public void m_8037_() {
+          super.m_8037_();
+          BlockPos blockpos = this.f_30274_.m_20183_();
+-         if (!this.f_30274_.m_20069_() && this.m_25625_()) {
++         if (!(this.f_30274_.m_20069_() || this.f_30274_.isInFluidType((fluidType, height) -> this.f_30274_.canSwimInFluidType(fluidType))) && this.m_25625_()) {
+             if (this.f_30274_.f_30129_ < 1) {
+                this.f_30274_.m_30236_(true);
+             } else if (this.f_30274_.f_30129_ > this.m_183277_(200)) {
+@@ -493,7 +_,7 @@
+       }
+ 
+       private void m_30288_() {
+-         if (this.f_30284_.m_20069_()) {
++         if (this.f_30284_.m_20069_() || this.f_30284_.isInFluidType((fluidType, height) -> this.f_30284_.canSwimInFluidType(fluidType))) {
+             this.f_30284_.m_20256_(this.f_30284_.m_20184_().m_82520_(0.0D, 0.005D, 0.0D));
+             if (!this.f_30284_.m_30208_().m_203195_(this.f_30284_.m_20182_(), 16.0D)) {
+                this.f_30284_.m_7910_(Math.max(this.f_30284_.m_6113_() / 2.0F, 0.08F));
+@@ -559,7 +_,7 @@
+          Mob mob = this.f_26494_;
+          if (mob instanceof Turtle turtle) {
+             if (turtle.m_30212_()) {
+-               return this.f_26495_.m_8055_(p_30300_).m_60713_(Blocks.f_49990_);
++               return turtle.canSwimInFluidType(this.f_26495_.m_8055_(p_30300_).m_60819_().getFluidType());
+             }
+          }
+ 
+@@ -576,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return !this.f_25725_.m_20069_() && !this.f_30301_.m_30211_() && !this.f_30301_.m_30205_() ? super.m_8036_() : false;
++         return !(this.f_25725_.m_20069_() || this.f_25725_.isInFluidType((fluidType, height) -> this.f_25725_.canSwimInFluidType(fluidType))) && !this.f_30301_.m_30211_() && !this.f_30301_.m_30205_() ? super.m_8036_() : false;
+       }
+    }
+ 
+@@ -591,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return !this.f_30329_.m_30211_() && !this.f_30329_.m_30205_() && this.f_30329_.m_20069_();
++         return !this.f_30329_.m_30211_() && !this.f_30329_.m_30205_() && (this.f_30329_.m_20069_() || this.f_30329_.isInFluidType((fluidType, height) -> this.f_30329_.canSwimInFluidType(fluidType)));
+       }
+ 
+       public void m_8056_() {

--- a/patches/minecraft/net/minecraft/world/entity/animal/WaterAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/WaterAnimal.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/WaterAnimal.java
++++ b/net/minecraft/world/entity/animal/WaterAnimal.java
+@@ -42,7 +_,7 @@
+    }
+ 
+    protected void m_6229_(int p_30344_) {
+-      if (this.m_6084_() && !this.m_20072_()) {
++      if (this.m_6084_() && !this.m_20072_() && this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType))) {
+          this.m_20301_(p_30344_ - 1);
+          if (this.m_20146_() == -20) {
+             this.m_20301_(0);

--- a/patches/minecraft/net/minecraft/world/entity/animal/WaterAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/WaterAnimal.java.patch
@@ -5,7 +5,7 @@
  
     protected void m_6229_(int p_30344_) {
 -      if (this.m_6084_() && !this.m_20072_()) {
-+      if (this.m_6084_() && !this.m_20072_() && this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType))) {
++      if (this.m_6084_() && !this.m_20072_() && this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType), true)) {
           this.m_20301_(p_30344_ - 1);
           if (this.m_20146_() == -20) {
              this.m_20301_(0);

--- a/patches/minecraft/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/animal/axolotl/Axolotl.java
++++ b/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+@@ -155,7 +_,7 @@
+    }
+ 
+    protected void m_149193_(int p_149194_) {
+-      if (this.m_6084_() && !this.m_20071_()) {
++      if (this.m_6084_() && !this.m_20071_() && this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType), true)) {
+          this.m_20301_(p_149194_ - 1);
+          if (this.m_20146_() == -20) {
+             this.m_20301_(0);
+@@ -284,7 +_,7 @@
+ 
+    public boolean m_6469_(DamageSource p_149115_, float p_149116_) {
+       float f = this.m_21223_();
+-      if (!this.f_19853_.f_46443_ && !this.m_21525_() && this.f_19853_.f_46441_.m_188503_(3) == 0 && ((float)this.f_19853_.f_46441_.m_188503_(3) < p_149116_ || f / this.m_21233_() < 0.5F) && p_149116_ < f && this.m_20069_() && (p_149115_.m_7639_() != null || p_149115_.m_7640_() != null) && !this.m_149175_()) {
++      if (!this.f_19853_.f_46443_ && !this.m_21525_() && this.f_19853_.f_46441_.m_188503_(3) == 0 && ((float)this.f_19853_.f_46441_.m_188503_(3) < p_149116_ || f / this.m_21233_() < 0.5F) && p_149116_ < f && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) && (p_149115_.m_7639_() != null || p_149115_.m_7640_() != null) && !this.m_149175_()) {
+          this.f_20939_.m_21879_(MemoryModuleType.f_148195_, 200);
+       }
+ 
+@@ -423,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_149181_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(this.m_6113_(), p_149181_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));

--- a/patches/minecraft/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java.patch
@@ -1,0 +1,39 @@
+--- a/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java
++++ b/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java
+@@ -73,7 +_,7 @@
+    }
+ 
+    private static void m_149308_(Brain<Axolotl> p_149309_) {
+-      p_149309_.m_21900_(Activity.f_37979_, ImmutableList.of(Pair.of(0, new RunSometimes<>(new SetEntityLookTarget(EntityType.f_20532_, 6.0F), UniformInt.m_146622_(30, 60))), Pair.of(1, new AnimalMakeLove(EntityType.f_147039_, 0.2F)), Pair.of(2, new RunOne<>(ImmutableList.of(Pair.of(new FollowTemptation(AxolotlAi::m_149300_), 1), Pair.of(new BabyFollowAdult<>(f_149279_, AxolotlAi::m_149294_), 1)))), Pair.of(3, new StartAttacking<>(AxolotlAi::m_149298_)), Pair.of(3, new TryFindWater(6, 0.15F)), Pair.of(4, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.5F), 2), Pair.of(new RandomStroll(0.15F, false), 2), Pair.of(new SetWalkTargetFromLookTarget(AxolotlAi::m_182380_, AxolotlAi::m_149300_, 3), 3), Pair.of(new RunIf<>(Entity::m_20072_, new DoNothing(30, 60)), 5), Pair.of(new RunIf<>(Entity::m_20096_, new DoNothing(200, 400)), 5))))));
++      p_149309_.m_21900_(Activity.f_37979_, ImmutableList.of(Pair.of(0, new RunSometimes<>(new SetEntityLookTarget(EntityType.f_20532_, 6.0F), UniformInt.m_146622_(30, 60))), Pair.of(1, new AnimalMakeLove(EntityType.f_147039_, 0.2F)), Pair.of(2, new RunOne<>(ImmutableList.of(Pair.of(new FollowTemptation(AxolotlAi::m_149300_), 1), Pair.of(new BabyFollowAdult<>(f_149279_, AxolotlAi::m_149294_), 1)))), Pair.of(3, new StartAttacking<>(AxolotlAi::m_149298_)), Pair.of(3, new TryFindWater(6, 0.15F)), Pair.of(4, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.5F), 2), Pair.of(new RandomStroll(0.15F, false), 2), Pair.of(new SetWalkTargetFromLookTarget(AxolotlAi::m_182380_, AxolotlAi::m_149300_, 3), 3), Pair.of(new RunIf<>(axolotl -> axolotl.m_20072_() || axolotl.isInFluidType((fluidType, height) -> axolotl.canSwimInFluidType(fluidType)), new DoNothing(30, 60)), 5), Pair.of(new RunIf<>(Entity::m_20096_, new DoNothing(200, 400)), 5))))));
+    }
+ 
+    private static boolean m_182380_(LivingEntity p_182381_) {
+@@ -81,7 +_,7 @@
+       Optional<PositionTracker> optional = p_182381_.m_6274_().m_21952_(MemoryModuleType.f_26371_);
+       if (optional.isPresent()) {
+          BlockPos blockpos = optional.get().m_6675_();
+-         return level.m_46801_(blockpos) == p_182381_.m_20072_();
++         return level.m_46801_(blockpos) == p_182381_.m_20072_() || !level.m_6425_(blockpos).getFluidType().isAir() == p_182381_.canSwimInFluidType(level.m_6425_(blockpos).getFluidType());
+       } else {
+          return false;
+       }
+@@ -100,15 +_,15 @@
+    }
+ 
+    private static float m_149288_(LivingEntity p_149289_) {
+-      return p_149289_.m_20072_() ? 0.6F : 0.15F;
++      return p_149289_.m_20072_() || p_149289_.isInFluidType((fluidType, height) -> p_149289_.canSwimInFluidType(fluidType)) ? 0.6F : 0.15F;
+    }
+ 
+    private static float m_149294_(LivingEntity p_149295_) {
+-      return p_149295_.m_20072_() ? 0.6F : 0.15F;
++      return p_149295_.m_20072_() || p_149295_.isInFluidType((fluidType, height) -> p_149295_.canSwimInFluidType(fluidType)) ? 0.6F : 0.15F;
+    }
+ 
+    private static float m_149300_(LivingEntity p_149301_) {
+-      return p_149301_.m_20072_() ? 0.5F : 0.15F;
++      return p_149301_.m_20072_() || p_149301_.isInFluidType((fluidType, height) -> p_149301_.canSwimInFluidType(fluidType)) ? 0.5F : 0.15F;
+    }
+ 
+    private static Optional<? extends LivingEntity> m_149298_(Axolotl p_149299_) {

--- a/patches/minecraft/net/minecraft/world/entity/animal/frog/Frog.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/frog/Frog.java.patch
@@ -1,0 +1,34 @@
+--- a/net/minecraft/world/entity/animal/frog/Frog.java
++++ b/net/minecraft/world/entity/animal/frog/Frog.java
+@@ -158,11 +_,11 @@
+    }
+ 
+    private boolean m_218526_() {
+-      return this.f_19861_ && this.m_20184_().m_165925_() > 1.0E-6D && !this.m_20072_();
++      return this.f_19861_ && this.m_20184_().m_165925_() > 1.0E-6D && !(this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)));
+    }
+ 
+    private boolean m_218527_() {
+-      return this.m_20184_().m_165925_() > 1.0E-6D && this.m_20072_();
++      return this.m_20184_().m_165925_() > 1.0E-6D && (this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)));
+    }
+ 
+    protected void m_8024_() {
+@@ -186,7 +_,7 @@
+          if (this.m_218527_()) {
+             this.f_218464_.m_216973_();
+             this.f_218463_.m_216982_(this.f_19797_);
+-         } else if (this.m_20072_()) {
++         } else if (this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) {
+             this.f_218463_.m_216973_();
+             this.f_218464_.m_216982_(this.f_19797_);
+          } else {
+@@ -314,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_218530_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(this.m_6113_(), p_218530_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));

--- a/patches/minecraft/net/minecraft/world/entity/animal/frog/FrogAi.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/frog/FrogAi.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/frog/FrogAi.java
++++ b/net/minecraft/world/entity/animal/frog/FrogAi.java
+@@ -87,7 +_,7 @@
+          return 1.25F;
+       })), Pair.of(2, new StartAttacking<>(FrogAi::m_218588_, (p_218601_) -> {
+          return p_218601_.m_6274_().m_21952_(MemoryModuleType.f_148194_);
+-      })), Pair.of(3, new TryFindLand(8, 1.5F)), Pair.of(5, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.75F), 1), Pair.of(new RandomStroll(1.0F, true), 1), Pair.of(new SetWalkTargetFromLookTarget(1.0F, 3), 1), Pair.of(new RunIf<>(Entity::m_20072_, new DoNothing(30, 60)), 5))))), ImmutableSet.of(Pair.of(MemoryModuleType.f_148200_, MemoryStatus.VALUE_ABSENT), Pair.of(MemoryModuleType.f_217766_, MemoryStatus.VALUE_PRESENT)));
++      })), Pair.of(3, new TryFindLand(8, 1.5F)), Pair.of(5, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.75F), 1), Pair.of(new RandomStroll(1.0F, true), 1), Pair.of(new SetWalkTargetFromLookTarget(1.0F, 3), 1), Pair.of(new RunIf<>(frog -> frog.m_20072_() || frog.isInFluidType((fluidType, height) -> frog.canSwimInFluidType(fluidType)), new DoNothing(30, 60)), 5))))), ImmutableSet.of(Pair.of(MemoryModuleType.f_148200_, MemoryStatus.VALUE_ABSENT), Pair.of(MemoryModuleType.f_217766_, MemoryStatus.VALUE_PRESENT)));
+    }
+ 
+    private static void m_218598_(Brain<Frog> p_218599_) {

--- a/patches/minecraft/net/minecraft/world/entity/animal/frog/TadpoleAi.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/frog/TadpoleAi.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/frog/TadpoleAi.java
++++ b/net/minecraft/world/entity/animal/frog/TadpoleAi.java
+@@ -45,7 +_,7 @@
+    private static void m_218747_(Brain<Tadpole> p_218748_) {
+       p_218748_.m_21900_(Activity.f_37979_, ImmutableList.of(Pair.of(0, new RunSometimes<>(new SetEntityLookTarget(EntityType.f_20532_, 6.0F), UniformInt.m_146622_(30, 60))), Pair.of(1, new FollowTemptation((p_218740_) -> {
+          return 1.25F;
+-      })), Pair.of(2, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.5F), 2), Pair.of(new SetWalkTargetFromLookTarget(0.5F, 3), 3), Pair.of(new RunIf<>(Entity::m_20072_, new DoNothing(30, 60)), 5))))));
++      })), Pair.of(2, new GateBehavior<>(ImmutableMap.of(MemoryModuleType.f_26370_, MemoryStatus.VALUE_ABSENT), ImmutableSet.of(), GateBehavior.OrderPolicy.ORDERED, GateBehavior.RunningPolicy.TRY_ALL, ImmutableList.of(Pair.of(new RandomSwim(0.5F), 2), Pair.of(new SetWalkTargetFromLookTarget(0.5F, 3), 3), Pair.of(new RunIf<>(tadpole -> tadpole.m_20072_() || tadpole.isInFluidType((fluidType, height) -> tadpole.canSwimInFluidType(fluidType)), new DoNothing(30, 60)), 5))))));
+    }
+ 
+    public static void m_218743_(Tadpole p_218744_) {

--- a/patches/minecraft/net/minecraft/world/entity/monster/Drowned.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Drowned.java.patch
@@ -1,0 +1,80 @@
+--- a/net/minecraft/world/entity/monster/Drowned.java
++++ b/net/minecraft/world/entity/monster/Drowned.java
+@@ -174,7 +_,7 @@
+ 
+    public boolean m_32395_(@Nullable LivingEntity p_32396_) {
+       if (p_32396_ != null) {
+-         return !this.f_19853_.m_46461_() || p_32396_.m_20069_();
++         return !this.f_19853_.m_46461_() || (p_32396_.m_20069_() || p_32396_.isInFluidType((fluidType, height) -> p_32396_.canSwimInFluidType(fluidType)));
+       } else {
+          return false;
+       }
+@@ -189,12 +_,12 @@
+          return true;
+       } else {
+          LivingEntity livingentity = this.m_5448_();
+-         return livingentity != null && livingentity.m_20069_();
++         return livingentity != null && (livingentity.m_20069_() || livingentity.isInFluidType((fluidType, height) -> livingentity.canSwimInFluidType(fluidType)));
+       }
+    }
+ 
+    public void m_7023_(Vec3 p_32394_) {
+-      if (this.m_6142_() && this.m_20069_() && this.m_32392_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) && this.m_32392_()) {
+          this.m_19920_(0.01F, p_32394_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));
+@@ -206,7 +_,7 @@
+ 
+    public void m_5844_() {
+       if (!this.f_19853_.f_46443_) {
+-         if (this.m_6142_() && this.m_20069_() && this.m_32392_()) {
++         if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) && this.m_32392_()) {
+             this.f_21344_ = this.f_32340_;
+             this.m_20282_(true);
+          } else {
+@@ -273,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return super.m_8036_() && !this.f_32407_.f_19853_.m_46461_() && this.f_32407_.m_20069_() && this.f_32407_.m_20186_() >= (double)(this.f_32407_.f_19853_.m_5736_() - 3);
++         return super.m_8036_() && !this.f_32407_.f_19853_.m_46461_() && (this.f_32407_.m_20069_() || this.f_32407_.isInFluidType((fluidType, height) -> this.f_32407_.canSwimInFluidType(fluidType))) && this.f_32407_.m_20186_() >= (double)(this.f_32407_.f_19853_.m_5736_() - 3);
+       }
+ 
+       public boolean m_8045_() {
+@@ -314,7 +_,7 @@
+       public boolean m_8036_() {
+          if (!this.f_32423_.m_46461_()) {
+             return false;
+-         } else if (this.f_32418_.m_20069_()) {
++         } else if (this.f_32418_.m_20069_() || this.f_32418_.isInFluidType((fluidType, height) -> this.f_32418_.canSwimInFluidType(fluidType))) {
+             return false;
+          } else {
+             Vec3 vec3 = this.m_32430_();
+@@ -344,7 +_,7 @@
+ 
+          for(int i = 0; i < 10; ++i) {
+             BlockPos blockpos1 = blockpos.m_7918_(randomsource.m_188503_(20) - 10, 2 - randomsource.m_188503_(8), randomsource.m_188503_(20) - 10);
+-            if (this.f_32423_.m_8055_(blockpos1).m_60713_(Blocks.f_49990_)) {
++            if (this.f_32418_.canSwimInFluidType(this.f_32423_.m_8055_(blockpos1).m_60819_().getFluidType())) {
+                return Vec3.m_82539_(blockpos1);
+             }
+          }
+@@ -363,7 +_,7 @@
+ 
+       public void m_8126_() {
+          LivingEntity livingentity = this.f_32431_.m_5448_();
+-         if (this.f_32431_.m_32392_() && this.f_32431_.m_20069_()) {
++         if (this.f_32431_.m_32392_() && (this.f_32431_.m_20069_() || this.f_32431_.isInFluidType((fluidType, height) -> this.f_32431_.canSwimInFluidType(fluidType)))) {
+             if (livingentity != null && livingentity.m_20186_() > this.f_32431_.m_20186_() || this.f_32431_.f_32342_) {
+                this.f_32431_.m_20256_(this.f_32431_.m_20184_().m_82520_(0.0D, 0.002D, 0.0D));
+             }
+@@ -409,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return !this.f_32435_.f_19853_.m_46461_() && this.f_32435_.m_20069_() && this.f_32435_.m_20186_() < (double)(this.f_32437_ - 2);
++         return !this.f_32435_.f_19853_.m_46461_() && (this.f_32435_.m_20069_() || this.f_32435_.isInFluidType((fluidType, height) -> this.f_32435_.canSwimInFluidType(fluidType))) && this.f_32435_.m_20186_() < (double)(this.f_32437_ - 2);
+       }
+ 
+       public boolean m_8045_() {

--- a/patches/minecraft/net/minecraft/world/entity/monster/Guardian.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Guardian.java.patch
@@ -1,0 +1,55 @@
+--- a/net/minecraft/world/entity/monster/Guardian.java
++++ b/net/minecraft/world/entity/monster/Guardian.java
+@@ -180,14 +_,14 @@
+    }
+ 
+    public float m_5610_(BlockPos p_32831_, LevelReader p_32832_) {
+-      return p_32832_.m_6425_(p_32831_).m_205070_(FluidTags.f_13131_) ? 10.0F + p_32832_.m_220419_(p_32831_) : super.m_5610_(p_32831_, p_32832_);
++      return p_32832_.m_6425_(p_32831_).isPathfindable(p_32832_, p_32831_, this) ? 10.0F + p_32832_.m_220419_(p_32831_) : super.m_5610_(p_32831_, p_32832_);
+    }
+ 
+    public void m_8107_() {
+       if (this.m_6084_()) {
+          if (this.f_19853_.f_46443_) {
+             this.f_32799_ = this.f_32798_;
+-            if (!this.m_20069_()) {
++            if (!(this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+                this.f_32800_ = 2.0F;
+                Vec3 vec3 = this.m_20184_();
+                if (vec3.f_82480_ > 0.0D && this.f_32805_ && !this.m_20067_()) {
+@@ -207,7 +_,7 @@
+ 
+             this.f_32798_ += this.f_32800_;
+             this.f_32802_ = this.f_32801_;
+-            if (!this.m_20072_()) {
++            if (!(this.m_20072_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+                this.f_32801_ = this.f_19796_.m_188501_();
+             } else if (this.m_32854_()) {
+                this.f_32801_ += (0.0F - this.f_32801_) * 0.25F;
+@@ -215,7 +_,7 @@
+                this.f_32801_ += (1.0F - this.f_32801_) * 0.06F;
+             }
+ 
+-            if (this.m_32854_() && this.m_20069_()) {
++            if (this.m_32854_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+                Vec3 vec31 = this.m_20252_(0.0F);
+ 
+                for(int i = 0; i < 2; ++i) {
+@@ -250,7 +_,7 @@
+             }
+          }
+ 
+-         if (this.m_20072_()) {
++         if (this.m_20072_() || (this.isInFluidType() && !this.isInFluidType((fluidType, height) -> this.canDrownInFluidType(fluidType)))) {
+             this.m_20301_(300);
+          } else if (this.f_19861_) {
+             this.m_20256_(this.m_20184_().m_82520_((double)((this.f_19796_.m_188501_() * 2.0F - 1.0F) * 0.4F), 0.5D, (double)((this.f_19796_.m_188501_() * 2.0F - 1.0F) * 0.4F)));
+@@ -311,7 +_,7 @@
+    }
+ 
+    public void m_7023_(Vec3 p_32858_) {
+-      if (this.m_6142_() && this.m_20069_()) {
++      if (this.m_6142_() && (this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
+          this.m_19920_(0.1F, p_32858_);
+          this.m_6478_(MoverType.SELF, this.m_20184_());
+          this.m_20256_(this.m_20184_().m_82490_(0.9D));

--- a/patches/minecraft/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Slime.java.patch
@@ -8,16 +8,34 @@
           for(int j = 0; j < i * 8; ++j) {
              float f = this.f_19796_.m_188501_() * ((float)Math.PI * 2F);
              float f1 = this.f_19796_.m_188501_() * 0.5F + 0.5F;
-@@ -316,6 +_,12 @@
-    public EntityDimensions m_6972_(Pose p_33597_) {
+@@ -317,6 +_,12 @@
        return super.m_6972_(p_33597_).m_20388_(0.255F * (float)this.m_33632_());
     }
-+
+ 
 +   /**
 +    * Called when the slime spawns particles on landing, see onUpdate.
 +    * Return true to prevent the spawning of the default particles.
 +    */
 +   protected boolean spawnCustomParticles() { return false; }
- 
++
     static class SlimeAttackGoal extends Goal {
        private final Slime f_33645_;
+       private int f_33646_;
+@@ -375,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return (this.f_33653_.m_20069_() || this.f_33653_.m_20077_()) && this.f_33653_.m_21566_() instanceof Slime.SlimeMoveControl;
++         return (this.f_33653_.m_20069_() || this.f_33653_.m_20077_() || this.f_33653_.isInFluidType((fluidType, height) -> this.f_33653_.canSwimInFluidType(fluidType))) && this.f_33653_.m_21566_() instanceof Slime.SlimeMoveControl;
+       }
+ 
+       public boolean m_183429_() {
+@@ -474,7 +_,7 @@
+       }
+ 
+       public boolean m_8036_() {
+-         return this.f_33675_.m_5448_() == null && (this.f_33675_.f_19861_ || this.f_33675_.m_20069_() || this.f_33675_.m_20077_() || this.f_33675_.m_21023_(MobEffects.f_19620_)) && this.f_33675_.m_21566_() instanceof Slime.SlimeMoveControl;
++         return this.f_33675_.m_5448_() == null && (this.f_33675_.f_19861_ || this.f_33675_.m_20069_() || this.f_33675_.m_20077_() || this.f_33675_.isInFluidType((fluidType, height) -> this.f_33675_.canSwimInFluidType(fluidType)) || this.f_33675_.m_21023_(MobEffects.f_19620_)) && this.f_33675_.m_21566_() instanceof Slime.SlimeMoveControl;
+       }
+ 
+       public void m_8037_() {

--- a/patches/minecraft/net/minecraft/world/level/block/FrogspawnBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FrogspawnBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/FrogspawnBlock.java
++++ b/net/minecraft/world/level/block/FrogspawnBlock.java
+@@ -74,7 +_,7 @@
+    private static boolean m_221187_(BlockGetter p_221188_, BlockPos p_221189_) {
+       FluidState fluidstate = p_221188_.m_6425_(p_221189_);
+       FluidState fluidstate1 = p_221188_.m_6425_(p_221189_.m_7494_());
+-      return fluidstate.m_76152_() == Fluids.f_76193_ && fluidstate1.m_76152_() == Fluids.f_76191_;
++      return fluidstate.getFluidType().canSwim() && fluidstate1.m_76152_() == Fluids.f_76191_;
+    }
+ 
+    private void m_221181_(ServerLevel p_221182_, BlockPos p_221183_, RandomSource p_221184_) {

--- a/patches/minecraft/net/minecraft/world/level/block/SlabBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/SlabBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/SlabBlock.java
++++ b/net/minecraft/world/level/block/SlabBlock.java
+@@ -113,7 +_,7 @@
+          case LAND:
+             return false;
+          case WATER:
+-            return p_56377_.m_6425_(p_56378_).m_205070_(FluidTags.f_13131_);
++            return p_56377_.m_6425_(p_56378_).isPathfindable(p_56377_, p_56378_, null);
+          case AIR:
+             return false;
+          default:

--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -18,6 +18,15 @@
     }
  
     /** @deprecated */
+@@ -108,7 +_,7 @@
+          case LAND:
+             return !p_60475_.m_60838_(p_60476_, p_60477_);
+          case WATER:
+-            return p_60476_.m_6425_(p_60477_).m_205070_(FluidTags.f_13131_);
++            return p_60476_.m_6425_(p_60477_).isPathfindable(p_60476_, p_60477_, null);
+          case AIR:
+             return !p_60475_.m_60838_(p_60476_, p_60477_);
+          default:
 @@ -142,7 +_,7 @@
     /** @deprecated */
     @Deprecated

--- a/patches/minecraft/net/minecraft/world/level/pathfinder/SwimNodeEvaluator.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/pathfinder/SwimNodeEvaluator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/pathfinder/SwimNodeEvaluator.java
++++ b/net/minecraft/world/level/pathfinder/SwimNodeEvaluator.java
+@@ -117,7 +_,7 @@
+                   return BlockPathTypes.BREACH;
+                }
+ 
+-               if (!fluidstate.m_205070_(FluidTags.f_13131_)) {
++               if (!fluidstate.isPathfindable(p_77472_, blockpos$mutableblockpos, this.f_77313_)) {
+                   return BlockPathTypes.BLOCKED;
+                }
+             }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -8,7 +8,9 @@ package net.minecraftforge.common;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,6 +47,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.animal.Dolphin;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -1443,5 +1446,12 @@ public class ForgeHooks
     public static String prefixNamespace(ResourceLocation registryKey)
     {
         return registryKey.getNamespace().equals("minecraft") ? registryKey.getPath() : registryKey.getNamespace() +  "/"  + registryKey.getPath();
+    }
+
+    private static final BiPredicate<Dolphin, ItemEntity> DOLPHIN_ALLOWED_ITEMS = (dolphin, item) -> !item.hasPickUpDelay() && item.isAlive() && item.isInFluidType(((fluidType, height) -> dolphin.canSwimInFluidType(fluidType)));
+
+    public static Predicate<ItemEntity> dolphinAllowedItems(Dolphin dolphin)
+    {
+        return item -> DOLPHIN_ALLOWED_ITEMS.test(dolphin, item);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
@@ -164,4 +164,19 @@ public interface IForgeFluid
     {
         return getFluidType().canExtinguish(state, getter, pos);
     }
+
+    /**
+     * Returns whether an entity can path through the fluid during node
+     * evaluation.
+     *
+     * @param state the state of the fluid
+     * @param getter the getter which can grab this fluid
+     * @param pos the position of the fluid
+     * @param mob the entity pathing through the fluid, can be {@code null}
+     * @return {@code true} if the entity can path through the fluid, {@code false} otherwise
+     */
+    default boolean isPathfindable(FluidState state, BlockGetter getter, BlockPos pos, @Nullable Mob mob)
+    {
+        return getFluidType().isPathfindable(state, getter, pos, mob);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
@@ -154,4 +154,18 @@ public interface IForgeFluidState
     {
         return self().getType().canExtinguish(self(), getter, pos);
     }
+
+    /**
+     * Returns whether entities can path through the fluid during node
+     * evaluation.
+     *
+     * @param getter the getter which can grab this fluid
+     * @param pos the position of the fluid
+     * @param mob the entity pathing through the fluid, can be {@code null}
+     * @return {@code true} if the entity can path through the fluid, {@code false} otherwise
+     */
+    default boolean isPathfindable(BlockGetter getter, BlockPos pos, @Nullable Mob mob)
+    {
+        return self().getType().isPathfindable(self(), getter, pos, mob);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -30,7 +30,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void jumpInFluid(FluidType type)
     {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double)0.04F * self().getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+        type.entityJump(self());
     }
 
     /**
@@ -40,7 +40,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void sinkInFluid(FluidType type)
     {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double)-0.04F * self().getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+        type.entitySink(self());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -1,6 +1,9 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.Dolphin;
+import net.minecraft.world.entity.animal.WaterAnimal;
+import net.minecraft.world.entity.monster.Guardian;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeMod;
@@ -49,6 +52,9 @@ public interface IForgeLivingEntity extends IForgeEntity
     default boolean canDrownInFluidType(FluidType type)
     {
         if (type == ForgeMod.WATER_TYPE.get()) return !self().canBreatheUnderwater();
+        else if (type == ForgeMod.EMPTY_TYPE.get()
+            && (self() instanceof WaterAnimal && !(self() instanceof Dolphin))) // Water animal that isn't dolphin drown in air
+            return true;
         return type.canDrownIn(self());
     }
 

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -389,6 +389,26 @@ public class FluidType
     }
 
     /**
+     * Performs what to do when an entity attempts to go up or "jump" in a fluid.
+     *
+     * @param entity the entity in the fluid
+     */
+    public void entityJump(LivingEntity entity)
+    {
+        entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+    }
+
+    /**
+     * Performs what to do when an entity attempts to go down or "sink" in a fluid.
+     *
+     * @param entity the entity in the fluid
+     */
+    public void entitySink(LivingEntity entity)
+    {
+        entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)-0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+    }
+
+    /**
      * Returns a sound to play when a certain action is performed by the
      * entity in the fluid. If no sound is present, then the sound will be
      * {@code null}.

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -144,6 +144,16 @@ public class FluidType
     }
 
     /**
+     * Returns whether the fluid can be swum in.
+     *
+     * @return {@code true} if the fluid can be swum in, {@code false} otherwise
+     */
+    public boolean canSwim()
+    {
+        return this.canSwim;
+    }
+
+    /**
      * Returns the light level emitted by the fluid.
      *
      * <p>Note: This should be a value between {@code [0,15]}. If not specified, the
@@ -260,7 +270,7 @@ public class FluidType
      */
     public boolean canSwim(Entity entity)
     {
-        return this.canSwim;
+        return this.canSwim();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -188,11 +188,11 @@ public class FluidType
     }
 
     /**
-     * Returns the viscosity, or thickness, of the fluid.
+     * Returns the viscosity, or movement resistance, of the fluid.
      *
      * <p>Note: This is an arbitrary number. The value should never be negative.
-     * Higher viscosity values indicate that the fluid flows more slowly. If not
-     * specified, the viscosity is approximately equivalent to the real-life
+     * Higher viscosity values indicate that the entity moves more slowly through the fluid.
+     * If not specified, the viscosity is approximately equivalent to the real-life
      * viscosity of water in {@code m/s^2}.
      *
      * @return the viscosity of the fluid
@@ -547,11 +547,11 @@ public class FluidType
     }
 
     /**
-     * Returns the viscosity, or thickness, of the fluid.
+     * Returns the viscosity, or movement resistance, of the fluid.
      *
      * <p>Note: This is an arbitrary number. The value should never be negative.
-     * Higher viscosity values indicate that the fluid flows more slowly. If not
-     * specified, the viscosity is approximately equivalent to the real-life
+     * Higher viscosity values indicate that the entity moves more slowly through the fluid.
+     * If not specified, the viscosity is approximately equivalent to the real-life
      * viscosity of water in {@code m/s^2}.
      *
      * @param state the state of the fluid
@@ -673,11 +673,11 @@ public class FluidType
     }
 
     /**
-     * Returns the viscosity, or thickness, of the fluid.
+     * Returns the viscosity, or movement resistance, of the fluid.
      *
      * <p>Note: This is an arbitrary number. The value should never be negative.
-     * Higher viscosity values indicate that the fluid flows more slowly. If not
-     * specified, the viscosity is approximately equivalent to the real-life
+     * Higher viscosity values indicate that the entity moves more slowly through the fluid.
+     * If not specified, the viscosity is approximately equivalent to the real-life
      * viscosity of water in {@code m/s^2}.
      *
      * @param stack the stack holding the fluid
@@ -1122,7 +1122,7 @@ public class FluidType
         }
 
         /**
-         * Sets the viscosity, or thickness, of the fluid.
+         * Sets the viscosity, or movement resistance, of the fluid.
          *
          * @param viscosity the viscosity of the fluid
          * @return the property holder instance

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -459,6 +459,21 @@ public class FluidType
     }
 
     /**
+     * Returns whether an entity can path through the fluid during node
+     * evaluation.
+     *
+     * @param state the state of the fluid
+     * @param getter the getter which can grab this fluid
+     * @param pos the position of the fluid
+     * @param mob the entity pathing through the fluid, can be {@code null}
+     * @return {@code true} if the entity can path through the fluid, {@code false} otherwise
+     */
+    public boolean isPathfindable(FluidState state, BlockGetter getter, BlockPos pos, @Nullable Mob mob)
+    {
+        return this.canSwim;
+    }
+
+    /**
      * Returns a sound to play when a certain action is performed at a
      * position. If no sound is present, then the sound will be {@code null}.
      *

--- a/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
@@ -79,7 +79,7 @@ public class FluidTypeTest
     }
 
     private static final RegistryObject<FluidType> TEST_FLUID_TYPE = FLUID_TYPES.register("test_fluid", () ->
-            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true))
+            new FluidType(FluidType.Properties.create().canDrown(false).supportsBoating(true).canHydrate(true))
             {
                 @Override
                 public void initializeClient(Consumer<IFluidTypeRenderProperties> consumer)


### PR DESCRIPTION
Fixes the interactions of mobs which implement specific methods of swimming and drowning in relation to custom fluids. Some behaviors of entities are also fixed to their entanglement with either swimming or drowning.

This is for the following mobs:
* axolotl
* cod
* dolphin
* drowned
* guardian
* elder guardian
* pufferfish
* salmon
* squid
* glow squid
* tropical fish
* frog
* bee
* magma cube
* slime
* tadpole
* turtle