### PR TITLE
Fix crash after loading error due to fluid texture gathering and config lookup

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -472,6 +472,8 @@ public class ForgeHooksClient
 
     public static void gatherFluidTextures(Set<Material> textures)
     {
+        if (!ModLoader.isLoadingStateValid()) return;
+
         ForgeRegistries.FLUIDS.getValues().stream()
                 .flatMap(ForgeHooksClient::getFluidMaterials)
                 .forEach(textures::add);

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -147,7 +147,7 @@ public class ClientModLoader
         boolean showWarnings = true;
         try {
             showWarnings = ForgeConfig.CLIENT.showLoadWarnings.get();
-        } catch (NullPointerException e) {
+        } catch (NullPointerException | IllegalStateException e) {
             // We're in an early error state, config is not available. Assume true.
         }
         if (!showWarnings) {


### PR DESCRIPTION
This PR fixes two crashes that prevent the loading error screen from showing up when a loading error (such as a dependency issue) occurred:

1. The `ModelBakery` collects fluid textures which accesses the `IFluidRenderProperties` and crashes when it tries to get the `FluidType` for the fluid, which is unregistered due to the prior loading error
2. Configs aren't loaded after a loading error, which crashes when the `ClientModLoader` checks if the loading error screen should be displayed. While this config lookup was already partially guarded, the exception thrown by the "config loaded" precondition was not added to the catch when the precondition was added.

Fixes #8772 