### PR TITLE
Remove the configuration option for handling empty tags in ingredients.

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -114,7 +114,7 @@
              list.add(new ItemStack(holder));
           }
  
-+         if (list.size() == 0 && !net.minecraftforge.common.ForgeConfig.SERVER.treatEmptyTagsAsAir.get()) {
++         if (list.size() == 0) {
 +            list.add(new ItemStack(net.minecraft.world.level.block.Blocks.f_50375_).m_41714_(net.minecraft.network.chat.Component.m_237113_("Empty Tag: " + this.f_43959_.f_203868_())));
 +         }
           return list;

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -28,8 +28,6 @@ public class ForgeConfig {
         public final DoubleValue zombieBaseSummonChance;
         public final DoubleValue zombieBabyChance;
 
-        public final BooleanValue treatEmptyTagsAsAir;
-
         public final BooleanValue fixAdvancementLoading;
 
         public final ConfigValue<String> permissionHandler;
@@ -67,12 +65,6 @@ public class ForgeConfig {
                     .translation("forge.configgui.zombieBabyChance")
                     .worldRestart()
                     .defineInRange("zombieBabyChance", 0.05D, 0.0D, 1.0D);
-
-            treatEmptyTagsAsAir = builder
-                    .comment("Vanilla will treat crafting recipes using empty tags as air, and allow you to craft with nothing in that slot. This changes empty tags to use BARRIER as the item. To prevent crafting with air.")
-                    .translation("forge.configgui.treatEmptyTagsAsAir")
-                    .define("treatEmptyTagsAsAir", false);
-
             fixAdvancementLoading = builder
                     .comment("Fix advancement loading to use a proper topological sort. This may have visibility side-effects and can thus be turned off if needed for data-pack compatibility.")
                     .translation("forge.configgui.fixAdvancementLoading")

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1048,7 +1048,7 @@ public class ForgeHooks
     {
         ItemStack[] items = ingredient.getItems();
         if (items.length == 0) return true;
-        if (items.length == 1 && !ForgeConfig.SERVER.treatEmptyTagsAsAir.get())
+        if (items.length == 1)
         {
             //If we potentially added a barrier due to the ingredient being an empty tag, try and check if it is the stack we added
             ItemStack item = items[0];


### PR DESCRIPTION
Now empty tags are considered broken in all states.

If somebody would iterate through the ingredients during events fired based on reload listeners the config value would still be unloaded causing a crash in dev, and undefined behavior in production.

After discussion it was decided to make the default behavior the standard and remove the config option.