### PR TITLE
[DRAFT] ItemStack-sensitive method for shears in dispensers

### DIFF
--- a/patches/minecraft/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
++++ b/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
+@@ -26,7 +_,7 @@
+       Level level = p_123580_.m_7727_();
+       if (!level.m_5776_()) {
+          BlockPos blockpos = p_123580_.m_7961_().m_121945_(p_123580_.m_6414_().m_61143_(DispenserBlock.f_52659_));
+-         this.m_123573_(m_123576_((ServerLevel)level, blockpos) || m_123582_((ServerLevel)level, blockpos));
++         this.m_123573_(m_123576_((ServerLevel)level, blockpos) || tryShearLivingEntity((ServerLevel)level, blockpos, p_123581_));
+          if (this.m_123570_() && p_123581_.m_220157_(1, level.m_213780_(), (ServerPlayer)null)) {
+             p_123581_.m_41764_(0);
+          }
+@@ -53,11 +_,11 @@
+       return false;
+    }
+ 
+-   private static boolean m_123582_(ServerLevel p_123583_, BlockPos p_123584_) {
++   private static boolean tryShearLivingEntity(ServerLevel p_123583_, BlockPos p_123584_, ItemStack pItemStack) {
+       for(LivingEntity livingentity : p_123583_.m_6443_(LivingEntity.class, new AABB(p_123584_), EntitySelector.f_20408_)) {
+          if (livingentity instanceof Shearable shearable) {
+             if (shearable.m_6220_()) {
+-               shearable.m_5851_(SoundSource.BLOCKS);
++               shearable.shear(SoundSource.BLOCKS, pItemStack);
+                p_123583_.m_142346_((Entity)null, GameEvent.f_157781_, p_123584_);
+                return true;
+             }

--- a/patches/minecraft/net/minecraft/world/entity/Shearable.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Shearable.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/Shearable.java
 +++ b/net/minecraft/world/entity/Shearable.java
-@@ -2,8 +_,11 @@
+@@ -2,8 +_,13 @@
  
  import net.minecraft.sounds.SoundSource;
  
@@ -11,4 +11,6 @@
  
 +   @Deprecated // Forge: Use IForgeShearable
     boolean m_6220_();
++
++   default void shear(SoundSource pSoundSource, net.minecraft.world.item.ItemStack shears) { m_5851_(pSoundSource); }
  }


### PR DESCRIPTION
Dispensers currently have no way to send the level of fortune/looting to the entity being sheared. This could have been done in principle with the IForgeShearable interface but wasn't ever implemented to do so, and #8753 is a proposed change to remove that system in favor of tool actions.

Ultimately I'm not particularly happy with where this leaves block shearing - the fact that dispensers have never supported *all* vanilla block shearing actions [you can't e.g. carve a pumpkin, or trim vines, with a dispenser] makes it difficult to consider implementing this in a general way [two well-known mods that add custom beehives register their own replacement dispenser actions, and even prior to my other PR beehives never implemented IForgeShearable].