### PR TITLE
Default IItemHandler capability for shulker box itemstacks

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -40,6 +40,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.items.wrapper.ShulkerItemStackInvWrapper;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -654,6 +655,10 @@ public interface IForgeItem
     @Nullable
     default net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt)
     {
+        net.minecraftforge.common.capabilities.ICapabilityProvider shulkerBoxCap =
+                ShulkerItemStackInvWrapper.AttachmentHandler.listenCapabilitiesAttachment(stack);
+        if (shulkerBoxCap != null)
+            return shulkerBoxCap;
         return null;
     }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -655,11 +655,8 @@ public interface IForgeItem
     @Nullable
     default net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt)
     {
-        net.minecraftforge.common.capabilities.ICapabilityProvider shulkerBoxCap =
-                ShulkerItemStackInvWrapper.AttachmentHandler.listenCapabilitiesAttachment(stack);
-        if (shulkerBoxCap != null)
-            return shulkerBoxCap;
-        return null;
+        var ret = ShulkerItemStackInvWrapper.createDefaultProvider(stack);
+        return ret;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/items/wrapper/ItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ItemStackInvWrapper.java
@@ -1,0 +1,190 @@
+package net.minecraftforge.items.wrapper;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+
+public class ItemStackInvWrapper implements IItemHandler
+{
+    private final int size;
+    private final ItemStack stack;
+    private final Predicate<ItemStack> canHold;
+
+    public ItemStackInvWrapper(ItemStack stack, int size, Predicate<ItemStack> canHold)
+    {
+        this.size = size;
+        this.stack = stack;
+        this.canHold = canHold;
+    }
+
+    @Override
+    public int getSlots()
+    {
+        return this.size;
+    }
+
+    @Override
+    public @NotNull ItemStack getStackInSlot(int slot)
+    {
+        if (slot < getSlots()) {
+            return getItemList().get(slot);
+        }
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
+    {
+        NonNullList<ItemStack> itemStacks = getItemList();
+        if (stack.isEmpty())
+            return ItemStack.EMPTY;
+
+        ItemStack stackInSlot = itemStacks.get(slot);
+
+        int m;
+        if (!stackInSlot.isEmpty())
+        {
+            if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
+                return stack;
+
+            if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
+                return stack;
+
+            if (!this.isItemValid(slot, stack))
+                return stack;
+
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
+
+            if (stack.getCount() <= m)
+            {
+                if (!simulate)
+                {
+                    ItemStack copy = stack.copy();
+                    copy.grow(stackInSlot.getCount());
+                    itemStacks.set(slot, copy);
+                    this.setItemList(itemStacks);
+                }
+
+                return ItemStack.EMPTY;
+            }
+            else
+            {
+                // copy the stack to not modify the original one
+                stack = stack.copy();
+                if (!simulate)
+                {
+                    ItemStack copy = stack.split(m);
+                    copy.grow(stackInSlot.getCount());
+                    itemStacks.set(slot, copy);
+                    this.setItemList(itemStacks);
+                    return stack;
+                }
+                else
+                {
+                    stack.shrink(m);
+                    return stack;
+                }
+            }
+        }
+        else
+        {
+            if (!this.isItemValid(slot, stack))
+                return stack;
+
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
+            if (m < stack.getCount())
+            {
+                // copy the stack to not modify the original one
+                stack = stack.copy();
+                if (!simulate)
+                {
+                    itemStacks.set(slot, stack.split(m));
+                    this.setItemList(itemStacks);
+                    return stack;
+                }
+                else
+                {
+                    stack.shrink(m);
+                    return stack;
+                }
+            }
+            else
+            {
+                if (!simulate)
+                {
+                    itemStacks.set(slot, stack);
+                    this.setItemList(itemStacks);
+                }
+                return ItemStack.EMPTY;
+            }
+        }
+    }
+
+    @Override
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate)
+    {
+        NonNullList<ItemStack> itemStacks = getItemList();
+        if (amount == 0)
+            return ItemStack.EMPTY;
+
+        ItemStack stackInSlot = itemStacks.get(slot);
+
+        if (stackInSlot.isEmpty())
+            return ItemStack.EMPTY;
+
+        if (simulate)
+        {
+            if (stackInSlot.getCount() < amount)
+            {
+                return stackInSlot.copy();
+            }
+            else
+            {
+                ItemStack copy = stackInSlot.copy();
+                copy.setCount(amount);
+                return copy;
+            }
+        }
+        else
+        {
+            int m = Math.min(stackInSlot.getCount(), amount);
+
+            ItemStack decrStackSize = ContainerHelper.removeItem(itemStacks, slot, m);
+            this.setItemList(itemStacks);
+            return decrStackSize;
+        }
+    }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return 64;
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack)
+    {
+        return canHold.test(stack);
+    }
+
+    public NonNullList<ItemStack> getItemList()
+    {
+        NonNullList<ItemStack> itemStacks = NonNullList.withSize(getSlots(), ItemStack.EMPTY);
+        CompoundTag rootTag = this.stack.getTag();
+        if (rootTag != null && rootTag.contains("Items", 9)) {
+            ContainerHelper.loadAllItems(rootTag, itemStacks);
+        }
+        return itemStacks;
+    }
+
+    public void setItemList(NonNullList<ItemStack> itemStacks)
+    {
+        ContainerHelper.saveAllItems(this.stack.getOrCreateTag(), itemStacks);
+    }
+}

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -9,13 +9,12 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
@@ -198,7 +197,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandler, ICapabilityProv
     public NonNullList<ItemStack> getItemList()
     {
         NonNullList<ItemStack> itemStacks = NonNullList.withSize(getSlots(), ItemStack.EMPTY);
-        CompoundTag rootTag = this.stack.getTag();
+        CompoundTag rootTag = BlockItem.getBlockEntityData(this.stack);
         if (rootTag != null && rootTag.contains("Items", 9)) {
             ContainerHelper.loadAllItems(rootTag, itemStacks);
         }
@@ -207,7 +206,9 @@ public class ShulkerItemStackInvWrapper implements IItemHandler, ICapabilityProv
 
     public void setItemList(NonNullList<ItemStack> itemStacks)
     {
-        ContainerHelper.saveAllItems(this.stack.getOrCreateTag(), itemStacks);
+        CompoundTag existing = BlockItem.getBlockEntityData(this.stack);
+        BlockItem.setBlockEntityData(this.stack, BlockEntityType.SHULKER_BOX,
+                ContainerHelper.saveAllItems(existing == null ? new CompoundTag() : existing, itemStacks));
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -33,13 +33,40 @@ import java.util.Set;
 @ApiStatus.Internal
 public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
 {
+    @ApiStatus.Internal
+    @Nullable
+    public static ICapabilityProvider createDefaultProvider(ItemStack itemStack)
+    {
+        var item = itemStack.getItem();
+        if (item == Items.SHULKER_BOX ||
+            item == Items.BLACK_SHULKER_BOX ||
+            item == Items.BLUE_SHULKER_BOX ||
+            item == Items.BROWN_SHULKER_BOX ||
+            item == Items.CYAN_SHULKER_BOX ||
+            item == Items.GRAY_SHULKER_BOX ||
+            item == Items.GREEN_SHULKER_BOX ||
+            item == Items.LIGHT_BLUE_SHULKER_BOX ||
+            item == Items.LIGHT_GRAY_SHULKER_BOX ||
+            item == Items.LIME_SHULKER_BOX ||
+            item == Items.MAGENTA_SHULKER_BOX ||
+            item == Items.ORANGE_SHULKER_BOX ||
+            item == Items.PINK_SHULKER_BOX ||
+            item == Items.PURPLE_SHULKER_BOX ||
+            item == Items.RED_SHULKER_BOX ||
+            item == Items.WHITE_SHULKER_BOX ||
+            item == Items.YELLOW_SHULKER_BOX
+        )
+            return new ShulkerItemStackInvWrapper(itemStack);
+        return null;
+    }
+
     private final ItemStack stack;
     private final LazyOptional<IItemHandler> holder = LazyOptional.of(() -> this);
 
     private CompoundTag cachedTag;
     private NonNullList<ItemStack> itemStacksCache;
 
-    public ShulkerItemStackInvWrapper(ItemStack stack)
+    private ShulkerItemStackInvWrapper(ItemStack stack)
     {
         this.stack = stack;
     }
@@ -147,7 +174,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
         }
     }
 
-    protected void validateSlotIndex(int slot)
+    private void validateSlotIndex(int slot)
     {
         if (slot < 0 || slot >= getSlots())
             throw new RuntimeException("Slot " + slot + " not in valid range - [0," + getSlots() + ")");
@@ -175,7 +202,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
         setItemList(itemStacks);
     }
 
-    protected NonNullList<ItemStack> getItemList()
+    private NonNullList<ItemStack> getItemList()
     {
         CompoundTag rootTag = BlockItem.getBlockEntityData(this.stack);
         if (cachedTag == null || !cachedTag.equals(rootTag))
@@ -183,7 +210,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
         return itemStacksCache;
     }
 
-    protected NonNullList<ItemStack> refreshItemList(CompoundTag rootTag)
+    private NonNullList<ItemStack> refreshItemList(CompoundTag rootTag)
     {
         NonNullList<ItemStack> itemStacks = NonNullList.withSize(getSlots(), ItemStack.EMPTY);
         if (rootTag != null && rootTag.contains("Items", CompoundTag.TAG_LIST))
@@ -194,7 +221,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
         return itemStacks;
     }
 
-    protected void setItemList(NonNullList<ItemStack> itemStacks)
+    private void setItemList(NonNullList<ItemStack> itemStacks)
     {
         CompoundTag existing = BlockItem.getBlockEntityData(this.stack);
         CompoundTag rootTag = ContainerHelper.saveAllItems(existing == null ? new CompoundTag() : existing, itemStacks);
@@ -207,39 +234,5 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     public <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side)
     {
         return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.orEmpty(cap, this.holder);
-    }
-
-    @ApiStatus.Internal
-    public static class AttachmentHandler
-    {
-        private static final Set<ResourceLocation> SHULKER_ITEMS = Set.of(
-                new ResourceLocation("shulker_box"),
-                new ResourceLocation("black_shulker_box"),
-                new ResourceLocation("blue_shulker_box"),
-                new ResourceLocation("brown_shulker_box"),
-                new ResourceLocation("cyan_shulker_box"),
-                new ResourceLocation("gray_shulker_box"),
-                new ResourceLocation("green_shulker_box"),
-                new ResourceLocation("light_blue_shulker_box"),
-                new ResourceLocation("light_gray_shulker_box"),
-                new ResourceLocation("lime_shulker_box"),
-                new ResourceLocation("magenta_shulker_box"),
-                new ResourceLocation("orange_shulker_box"),
-                new ResourceLocation("pink_shulker_box"),
-                new ResourceLocation("purple_shulker_box"),
-                new ResourceLocation("red_shulker_box"),
-                new ResourceLocation("white_shulker_box"),
-                new ResourceLocation("yellow_shulker_box"));
-
-        @ApiStatus.Internal
-        @Nullable
-        public static ICapabilityProvider listenCapabilitiesAttachment(ItemStack itemStack)
-        {
-            if (SHULKER_ITEMS.contains(ForgeRegistries.ITEMS.getKey(itemStack.getItem())))
-            {
-                return new ShulkerItemStackInvWrapper(itemStack);
-            }
-            return null;
-        }
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -55,11 +55,8 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     @NotNull
     public ItemStack getStackInSlot(int slot)
     {
-        if (slot < getSlots())
-        {
-            return getItemList().get(slot);
-        }
-        return ItemStack.EMPTY;
+        validateSlotIndex(slot);
+        return getItemList().get(slot);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
-import java.util.function.Predicate;
 
 @Mod.EventBusSubscriber(modid = "forge")
 public class ShulkerItemStackInvWrapper implements IItemHandler, ICapabilityProvider
@@ -51,7 +50,8 @@ public class ShulkerItemStackInvWrapper implements IItemHandler, ICapabilityProv
     @NotNull
     public ItemStack getStackInSlot(int slot)
     {
-        if (slot < getSlots()) {
+        if (slot < getSlots())
+        {
             return getItemList().get(slot);
         }
         return ItemStack.EMPTY;
@@ -237,8 +237,10 @@ public class ShulkerItemStackInvWrapper implements IItemHandler, ICapabilityProv
             Items.YELLOW_SHULKER_BOX);
 
     @SubscribeEvent
-    public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event) {
-        if (SHULKER_ITEMS.contains(event.getObject().getItem())) {
+    public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event)
+    {
+        if (SHULKER_ITEMS.contains(event.getObject().getItem()))
+        {
             event.addCapability(new ResourceLocation("forge","shulker_box"), new ShulkerItemStackInvWrapper(event.getObject()));
         }
     }

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -89,8 +89,6 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     @NotNull
     public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
     {
-        NonNullList<ItemStack> itemStacks = getItemList();
-
         if (stack.isEmpty())
             return ItemStack.EMPTY;
 
@@ -98,6 +96,8 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
             return stack;
 
         validateSlotIndex(slot);
+
+        NonNullList<ItemStack> itemStacks = getItemList();
 
         ItemStack existing = itemStacks.get(slot);
 

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -30,7 +30,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 
-@Mod.EventBusSubscriber(modid = "forge")
 public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
 {
     private final ItemStack stack;
@@ -209,30 +208,32 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
         return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.orEmpty(cap, this.holder);
     }
 
-    private static final Set<Item> SHULKER_ITEMS = Set.of(Items.SHULKER_BOX,
-            Items.BLACK_SHULKER_BOX,
-            Items.BLUE_SHULKER_BOX,
-            Items.BROWN_SHULKER_BOX,
-            Items.CYAN_SHULKER_BOX,
-            Items.GRAY_SHULKER_BOX,
-            Items.GREEN_SHULKER_BOX,
-            Items.LIGHT_BLUE_SHULKER_BOX,
-            Items.LIGHT_GRAY_SHULKER_BOX,
-            Items.LIME_SHULKER_BOX,
-            Items.MAGENTA_SHULKER_BOX,
-            Items.ORANGE_SHULKER_BOX,
-            Items.PINK_SHULKER_BOX,
-            Items.PURPLE_SHULKER_BOX,
-            Items.RED_SHULKER_BOX,
-            Items.WHITE_SHULKER_BOX,
-            Items.YELLOW_SHULKER_BOX);
-
-    @SubscribeEvent
-    protected static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event)
+    @Mod.EventBusSubscriber(modid = "forge")
+    private static class AttachmentHandler
     {
-        if (SHULKER_ITEMS.contains(event.getObject().getItem()))
-        {
-            event.addCapability(new ResourceLocation("forge","shulker_box"), new ShulkerItemStackInvWrapper(event.getObject()));
+        private static final Set<Item> SHULKER_ITEMS = Set.of(Items.SHULKER_BOX,
+                Items.BLACK_SHULKER_BOX,
+                Items.BLUE_SHULKER_BOX,
+                Items.BROWN_SHULKER_BOX,
+                Items.CYAN_SHULKER_BOX,
+                Items.GRAY_SHULKER_BOX,
+                Items.GREEN_SHULKER_BOX,
+                Items.LIGHT_BLUE_SHULKER_BOX,
+                Items.LIGHT_GRAY_SHULKER_BOX,
+                Items.LIME_SHULKER_BOX,
+                Items.MAGENTA_SHULKER_BOX,
+                Items.ORANGE_SHULKER_BOX,
+                Items.PINK_SHULKER_BOX,
+                Items.PURPLE_SHULKER_BOX,
+                Items.RED_SHULKER_BOX,
+                Items.WHITE_SHULKER_BOX,
+                Items.YELLOW_SHULKER_BOX);
+
+        @SubscribeEvent
+        public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event) {
+            if (SHULKER_ITEMS.contains(event.getObject().getItem())) {
+                event.addCapability(new ResourceLocation("forge", "shulker_box"), new ShulkerItemStackInvWrapper(event.getObject()));
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -18,20 +18,20 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.Set;
 
-class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
+@ApiStatus.Internal
+public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
 {
     private final ItemStack stack;
     private final LazyOptional<IItemHandler> holder = LazyOptional.of(() -> this);
@@ -178,7 +178,7 @@ class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityP
     protected NonNullList<ItemStack> getItemList()
     {
         CompoundTag rootTag = BlockItem.getBlockEntityData(this.stack);
-        if (!Objects.equals(cachedTag,rootTag))
+        if (cachedTag == null || !cachedTag.equals(rootTag))
             itemStacksCache = refreshItemList(rootTag);
         return itemStacksCache;
     }
@@ -209,35 +209,37 @@ class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityP
         return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.orEmpty(cap, this.holder);
     }
 
-    @Mod.EventBusSubscriber(modid = "forge")
-    private static class AttachmentHandler
+    @ApiStatus.Internal
+    public static class AttachmentHandler
     {
-        private static final Set<Item> SHULKER_ITEMS = Set.of(
-                Items.SHULKER_BOX,
-                Items.BLACK_SHULKER_BOX,
-                Items.BLUE_SHULKER_BOX,
-                Items.BROWN_SHULKER_BOX,
-                Items.CYAN_SHULKER_BOX,
-                Items.GRAY_SHULKER_BOX,
-                Items.GREEN_SHULKER_BOX,
-                Items.LIGHT_BLUE_SHULKER_BOX,
-                Items.LIGHT_GRAY_SHULKER_BOX,
-                Items.LIME_SHULKER_BOX,
-                Items.MAGENTA_SHULKER_BOX,
-                Items.ORANGE_SHULKER_BOX,
-                Items.PINK_SHULKER_BOX,
-                Items.PURPLE_SHULKER_BOX,
-                Items.RED_SHULKER_BOX,
-                Items.WHITE_SHULKER_BOX,
-                Items.YELLOW_SHULKER_BOX);
+        private static final Set<ResourceLocation> SHULKER_ITEMS = Set.of(
+                new ResourceLocation("shulker_box"),
+                new ResourceLocation("black_shulker_box"),
+                new ResourceLocation("blue_shulker_box"),
+                new ResourceLocation("brown_shulker_box"),
+                new ResourceLocation("cyan_shulker_box"),
+                new ResourceLocation("gray_shulker_box"),
+                new ResourceLocation("green_shulker_box"),
+                new ResourceLocation("light_blue_shulker_box"),
+                new ResourceLocation("light_gray_shulker_box"),
+                new ResourceLocation("lime_shulker_box"),
+                new ResourceLocation("magenta_shulker_box"),
+                new ResourceLocation("orange_shulker_box"),
+                new ResourceLocation("pink_shulker_box"),
+                new ResourceLocation("purple_shulker_box"),
+                new ResourceLocation("red_shulker_box"),
+                new ResourceLocation("white_shulker_box"),
+                new ResourceLocation("yellow_shulker_box"));
 
-        @SubscribeEvent
-        public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event)
+        @ApiStatus.Internal
+        @Nullable
+        public static ICapabilityProvider listenCapabilitiesAttachment(ItemStack itemStack)
         {
-            if (SHULKER_ITEMS.contains(event.getObject().getItem()))
+            if (SHULKER_ITEMS.contains(ForgeRegistries.ITEMS.getKey(itemStack.getItem())))
             {
-                event.addCapability(new ResourceLocation("forge", "shulker_box"), new ShulkerItemStackInvWrapper(event.getObject()));
+                return new ShulkerItemStackInvWrapper(itemStack);
             }
+            return null;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -28,9 +28,10 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Set;
 
-public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
+class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityProvider
 {
     private final ItemStack stack;
     private final LazyOptional<IItemHandler> holder = LazyOptional.of(() -> this);
@@ -41,7 +42,6 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     public ShulkerItemStackInvWrapper(ItemStack stack)
     {
         this.stack = stack;
-        this.itemStacksCache = refreshItemList(BlockItem.getBlockEntityData(this.stack));
     }
 
     @Override
@@ -177,7 +177,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     protected NonNullList<ItemStack> getItemList()
     {
         CompoundTag rootTag = BlockItem.getBlockEntityData(this.stack);
-        if ((cachedTag != null && !cachedTag.equals(rootTag)) || rootTag == null)
+        if (!Objects.equals(cachedTag,rootTag))
             itemStacksCache = refreshItemList(rootTag);
         return itemStacksCache;
     }
@@ -185,7 +185,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     protected NonNullList<ItemStack> refreshItemList(CompoundTag rootTag)
     {
         NonNullList<ItemStack> itemStacks = NonNullList.withSize(getSlots(), ItemStack.EMPTY);
-        if (rootTag != null && rootTag.contains("Items", 9)) {
+        if (rootTag != null && rootTag.contains("Items", CompoundTag.TAG_LIST)) {
             ContainerHelper.loadAllItems(rootTag, itemStacks);
         }
         cachedTag = rootTag;
@@ -196,8 +196,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     {
         CompoundTag existing = BlockItem.getBlockEntityData(this.stack);
         CompoundTag rootTag = ContainerHelper.saveAllItems(existing == null ? new CompoundTag() : existing, itemStacks);
-        BlockItem.setBlockEntityData(this.stack, BlockEntityType.SHULKER_BOX,
-                rootTag);
+        BlockItem.setBlockEntityData(this.stack, BlockEntityType.SHULKER_BOX, rootTag);
         cachedTag = rootTag;
     }
 
@@ -211,7 +210,8 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapa
     @Mod.EventBusSubscriber(modid = "forge")
     private static class AttachmentHandler
     {
-        private static final Set<Item> SHULKER_ITEMS = Set.of(Items.SHULKER_BOX,
+        private static final Set<Item> SHULKER_ITEMS = Set.of(
+                Items.SHULKER_BOX,
                 Items.BLACK_SHULKER_BOX,
                 Items.BLUE_SHULKER_BOX,
                 Items.BROWN_SHULKER_BOX,

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -10,13 +10,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Predicate;
 
-public class ItemStackInvWrapper implements IItemHandler
+public class ShulkerItemStackInvWrapper implements IItemHandler
 {
     private final int size;
     private final ItemStack stack;
     private final Predicate<ItemStack> canHold;
 
-    public ItemStackInvWrapper(ItemStack stack, int size, Predicate<ItemStack> canHold)
+    public ShulkerItemStackInvWrapper(ItemStack stack, int size, Predicate<ItemStack> canHold)
     {
         this.size = size;
         this.stack = stack;

--- a/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -166,7 +166,8 @@ class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityP
     }
 
     @Override
-    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
+    public void setStackInSlot(int slot, @NotNull ItemStack stack)
+    {
         validateSlotIndex(slot);
         if (!isItemValid(slot, stack)) throw new RuntimeException("Invalid stack " + stack + " for slot " + slot + ")");
         NonNullList<ItemStack> itemStacks = getItemList();
@@ -185,7 +186,8 @@ class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityP
     protected NonNullList<ItemStack> refreshItemList(CompoundTag rootTag)
     {
         NonNullList<ItemStack> itemStacks = NonNullList.withSize(getSlots(), ItemStack.EMPTY);
-        if (rootTag != null && rootTag.contains("Items", CompoundTag.TAG_LIST)) {
+        if (rootTag != null && rootTag.contains("Items", CompoundTag.TAG_LIST))
+        {
             ContainerHelper.loadAllItems(rootTag, itemStacks);
         }
         cachedTag = rootTag;
@@ -230,8 +232,10 @@ class ShulkerItemStackInvWrapper implements IItemHandlerModifiable, ICapabilityP
                 Items.YELLOW_SHULKER_BOX);
 
         @SubscribeEvent
-        public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event) {
-            if (SHULKER_ITEMS.contains(event.getObject().getItem())) {
+        public static void listenCapabilitiesAttachment(AttachCapabilitiesEvent<ItemStack> event)
+        {
+            if (SHULKER_ITEMS.contains(event.getObject().getItem()))
+            {
                 event.addCapability(new ResourceLocation("forge", "shulker_box"), new ShulkerItemStackInvWrapper(event.getObject()));
             }
         }


### PR DESCRIPTION
Forge provides an `IItemHandler` capability for most built-in block entities and entities, and provides fluid capabilities for buckets, but does not provide a built-in item capabillity for shulker box items. This PR includes a simple implementation of such a capability, as discussed a bit on discord; concerns about performance were taken into account mostly only when attaching the capability, as it does not seem likely that many shulker box items will be interacted with in this way in a single tick. Otherwise, the `IItemHandler` is very similar to the wrappers given to vanilla container inventories.