### PR TITLE
Bump JarJar to fix some version range selectors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     APACHE_COMMONS_LANG3_VERSION = '3.12.0'
     JOPT_SIMPLE_VERSION = '5.0.4'
     COMMONS_IO_VERSION = '2.11.0'
-    JARJAR_VERSION = '0.2.24'
+    JARJAR_VERSION = '0.2.26'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)


### PR DESCRIPTION
After the FAP Jar-In-Jar seems to be getting more use.
Some modders pointed out that certain version ranges seemed valid from the specification (and they were) but that the selector still rejected them.

This was fixed in JarJar 0.2.25 and 0.2.26 which this PR updates to.