### PR TITLE
Multiple tweaks and fixes to the recent changes in the client refactor PR: Part 2

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -56,7 +56,7 @@
                 float f1 = (float)(i >> 8 & 255) / 255.0F;
                 float f2 = (float)(i & 255) / 255.0F;
 -               this.f_110900_.m_111067_(p_110914_.m_85850_(), p_110915_.m_6299_(ItemBlockRenderTypes.m_109284_(p_110913_, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_);
-+            this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(ItemBlockRenderTypes.m_109284_(p_110913_, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, renderType);
++            this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(renderType), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, renderType);
                 break;
              case ENTITYBLOCK_ANIMATED:
 -               this.f_173397_.m_108829_(new ItemStack(p_110913_.m_60734_()), ItemTransforms.TransformType.NONE, p_110914_, p_110915_, p_110916_, p_110917_);

--- a/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -51,12 +51,13 @@
        RenderShape rendershape = p_110913_.m_60799_();
        if (rendershape != RenderShape.INVISIBLE) {
           switch (rendershape) {
-@@ -97,10 +_,11 @@
+@@ -97,10 +_,12 @@
                 float f = (float)(i >> 16 & 255) / 255.0F;
                 float f1 = (float)(i >> 8 & 255) / 255.0F;
                 float f2 = (float)(i & 255) / 255.0F;
 -               this.f_110900_.m_111067_(p_110914_.m_85850_(), p_110915_.m_6299_(ItemBlockRenderTypes.m_109284_(p_110913_, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_);
-+            this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(renderType), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, renderType);
++               for (net.minecraft.client.renderer.RenderType rt : bakedmodel.getRenderTypes(p_110913_, RandomSource.m_216335_(42), modelData))
++                  this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(renderType != null ? renderType : net.minecraftforge.client.ForgeHooksClient.getEntityRenderType(rt, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, rt);
                 break;
              case ENTITYBLOCK_ANIMATED:
 -               this.f_173397_.m_108829_(new ItemStack(p_110913_.m_60734_()), ItemTransforms.TransformType.NONE, p_110914_, p_110915_, p_110916_, p_110917_);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -953,6 +953,20 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
     }
 
+    /**
+     * Mimics the behavior of {@link net.minecraft.client.renderer.ItemBlockRenderTypes#getRenderType(BlockState, boolean)}
+     * for the input {@link RenderType}.
+     */
+    @NotNull
+    public static RenderType getEntityRenderType(RenderType chunkRenderType, boolean fabulous)
+    {
+        if (chunkRenderType != RenderType.translucent())
+            return Sheets.cutoutBlockSheet();
+        if (!Minecraft.useShaderTransparency())
+            return Sheets.translucentCullBlockSheet();
+        return fabulous ? Sheets.translucentCullBlockSheet() : Sheets.translucentItemSheet();
+    }
+
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid="forge", bus= Mod.EventBusSubscriber.Bus.MOD)
     public static class ClientEvents
     {

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -125,6 +125,12 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
         return textures;
     }
 
+    @Override
+    public Set<String> getComponentNames(boolean recursive)
+    {
+        return children.keySet();
+    }
+
     public static class Baked implements IDynamicBakedModel
     {
         private final boolean isAmbientOcclusion;

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -126,7 +126,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
     }
 
     @Override
-    public Set<String> getComponentNames(boolean recursive)
+    public Set<String> getConfigurableComponentNames()
     {
         return children.keySet();
     }

--- a/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
@@ -147,6 +147,7 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
         this.customGeometry = other.customGeometry;
         this.rootTransform = other.rootTransform;
         this.visibilityData.copyFrom(other.visibilityData);
+        this.renderTypeHint = other.renderTypeHint;
     }
 
     public Collection<Material> getTextureDependencies(Function<ResourceLocation, UnbakedModel> modelGetter, Set<Pair<String, String>> missingTextureErrors)

--- a/src/main/java/net/minecraftforge/client/model/geometry/IUnbakedGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IUnbakedGeometry.java
@@ -32,4 +32,12 @@ public interface IUnbakedGeometry<T extends IUnbakedGeometry<T>>
     BakedModel bake(IGeometryBakingContext context, ModelBakery bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation);
 
     Collection<Material> getMaterials(IGeometryBakingContext context, Function<ResourceLocation, UnbakedModel> modelGetter, Set<Pair<String, String>> missingTextureErrors);
+
+    /**
+     * {@return a set of all the components whose visibility may be configured via {@link IGeometryBakingContext}}
+     */
+    default Set<String> getComponentNames(boolean recursive)
+    {
+        return Set.of();
+    }
 }

--- a/src/main/java/net/minecraftforge/client/model/geometry/IUnbakedGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IUnbakedGeometry.java
@@ -36,7 +36,7 @@ public interface IUnbakedGeometry<T extends IUnbakedGeometry<T>>
     /**
      * {@return a set of all the components whose visibility may be configured via {@link IGeometryBakingContext}}
      */
-    default Set<String> getComponentNames(boolean recursive)
+    default Set<String> getConfigurableComponentNames()
     {
         return Set.of();
     }

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -367,14 +367,14 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
     @Override
     public Set<String> getComponentNames(boolean recursive)
     {
-        if (!recursive) return rootComponentNames;
-        if (allComponentNames == null)
-        {
-            allComponentNames = new HashSet<>();
-            for (var group : parts.values())
-                group.addNamesRecursively(allComponentNames);
-        }
-        return allComponentNames;
+        if (!recursive)
+            return rootComponentNames;
+        if (allComponentNames != null)
+            return allComponentNames;
+        var names = new HashSet<String>();
+        for (var group : parts.values())
+            group.addNamesRecursively(names);
+        return allComponentNames = Collections.unmodifiableSet(names);
     }
 
     private Pair<BakedQuad, Direction> makeQuad(int[][] indices, int tintIndex, Vector4f colorTint, Vector4f ambientColor, TextureAtlasSprite texture, Transformation transform)
@@ -571,7 +571,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
                          .collect(Collectors.toSet());
         }
 
-        public void addNamesRecursively(Set<String> names)
+        protected void addNamesRecursively(Set<String> names)
         {
             names.add(name());
         }
@@ -619,7 +619,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
         }
 
         @Override
