### PR TITLE
Create PieceBeardifierModifier to re-enable piecewise beardifier definitions

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/Beardifier.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/Beardifier.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/levelgen/Beardifier.java
++++ b/net/minecraft/world/level/levelgen/Beardifier.java
+@@ -43,6 +_,11 @@
+ 
+          for(StructurePiece structurepiece : p_223936_.m_73602_()) {
+             if (structurepiece.m_73411_(p_223939_, 12)) {
++               if (structurepiece instanceof net.minecraftforge.common.world.PieceBeardifierModifier pieceBeardifierModifier) {
++                  if (pieceBeardifierModifier.getTerrainAdjustment() != TerrainAdjustment.NONE) {
++                     objectlist.add(new Beardifier.Rigid(pieceBeardifierModifier.getBeardifierBox(), pieceBeardifierModifier.getTerrainAdjustment(), pieceBeardifierModifier.getGroundLevelDelta()));
++                  }
++               } else
+                if (structurepiece instanceof PoolElementStructurePiece) {
+                   PoolElementStructurePiece poolelementstructurepiece = (PoolElementStructurePiece)structurepiece;
+                   StructureTemplatePool.Projection structuretemplatepool$projection = poolelementstructurepiece.m_209918_().m_210539_();

--- a/src/main/java/net/minecraftforge/common/world/PieceBeardifierModifier.java
+++ b/src/main/java/net/minecraftforge/common/world/PieceBeardifierModifier.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.common.world;
+
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.level.levelgen.structure.TerrainAdjustment;
+
+/** Implement this interface in a {@link net.minecraft.world.level.levelgen.structure.StructurePiece} class extension to modify its {@link net.minecraft.world.level.levelgen.Beardifier} behavior. */
+public interface PieceBeardifierModifier {
+    BoundingBox getBeardifierBox();
+
+    TerrainAdjustment getTerrainAdjustment();
+
+    int getGroundLevelDelta();
+}


### PR DESCRIPTION
As of Minecraft 1.18.2, `StructurePiece`s had a method `getNoiseEffect()` that returned a `NoiseEffect`. This method was referenced by the `Beardifier` class inside `compute()` and enabled Modded Structure Piece implementations to control their bounding box's influence on the noise-generated terrain.

With the introduction of Minecraft 1.19's `Beardifier.Rigid`, it introduced a regression where `StructurePiece` implementations were no longer able to be referenced for the type of contribution to the terrain. This functionality has been relegated to the `Structure` implementation.

This pull request restores this functionality to the `StructurePiece` if they opt in by implementing `PieceBeardifierModifier`, and uses its position in the code to also cede more control to each individual `PieceBeardifierModifier` implementer over the noise beardification.