### PR TITLE
[1.19.x] Add getter for correct BiomeSpecialEffectsBuilder to BiomeInfo$Builder

### DIFF
--- a/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
@@ -157,10 +157,10 @@ public class ModifiableBiomeInfo
             {
                 return effects;
             }
-            
+
             public BiomeSpecialEffectsBuilder getSpecialEffects()
             {
-            	return effects;
+                return effects;
             }
 
             public BiomeGenerationSettingsBuilder getGenerationSettings()

--- a/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
@@ -152,7 +152,7 @@ public class ModifiableBiomeInfo
              * 
              * @deprecated Use {@link #getSpecialEffects()} as it provides read access. TODO remove this by 1.20
              */
-            @Deprecated(forRemoval=true)
+            @Deprecated(forRemoval=true, since="1.19")
             public BiomeSpecialEffects.Builder getEffects()
             {
                 return effects;

--- a/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
@@ -106,7 +106,7 @@ public class ModifiableBiomeInfo
         public static class Builder
         {
             private ClimateSettingsBuilder climateSettings;
-            private BiomeSpecialEffects.Builder effects;
+            private BiomeSpecialEffectsBuilder effects;
             private BiomeGenerationSettingsBuilder generationSettings;
             private MobSpawnSettingsBuilder mobSpawnSettings;
             
@@ -117,7 +117,7 @@ public class ModifiableBiomeInfo
             public static Builder copyOf(final BiomeInfo original)
             {
                 final ClimateSettingsBuilder climateBuilder = ClimateSettingsBuilder.copyOf(original.climateSettings());
-                final BiomeSpecialEffects.Builder effectsBuilder = BiomeSpecialEffectsBuilder.copyOf(original.effects());
+                final BiomeSpecialEffectsBuilder effectsBuilder = BiomeSpecialEffectsBuilder.copyOf(original.effects());
                 final BiomeGenerationSettingsBuilder generationBuilder = new BiomeGenerationSettingsBuilder(original.generationSettings());
                 final MobSpawnSettingsBuilder mobSpawnBuilder = new MobSpawnSettingsBuilder(original.mobSpawnSettings());
                 
@@ -129,7 +129,7 @@ public class ModifiableBiomeInfo
                     );
             }
             
-            private Builder(final ClimateSettingsBuilder climateSettings, final BiomeSpecialEffects.Builder effects, final BiomeGenerationSettingsBuilder generationSettings, final MobSpawnSettingsBuilder mobSpawnSettings)
+            private Builder(final ClimateSettingsBuilder climateSettings, final BiomeSpecialEffectsBuilder effects, final BiomeGenerationSettingsBuilder generationSettings, final MobSpawnSettingsBuilder mobSpawnSettings)
             {
                 this.climateSettings = climateSettings;
                 this.effects = effects;
@@ -147,7 +147,7 @@ public class ModifiableBiomeInfo
                 return climateSettings;
             }
 
-            public BiomeSpecialEffects.Builder getEffects()
+            public BiomeSpecialEffectsBuilder getEffects()
             {
                 return effects;
             }

--- a/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/minecraftforge/common/world/ModifiableBiomeInfo.java
@@ -147,9 +147,20 @@ public class ModifiableBiomeInfo
                 return climateSettings;
             }
 
-            public BiomeSpecialEffectsBuilder getEffects()
+            /**
+             * {@return Builder for client special effects}
+             * 
+             * @deprecated Use {@link #getSpecialEffects()} as it provides read access. TODO remove this by 1.20
+             */
+            @Deprecated(forRemoval=true)
+            public BiomeSpecialEffects.Builder getEffects()
             {
                 return effects;
+            }
+            
+            public BiomeSpecialEffectsBuilder getSpecialEffects()
+            {
+            	return effects;
             }
 
             public BiomeGenerationSettingsBuilder getGenerationSettings()


### PR DESCRIPTION
One of the intentions of the BiomeModifier api was to provide read access to the current and modified state of a biome to a BiomeModifier, so that the BiomeModifier can read the state to determine whether to make further modifications.

To facilitate this, forge extensions of vanilla's builders for climate and client special effects were used, to provide read access to the builders' fields (the vanilla builders have setters but no getters), in a similar manner to the generation and mob spawn builder extensions originally created for the BiomeLoadingEvent.

However, due to a clerical error, the getter for the special effects builder provides the vanilla builder type, not the forge extension. The actual implementation is still the forge extension, but mods have to cast to the forge builder to use its getters. This PR adds a getter to the API that returns the correct builder type.