### PR TITLE
Pass renderType to IForgeBakedModel.useAmbientOcclusion

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -12,7 +12,7 @@
 +      tesselateBlock(p_234380_, p_234381_, p_234382_, p_234383_, p_234384_, p_234385_, p_234386_, p_234387_, p_234388_, p_234389_, net.minecraftforge.client.model.data.ModelData.EMPTY, null);
 +   }
 +   public void tesselateBlock(BlockAndTintGetter p_111048_, BakedModel p_111049_, BlockState p_111050_, BlockPos p_111051_, PoseStack p_111052_, VertexConsumer p_111053_, boolean p_111054_, RandomSource p_111055_, long p_111056_, int p_111057_, net.minecraftforge.client.model.data.ModelData modelData, net.minecraft.client.renderer.RenderType renderType) {
-+      boolean flag = Minecraft.m_91086_() && p_111050_.getLightEmission(p_111048_, p_111051_) == 0 && p_111049_.m_7541_();
++      boolean flag = Minecraft.m_91086_() && p_111050_.getLightEmission(p_111048_, p_111051_) == 0 && p_111049_.useAmbientOcclusion(p_111050_, renderType);
 +      Vec3 vec3 = p_111050_.m_60824_(p_111048_, p_111051_);
 +      p_111052_.m_85837_(vec3.f_82479_, vec3.f_82480_, vec3.f_82481_);
 +      modelData = p_111049_.getModelData(p_111048_, p_111051_, p_111050_, modelData);

--- a/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -53,12 +53,16 @@
        }
     }
  
-@@ -77,6 +_,10 @@
+@@ -77,6 +_,14 @@
        return this.f_119453_;
     }
  
 +   public boolean useAmbientOcclusion(BlockState state) {
 +      return this.defaultModel.useAmbientOcclusion(state);
++   }
++
++   public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
++      return this.defaultModel.useAmbientOcclusion(state, renderType);
 +   }
 +
     public boolean m_7539_() {

--- a/patches/minecraft/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -22,13 +22,18 @@
        }).orElse(Collections.emptyList());
     }
  
-@@ -38,6 +_,11 @@
+@@ -38,6 +_,16 @@
        return this.f_119542_.m_7541_();
     }
  
 +   @Override
 +   public boolean useAmbientOcclusion(BlockState state) {
 +      return this.f_119542_.useAmbientOcclusion(state);
++   }
++
++   @Override
++   public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
++      return this.f_119542_.useAmbientOcclusion(state, renderType);
 +   }
 +
     public boolean m_7539_() {

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -49,6 +49,11 @@ public interface IForgeBakedModel
         return self().useAmbientOcclusion();
     }
 
+    default boolean useAmbientOcclusion(BlockState state, RenderType renderType)
+    {
+        return self().useAmbientOcclusion(state);
+    }
+
     /**
      * Applies a transform for the given {@link ItemTransforms.TransformType} and {@code applyLeftHandTransform}, and
      * returns the model to be rendered.

--- a/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
@@ -58,6 +58,12 @@ public abstract class BakedModelWrapper<T extends BakedModel> implements BakedMo
     }
 
     @Override
+    public boolean useAmbientOcclusion(BlockState state, RenderType renderType)
+    {
+        return originalModel.useAmbientOcclusion(state, renderType);
+    }
+
+    @Override
     public boolean isGui3d()
     {
         return originalModel.isGui3d();


### PR DESCRIPTION
It would be nice to have RenderType passed to IForgeBakedModel.useAmbientOcclusion so that a model that renders in multiple RenderTypes can have AO in some but not other.

Before the recent rendering rework I had checks for MinecraftForgeClient.getRenderType in useAmbientOcclusion but that's not possible anymore.
