### PR TITLE
[1.19.x] Fix TagsProviders for datapack registries not recognizing existing files

### DIFF
--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -57,7 +57,7 @@
 +      // Optional tags should not be validated
 +
 +      if (reference.isRequired()) {
-+         return existingFileHelper == null || !existingFileHelper.exists(reference.getId(), reference.f_215914_ ? resourceType : elementResourceType);
++         return existingFileHelper == null || !existingFileHelper.exists(reference.getId(), reference.isTag() ? resourceType : elementResourceType);
 +      }
 +      return false;
 +   }

--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -1,12 +1,13 @@
 --- a/net/minecraft/data/tags/TagsProvider.java
 +++ b/net/minecraft/data/tags/TagsProvider.java
-@@ -29,10 +_,30 @@
+@@ -29,10 +_,32 @@
     protected final DataGenerator.PathProvider f_236439_;
     protected final Registry<T> f_126540_;
     protected final Map<ResourceLocation, TagBuilder> f_126543_ = Maps.newLinkedHashMap();
 +   protected final String modId;
 +   protected final net.minecraftforge.common.data.ExistingFileHelper existingFileHelper;
 +   private final net.minecraftforge.common.data.ExistingFileHelper.IResourceType resourceType;
++   private final net.minecraftforge.common.data.ExistingFileHelper.IResourceType elementResourceType; // FORGE: Resource type for validating required references to datapack registry elements.
  
 +   /**
 +    * @see #TagsProvider(DataGenerator, Registry, String, net.minecraftforge.common.data.ExistingFileHelper)
@@ -22,6 +23,7 @@
 +      this.modId = modId;
 +      this.existingFileHelper = existingFileHelper;
 +      this.resourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", TagManager.m_203918_(p_126547_.m_123023_()));
++      this.elementResourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", net.minecraftforge.common.ForgeHooks.prefixNamespace(p_126547_.m_123023_().m_135782_()));
 +   }
 +
 +   // Forge: Allow customizing the path for a given tag or returning null
@@ -47,16 +49,15 @@
  
              try {
                 DataProvider.m_236072_(p_236446_, jsonelement, path);
-@@ -65,24 +_,37 @@
+@@ -65,24 +_,36 @@
        });
     }
  
 +   private boolean missing(TagEntry reference) {
-+      // We only care about non-optional tag entries, this is the only type that can reference a resource and needs validation
 +      // Optional tags should not be validated
 +
 +      if (reference.isRequired()) {
-+         return existingFileHelper == null || !existingFileHelper.exists(reference.getId(), resourceType);
++         return existingFileHelper == null || !existingFileHelper.exists(reference.getId(), reference.f_215914_ ? resourceType : elementResourceType);
 +      }
 +      return false;
 +   }

--- a/patches/minecraft/net/minecraft/tags/TagEntry.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagEntry.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/tags/TagEntry.java
 +++ b/net/minecraft/tags/TagEntry.java
-@@ -113,6 +_,14 @@
+@@ -113,6 +_,18 @@
        return stringbuilder.toString();
     }
  
@@ -10,6 +10,10 @@
 +
 +   public boolean isRequired() {
 +      return f_215915_;
++   }
++
++   public boolean isTag() {
++      return f_215914_;
 +   }
 +
     public interface Lookup<T> {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -277,6 +277,7 @@ public net.minecraft.server.network.ServerLoginPacketListenerImpl f_10021_ # gam
 public net.minecraft.server.packs.AbstractPackResources f_10203_ # file
 public net.minecraft.server.packs.PackType f_143750_ # bridgeType
 public net.minecraft.server.packs.resources.FallbackResourceManager f_10599_ # fallbacks
+public net.minecraft.tags.TagEntry f_215914_ # tag
 public net.minecraft.util.ExtraCodecs$EitherCodec
 public net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix$Conversion
 public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # submitAsync

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -277,7 +277,6 @@ public net.minecraft.server.network.ServerLoginPacketListenerImpl f_10021_ # gam
 public net.minecraft.server.packs.AbstractPackResources f_10203_ # file
 public net.minecraft.server.packs.PackType f_143750_ # bridgeType
 public net.minecraft.server.packs.resources.FallbackResourceManager f_10599_ # fallbacks
-public net.minecraft.tags.TagEntry f_215914_ # tag
 public net.minecraft.util.ExtraCodecs$EitherCodec
 public net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix$Conversion
 public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # submitAsync


### PR DESCRIPTION
Fixes #8760

This fix was implemented by altering the patch to TagsProviders to query ExistingFileHelper for the correct path for element-reference entries (where previously it always queried it for a path in the tag folder whether the entry was an element or tag reference).

The fix was verified for existing json files by adding the following json and datagenerator:

`main/resources/data/forge/worldgen/configured_feature/datagen_test.json`
```json
{
  "type": "minecraft:no_op",
  "config": {}
}
```

```java
  public void gatherData(GatherDataEvent event)
  {
        DataGenerator gen = event.getGenerator();
        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
        RegistryAccess registryAccess = RegistryAccess.builtinCopy();
        Registry<ConfiguredFeature<?,?>> configuredFeatures = registryAccess.registryOrThrow(Registry.CONFIGURED_FEATURE_REGISTRY);
        gen.addProvider(event.includeServer(), new TagsProvider<>(gen, configuredFeatures, "forge", existingFileHelper)
        {
            @Override
            protected void addTags()
            {
                this.tag(TagKey.create(Registry.CONFIGURED_FEATURE_REGISTRY, new ResourceLocation("forge", "datagen_test_tag")))
                    .add(ResourceKey.create(Registry.CONFIGURED_FEATURE_REGISTRY, new ResourceLocation("forge", "datagen_test")));
            }
        });
  }
```

Running datagen correctly produced the tag file without errors.

The fix was validated for file paths of other datagenerated files by using this datagenerator (without an existing json):

```java
    public void gatherData(GatherDataEvent event)
    {
        DataGenerator gen = event.getGenerator();
        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
        RegistryAccess registryAccess = RegistryAccess.builtinCopy();
        RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, registryAccess);
        Registry<ConfiguredFeature<?,?>> configuredFeatures = registryAccess.registryOrThrow(Registry.CONFIGURED_FEATURE_REGISTRY);
        gen.addProvider(event.includeServer(), JsonCodecProvider.forDatapackRegistry(gen, existingFileHelper, "forge", ops, Registry.CONFIGURED_FEATURE_REGISTRY,
            Map.of(new ResourceLocation("forge", "datagen_test"), new ConfiguredFeature<>(Feature.NO_OP, NoneFeatureConfiguration.INSTANCE))));
        gen.addProvider(event.includeServer(), new TagsProvider<>(gen, configuredFeatures, "forge", existingFileHelper)
        {
            @Override
            protected void addTags()
            {
                this.tag(TagKey.create(Registry.CONFIGURED_FEATURE_REGISTRY, new ResourceLocation("forge", "datagen_test_tag")))
                    .add(ResourceKey.create(Registry.CONFIGURED_FEATURE_REGISTRY, new ResourceLocation("forge", "datagen_test")));
            }
        });
    }
```

The tag file was correctly generated without errors.