### PR TITLE
Add MC-105317 fix into patch to rotate entities in structures properly

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
@@ -92,8 +92,8 @@
              m_74543_(p_74524_, compoundtag).ifPresent((p_205061_) -> {
 -               float f = p_205061_.m_7890_(p_74527_);
 -               f += p_205061_.m_6961_(p_74526_) - p_205061_.m_146908_();
-+               float f = p_205061_.m_6961_(placementIn.m_74401_());
-+               f = f + (p_205061_.m_146908_() - p_205061_.m_7890_(placementIn.m_74404_()));
++               float f = p_205061_.m_7890_(placementIn.m_74404_());
++               f += p_205061_.m_6961_(placementIn.m_74401_()) - p_205061_.m_146908_();
                 p_205061_.m_7678_(vec31.f_82479_, vec31.f_82480_, vec31.f_82481_, f, p_205061_.m_146909_());
 -               if (p_74530_ && p_205061_ instanceof Mob) {
 +               if (placementIn.m_74414_() && p_205061_ instanceof Mob) {


### PR DESCRIPTION
Mojang fixed the bug where entities spawned by structures do not rotate properly. Here's their bug report:
https://bugs.mojang.com/browse/MC-105317

Forge's patch into Structure Template is still using the old bugged way of rotating entities. 
The bugged old way: mirror + (rotEntity - rotStruct)
The Mojang fixed way: rotStruct + (mirror - rotEntity)

To test, put on this datapack and do `/locate structure minecraft:village_plains` and teleport to many villages. The datapack replaced the town center of these non-zombified villages to have a sad warden and sad creeper facing the same direction as the granite arrow.
[test_structure_rotation.zip](https://github.com/MinecraftForge/MinecraftForge/files/8976188/test_structure_rotation.zip)
![image](https://user-images.githubusercontent.com/40846040/175536225-eb70e3f4-af4a-4f0b-ba2a-0f101e76a897.png)

Facing east with unpatched forge looking at a south rotated piece with warden and creeper facing north.
![image](https://user-images.githubusercontent.com/40846040/175539148-55447a48-7bbf-4977-8611-6fa0b9d58a10.png)

Patched forge with the same conditions as above:
![image](https://user-images.githubusercontent.com/40846040/175539207-1173750a-e452-4123-80bc-d9b187c382c3.png)

This will need to be backported to 1.18.2 as mojang fixed the bug there but forge hasn't.
