### PR TITLE
Method parity between vanilla registries and Forge registry wrappers

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -309,6 +309,13 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
 
     @NotNull
     @Override
+    public Set<ResourceKey<V>> getResourceKeys()
+    {
+        return Collections.unmodifiableSet(this.keys.keySet());
+    }
+
+    @NotNull
+    @Override
     public Collection<V> getValues()
     {
         return Collections.unmodifiableSet(this.names.values());

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -308,8 +308,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     }
 
     @NotNull
-    @Override
-    public Set<ResourceKey<V>> getResourceKeys()
+    Set<ResourceKey<V>> getResourceKeys()
     {
         return Collections.unmodifiableSet(this.keys.keySet());
     }

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -46,6 +46,7 @@ public interface IForgeRegistry<V> extends Iterable<V>
     @NotNull Optional<ResourceKey<V>> getResourceKey(V value);
 
     @NotNull Set<ResourceLocation>         getKeys();
+    @NotNull Set<ResourceKey<V>>           getResourceKeys();
     @NotNull Collection<V>                 getValues();
     @NotNull Set<Entry<ResourceKey<V>, V>> getEntries();
 

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -46,7 +46,6 @@ public interface IForgeRegistry<V> extends Iterable<V>
     @NotNull Optional<ResourceKey<V>> getResourceKey(V value);
 
     @NotNull Set<ResourceLocation>         getKeys();
-    @NotNull Set<ResourceKey<V>>           getResourceKeys();
     @NotNull Collection<V>                 getValues();
     @NotNull Set<Entry<ResourceKey<V>, V>> getEntries();
 

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -192,7 +192,8 @@ class NamespacedDefaultedWrapper<T> extends DefaultedRegistry<T> implements ILoc
 
     @Override public Optional<Holder<T>> getHolder(int id) { return this.holders.getHolder(id); }
     @Override public Optional<Holder<T>> getHolder(ResourceKey<T> key) { return this.holders.getHolder(key); }
-    @Override public DataResult<Holder<T>> getOrCreateHolder(ResourceKey<T> key) { return DataResult.success(this.holders.getOrCreateHolder(key)); }
+    @Override public DataResult<Holder<T>> getOrCreateHolder(ResourceKey<T> key) { return this.holders.getOrCreateHolder(key); }
+    @Override public Holder<T> getOrCreateHolderOrThrow(ResourceKey<T> key) { return this.holders.getOrCreateHolderOrThrow(key); }
     @Override public Optional<Holder<T>> getRandom(RandomSource rand) { return this.holders.getRandom(rand); }
     @Override public Stream<Holder.Reference<T>> holders() { return this.holders.holders();  }
     @Override public boolean isKnownTagName(TagKey<T> name) { return this.holders.isKnownTagName(name); }

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -167,6 +167,12 @@ class NamespacedDefaultedWrapper<T> extends DefaultedRegistry<T> implements ILoc
     }
 
     @Override
