### PR TITLE
[1.19] Fix certain user-configured options being overwritten

### DIFF
--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -8,8 +8,22 @@
        this.f_92060_ = p_92138_;
        this.f_92110_ = new File(p_92139_, "options.txt");
        boolean flag = p_92138_.m_91103_();
-@@ -887,10 +_,14 @@
+@@ -807,6 +_,10 @@
+    }
+ 
+    private void m_168427_(Options.FieldAccess p_168428_) {
++      processOptions(p_168428_, false);
++   }
++   private void processOptions(Options.FieldAccess p_168428_, boolean onlyKeyBinds) {
++      if (!onlyKeyBinds) { //FORGE: prevent overwriting user's settings when reloading options after game startup
+       p_168428_.m_213982_("autoJump", this.f_92036_);
+       p_168428_.m_213982_("autoSuggestions", this.f_92037_);
+       p_168428_.m_213982_("chatColors", this.f_92038_);
+@@ -885,14 +_,20 @@
+       p_168428_.m_213982_("allowServerListing", this.f_193762_);
+       p_168428_.m_213982_("chatPreview", this.f_231796_);
        p_168428_.m_213982_("onlyShowSecureChat", this.f_231798_);
++      }
  
        for(KeyMapping keymapping : this.f_92059_) {
 -         String s = keymapping.m_90865_();
@@ -24,7 +38,28 @@
 +               keymapping.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.NONE, InputConstants.m_84851_(s1));
           }
        }
++      if (onlyKeyBinds) return; //FORGE: prevent overwriting user's settings when reloading options after game startup
  
+       for(SoundSource soundsource : SoundSource.values()) {
+          this.f_92109_.computeFloat(soundsource, (p_231866_, p_231867_) -> {
+@@ -955,7 +_,7 @@
+             }
+          }
+ 
+-         this.m_168427_(new Options.FieldAccess() {
++         this.processOptions(new Options.FieldAccess() {
+             @Nullable
+             private String m_168458_(String p_168459_) {
+                return compoundtag1.m_128441_(p_168459_) ? compoundtag1.m_128461_(p_168459_) : null;
+@@ -1022,7 +_,7 @@
+                String s = this.m_168458_(p_168470_);
+                return (T)(s == null ? p_168471_ : p_168472_.apply(s));
+             }
+-         });
++         }, Minecraft.m_91087_().m_91396_()); //FORGE: prevent overwriting user's settings when reloading options after game startup
+          if (compoundtag1.m_128441_("fullscreenResolution")) {
+             this.f_92123_ = compoundtag1.m_128461_("fullscreenResolution");
+          }
 @@ -1058,6 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -8,23 +8,15 @@
        this.f_92060_ = p_92138_;
        this.f_92110_ = new File(p_92139_, "options.txt");
        boolean flag = p_92138_.m_91103_();
-@@ -807,6 +_,10 @@
-    }
- 
-    private void m_168427_(Options.FieldAccess p_168428_) {
-+      processOptions(p_168428_, false);
-+   }
-+   private void processOptions(Options.FieldAccess p_168428_, boolean onlyKeyBinds) {
-+      if (!onlyKeyBinds) { //FORGE: prevent overwriting user's settings when reloading options after game startup
-       p_168428_.m_213982_("autoJump", this.f_92036_);
-       p_168428_.m_213982_("autoSuggestions", this.f_92037_);
-       p_168428_.m_213982_("chatColors", this.f_92038_);
-@@ -885,14 +_,20 @@
-       p_168428_.m_213982_("allowServerListing", this.f_193762_);
+@@ -886,11 +_,20 @@
        p_168428_.m_213982_("chatPreview", this.f_231796_);
        p_168428_.m_213982_("onlyShowSecureChat", this.f_231798_);
-+      }
  
++      processOptionsForge(p_168428_);
++   }
++   // FORGE: split off to allow reloading options after mod loading is done
++   private void processOptionsForge(Options.FieldAccess p_168428_)
++   {
        for(KeyMapping keymapping : this.f_92059_) {
 -         String s = keymapping.m_90865_();
 +         String s = keymapping.m_90865_() + (keymapping.getKeyModifier() != net.minecraftforge.client.settings.KeyModifier.NONE ? ":" + keymapping.getKeyModifier() : "");
@@ -38,28 +30,27 @@
 +               keymapping.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.NONE, InputConstants.m_84851_(s1));
           }
        }
-+      if (onlyKeyBinds) return; //FORGE: prevent overwriting user's settings when reloading options after game startup
  
