### PR TITLE
[1.19.x] Fix door datagenerator

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -534,29 +534,56 @@ public abstract class BlockStateProvider implements DataProvider {
     }
 
     private void doorBlockInternal(DoorBlock block, String baseName, ResourceLocation bottom, ResourceLocation top) {
-        ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom", bottom, top);
-        ModelFile bottomRight = models().doorBottomRight(baseName + "_bottom_hinge", bottom, top);
-        ModelFile topLeft = models().doorTopLeft(baseName + "_top", bottom, top);
-        ModelFile topRight = models().doorTopRight(baseName + "_top_hinge", bottom, top);
-        doorBlock(block, bottomLeft, bottomRight, topLeft, topRight);
+        ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom_left", bottom, top);
+        ModelFile bottomLeftOpen = models().doorBottomLeftOpen(baseName + "_bottom_left_open", bottom, top);
+        ModelFile bottomRight = models().doorBottomRight(baseName + "_bottom_right", bottom, top);
+        ModelFile bottomRightOpen = models().doorBottomRightOpen(baseName + "_bottom_right_open", bottom, top);
+        ModelFile topLeft = models().doorTopLeft(baseName + "_top_left", bottom, top);
+        ModelFile topLeftOpen = models().doorTopLeftOpen(baseName + "_top_left_open", bottom, top);
+        ModelFile topRight = models().doorTopRight(baseName + "_top_right", bottom, top);
+        ModelFile topRightOpen = models().doorTopRightOpen(baseName + "_top_right_open", bottom, top);
+        doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
     }
 
