### PR TITLE
[1.19.x] Fixed CompositeModel.Baked.Builder.build() passing arguments in the wrong order

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -318,7 +318,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
                     childrenBuilder.put("model_" + (i++), model);
                     itemPassesBuilder.add(model);
                 }
-                return new Baked(isAmbientOcclusion, isGui3d, isSideLit, particle, transforms, overrides, childrenBuilder.build(), itemPassesBuilder.build());
+                return new Baked(isGui3d, isSideLit, isAmbientOcclusion, particle, transforms, overrides, childrenBuilder.build(), itemPassesBuilder.build());
             }
         }
 


### PR DESCRIPTION
# The Issue
When creating a `CompositeModel` from it's builder, the `isAmbientOcclusion` field is passed as the first argument when it should be the third. This causes items using the builder, such as `ItemLayerModel` to render with the wrong GUI lighting.

# Testing
Screenshot from using this resource pack to make gold swords have a glowing blade: [Emissive Sword.zip](https://github.com/MinecraftForge/MinecraftForge/files/9078304/Emissive.Sword.zip)

![2022-07-09_22 29 06](https://user-images.githubusercontent.com/15661705/178128995-364774d0-a177-456a-8791-adce998b5bf0.png)
 