### PR TITLE
[1.19] Allow blocks to provide a dynamic MaterialColor for display on maps

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -88,7 +88,8 @@
        }
  
        public MaterialColor m_60780_(BlockGetter p_60781_, BlockPos p_60782_) {
-          return this.f_60598_;
+-         return this.f_60598_;
++         return m_60734_().getMapColor(this.m_7160_(), p_60781_, p_60782_, this.f_60598_);
        }
  
 +      /** @deprecated use {@link BlockState#rotate(LevelAccessor, BlockPos, Rotation)} */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -23,7 +23,9 @@ import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.core.Direction;
@@ -878,5 +880,18 @@ public interface IForgeBlock
     default boolean canBeHydrated(BlockState state, BlockGetter getter, BlockPos pos, FluidState fluid, BlockPos fluidPos)
     {
         return fluid.canHydrate(getter, fluidPos, state, pos);
+    }
+
+    /**
+     * Returns the {@link MaterialColor} shown on the map.
+     *
+     * @param state The state of this block
+     * @param level The level this block is in
+     * @param pos The blocks position in the level
+     * @param defaultColor The {@code MaterialColor} configured for the given {@code BlockState} in the {@link BlockBehaviour.Properties}
+     */
+    default MaterialColor getMapColor(BlockState state, BlockGetter level, BlockPos pos, MaterialColor defaultColor)
+    {
+        return defaultColor;
     }
 }


### PR DESCRIPTION
This PR allows blocks to provide the `MaterialColor` for display on maps dependent on dynamic data.

The context needed for this is already present, it's just not forwarded from the `BlockState` to the `BlockState`. This PR adds an extension method forwarding the necessary context to the block.

Example use cases would be:
- Allow mods like [RGB Blocks](https://www.curseforge.com/minecraft/mc-mods/rgb-blocks-forge) to provide the `MaterialColor` that is closest to the actual RGB value of the block
- Allow mods like [FramedBlocks](https://www.curseforge.com/minecraft/mc-mods/framedblocks) that add blocks that mimic other blocks to proxy the `MaterialColor` of the block that is being mimicked