### PR TITLE
[1.19.x] Allow Generic Jump and Sink for Custom Fluids

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -27,7 +27,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void jumpInFluid(FluidType type)
     {
-        type.jumpInFluid(self());
+        type.entityJump(self());
     }
 
     /**
@@ -37,7 +37,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void sinkInFluid(FluidType type)
     {
-        type.sinkInFluid(self());
+        type.entitySink(self());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLivingEntity.java
@@ -27,7 +27,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void jumpInFluid(FluidType type)
     {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double)0.04F * self().getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+        type.jumpInFluid(self());
     }
 
     /**
@@ -37,7 +37,7 @@ public interface IForgeLivingEntity extends IForgeEntity
      */
     default void sinkInFluid(FluidType type)
     {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double)-0.04F * self().getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+        type.sinkInFluid(self());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -383,7 +383,7 @@ public class FluidType
      *
      * @param entity the entity in the fluid
      */
-    public void jumpInFluid(LivingEntity entity)
+    public void entityJump(LivingEntity entity)
     {
         entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
     }
@@ -393,7 +393,7 @@ public class FluidType
      *
      * @param entity the entity in the fluid
      */
-    public void sinkInFluid(LivingEntity entity)
+    public void entitySink(LivingEntity entity)
     {
         entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)-0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
     }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -379,6 +379,26 @@ public class FluidType
     }
 
     /**
+     * Performs what to do when an entity attempts to go up or "jump" in a fluid.
+     *
+     * @param entity the entity in the fluid
+     */
+    public void jumpInFluid(LivingEntity entity)
+    {
+        entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+    }
+
+    /**
+     * Performs what to do when an entity attempts to go down or "sink" in a fluid.
+     *
+     * @param entity the entity in the fluid
+     */
+    public void sinkInFluid(LivingEntity entity)
+    {
+        entity.setDeltaMovement(entity.getDeltaMovement().add(0.0D, (double)-0.04F * entity.getAttributeValue(ForgeMod.SWIM_SPEED.get()), 0.0D));
+    }
+
+    /**
      * Returns a sound to play when a certain action is performed by the
      * entity in the fluid. If no sound is present, then the sound will be
      * {@code null}.


### PR DESCRIPTION
Routes `IForgeLivingEntity#jumpInFluid` and `IForgeLivingEntity#sinkInFluid` to the fluid type for allow for a generic definition across the fluid.