### PR TITLE
[Bump] Update to the latest JarJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     APACHE_COMMONS_LANG3_VERSION = '3.12.0'
     JOPT_SIMPLE_VERSION = '5.0.4'
     COMMONS_IO_VERSION = '2.11.0'
-    JARJAR_VERSION = '0.2.26'
+    JARJAR_VERSION = '0.3.0'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -96,7 +96,9 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
     @NotNull
     private Stream<ModWithVersionRange> getModWithVersionRangeStream(final JarSelector.SourceWithRequestedVersionRange<IModFile> file)
     {
-        return file.source().getModFileInfo().getMods().stream().map(modInfo -> new ModWithVersionRange(modInfo, file.requestedVersionRange(), file.includedVersion()));
+        return file.sources().stream().map(IModFile::getModFileInfo)
+                .flatMap(modFileInfo -> modFileInfo.getMods().stream())
+                .map(modInfo -> new ModWithVersionRange(modInfo, file.requestedVersionRange(), file.includedVersion()));
     }
 
     @NotNull


### PR DESCRIPTION
This fixes a collision issue where 2 jars could provide the exact match to a requested jar, causing a problem when source jars were being detected to load them from.

Closes: #8843 