### PR TITLE
Allow modded blocks overriding canStickTo prevent sticking to vanilla blocks/other modded blocks

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/piston/PistonStructureResolver.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/piston/PistonStructureResolver.java.patch
@@ -46,7 +46,7 @@
 +               oldState = blockstate;
                 blockstate = this.f_60409_.m_8055_(blockpos);
 -               if (blockstate.m_60795_() || !m_155939_(blockstate1, blockstate) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
-+               if (blockstate.m_60795_() || !oldState.canStickTo(blockstate) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
++               if (blockstate.m_60795_() || (!oldState.canStickTo(blockstate) && !blockstate.canStickTo(oldState)) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
                    break;
                 }
  
@@ -64,7 +64,7 @@
              BlockPos blockpos = p_60432_.m_121945_(direction);
              BlockState blockstate1 = this.f_60409_.m_8055_(blockpos);
 -            if (m_155939_(blockstate1, blockstate) && !this.m_60433_(blockpos, direction)) {
-+            if (blockstate1.canStickTo(blockstate) && !this.m_60433_(blockpos, direction)) {
++            if (blockstate1.canStickTo(blockstate) && blockstate.canStickTo(blockstate1) && !this.m_60433_(blockpos, direction)) {
                 return false;
              }
           }

--- a/patches/minecraft/net/minecraft/world/level/block/piston/PistonStructureResolver.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/piston/PistonStructureResolver.java.patch
@@ -46,7 +46,7 @@
 +               oldState = blockstate;
                 blockstate = this.f_60409_.m_8055_(blockpos);
 -               if (blockstate.m_60795_() || !m_155939_(blockstate1, blockstate) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
-+               if (blockstate.m_60795_() || (!oldState.canStickTo(blockstate) && !blockstate.canStickTo(oldState)) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
++               if (blockstate.m_60795_() || !(oldState.canStickTo(blockstate) && blockstate.canStickTo(oldState)) || !PistonBaseBlock.m_60204_(blockstate, this.f_60409_, blockpos, this.f_60413_, false, this.f_60413_.m_122424_()) || blockpos.equals(this.f_60410_)) {
                    break;
                 }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -444,7 +444,7 @@ public interface IForgeBlockState
      */
     default boolean canStickTo(@NotNull BlockState other)
     {
-        return self().getBlock().canStickTo(self(), other) && other.getBlock().canStickTo(other, self());
+        return self().getBlock().canStickTo(self(), other);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -39,6 +39,7 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface IForgeBlockState
@@ -441,9 +442,9 @@ public interface IForgeBlockState
      * @param other Other block
      * @return True to link blocks
      */
-    default boolean canStickTo(BlockState other)
+    default boolean canStickTo(@NotNull BlockState other)
     {
-        return self().getBlock().canStickTo(self(), other);
+        return self().getBlock().canStickTo(self(), other) && other.getBlock().canStickTo(other, self());
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/block/StickyBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/StickyBlockTest.java
@@ -6,16 +6,23 @@
 package net.minecraftforge.debug.block;
 
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ObjectHolder;
 import net.minecraftforge.registries.RegisterEvent;
+import net.minecraftforge.registries.RegistryObject;
+import org.jetbrains.annotations.Nullable;
 
 @Mod(StickyBlockTest.MODID)
 @Mod.EventBusSubscriber(bus = Bus.MOD)
@@ -23,26 +30,49 @@ public class StickyBlockTest
 {
     static final String MODID = "custom_slime_block_test";
     static final String BLOCK_ID = "test_block";
+    static final String BLOCK_ID_2 = "test_block_2";
 
-    @ObjectHolder(registryName = "block", value = BLOCK_ID)
-    public static Block BLUE_BLOCK;
+    public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS.getRegistryName(), MODID);
 
-    @SubscribeEvent
-    public static void registerBlocks(RegisterEvent event)
+    public static final RegistryObject<Block> BLUE_BLOCK = BLOCKS.register(BLOCK_ID, () -> new Block(Block.Properties.of(Material.STONE))
     {
-        event.register(ForgeRegistries.Keys.BLOCKS, helper -> helper.register(BLOCK_ID, new Block(Block.Properties.of(Material.STONE))
+        @Override
+        public boolean isStickyBlock(BlockState state)
         {
-            @Override
-            public boolean isStickyBlock(BlockState state)
-            {
-                return true;
-            }
-        }));
-    }
+            return true;
+        }
+    });
 
-    @SubscribeEvent
-    public static void registerItems(RegisterEvent event)
+    public static final RegistryObject<Block> RED_BLOCK = BLOCKS.register(BLOCK_ID_2, () -> new Block(Block.Properties.of(Material.STONE))
     {
-        event.register(ForgeRegistries.Keys.ITEMS, helper -> helper.register(BLOCK_ID, new BlockItem(BLUE_BLOCK, new Item.Properties())));
+        @Override
+        public boolean isStickyBlock(BlockState state)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isSlimeBlock(BlockState state)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean canStickTo(BlockState state, BlockState other)
+        {
+            if (state.getBlock() == RED_BLOCK.get() && other.getBlock() == Blocks.SLIME_BLOCK) return false;
+            return state.isStickyBlock() || other.isStickyBlock();
+        }
+    });
+
+    public static final RegistryObject<Item> BLUE_BLOCK_ITEM = ITEMS.register(BLOCK_ID, () -> new BlockItem(BLUE_BLOCK.get(), new Item.Properties()));
+    public static final RegistryObject<Item> RED_BLOCK_ITEM = ITEMS.register(BLOCK_ID_2, () -> new BlockItem(RED_BLOCK.get(), new Item.Properties()));
+
+    public StickyBlockTest()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        BLOCKS.register(modEventBus);
+        ITEMS.register(modEventBus);
     }
 }


### PR DESCRIPTION
Basically, before, overriding canStickTo in a modded block to try and prevent sticking to vanilla slime blocks would fail when the game checks the stickiness through the vanilla block. This PR makes it so that Forge's blockstate canStickTo checks to make sure both blocks passes their canStickTo checks.

Example modded sticky block that uses canStickTo to prevent sticking to vanilla slime blocks but sticks to everything else
https://user-images.githubusercontent.com/40846040/178077123-354022ad-57f2-4b74-a23a-96cd182cfa43.mp4

This PR was done in a way to try and prevent a breaking change. Though if the other block check is not desirable to be in the blockstate, I can move the check to the patches instead. Also, set non-null on param for blockstate canStickTo because passing in null will crash majority of blocks with the default canStickTo implementation even before this pr.

Fixes #7122.
