### PR TITLE
Fixed edge case with wrongly thrown getOrCreateDirectory exception.

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
@@ -29,7 +29,10 @@ public class FileUtils
             try {
                 Files.createDirectory(dirPath);
             } catch (IOException e) {
-                if (e instanceof FileAlreadyExistsException) {
+                if (e instanceof FileAlreadyExistsException && Files.isDirectory(dirPath)) {
+                    LOGGER.warn(CORE, "Failed to create {} directory, found existing directory : {}", dirLabel, dirPath);
+                    return dirPath;
+                } else if (e instanceof FileAlreadyExistsException) {
                     LOGGER.error(CORE, "Failed to create {} directory - there is a file in the way", dirLabel);
                 } else {
                     LOGGER.error(CORE, "Problem with creating {} directory (Permissions?)", dirLabel, e);


### PR DESCRIPTION
There is an edge case, where the first check could be passed and a exception happen later within the createDirectory call under Windows 11.

In my case several mods share the same config directory and so it could be that `java.nio.file.FileAlreadyExistsException` is thrown wrongly for an existing directory.
This additional check makes sure that it's only throws a exception if the error is not related to an existing directory, which was created in the mean time, between the former check.

Example exception with the current logic:
https://gist.github.com/MarkusBordihn/d6ae16139733c7c088c2e8aea02e2f5e