### PR TITLE
[1.19] Fix default audio device error

### DIFF
--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/Options.java
 +++ b/net/minecraft/client/Options.java
+@@ -515,7 +_,7 @@
+    }, new OptionInstance.LazyEnum<>(() -> {
+       return Stream.concat(Stream.of(""), Minecraft.m_91087_().m_91106_().m_194525_().stream()).toList();
+    }, (p_232011_) -> {
+-      return Minecraft.m_91087_().m_91396_() && p_232011_ != "" && !Minecraft.m_91087_().m_91106_().m_194525_().contains(p_232011_) ? Optional.empty() : Optional.of(p_232011_);
++      return Minecraft.m_91087_().m_91396_() && (p_232011_ == null || !p_232011_.isEmpty()) && !Minecraft.m_91087_().m_91106_().m_194525_().contains(p_232011_) ? Optional.empty() : Optional.of(p_232011_);
+    }, Codec.STRING), "", (p_231994_) -> {
+       SoundManager soundmanager = Minecraft.m_91087_().m_91106_();
+       soundmanager.m_194526_();
 @@ -772,6 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/Options.java
 +++ b/net/minecraft/client/Options.java
-@@ -515,7 +_,7 @@
+@@ -515,7 +_,8 @@
     }, new OptionInstance.LazyEnum<>(() -> {
        return Stream.concat(Stream.of(""), Minecraft.m_91087_().m_91106_().m_194525_().stream()).toList();
     }, (p_232011_) -> {
 -      return Minecraft.m_91087_().m_91396_() && p_232011_ != "" && !Minecraft.m_91087_().m_91106_().m_194525_().contains(p_232011_) ? Optional.empty() : Optional.of(p_232011_);
++      // FORGE: fix incorrect string comparison - PR #8767
 +      return Minecraft.m_91087_().m_91396_() && (p_232011_ == null || !p_232011_.isEmpty()) && !Minecraft.m_91087_().m_91106_().m_194525_().contains(p_232011_) ? Optional.empty() : Optional.of(p_232011_);
     }, Codec.STRING), "", (p_231994_) -> {
        SoundManager soundmanager = Minecraft.m_91087_().m_91106_();


### PR DESCRIPTION
This PR fixes an incorrect string comparison in the validator of the sound device selection, causing the validation to fail, which logs `[17:05:00] [Render thread/ERROR] [minecraft/OptionInstance]: Illegal option value  for translation{key='options.audioDevice', args=[]}` and resets the selection to the default value when the selection is set to `Device: System Default` (there is a double space between `value` and `for`).

This issue is reproducable in forgedev, userdev and a Forge production environment, except for the first start when the options file doesn't exist yet.
This issue is not reproducable in a vanilla production environment.
SizableShrimp was able to reproduce it in fmlonly, so it's likely not caused by a Forge patch: <https://discord.com/channels/313125603924639766/852298000042164244/987745376297705472>