### PR TITLE
Re-apply missing patch to ServerLevel.EntityCallbacks#onTrackingEnd()

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -211,7 +211,7 @@
                 ServerLevel.this.f_143247_.put(enderdragonpart.m_19879_(), enderdragonpart);
              }
           }
-@@ -1569,17 +_,23 @@
+@@ -1569,17 +_,26 @@
              ServerLevel.this.f_143246_.remove(mob);
           }
  
@@ -223,8 +223,10 @@
              }
           }
  
--         p_143375_.m_213651_(DynamicGameEventListener::m_223634_);
-+         p_143375_.m_213651_(DynamicGameEventListener::m_223641_);
+          p_143375_.m_213651_(DynamicGameEventListener::m_223634_);
++
++         p_143375_.onRemovedFromWorld();
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityLeaveWorldEvent(p_143375_, ServerLevel.this));
        }
  
 +      @Override


### PR DESCRIPTION
See issue #8826 - `IForgeEntity#onRemovedFromWorld()` not being called server-side

This also undoes the patch immediately above, which changed the reference to `DynamicGameEventListener::remove` to `DynamicGameEventListener::move`.  As far as I can tell (feedback welcome), calling `p_143375_.updateDynamicGameEventListener(DynamicGameEventListener::remove)` is the correct behaviour here; the entity is being removed, not moving between chunks.