### PR TITLE
[Bump] Update to the latest JarJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ ext {
     ASM_VERSION = '9.2'
     INSTALLER_VERSION = '2.1.+'
     MIXIN_VERSION = '0.8.5'
-    JARJAR_VERSION = '0.2.26'
+    JARJAR_VERSION = '0.3.0'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -96,7 +96,9 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
     @NotNull
     private Stream<ModWithVersionRange> getModWithVersionRangeStream(final JarSelector.SourceWithRequestedVersionRange<IModFile> file)
     {
-        return file.source().getModFileInfo().getMods().stream().map(modInfo -> new ModWithVersionRange(modInfo, file.requestedVersionRange(), file.includedVersion()));
+        return file.sources().stream().map(IModFile::getModFileInfo)
+                .flatMap(modFileInfo -> modFileInfo.getMods().stream())
+                .map(modInfo -> new ModWithVersionRange(modInfo, file.requestedVersionRange(), file.includedVersion()));
     }
 
     @NotNull

--- a/src/main/java/net/minecraftforge/logging/CrashReportExtender.java
+++ b/src/main/java/net/minecraftforge/logging/CrashReportExtender.java
@@ -64,7 +64,7 @@ public class CrashReportExtender
             }
             if (cause != null)
                 category.applyStackTrace(cause);
-            category.setDetail("Mod File", () -> modInfo.map(IModInfo::getOwningFile).map(t-> t.getFile().getFileName()).orElse("NO FILE INFO"));
+            category.setDetail("Mod File", () -> modInfo.map(IModInfo::getOwningFile).map(t-> t.getFile().getFilePath().toUri().getPath()).orElse("NO FILE INFO"));
             category.setDetail("Failure message", () -> mle.getCleanMessage().replace("\n", "\n\t\t"));
             category.setDetail("Mod Version", () -> modInfo.map(IModInfo::getVersion).map(Object::toString).orElse("NO MOD INFO AVAILABLE"));
             category.setDetail("Mod Issue URL", () -> modInfo.map(IModInfo::getOwningFile).map(IModFileInfo.class::cast).flatMap(mfi->mfi.getConfig().<String>getConfigElement("issueTrackerURL")).orElse("NOT PROVIDED"));


### PR DESCRIPTION
This fixes a collision issue where 2 jars could provide the exact match to a requested jar, causing a problem when source jars were being detected to load them from.

This also outputs the full path in the crash report of a mod file that causes the crash making it easier to find the source of a crash. Backports #8856.