### PR TITLE
Make a proper initialization state for RemoveBlockGoal

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
@@ -1,11 +1,24 @@
 --- a/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
-@@ -34,7 +_,7 @@
+@@ -31,10 +_,11 @@
+       super(p_25841_, p_25842_, 24, p_25843_);
+       this.f_25836_ = p_25840_;
+       this.f_25837_ = p_25841_;
++      this.f_25602_ = null; // Forge: We explicitly set this to null, it gets initialized in the onUse call.
     }
  
     public boolean m_8036_() {
 -      if (!this.f_25837_.f_19853_.m_46469_().m_46207_(GameRules.f_46132_)) {
-+      if (!net.minecraftforge.common.ForgeHooks.canEntityDestroy(this.f_25837_.f_19853_, this.f_25602_, this.f_25837_)) {
++      if (this.f_25602_ != null && !net.minecraftforge.common.ForgeHooks.canEntityDestroy(this.f_25837_.f_19853_, this.f_25602_, this.f_25837_)) {
           return false;
        } else if (this.f_25600_ > 0) {
           --this.f_25600_;
+@@ -133,7 +_,7 @@
+       if (chunkaccess == null) {
+          return false;
+       } else {
+-         return chunkaccess.m_8055_(p_25851_).m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_();
++         return chunkaccess.m_8055_(p_25851_).m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_() && net.minecraftforge.common.ForgeHooks.canEntityDestroy(this.f_25837_.f_19853_, p_25851_, this.f_25837_);
+       }
+    }
+ }


### PR DESCRIPTION
This fixes a case where the goal tries to access the 0,0,0 position as that is its initial value.
Since this position is not always loaded it causes an issue where the goal would get stuck.

Closes: #8853

Note: there is an aligned issue where a turtle egg on 0,0,0 would cause zombies to track there regardless of world position. This implicitly fixes this but it is only tangentially related as such no link to a Mojira issue is made.