### PR TITLE
[1.19.x] Fix shulker boxes allowing input of items, that return false for Item#canFitInsideContainerItems, through hoppers.

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
@@ -5,7 +5,7 @@
  
     public boolean m_7155_(int p_59663_, ItemStack p_59664_, @Nullable Direction p_59665_) {
 -      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock);
-+      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock) || p_59664_.m_41720_().m_142095_(); // FORGE: Make shulker boxes respect Item#canFitInsideContainerItems
++      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock) && p_59664_.m_41720_().m_142095_(); // FORGE: Make shulker boxes respect Item#canFitInsideContainerItems
     }
  
     public boolean m_7157_(int p_59682_, ItemStack p_59683_, Direction p_59684_) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
@@ -5,7 +5,7 @@
  
     public boolean m_7155_(int p_59663_, ItemStack p_59664_, @Nullable Direction p_59665_) {
 -      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock);
-+      return p_59664_.m_41720_().m_142095_();
++      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock) || p_59664_.m_41720_().m_142095_(); // FORGE: Make shulker boxes respect Item#canFitInsideContainerItems
     }
  
     public boolean m_7157_(int p_59682_, ItemStack p_59683_, Direction p_59684_) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
@@ -1,14 +1,23 @@
 --- a/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
-@@ -235,6 +_,11 @@
-       return this.f_59647_ == ShulkerBoxBlockEntity.AnimationStatus.CLOSED;
+@@ -211,7 +_,7 @@
     }
  
+    public boolean m_7155_(int p_59663_, ItemStack p_59664_, @Nullable Direction p_59665_) {
+-      return !(Block.m_49814_(p_59664_.m_41720_()) instanceof ShulkerBoxBlock);
++      return p_59664_.m_41720_().m_142095_();
+    }
+ 
+    public boolean m_7157_(int p_59682_, ItemStack p_59683_, Direction p_59684_) {
+@@ -233,6 +_,11 @@
+ 
+    public boolean m_59702_() {
+       return this.f_59647_ == ShulkerBoxBlockEntity.AnimationStatus.CLOSED;
++   }
++
 +   @Override
 +   protected net.minecraftforge.items.IItemHandler createUnSidedHandler() {
 +      return new net.minecraftforge.items.wrapper.SidedInvWrapper(this, Direction.UP);
-+   }
-+
+    }
+ 
     public static enum AnimationStatus {
-       CLOSED,
-       OPENING,


### PR DESCRIPTION
Currently you can input items that return false for `Item#canFitInsideContainerItems` into shulker boxes via hoppers (and probably also other item transport methods).
This is not a problem in the GUI since `ShulkerBoxSlot` correctly delegates to `Item#canFitInsideContainerItems` while `ShulkerBoxBlockEntity#canPlaceItemThroughFace` specifically checks if the items block representation is `ShulkerBoxBlock`.
This PR fixes this wrong check by making `ShulkerBoxBlockEntity#canPlaceItemThroughFace` delegate to `Item#canFitInsideContainerItems` too.