### PR TITLE
[1.19.x] The ServerTickEvent will now contain a reference to the MinecraftServer.

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -95,7 +95,7 @@
  
     public void m_5705_(BooleanSupplier p_129871_) {
        long i = Util.m_137569_();
-+      net.minecraftforge.event.ForgeEventFactory.onPreServerTick(p_129871_);
++      net.minecraftforge.event.ForgeEventFactory.onPreServerTick(p_129871_, this);
        ++this.f_129766_;
        this.m_5703_(p_129871_);
        if (i - this.f_129724_ >= 5000000000L) {
@@ -111,7 +111,7 @@
        long i1 = Util.m_137569_();
        this.f_129735_.m_13755_(i1 - i);
        this.f_129754_.m_7238_();
-+      net.minecraftforge.event.ForgeEventFactory.onPostServerTick(p_129871_);
++      net.minecraftforge.event.ForgeEventFactory.onPostServerTick(p_129871_, this);
     }
  
     public void m_5703_(BooleanSupplier p_129954_) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -15,6 +15,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.network.chat.ChatSender;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.players.PlayerList;
 import net.minecraft.util.RandomSource;
@@ -814,13 +815,13 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new TickEvent.ClientTickEvent(TickEvent.Phase.END));
     }
 
-    public static void onPreServerTick(BooleanSupplier haveTime)
+    public static void onPreServerTick(BooleanSupplier haveTime, MinecraftServer server)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.START, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.START, haveTime, server));
     }
 
-    public static void onPostServerTick(BooleanSupplier haveTime)
+    public static void onPostServerTick(BooleanSupplier haveTime, MinecraftServer server)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END, haveTime, server));
     }
 }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -59,9 +59,9 @@ public class TickEvent extends Event
          * @return Returns the {@link MinecraftServer} that is currently ticking.
          */
         public MinecraftServer getServer()
-		{
-			return server;
-		}
+        {
+            return server;
+        }
     }
 
     public static class ClientTickEvent extends TickEvent {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -56,7 +56,7 @@ public class TickEvent extends Event
         }
         
         /**
-         * @return Returns the {@link MinecraftServer} that is currently ticking.
+         * {@return the {@link MinecraftServer} instance}
          */
         public MinecraftServer getServer()
         {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.server.MinecraftServer;
 
 import java.util.function.BooleanSupplier;
 
@@ -35,11 +36,13 @@ public class TickEvent extends Event
 
     public static class ServerTickEvent extends TickEvent {
         private final BooleanSupplier haveTime;
+        private MinecraftServer server;
 
-        public ServerTickEvent(Phase phase, BooleanSupplier haveTime)
+        public ServerTickEvent(Phase phase, BooleanSupplier haveTime, MinecraftServer server)
         {
             super(Type.SERVER, LogicalSide.SERVER, phase);
             this.haveTime = haveTime;
+            this.server = server;
         }
 
         /**
@@ -51,6 +54,14 @@ public class TickEvent extends Event
         {
             return this.haveTime.getAsBoolean();
         }
+        
+        /**
+         * @return Returns the {@link MinecraftServer} that is currently ticking.
+         */
+        public MinecraftServer getServer()
+		{
+			return server;
+		}
     }
 
     public static class ClientTickEvent extends TickEvent {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -56,7 +56,7 @@ public class TickEvent extends Event
         }
         
         /**
-         * {@return the {@link MinecraftServer} instance}
+         * {@return the server instance}
          */
         public MinecraftServer getServer()
         {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -36,7 +36,7 @@ public class TickEvent extends Event
 
     public static class ServerTickEvent extends TickEvent {
         private final BooleanSupplier haveTime;
-        private MinecraftServer server;
+        private final MinecraftServer server;
 
         public ServerTickEvent(Phase phase, BooleanSupplier haveTime, MinecraftServer server)
         {


### PR DESCRIPTION
This PR adds the ability for modders to retrieve an instance of a `MinecraftServer` directly with a getter in the `ServerTickEvent` instead of having to call `ServerLifecycleHooks.getCurrentServer()`.

This greatly improves readability in my opinion, instead of having to write
```java
@SubscribeEvent
public static void onServerTick(ServerTickEvent event)
{
        System.out.println("Current tick: " + ServerLifecycleHooks.getCurrentServer().getTickCount());
}
```
you can just write
```java
@SubscribeEvent
public static void onServerTick(ServerTickEvent event)
{
        System.out.println("Current tick: " + event.getServer().getTickCount());
}
```

This also has the added advantage of presenting the modder with a more obvious solution; Knowing of the existence of `ServerLifecycleHooks.getCurrentServer()` is not trivial, one expects to find a reference to a `MinecraftServer` in the `ServerTickEvent`.