### PR TITLE
[1.19.X] Allow LazyOptional listeners to be weakly registered

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/NonNullBiConsumer.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullBiConsumer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Equivalent to {@link BiConsumer}, except with nonnull contract.
+ *
+ * @see BiConsumer
+ */
+@FunctionalInterface
+public interface NonNullBiConsumer<T, U>
+{
+    void accept(@NotNull T t, @NotNull U u);
+}


### PR DESCRIPTION
In the current LazyOptional implementation, if BlockEntity A registers a listener on BlockEntity B's LazyOptional, even if BlockEntity A is removed from the world, it won't be evicted from memory, as it's still being referenced by the listener callback held by BlockEntity B. Moreover, even if BlockEntity B's LazyOptional is invalidated, the listeners are still retained in memory and won't be considered for GC until the LazyOptional itself has no references.

This PR addresses both of those issues by adding a new method to `LazyOptional` which allows listeners to be registered via a `WeakReference`, as well as clearing the list of listeners after they have been notified of the LazyOptional's invalidation.

An example usage would look like: `myLazyOptional.addListener(myObject, MyObjectType::callback)` as opposed to the current `myLazyOptional.addListener(myObject::callback)`.