### PR TITLE
Fix #8833 - Use the new screen as the screen to open.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -157,7 +157,7 @@
 +      if (p_91153_ != null) {
 +         var event = new net.minecraftforge.client.event.ScreenEvent.Opening(old, p_91153_);
 +         if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
-+         p_91153_ = event.getScreen();
++         p_91153_ = event.getNewScreen();
 +      }
 +
 +      if (old != null && p_91153_ != old) {


### PR DESCRIPTION
This fixes a regression introduced during the client refactor #8786.
Now uses the correct method to determine the screen to open.