### PR TITLE
Add FML config to disable DFU optimizations client-side.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,7 @@ def sharedFmlonlyForge = { Project prj ->
                 property 'nativesDirectory', '{natives}'
                 if (prj.name == 'forge') {
                     property 'forge.enableGameTest', 'true'
+                    args '--disable-dfu-optimizations'
                 }
 
                 args '--launchTarget', "${launchPrefix}clientuserdev"
@@ -953,6 +954,7 @@ project(':forge') {
             forge_client {
                 property 'eventbus.checkTypesOnDispatch', 'true'
                 args '--launchTarget', 'forgeclientdev'
+                args '--disable-dfu-optimizations'
                 ideaModule "${rootProject.name}.${project.name}.main"
                 mods {
                     minecraft { source sourceSets.main }
@@ -963,6 +965,7 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
+                args '--disable-dfu-optimizations'
                 property 'forge.enableGameTest', 'true'
                 environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
 

--- a/build.gradle
+++ b/build.gradle
@@ -380,7 +380,6 @@ def sharedFmlonlyForge = { Project prj ->
                 property 'nativesDirectory', '{natives}'
                 if (prj.name == 'forge') {
                     property 'forge.enableGameTest', 'true'
-                    args '--disable-dfu-optimizations'
                 }
 
                 args '--launchTarget', "${launchPrefix}clientuserdev"
@@ -954,7 +953,6 @@ project(':forge') {
             forge_client {
                 property 'eventbus.checkTypesOnDispatch', 'true'
                 args '--launchTarget', 'forgeclientdev'
-                args '--disable-dfu-optimizations'
                 ideaModule "${rootProject.name}.${project.name}.main"
                 mods {
                     minecraft { source sourceSets.main }
@@ -965,7 +963,6 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
-                args '--disable-dfu-optimizations'
                 property 'forge.enableGameTest', 'true'
                 environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -29,6 +29,7 @@ public class FMLConfig
         configSpec.define("maxThreads", -1);
         configSpec.define("versionCheck", Boolean.TRUE);
         configSpec.define("defaultConfigPath",  "defaultconfigs");
+        configSpec.define("disableOptimizedDFU", Boolean.TRUE);
     }
 
     private CommentedFileConfig configData;
@@ -87,5 +88,9 @@ public class FMLConfig
 
     public static String defaultConfigPath() {
         return INSTANCE.configData.<String>getOptional("defaultConfigPath").orElse("defaultconfigs");
+    }
+
+    public static boolean isOptimizedDFUDisabled() {
+        return INSTANCE.configData.<Boolean>getOptional("disableOptimizedDFU").orElse(Boolean.TRUE);
     }
 }

--- a/fmlloader/src/main/resources/META-INF/defaultfmlconfig.toml
+++ b/fmlloader/src/main/resources/META-INF/defaultfmlconfig.toml
@@ -4,3 +4,5 @@ splashscreen = true
 maxThreads = -1
 # Enable forge global version checking
 versionCheck = true
+# Disables Optimized DFU client-side.
+disableOptimizedDFU = true

--- a/patches/minecraft/net/minecraft/client/main/Main.java.patch
+++ b/patches/minecraft/net/minecraft/client/main/Main.java.patch
@@ -1,5 +1,32 @@
 --- a/net/minecraft/client/main/Main.java
 +++ b/net/minecraft/client/main/Main.java
+@@ -49,7 +_,6 @@
+    @DontObfuscate
+    public static void main(String[] p_129642_) {
+       SharedConstants.m_142977_();
+-      SharedConstants.m_214358_();
+       OptionParser optionparser = new OptionParser();
+       optionparser.allowsUnrecognizedOptions();
+       optionparser.accepts("demo");
+@@ -82,6 +_,7 @@
+       OptionSpec<String> optionspec22 = optionparser.accepts("assetIndex").withRequiredArg();
+       OptionSpec<String> optionspec23 = optionparser.accepts("userType").withRequiredArg().defaultsTo(User.Type.LEGACY.m_193808_());
+       OptionSpec<String> optionspec24 = optionparser.accepts("versionType").withRequiredArg().defaultsTo("release");
++      OptionSpec<Void> disableDFUOptimizations = optionparser.accepts("disable-dfu-optimizations");
+       OptionSpec<String> optionspec25 = optionparser.nonOptions();
+       OptionSet optionset = optionparser.parse(p_129642_);
+       List<String> list = optionset.valuesOf(optionspec25);
+@@ -89,6 +_,10 @@
+          System.out.println("Completely ignored arguments: " + list);
+       }
+ 
++      if (!optionset.has(disableDFUOptimizations)) {
++         SharedConstants.m_214358_();
++      }
++
+       String s = m_129638_(optionset, optionspec6);
+       Proxy proxy = Proxy.NO_PROXY;
+       if (s != null) {
 @@ -135,7 +_,7 @@
        }
  

--- a/patches/minecraft/net/minecraft/client/main/Main.java.patch
+++ b/patches/minecraft/net/minecraft/client/main/Main.java.patch
@@ -1,32 +1,13 @@
 --- a/net/minecraft/client/main/Main.java
 +++ b/net/minecraft/client/main/Main.java
-@@ -49,7 +_,6 @@
+@@ -49,6 +_,7 @@
     @DontObfuscate
     public static void main(String[] p_129642_) {
        SharedConstants.m_142977_();
--      SharedConstants.m_214358_();
++      if (!net.minecraftforge.fml.loading.FMLConfig.isOptimizedDFUDisabled())
+       SharedConstants.m_214358_();
        OptionParser optionparser = new OptionParser();
        optionparser.allowsUnrecognizedOptions();
-       optionparser.accepts("demo");
-@@ -82,6 +_,7 @@
-       OptionSpec<String> optionspec22 = optionparser.accepts("assetIndex").withRequiredArg();
-       OptionSpec<String> optionspec23 = optionparser.accepts("userType").withRequiredArg().defaultsTo(User.Type.LEGACY.m_193808_());
-       OptionSpec<String> optionspec24 = optionparser.accepts("versionType").withRequiredArg().defaultsTo("release");
-+      OptionSpec<Void> disableDFUOptimizations = optionparser.accepts("disable-dfu-optimizations");
-       OptionSpec<String> optionspec25 = optionparser.nonOptions();
-       OptionSet optionset = optionparser.parse(p_129642_);
-       List<String> list = optionset.valuesOf(optionspec25);
-@@ -89,6 +_,10 @@
-          System.out.println("Completely ignored arguments: " + list);
-       }
- 
-+      if (!optionset.has(disableDFUOptimizations)) {
-+         SharedConstants.m_214358_();
-+      }
-+
-       String s = m_129638_(optionset, optionspec6);
-       Proxy proxy = Proxy.NO_PROXY;
-       if (s != null) {
 @@ -135,7 +_,7 @@
        }
  


### PR DESCRIPTION
Adds an FML config option to disable DFU optimizations client-side, enabled by default.

Greatly speeds up the client loading process as Optimized DFU lookups are not usually required in modded environments. 

Whilst this does happen off-thread, it is a massive operation taking over 13 seconds for me on my 5950x pinning all my CPU cores in the process.