-       for(SoundSource soundsource : SoundSource.values()) {
-          this.f_92109_.computeFloat(soundsource, (p_231866_, p_231867_) -> {
-@@ -955,7 +_,7 @@
+@@ -911,6 +_,9 @@
+    }
+ 
+    public void m_92140_() {
++      this.load(false);
++   }
++   public void load(boolean limited) {
+       try {
+          if (!this.f_92110_.exists()) {
+             return;
+@@ -955,7 +_,8 @@
              }
           }
  
 -         this.m_168427_(new Options.FieldAccess() {
-+         this.processOptions(new Options.FieldAccess() {
++         java.util.function.Consumer<FieldAccess> processor = limited ? this::processOptionsForge : this::m_168427_;
++         processor.accept(new Options.FieldAccess() {
              @Nullable
              private String m_168458_(String p_168459_) {
                 return compoundtag1.m_128441_(p_168459_) ? compoundtag1.m_128461_(p_168459_) : null;
-@@ -1022,7 +_,7 @@
-                String s = this.m_168458_(p_168470_);
-                return (T)(s == null ? p_168471_ : p_168472_.apply(s));
-             }
--         });
-+         }, Minecraft.m_91087_().m_91396_()); //FORGE: prevent overwriting user's settings when reloading options after game startup
-          if (compoundtag1.m_128441_("fullscreenResolution")) {
-             this.f_92123_ = compoundtag1.m_128461_("fullscreenResolution");
-          }
 @@ -1058,6 +_,7 @@
     }
  

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -127,7 +127,7 @@ public class ClientModLoader
         loading = false;
         loadingComplete = true;
         // reload game settings on main thread
-        syncExecutor.execute(()->mc.options.load());
+        syncExecutor.execute(()->mc.options.load(true));
     }
 
     public static VersionChecker.Status checkForUpdates()

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -1,4 +1,5 @@
 net/minecraft/advancements/Advancement$Builder.fromJson(Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;Lnet/minecraftforge/common/crafting/conditions/ICondition$IContext;)Lnet/minecraft/advancements/Advancement$Builder;=|p_138381_,p_138382_,context
+net/minecraft/client/Options.processOptions(Lnet/minecraft/client/Options$FieldAccess;Z)V=|p_168428_,onlyKeyBinds
 net/minecraft/client/gui/screens/MenuScreens.getScreenFactory(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/Minecraft;ILnet/minecraft/network/chat/Component;)Ljava/util/Optional;=|p_96202_,p_96203_,p_96204_,p_96205_
 net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.doLoadLevel(Lnet/minecraft/client/gui/screens/Screen;Ljava/lang/String;ZZZ)V=|p_233146_,p_233147_,p_233148_,p_233149_,confirmExperimentalWarning
 net/minecraft/client/renderer/ScreenEffectRenderer.getOverlayBlock(Lnet/minecraft/world/entity/player/Player;)Lorg/apache/commons/lang3/tuple/Pair;=|p_110717_

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -1,5 +1,5 @@
 net/minecraft/advancements/Advancement$Builder.fromJson(Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;Lnet/minecraftforge/common/crafting/conditions/ICondition$IContext;)Lnet/minecraft/advancements/Advancement$Builder;=|p_138381_,p_138382_,context
-net/minecraft/client/Options.processOptions(Lnet/minecraft/client/Options$FieldAccess;Z)V=|p_168428_,onlyKeyBinds
+net/minecraft/client/Options.processOptionsForge(Lnet/minecraft/client/Options$FieldAccess;)V=|p_168428_
 net/minecraft/client/gui/screens/MenuScreens.getScreenFactory(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/Minecraft;ILnet/minecraft/network/chat/Component;)Ljava/util/Optional;=|p_96202_,p_96203_,p_96204_,p_96205_
 net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.doLoadLevel(Lnet/minecraft/client/gui/screens/Screen;Ljava/lang/String;ZZZ)V=|p_233146_,p_233147_,p_233148_,p_233149_,confirmExperimentalWarning
 net/minecraft/client/renderer/ScreenEffectRenderer.getOverlayBlock(Lnet/minecraft/world/entity/player/Player;)Lorg/apache/commons/lang3/tuple/Pair;=|p_110717_


### PR DESCRIPTION
This PR fixes user-configured options being overwritten with incorrectly "corrected" values when Forge reloads options after mod loading is done and on every resource reload. Fixes #8770.

I am opening this as a draft for now because I have not found a way to fully test the impact of this patch and I am also not particularly happy with this solution, so critical feedback would be highly appreciated.