### PR TITLE
[1.19.x] Fix MultiPartBakedModel not using model-driven render types

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -32,7 +32,7 @@
        if (p_235050_ == null) {
           return Collections.emptyList();
        } else {
-@@ -60,16 +_,17 @@
+@@ -60,16 +_,18 @@
              this.f_119460_.put(p_235050_, bitset);
           }
  
@@ -44,6 +44,7 @@
              if (bitset.get(j)) {
 -               list.addAll(this.f_119459_.get(j).getRight().m_213637_(p_235050_, p_235051_, RandomSource.m_216335_(k)));
 +               var model = this.f_119459_.get(j).getRight();
++               if (model.getRenderTypes(p_235050_, p_235052_, modelData).contains(renderType)) // FORGE: Only put quad data if the model is using the render type passed
 +               list.add(model.getQuads(p_235050_, p_235051_, RandomSource.m_216335_(k), net.minecraftforge.client.model.data.MultipartModelData.resolve(modelData, model), renderType));
              }
           }
@@ -68,7 +69,7 @@
     public boolean m_7539_() {
        return this.f_119454_;
     }
-@@ -89,12 +_,22 @@
+@@ -89,16 +_,38 @@
        return false;
     }
  
@@ -84,10 +85,26 @@
 +   @Deprecated
     public ItemTransforms m_7442_() {
        return this.f_119457_;
-+   }
-+
-+   public BakedModel applyTransform(net.minecraft.client.renderer.block.model.ItemTransforms.TransformType transformType, com.mojang.blaze3d.vertex.PoseStack poseStack, boolean applyLeftHandTransform) {
-+      return this.defaultModel.applyTransform(transformType, poseStack, applyLeftHandTransform);
     }
  
++   public BakedModel applyTransform(net.minecraft.client.renderer.block.model.ItemTransforms.TransformType transformType, com.mojang.blaze3d.vertex.PoseStack poseStack, boolean applyLeftHandTransform) {
++      return this.defaultModel.applyTransform(transformType, poseStack, applyLeftHandTransform);
++   }
++
     public ItemOverrides m_7343_() {
+       return this.f_119458_;
++   }
++
++   private final java.util.Map<BlockState, net.minecraftforge.client.ChunkRenderTypeSet> stateRenderTypeCache = new java.util.concurrent.ConcurrentHashMap<>();
++
++   @Override // FORGE: Get render types based on the models used for the block state passed, and cache those values for future use.
++   public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(@org.jetbrains.annotations.NotNull BlockState state, @org.jetbrains.annotations.NotNull RandomSource rand, @org.jetbrains.annotations.NotNull net.minecraftforge.client.model.data.ModelData data) {
++       return this.stateRenderTypeCache.computeIfAbsent(state, s -> net.minecraftforge.client.ChunkRenderTypeSet.union(this.f_119459_.stream().filter(p -> p.getLeft().test(s)).map(p -> p.getRight().getRenderTypes(s, rand, data)).toList()));
++   }
++
++   @Override // FORGE: Get the render types for all selectors. Don't cache since itemStack could do custom things with NBT.
++   public List<net.minecraft.client.renderer.RenderType> getRenderTypes(net.minecraft.world.item.ItemStack itemStack, boolean fabulous) {
++       return this.f_119459_.stream().flatMap(p -> p.getRight().getRenderTypes(itemStack, fabulous).stream()).distinct().toList();
+    }
+ 
+    @OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
The title pretty much says it all. `MultiPartBakedModel` doesn't implement `IForgeBakedModel.getRenderTypes`, meaning multipart models can't utilize with model driven render types.

# Implementation
The `getRenderTypes` method for block states will get all render types applicable to the block state passed, based on what models will be rendered. These render types are then cached in `stateRenderTypeCache` for future access.

The `getRenderTypes` method for item stacks will check all possible models for their render types and return all of them. This is not cached since item stacks may use NBT to determine render types.

`getQuads` has an additional check for if the model who's quads we're about to add should be rendered given the render type passed. Without this, all the models will attempt to render under all render types associated with this model, negating the purpose of the above methods.

# Testing

Sample resource pack: [Test Pack.zip](https://github.com/MinecraftForge/MinecraftForge/files/9077852/Test.Pack.zip)
Screenshot of the resource pack in action:
![2022-07-09_16 07 45](https://user-images.githubusercontent.com/15661705/178121515-6b7008c8-cf06-4ed5-9c38-3420917fe01d.png)