+    public Set<ResourceKey<T>> registryKeySet()
+    {
+        return this.delegate.getResourceKeys();
+    }
+
+    @Override
     public Set<Map.Entry<ResourceKey<T>, T>> entrySet()
     {
         return this.delegate.getEntries();

--- a/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
@@ -95,7 +95,7 @@ class NamespacedHolderHelper<T>
         if (ref == null)
         {
             if (this.holderLookup != null)
-                return DataResult.error("This registry can't create new holders without value");
+                return DataResult.error("This registry can't create new holders without value. (requested key" + key + ")");
 
             if (this.frozen)
                 return DataResult.error("Registry is already frozen (trying to add key " + key + ")");
@@ -111,7 +111,7 @@ class NamespacedHolderHelper<T>
         return this.holdersByName.computeIfAbsent(key.location(), k ->
         {
             if (this.holderLookup != null)
-                throw new IllegalStateException("This registry can't create new holders without value");
+                throw new IllegalStateException("This registry can't create new holders without value. (requested key" + key + ")");
             if (this.frozen)
                 throw new IllegalStateException("Registry is already frozen (trying to add key " + k + ")");
             return Holder.Reference.createStandAlone(this.self, key);

--- a/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.mojang.serialization.DataResult;
+import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
 import net.minecraft.util.RandomSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -108,13 +109,12 @@ class NamespacedHolderHelper<T>
 
     Holder<T> getOrCreateHolderOrThrow(ResourceKey<T> key)
     {
-        return this.holdersByName.computeIfAbsent(key.location(), k ->
+        return LamdbaExceptionUtils.uncheck(() ->
         {
-            if (this.holderLookup != null)
-                throw new IllegalStateException("This registry can't create new holders without value (requested key: " + key + ")");
-            if (this.frozen)
-                throw new IllegalStateException("Registry is already frozen (trying to add key " + k + ")");
-            return Holder.Reference.createStandAlone(this.self, key);
+            DataResult<Holder<T>> dataResult = getOrCreateHolder(key);
+            if (dataResult.error().isPresent())
+                throw new IllegalStateException(dataResult.error().get().message());
+            return dataResult.result().get();
         });
     }
 

--- a/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
@@ -91,7 +91,7 @@ class NamespacedHolderHelper<T>
 
     DataResult<Holder<T>> getOrCreateHolder(ResourceKey<T> key)
     {
-        Holder.Reference<T> ref = this.holdersByName.get(key);
+        Holder.Reference<T> ref = this.holdersByName.get(key.location());
         if (ref == null)
         {
             if (this.holderLookup != null)

--- a/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
@@ -109,12 +109,9 @@ class NamespacedHolderHelper<T>
 
     Holder<T> getOrCreateHolderOrThrow(ResourceKey<T> key)
     {
-        return LamdbaExceptionUtils.uncheck(() ->
+        return getOrCreateHolder(key).getOrThrow(false, msg ->
         {
-            DataResult<Holder<T>> dataResult = getOrCreateHolder(key);
-            if (dataResult.error().isPresent())
-                throw new IllegalStateException(dataResult.error().get().message());
-            return dataResult.result().get();
+            throw new IllegalStateException(msg);
         });
     }
 

--- a/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedHolderHelper.java
@@ -95,7 +95,7 @@ class NamespacedHolderHelper<T>
         if (ref == null)
         {
             if (this.holderLookup != null)
-                return DataResult.error("This registry can't create new holders without value. (requested key" + key + ")");
+                return DataResult.error("This registry can't create new holders without value (requested key: " + key + ")");
 
             if (this.frozen)
                 return DataResult.error("Registry is already frozen (trying to add key " + key + ")");
@@ -111,7 +111,7 @@ class NamespacedHolderHelper<T>
         return this.holdersByName.computeIfAbsent(key.location(), k ->
         {
             if (this.holderLookup != null)
-                throw new IllegalStateException("This registry can't create new holders without value. (requested key" + key + ")");
+                throw new IllegalStateException("This registry can't create new holders without value (requested key: " + key + ")");
             if (this.frozen)
                 throw new IllegalStateException("Registry is already frozen (trying to add key " + k + ")");
             return Holder.Reference.createStandAlone(this.self, key);

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -165,6 +165,12 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
     }
 
     @Override
+    public Set<ResourceKey<T>> registryKeySet()
+    {
+        return this.delegate.getResourceKeys();
+    }
+
+    @Override
     public Set<Map.Entry<ResourceKey<T>, T>> entrySet()
     {
         return this.delegate.getEntries();

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -190,7 +190,8 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
 
     @Override public Optional<Holder<T>> getHolder(int id) { return this.holders.getHolder(id); }
     @Override public Optional<Holder<T>> getHolder(ResourceKey<T> key) { return this.holders.getHolder(key); }
-    @Override public DataResult<Holder<T>> getOrCreateHolder(ResourceKey<T> key) { return DataResult.success(this.holders.getOrCreateHolder(key)); }
+    @Override public DataResult<Holder<T>> getOrCreateHolder(ResourceKey<T> key) { return this.holders.getOrCreateHolder(key); }
+    @Override public Holder<T> getOrCreateHolderOrThrow(ResourceKey<T> key) { return this.holders.getOrCreateHolderOrThrow(key); }
     @Override public Optional<Holder<T>> getRandom(RandomSource rand) { return this.holders.getRandom(rand); }
     @Override public Stream<Holder.Reference<T>> holders() { return this.holders.holders();  }
     @Override public boolean isKnownTagName(TagKey<T> name) { return this.holders.isKnownTagName(name); }


### PR DESCRIPTION
Fixes #8758. This changes the implementation of `getOrCreateHolder` to more closely match the vanilla implementation (it can return an errored DataResult in cases where the registry value is needed or registry is frozen, rather than throwing) and moves the original implementation to `getOrCreateHolderOrThrow`. We also add the method `getResourceKeys` to IForgeRegistry. This also extends the relevant methods in NamespacedWrapper and NamespacedDefaultedWrapper.

As a side-note, I had a case before where I mistakenly did not call `ResourceKey#location` and when the method returned the errored DataResult, the error did not happen to have much helpful information regarding what the key and registry was. Perhaps when the holderLookup field is nonnull it should still say what key was attempted in both "getOrCreateHolder..." methods?