-        public void addNamesRecursively(Set<String> names)
+        protected void addNamesRecursively(Set<String> names)
         {
             super.addNamesRecursively(names);
             for (ModelObject object : parts.values())

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -364,11 +364,14 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
         return combined;
     }
 
-    @Override
-    public Set<String> getComponentNames(boolean recursive)
+    public Set<String> getRootComponentNames()
     {
-        if (!recursive)
-            return rootComponentNames;
+        return rootComponentNames;
+    }
+
+    @Override
+    public Set<String> getConfigurableComponentNames()
+    {
         if (allComponentNames != null)
             return allComponentNames;
         var names = new HashSet<String>();


### PR DESCRIPTION
### Add getter for the component names in an unbaked geometry
The old multipart geometries allowed you to access the children directly, but as it was agreed during the planning of the big refactor that direct access to children before baking should not be part of the API, that entire system was removed. However, while visibility configuration via `IGeometryBakingContext` remains and is the correct way to bake only part of the geometry, there is no longer a way to obtain a list of all the component names to be able to properly control their visibility. This PR re-adds that as per @pupnewfster's request.

### Fix render type hint not being copied in BlockGeometryBakingContext
This fixes an issue that prevents people from using render types with vanilla's generated item models, as they rely on `BlockGeometryBakingContext` being copied, and the render type hint was missed.

### Ensure BlockRenderDispatches's renderSingleBlock uses the correct buffer
The new model-controlled render types mean that this approach is no longer correct. This replaces it with a more appropriate one that visits every render type in the model and properly adapts it to the correct buffer target for dynamic rendering.