### PR TITLE
Provide additional context to the getFieldOfView event

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -56,7 +56,7 @@
           }
  
 -         return d0;
-+         return net.minecraftforge.client.ForgeHooksClient.getFieldOfView(this, p_109142_, p_109143_, d0);
++         return net.minecraftforge.client.ForgeHooksClient.getFieldOfView(this, p_109142_, p_109143_, d0, p_109144_);
        }
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -347,8 +347,9 @@ public class ForgeHooksClient
         return fovModifierEvent.getNewFovModifier();
     }
 
-    public static double getFieldOfView(GameRenderer renderer, Camera camera, double partialTick, double fov) {
-        ViewportEvent.ComputeFov event = new ViewportEvent.ComputeFov(renderer, camera, partialTick, fov);
+    public static double getFieldOfView(GameRenderer renderer, Camera camera, double partialTick, double fov, boolean usedConfiguredFov)
+    {
+        ViewportEvent.ComputeFov event = new ViewportEvent.ComputeFov(renderer, camera, partialTick, fov, usedConfiguredFov);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getFOV();
     }

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -349,12 +349,14 @@ public abstract class ViewportEvent extends Event
      */
     public static class ComputeFov extends ViewportEvent
     {
+        private final boolean usedConfiguredFov;
         private double fov;
 
         @ApiStatus.Internal
-        public ComputeFov(GameRenderer renderer, Camera camera, double renderPartialTicks, double fov)
+        public ComputeFov(GameRenderer renderer, Camera camera, double renderPartialTicks, double fov, boolean usedConfiguredFov)
         {
             super(renderer, camera, renderPartialTicks);
+            this.usedConfiguredFov = usedConfiguredFov;
             this.setFOV(fov);
         }
 
@@ -374,6 +376,14 @@ public abstract class ViewportEvent extends Event
         public void setFOV(double fov)
         {
             this.fov = fov;
+        }
+
+        /**
+         * {@return whether the base fov value started with a constant or was sourced from the fov set in the options}
+         */
+        public boolean usedConfiguredFov()
+        {
+            return usedConfiguredFov;
         }
     }
 }


### PR DESCRIPTION
Done as a breaking change just given the event just got moved which is a breaking change anyway (and it is forge method calls), but if this ends up dragging on I can easily adjust the PR to be non breaking.