### PR TITLE
Make cutout mipmaps explicitly opt-in for item/entity rendering

### DIFF
--- a/src/main/java/net/minecraftforge/client/NamedRenderTypeManager.java
+++ b/src/main/java/net/minecraftforge/client/NamedRenderTypeManager.java
@@ -50,7 +50,9 @@ public final class NamedRenderTypeManager
     {
         blockRenderTypes.put(new ResourceLocation("solid"), new RenderTypeGroup(RenderType.solid(), ForgeRenderTypes.ITEM_LAYERED_SOLID.get()));
         blockRenderTypes.put(new ResourceLocation("cutout"), new RenderTypeGroup(RenderType.cutout(), ForgeRenderTypes.ITEM_LAYERED_CUTOUT.get()));
-        blockRenderTypes.put(new ResourceLocation("cutout_mipped"), new RenderTypeGroup(RenderType.cutoutMipped(), ForgeRenderTypes.ITEM_LAYERED_CUTOUT_MIPPED.get()));
+        // Generally entity/item rendering shouldn't use mipmaps, so cutout_mipped has them off by default. To enforce them, use cutout_mipped_all.
+        blockRenderTypes.put(new ResourceLocation("cutout_mipped"), new RenderTypeGroup(RenderType.cutoutMipped(), ForgeRenderTypes.ITEM_LAYERED_CUTOUT.get()));
+        blockRenderTypes.put(new ResourceLocation("cutout_mipped_all"), new RenderTypeGroup(RenderType.cutoutMipped(), ForgeRenderTypes.ITEM_LAYERED_CUTOUT_MIPPED.get()));
         blockRenderTypes.put(new ResourceLocation("translucent"), new RenderTypeGroup(RenderType.translucent(), ForgeRenderTypes.ITEM_LAYERED_TRANSLUCENT.get()));
         blockRenderTypes.put(new ResourceLocation("tripwire"), new RenderTypeGroup(RenderType.tripwire(), ForgeRenderTypes.ITEM_LAYERED_TRANSLUCENT.get()));
     }

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -150,13 +150,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
      */
     public T renderType(String renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
-        ResourceLocation asLoc;
-        if (renderType.contains(":")) {
-            asLoc = new ResourceLocation(renderType);
-        } else {
-            asLoc = new ResourceLocation(getLocation().getNamespace(), renderType);
-        }
-        return renderType(asLoc);
+        return renderType(new ResourceLocation(renderType));
     }
 
     /**


### PR DESCRIPTION
Generally, mipmaps are not a desirable feature in cutout item/entity rendering. This can cause odd borders to show up around textures and is especially noticeable at low GUI resolutions.

This PR addresses that by making the default `cutout_mipped` named render type only use mipmaps for blocks, but not for item/entity rendering. To fill the gap, `cutout_mipped_all` has also been added, which enforces it across all contexts.

Attached is an image showcasing 3 different test cases (provided by XFactHD):
 - Vanilla's block sheet render type
 - Forge's implementation of cutout_mipped for the entity format
 - Forge's implementation of cutout for the entity format

The first (vanilla default for items) and third (new) look correct, however the second (current) shows a border that is not in the texture.

![image](https://user-images.githubusercontent.com/2066666/178124168-3c6b2f6d-13f7-4016-b15b-8c22c300dba7.png)

Special thanks to both Ellemes and XFactHD for helping debug this.

Edit: As per Pup's request, the render type domain in datagens now also defaults to `minecraft` if none is specified, putting it at parity with hand-made JSONs, which can just omit the domain.