### PR TITLE
[1.18.x] Fix static member ordering crash in UnitSprite

### DIFF
--- a/src/main/java/net/minecraftforge/client/textures/UnitSprite.java
+++ b/src/main/java/net/minecraftforge/client/textures/UnitSprite.java
@@ -19,8 +19,8 @@ import java.util.function.Function;
  */
 public class UnitSprite extends TextureAtlasSprite
 {
-    public static final UnitSprite INSTANCE = new UnitSprite();
     public static final ResourceLocation LOCATION = new ResourceLocation("forge", "unit");
+    public static final UnitSprite INSTANCE = new UnitSprite();
     public static final Function<Material, TextureAtlasSprite> GETTER = (x) -> INSTANCE;
 
     private UnitSprite()


### PR DESCRIPTION
This PR fixes #8795 by reordering the static fields in `UnitSprite` so that `LOCATION` is first then `INSTANCE`. The previous ordering caused `LOCATION` to be `null` during the construction
of the `UnitSprite`'s singleton `INSTANCE`, leading to potential errors as the atlas location for the sprite would be `null`.

This PR's fix mirrors the fix for the same issue in #8836, backporting it to LTS.
