### PR TITLE
Fix SP-Devtime world loading crash due to missing server configs

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -59,7 +59,7 @@
           for(int i = 0; i < p_44276_.size(); ++i) {
              Ingredient ingredient = Ingredient.m_43917_(p_44276_.get(i));
 -            if (!ingredient.m_43947_()) {
-+            if (net.minecraftforge.common.ForgeConfig.SERVER.skipEmptyShapelessCheck.get() || !ingredient.m_43947_()) {
++            if (true || !ingredient.m_43947_()) { //We skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early. Can not be done using a config value due to sync issues.
                 nonnulllist.add(ingredient);
              }
           }

--- a/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -59,7 +59,7 @@
           for(int i = 0; i < p_44276_.size(); ++i) {
              Ingredient ingredient = Ingredient.m_43917_(p_44276_.get(i));
 -            if (!ingredient.m_43947_()) {
-+            if (true || !ingredient.m_43947_()) { //We skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early. Can not be done using a config value due to sync issues.
++            if (true || !ingredient.m_43947_()) { // FORGE: Skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early. Can not be done using a config value due to sync issues.
                 nonnulllist.add(ingredient);
              }
           }

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -29,7 +29,6 @@ public class ForgeConfig {
         public final DoubleValue zombieBabyChance;
 
         public final BooleanValue treatEmptyTagsAsAir;
-        public final BooleanValue skipEmptyShapelessCheck;
 
         public final BooleanValue fixAdvancementLoading;
 
@@ -73,11 +72,6 @@ public class ForgeConfig {
                     .comment("Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.")
                     .translation("forge.configgui.treatEmptyTagsAsAir")
                     .define("treatEmptyTagsAsAir", false);
-
-            skipEmptyShapelessCheck = builder
-                  .comment("Skip checking if an ingredient is empty during shapeless recipe deserialization to prevent complex ingredients from caching tags too early.")
-                  .translation("forge.configgui.skipEmptyShapelessCheck")
-                  .define("skipEmptyShapelessCheck", true);
 
             fixAdvancementLoading = builder
                     .comment("Fix advancement loading to use a proper topological sort. This may have visibility side-effects and can thus be turned off if needed for data-pack compatibility.")

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -846,7 +846,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         {
             Preconditions.checkNotNull(spec, "Cannot get config value before spec is built");
             // TODO: Remove this dev-time check so this errors out on both production and dev
-            // This is dev-time-only in 1.18.2, to avoid breaking already published mods while forcing devs to fix their errors
+            // This is dev-time-only in 1.19.x, to avoid breaking already published mods while forcing devs to fix their errors
             if (!FMLEnvironment.production)
             {
                 // When the above if-check is removed, change message to "Cannot get config value before config is loaded"


### PR DESCRIPTION
When #8236 was merged, dev-time config access started check for the loading state of configuration entries.

If a single player world was opened straight from the main menu the configuration entry for handling empty ingredients was not loaded yet, since this is a server config yet no server exists at this point in time, causing a hard crash.

This PR removes the config option entirely and enables the behaviour by default.
Discussed internally.

Validated that the world now loads. Additionally checked that the advancement cleanup (Which has a similar check) now works, which it does, since that is run at a point where the server is loaded and configs have been synced.