### PR TITLE
[1.19] Add FogMode to ViewportEvent.RenderFog

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -438,7 +438,7 @@ public class ForgeHooksClient
         if (camera.getPosition().y < (double)((float)camera.getBlockPosition().getY() + state.getHeight(camera.getEntity().level, camera.getBlockPosition())))
             IClientFluidTypeExtensions.of(state).modifyFogRender(camera, mode, renderDistance, partialTick, nearDistance, farDistance, shape);
 
-        ViewportEvent.RenderFog event = new ViewportEvent.RenderFog(type, camera, partialTick, nearDistance, farDistance, shape);
+        ViewportEvent.RenderFog event = new ViewportEvent.RenderFog(mode, type, camera, partialTick, nearDistance, farDistance, shape);
         if (MinecraftForge.EVENT_BUS.post(event))
         {
             RenderSystem.setShaderFogStart(event.getNearPlaneDistance());

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -8,6 +8,7 @@ package net.minecraftforge.client.event;
 import com.mojang.blaze3d.shaders.FogShape;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.FogRenderer.FogMode;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.world.level.material.FogType;
 import net.minecraftforge.common.MinecraftForge;
@@ -79,15 +80,17 @@ public abstract class ViewportEvent extends Event
     @Cancelable
     public static class RenderFog extends ViewportEvent
     {
+        private final FogMode mode;
         private final FogType type;
         private float farPlaneDistance;
         private float nearPlaneDistance;
         private FogShape fogShape;
 
         @ApiStatus.Internal
-        public RenderFog(FogType type, Camera camera, float partialTicks, float nearPlaneDistance, float farPlaneDistance, FogShape fogShape)
+        public RenderFog(FogMode mode, FogType type, Camera camera, float partialTicks, float nearPlaneDistance, float farPlaneDistance, FogShape fogShape)
         {
             super(Minecraft.getInstance().gameRenderer, camera, partialTicks);
+            this.mode = mode;
             this.type = type;
             setFarPlaneDistance(farPlaneDistance);
             setNearPlaneDistance(nearPlaneDistance);
@@ -95,9 +98,17 @@ public abstract class ViewportEvent extends Event
         }
 
         /**
+         * {@return the mode of fog being rendered}
+         */
+        public FogMode getMode()
+        {
+            return mode;
+        }
+
+        /**
          * {@return the type of fog being rendered}
          */
-        public FogType getMode()
+        public FogType getType()
         {
             return type;
         }


### PR DESCRIPTION
Fixes #8762.

Most likely due to a mojang mapping rename, the `FogType` enum which contained an identifier to differ from terrain fog and sky fog was moved to `FogRenderer.FogMode`, which was removed from `ViewportEvent.RenderFog`. While the new `FogType` enum is no doubt helpful, it also removed the ability to identify if the fog that was being modified was either terrain fog or sky fog, and this PR aims to solve this.

Essentially, `getMode()` was renamed to `getType()`, and I added a new `getMode()` method which contains the instance of `FogMode`. I have also edited the constructor to accept a `FogMode` and have edited all instances of the construction of the event class (in which case it was just in `ForgeHooksClient`).

As always and with my last PR, feedback and edit requests are welcome.