### PR TITLE
Multiple tweaks and fixes to the recent changes in the client refactor PR

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
@@ -1,18 +1,20 @@
 --- a/net/minecraft/client/gui/components/BossHealthOverlay.java
 +++ b/net/minecraft/client/gui/components/BossHealthOverlay.java
-@@ -34,6 +_,7 @@
+@@ -34,6 +_,8 @@
  
           for(LerpingBossEvent lerpingbossevent : this.f_93699_.values()) {
              int k = i / 2 - 91;
 +            var event = net.minecraftforge.client.ForgeHooksClient.onCustomizeBossEventProgress(p_93705_, this.f_93698_.m_91268_(), lerpingbossevent, k, j, 10 + this.f_93698_.f_91062_.f_92710_);
++            if (!event.isCanceled()) {
              RenderSystem.m_157429_(1.0F, 1.0F, 1.0F, 1.0F);
              RenderSystem.m_157456_(0, f_93697_);
              this.m_93706_(p_93705_, k, j, lerpingbossevent);
-@@ -42,7 +_,7 @@
+@@ -42,7 +_,8 @@
              int i1 = i / 2 - l / 2;
              int j1 = j - 9;
              this.f_93698_.f_91062_.m_92763_(p_93705_, component, (float)i1, (float)j1, 16777215);
 -            j += 10 + 9;
++            }
 +            j += event.getIncrement();
              if (j >= this.f_93698_.m_91268_().m_85446_() / 3) {
                 break;

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -55,11 +55,13 @@ public abstract class CustomizeGuiOverlayEvent extends Event
     /**
      * Fired <b>before</b> a boss health bar is rendered to the screen.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+     * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+     * Cancelling this event will prevent the given bar from rendering.</p>
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
+    @Cancelable
     public static class BossEventProgress extends CustomizeGuiOverlayEvent
     {
         private final LerpingBossEvent bossEvent;
@@ -124,7 +126,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event
      * Fired <b>before</b> textual information is rendered to the debug screen.
      * This can be used to add or remove text information.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
@@ -162,7 +164,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event
     /**
      * Fired <b>before</b> the chat messages overlay is rendered to the screen.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.<p/>
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>

--- a/src/main/java/net/minecraftforge/client/gui/overlay/GuiOverlayManager.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/GuiOverlayManager.java
@@ -59,6 +59,7 @@ public final class GuiOverlayManager
                 .collect(ImmutableList.toImmutableList());
         OVERLAYS_BY_NAME = OVERLAYS.stream()
                 .collect(ImmutableMap.toImmutableMap(NamedGuiOverlay::id, Function.identity()));
+        assignVanillaOverlayTypes();
     }
 
     /**
@@ -71,6 +72,12 @@ public final class GuiOverlayManager
             overlays.put(entry.id(), entry.overlay);
             orderedOverlays.add(entry.id());
         }
+    }
+
+    private static void assignVanillaOverlayTypes()
+    {
+        for (var entry : VanillaGuiOverlay.values())
+            entry.type = OVERLAYS_BY_NAME.get(entry.id());
     }
 
     private GuiOverlayManager()

--- a/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -209,6 +209,7 @@ public enum VanillaGuiOverlay
 
     private final ResourceLocation id;
     final IGuiOverlay overlay;
+    NamedGuiOverlay type;
 
     VanillaGuiOverlay(String id, IGuiOverlay overlay)
     {
@@ -220,5 +221,10 @@ public enum VanillaGuiOverlay
     public ResourceLocation id()
     {
         return id;
+    }
+
+    public NamedGuiOverlay type()
+    {
+        return type;
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/DynamicFluidContainerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/DynamicFluidContainerModelBuilder.java
@@ -29,7 +29,7 @@ public class DynamicFluidContainerModelBuilder<T extends ModelBuilder<T>> extend
 
     protected DynamicFluidContainerModelBuilder(T parent, ExistingFileHelper existingFileHelper)
     {
-        super(new ResourceLocation("forge:bucket"), parent, existingFileHelper);
+        super(new ResourceLocation("forge:fluid_container"), parent, existingFileHelper);
     }
 
     public DynamicFluidContainerModelBuilder<T> fluid(Fluid fluid)

--- a/src/main/java/net/minecraftforge/client/textures/UnitTextureAtlasSprite.java
+++ b/src/main/java/net/minecraftforge/client/textures/UnitTextureAtlasSprite.java
@@ -18,8 +18,8 @@ import net.minecraft.resources.ResourceLocation;
  */
 public class UnitTextureAtlasSprite extends TextureAtlasSprite
 {
-    public static final UnitTextureAtlasSprite INSTANCE = new UnitTextureAtlasSprite();
     public static final ResourceLocation LOCATION = new ResourceLocation("forge", "unit");
+    public static final UnitTextureAtlasSprite INSTANCE = new UnitTextureAtlasSprite();
 
     private UnitTextureAtlasSprite()
     {


### PR DESCRIPTION
As discussed on Discord, I'll leave my two existing PRs untouched, and all other changes will be grouped into a single PR.

If anyone runs into any other issues, feel free to PR fixes to this branch of my fork and I'll review and merge them into this PR.

### Add an easy way to get the NamedGuiOverlay from a vanilla overlay
Adds a helper method to retrieve the `NamedGuiOverlay` from a `VanillaGuiOverlay`, allowing identity comparisons in events instead of having to resort to string comparison.

### Fix static member ordering crash in UnitTextureAtlasSprite
The way the two static fields are currently ordered causes the game to crash (for some reason only outside a dev environment??) due to referencing the uninitialized field `LOCATION` from the constructor invoked when assigning a value to `INSTANCE`.

Fixes #8795 on 1.19. **This probably needs a backport PR, since it's an issue in 1.18.X too.**

### Allow boss bar rendering to be cancelled
This reverts a change that prevents custom boss bars from being easily rendered.

I've discussed this with some community members, and we agree that this really shouldn't be the way to do it, but implementing it properly is going to require either some cooperation from Mojang, or custom network packets, so that will be left to a future PR.

### Make fluid container datagen use the new name
The dynamic fluid container loader is now called `forge:fluid_container`, but the datagen is outputting `forge:bucket`. This works fine for the time being, but the old loader name will be removed in 1.20, so this commit updates it to the right name.