### PR TITLE
[1.18.2] Allow blocks to provide a dynamic MaterialColor for display on maps

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -89,7 +89,8 @@
        }
  
        public MaterialColor m_60780_(BlockGetter p_60781_, BlockPos p_60782_) {
-          return this.f_60598_;
+-         return this.f_60598_;
++         return m_60734_().getMapColor(this.m_7160_(), p_60781_, p_60782_, this.f_60598_);
        }
  
 +      /** @deprecated use {@link BlockState#rotate(LevelAccessor, BlockPos, Rotation)} */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -24,7 +24,9 @@ import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.core.Direction;
@@ -845,4 +847,17 @@ public interface IForgeBlock
      * @param newState The new state of the block at the given position
      */
     default void onBlockStateChange(LevelReader level, BlockPos pos, BlockState oldState, BlockState newState) { }
+
+    /**
+     * Returns the {@link MaterialColor} shown on the map.
+     *
+     * @param state The state of this block
+     * @param level The level this block is in
+     * @param pos The blocks position in the level
+     * @param defaultColor The {@code MaterialColor} configured for the given {@code BlockState} in the {@link BlockBehaviour.Properties}
+     */
+    default MaterialColor getMapColor(BlockState state, BlockGetter level, BlockPos pos, MaterialColor defaultColor)
+    {
+        return defaultColor;
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/block/DynamicMapColorTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/DynamicMapColorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.world.level.material.MaterialColor;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.*;
+
+@Mod(DynamicMapColorTest.MOD_ID)
+public class DynamicMapColorTest
+{
+    public static final String MOD_ID = "dyn_map_color_test";
+
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MOD_ID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+
+    private static final RegistryObject<Block> TEST_BLOCK = BLOCKS.register("test_block", TestBlock::new);
+    private static final RegistryObject<Item> TEST_BLOCK_ITEM = ITEMS.register("test_block", () -> new BlockItem(
+            TEST_BLOCK.get(),
+            new Item.Properties()
+    ));
+
+    public DynamicMapColorTest()
+    {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        BLOCKS.register(modBus);
+        ITEMS.register(modBus);
+    }
+
+    private static class TestBlock extends Block
+    {
+        public TestBlock()
+        {
+            super(Properties.of(Material.GLASS));
+        }
+
+        @Override
+        public MaterialColor getMapColor(BlockState state, BlockGetter level, BlockPos pos, MaterialColor defaultColor)
+        {
+            BlockState below = level.getBlockState(pos.below());
+            if (!below.isAir())
+            {
+                return below.getMapColor(level, pos);
+            }
+            return defaultColor;
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -232,5 +232,7 @@ license="LGPL v2.1"
     modId="mod_mismatch_test"
 [[mods]]
     modId="blockstate_change_test"
+[[mods]]
+    modId="dyn_map_color_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/assets/dyn_map_color_test/blockstates/test_block.json
+++ b/src/test/resources/assets/dyn_map_color_test/blockstates/test_block.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "": { "model": "minecraft:block/glass" }
+    }
+}

--- a/src/test/resources/assets/dyn_map_color_test/models/item/test_block.json
+++ b/src/test/resources/assets/dyn_map_color_test/models/item/test_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "minecraft:item/glass"
+}


### PR DESCRIPTION
This PR is the LTS backport of #8812

This PR allows blocks to provide the `MaterialColor` for display on maps dependent on dynamic data.

The context needed for this is already present, it's just not forwarded from the `BlockState` to the `BlockState`. This PR adds an extension method forwarding the necessary context to the block.

Example use cases would be:
- Allow mods like [RGB Blocks](https://www.curseforge.com/minecraft/mc-mods/rgb-blocks-forge) to provide the `MaterialColor` that is closest to the actual RGB value of the block
- Allow mods like [FramedBlocks](https://www.curseforge.com/minecraft/mc-mods/framedblocks) that add blocks that mimic other blocks to proxy the `MaterialColor` of the block that is being mimicked