### PR TITLE
[1.19] Added missing parameters to ICloudRenderHandler, ISkyRenderHandler

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -105,7 +105,7 @@
        p_202429_.run();
 +      net.minecraftforge.client.ISkyRenderHandler renderHandler = f_109465_.m_104583_().getSkyRenderHandler();
 +      if (renderHandler != null) {
-+         renderHandler.render(f_109477_, p_202426_, p_202424_, f_109465_, f_109461_);
++         renderHandler.render(f_109477_, p_202426_, p_202424_, p_202425_, p_202427_, p_202428_, p_202429_, f_109465_, f_109461_);
 +         return;
 +      }
        if (!p_202428_) {
@@ -117,7 +117,7 @@
     public void m_172954_(PoseStack p_172955_, Matrix4f p_172956_, float p_172957_, double p_172958_, double p_172959_, double p_172960_) {
 +      net.minecraftforge.client.ICloudRenderHandler renderHandler = f_109465_.m_104583_().getCloudRenderHandler();
 +      if (renderHandler != null) {
-+         renderHandler.render(f_109477_, p_172957_, p_172955_, f_109465_, f_109461_, p_172958_, p_172959_, p_172960_);
++         renderHandler.render(f_109477_, p_172957_, p_172955_, p_172956_, f_109465_, f_109461_, p_172958_, p_172959_, p_172960_);
 +         return;
 +      }
        float f = this.f_109465_.m_104583_().m_108871_();

--- a/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 
@@ -16,5 +17,5 @@ import net.minecraft.client.multiplayer.ClientLevel;
  */
 @FunctionalInterface
 public interface ICloudRenderHandler {
-    void render(int ticks, float partialTick, PoseStack poseStack, ClientLevel level, Minecraft minecraft, double camX, double camY, double camZ);
+    void render(int ticks, float partialTick, PoseStack poseStack, Matrix4f matrix4f, ClientLevel level, Minecraft minecraft, double camX, double camY, double camZ);
 }

--- a/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
+import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 
@@ -16,5 +18,5 @@ import net.minecraft.client.multiplayer.ClientLevel;
  */
 @FunctionalInterface
 public interface ISkyRenderHandler {
-    void render(int ticks, float partialTick, PoseStack poseStack, ClientLevel level, Minecraft minecraft);
+    void render(int ticks, float partialTick, PoseStack poseStack, Matrix4f matrix4f, Camera camera, boolean isFoggy, Runnable runnable, ClientLevel level, Minecraft minecraft);
 }


### PR DESCRIPTION
This PR add missing parameters for `ICloudRenderHandler` and `ISkyRenderHandler`, that parameters are in the main method of `CloudRender` and `SkyRender`, and this PR added it to `ICloudRenderHandler` and `ISkyRenderHandler`.

Issue: https://github.com/MinecraftForge/MinecraftForge/issues/8362

CloudRender (main):
```java
   public void renderClouds(PoseStack p_172955_, Matrix4f p_172956_, float p_172957_, double p_172958_, double p_172959_, double p_172960_) {
   ```
SkyRender (main):
```java
public void renderSky(PoseStack p_202424_, Matrix4f p_202425_, float p_202426_, Camera p_202427_, boolean p_202428_, Runnable p_202429_) {
```

This PR add in the ICloudRenderHandler:
```java
Matrix4f matrix4f
```

This PR add in the ISkyRenderHandler:
```java
Matrix4f matrix4f, Camera camera, boolean isFoggy, Runnable runnable
```