-    public void doorBlock(DoorBlock block, ModelFile bottomLeft, ModelFile bottomRight, ModelFile topLeft, ModelFile topRight) {
+    public void doorBlock(DoorBlock block, ModelFile bottomLeft, ModelFile bottomLeftOpen , ModelFile bottomRight, ModelFile bottomRightOpen, ModelFile topLeft, ModelFile topLeftOpen, ModelFile topRight, ModelFile topRightOpen) {
         getVariantBuilder(block).forAllStatesExcept(state -> {
             int yRot = ((int) state.getValue(DoorBlock.FACING).toYRot()) + 90;
-            boolean rh = state.getValue(DoorBlock.HINGE) == DoorHingeSide.RIGHT;
+            boolean right = state.getValue(DoorBlock.HINGE) == DoorHingeSide.RIGHT;
             boolean open = state.getValue(DoorBlock.OPEN);
-            boolean right = rh ^ open;
+            boolean lower = state.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER;
             if (open) {
                 yRot += 90;
             }
-            if (rh && open) {
+            if (right && open) {
                 yRot += 180;
             }
             yRot %= 360;
-            return ConfiguredModel.builder().modelFile(state.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER ? (right ? bottomRight : bottomLeft) : (right ? topRight : topLeft))
-                    .rotationY(yRot)
-                    .build();
+
+            ModelFile model = null;
+            if (lower && right && open) {
+                model = bottomRightOpen;
+            } else if (lower && !right && open) {
+                model = bottomLeftOpen;
+            }
+            if (lower && right && !open) {
+                model = bottomRight;
+            } else if (lower && !right && !open) {
+                model = bottomLeft;
+            }
+            if (!lower && right && open) {
+                model = topRightOpen;
+            } else if (!lower && !right && open) {
+                model = topLeftOpen;
+            }
+            if (!lower && right && !open) {
+                model = topRight;
+            } else if (!lower && !right && !open) {
+                model = topLeft;
+            }
+
+            return ConfiguredModel.builder().modelFile(model)
+                .rotationY(yRot)
+                .build();
         }, DoorBlock.POWERED);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -545,7 +545,7 @@ public abstract class BlockStateProvider implements DataProvider {
         doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
     }
 
-    public void doorBlock(DoorBlock block, ModelFile bottomLeft, ModelFile bottomLeftOpen , ModelFile bottomRight, ModelFile bottomRightOpen, ModelFile topLeft, ModelFile topLeftOpen, ModelFile topRight, ModelFile topRightOpen) {
+    public void doorBlock(DoorBlock block, ModelFile bottomLeft, ModelFile bottomLeftOpen, ModelFile bottomRight, ModelFile bottomRightOpen, ModelFile topLeft, ModelFile topLeftOpen, ModelFile topRight, ModelFile topRightOpen) {
         getVariantBuilder(block).forAllStatesExcept(state -> {
             int yRot = ((int) state.getValue(DoorBlock.FACING).toYRot()) + 90;
             boolean right = state.getValue(DoorBlock.HINGE) == DoorHingeSide.RIGHT;

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -304,19 +304,35 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataPr
     }
 
     public T doorBottomLeft(String name, ResourceLocation bottom, ResourceLocation top) {
-        return door(name, "door_bottom", bottom, top);
+        return door(name, "door_bottom_left", bottom, top);
+    }
+
+    public T doorBottomLeftOpen(String name, ResourceLocation bottom, ResourceLocation top) {
+        return door(name, "door_bottom_left_open", bottom, top);
     }
 
     public T doorBottomRight(String name, ResourceLocation bottom, ResourceLocation top) {
-        return door(name, "door_bottom_rh", bottom, top);
+        return door(name, "door_bottom_right", bottom, top);
+    }
+
+    public T doorBottomRightOpen(String name, ResourceLocation bottom, ResourceLocation top) {
+        return door(name, "door_bottom_right_open", bottom, top);
     }
 
     public T doorTopLeft(String name, ResourceLocation bottom, ResourceLocation top) {
-        return door(name, "door_top", bottom, top);
+        return door(name, "door_top_left", bottom, top);
+    }
+
+    public T doorTopLeftOpen(String name, ResourceLocation bottom, ResourceLocation top) {
+        return door(name, "door_top_left_open", bottom, top);
     }
 
     public T doorTopRight(String name, ResourceLocation bottom, ResourceLocation top) {
-        return door(name, "door_top_rh", bottom, top);
+        return door(name, "door_top_right", bottom, top);
+    }
+
+    public T doorTopRightOpen(String name, ResourceLocation bottom, ResourceLocation top) {
+        return door(name, "door_top_right_open", bottom, top);
     }
 
     public T trapdoorBottom(String name, ResourceLocation texture) {

--- a/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
+++ b/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
@@ -798,7 +798,7 @@ public class DataGeneratorTest
             stairsBlock((StairBlock) Blocks.ACACIA_STAIRS, "acacia", mcLoc("block/acacia_planks"));
             slabBlock((SlabBlock) Blocks.ACACIA_SLAB, ForgeRegistries.BLOCKS.getKey(Blocks.ACACIA_PLANKS), mcLoc("block/acacia_planks"));
 
-            // TODO 1.19: fix fenceBlock, wallBlock, doorBlock, and co -SS
+            // TODO 1.19: fix fenceBlock, wallBlock, and co -SS
             // fenceBlock((FenceBlock) Blocks.ACACIA_FENCE, "acacia", mcLoc("block/acacia_planks"));
             fenceGateBlock((FenceGateBlock) Blocks.ACACIA_FENCE_GATE, "acacia", mcLoc("block/acacia_planks"));
 
@@ -806,8 +806,7 @@ public class DataGeneratorTest
 
             paneBlock((IronBarsBlock) Blocks.GLASS_PANE, "glass", mcLoc("block/glass"), mcLoc("block/glass_pane_top"));
 
-
-            // doorBlock((DoorBlock) Blocks.ACACIA_DOOR, "acacia", mcLoc("block/acacia_door_bottom"), mcLoc("block/acacia_door_top"));
+            doorBlock((DoorBlock) Blocks.ACACIA_DOOR, "acacia", mcLoc("block/acacia_door_bottom"), mcLoc("block/acacia_door_top"));
             trapdoorBlock((TrapDoorBlock) Blocks.ACACIA_TRAPDOOR, "acacia", mcLoc("block/acacia_trapdoor"), true);
             trapdoorBlock((TrapDoorBlock) Blocks.OAK_TRAPDOOR, "oak", mcLoc("block/oak_trapdoor"), false); // Test a non-orientable trapdoor
 


### PR DESCRIPTION
This PR fixes the door datagenerator in 1.19. This is a successor to #8687. It also addresses the comment about unnecessary complexity in `BlockStateProvider`.

The image below is a custom door which has been datagenned (closed/open states):
![door_datagen_test](https://user-images.githubusercontent.com/48810167/177239438-fbe54288-bdc7-4437-8d70-7118dd18fd78.png)