### PR TITLE
[1.19.x] Block Model Builder Root Transform Support

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -25,10 +25,8 @@ import javax.annotation.Nullable;
  * @see ModelProvider
  * @see ModelBuilder
  */
-public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
-
-    private static final Vector3f ONE = new Vector3f(1, 1, 1);
-
+public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
+{
     private final RootTransformBuilder rootTransform = new RootTransformBuilder();
 
     public BlockModelBuilder(ResourceLocation outputLocation, ExistingFileHelper existingFileHelper)
@@ -56,43 +54,24 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
         return json;
     }
 
-    private JsonArray writeVec3(Vector3f vector)
-    {
-        JsonArray array = new JsonArray();
-        array.add(vector.x());
-        array.add(vector.y());
-        array.add(vector.z());
-        return array;
-    }
-
-    private JsonArray writeQuaternion(Quaternion quaternion)
-    {
-        JsonArray array = new JsonArray();
-        array.add(quaternion.i());
-        array.add(quaternion.j());
-        array.add(quaternion.k());
-        array.add(quaternion.r());
-        return array;
-    }
-
     public class RootTransformBuilder
     {
-        public enum Origin implements StringRepresentable
+        public enum TransformOrigin implements StringRepresentable
         {
-            Center(new Vector3f(), "origin"),
-            Corner(new Vector3f(1f, 1f, 1f), "corner"),
-            OpposingCorner(new Vector3f(.5f, .5f, .5f), "opposing_corner");
+            CENTER(new Vector3f(), "origin"),
+            CORNER(new Vector3f(1f, 1f, 1f), "corner"),
+            OPPOSING_CORNER(new Vector3f(.5f, .5f, .5f), "opposing_corner");
 
             private final Vector3f vec;
             private final String name;
 
-            Origin(Vector3f vec, String name)
+            TransformOrigin(Vector3f vec, String name)
             {
                 this.vec = vec;
                 this.name = name;
             }
 
-            public Vector3f vec()
+            public Vector3f getVector()
             {
                 return vec;
             }
@@ -103,35 +82,36 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
                 return name;
             }
 
-            public static @Nullable Origin fromString(String originName)
+            public static @Nullable TransformOrigin fromString(String originName)
             {
-                if (Center.getSerializedName().equals(originName))
+                if (CENTER.getSerializedName().equals(originName))
                 {
-                    return Center;
+                    return CENTER;
                 }
-                if (Corner.getSerializedName().equals(originName))
+                if (CORNER.getSerializedName().equals(originName))
                 {
-                    return Corner;
+                    return CORNER;
                 }
-                if (OpposingCorner.getSerializedName().equals(originName))
+                if (OPPOSING_CORNER.getSerializedName().equals(originName))
                 {
-                    return OpposingCorner;
+                    return OPPOSING_CORNER;
                 }
                 return null;
             }
         }
+
+        private static final Vector3f ONE = new Vector3f(1, 1, 1);
 
         private Vector3f translation = Vector3f.ZERO;
         private Quaternion leftRotation = Quaternion.ONE.copy();
         private Quaternion rightRotation = Quaternion.ONE.copy();
         private Vector3f scale = ONE;
 
-        private @Nullable Origin origin;
+        private @Nullable TransformOrigin origin;
         private @Nullable Vector3f originVec;
 
         private RootTransformBuilder()
         {
-
         }
 
         /**
@@ -185,7 +165,15 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
             return this;
         }
 
-        public RootTransformBuilder postRotation(Quaternion postRotation) {
+        /**
+         * Sets the right rotation of the root transform.
+         *
+         * @param postRotation the right rotation
+         * @return this builder
+         * @throws NullPointerException if {@code rightRotation} is {@code null}
+         */
+        public RootTransformBuilder postRotation(Quaternion postRotation)
+        {
             return rightRotation(postRotation);
         }
 
@@ -253,7 +241,7 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
          * @throws NullPointerException if {@code origin} is {@code null}
          * @throws IllegalArgumentException if {@code origin} is not {@code center}, {@code corner} or {@code opposing-corner}
          */
-        public RootTransformBuilder origin(Origin origin)
+        public RootTransformBuilder origin(TransformOrigin origin)
         {
             this.origin = Preconditions.checkNotNull(origin, "Origin must not be null");;
             this.originVec = null;
@@ -297,12 +285,31 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
             {
                 transform.addProperty("origin", origin.getSerializedName());
             }
-            else if (originVec != null && originVec != Vector3f.ZERO)
+            else if (originVec != null && !originVec.equals(Vector3f.ZERO))
             {
                 transform.add("origin", writeVec3(originVec));
             }
 
             return transform;
+        }
+
+        private JsonArray writeVec3(Vector3f vector)
+        {
+            JsonArray array = new JsonArray();
+            array.add(vector.x());
+            array.add(vector.y());
+            array.add(vector.z());
+            return array;
+        }
+
+        private JsonArray writeQuaternion(Quaternion quaternion)
+        {
+            JsonArray array = new JsonArray();
+            array.add(quaternion.i());
+            array.add(quaternion.j());
+            array.add(quaternion.k());
+            array.add(quaternion.r());
+            return array;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -90,7 +90,6 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
          * @param y y translation
          * @param z z translation
          * @return this builder
-         * @throws NullPointerException if {@code translation} is {@code null}
          */
         public RootTransformBuilder translation(float x, float y, float z)
         {

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -14,6 +14,7 @@ import com.mojang.math.Vector3f;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringRepresentable;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -251,9 +251,9 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
 
         public enum TransformOrigin implements StringRepresentable
         {
-            CENTER(new Vector3f(), "origin"),
-            CORNER(new Vector3f(1f, 1f, 1f), "corner"),
-            OPPOSING_CORNER(new Vector3f(.5f, .5f, .5f), "opposing_corner");
+            CENTER(new Vector3f(.5f, .5f, .5f), "origin"),
+            CORNER(Vector3f.ZERO, "corner"),
+            OPPOSING_CORNER(ONE, "opposing_corner");
 
             private final Vector3f vec;
             private final String name;

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -5,8 +5,16 @@
 
 package net.minecraftforge.client.model.generators;
 
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.math.Quaternion;
+import com.mojang.math.Transformation;
+import com.mojang.math.Vector3f;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.data.ExistingFileHelper;
+
+import javax.annotation.Nullable;
 
 /**
  * Builder for block models, does not currently provide any additional
@@ -18,7 +26,231 @@ import net.minecraftforge.common.data.ExistingFileHelper;
  */
 public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
 
-    public BlockModelBuilder(ResourceLocation outputLocation, ExistingFileHelper existingFileHelper) {
+    private final RootTransformBuilder rootTransform = new RootTransformBuilder();
+
+    public BlockModelBuilder(ResourceLocation outputLocation, ExistingFileHelper existingFileHelper)
+    {
         super(outputLocation, existingFileHelper);
+    }
+
+    public RootTransformBuilder rootTransform()
+    {
+        return rootTransform;
+    }
+
+    @Override
+    public JsonObject toJson()
+    {
+        JsonObject json = super.toJson();
+
+        // Write the transform to an object
+        JsonObject transform = new JsonObject();
+
+        if (!rootTransform.translation.equals(Vector3f.ZERO))
+        {
+            transform.add("translation", writeVec3(rootTransform.translation));
+        }
+
+        if (!rootTransform.scale.equals(new Vector3f(1, 1, 1)))
+        {
+            transform.add("scale", writeVec3(rootTransform.scale));
+        }
+
+        Quaternion leftRotation = rootTransform.leftRotation;
+        if (!leftRotation.equals(Quaternion.ONE))
+        {
+            transform.add("left_rotation", writeQuaternion(leftRotation));
+        }
+
+        Quaternion rightRotation = rootTransform.rightRotation;
+        if (!rightRotation.equals(Quaternion.ONE))
+        {
+            transform.add("right_rotation", writeQuaternion(rightRotation));
+        }
+
+        if (rootTransform.originName != null)
+        {
+            transform.addProperty("origin", rootTransform.originName);
+        }
+        else if (rootTransform.origin != null && rootTransform.origin != Vector3f.ZERO)
+        {
+            transform.add("origin", writeVec3(rootTransform.origin));
+        }
+
+        // If there were any transform properties set, add them to the output.
+        if (transform.size() > 0)
+        {
+            json.add("transform", transform);
+        }
+
+        return json;
+    }
+
+    private JsonArray writeVec3(Vector3f vector)
+    {
+        JsonArray array = new JsonArray();
+        array.add(vector.x());
+        array.add(vector.y());
+        array.add(vector.z());
+        return array;
+    }
+
+    private JsonArray writeQuaternion(Quaternion quaternion)
+    {
+        JsonArray array = new JsonArray();
+        array.add(quaternion.i());
+        array.add(quaternion.j());
+        array.add(quaternion.k());
+        array.add(quaternion.r());
+        return array;
+    }
+
+    public class RootTransformBuilder
+    {
+        private Vector3f translation = Vector3f.ZERO;
+        private Quaternion leftRotation = Quaternion.ONE.copy();
+        private Quaternion rightRotation = Quaternion.ONE.copy();
+        private Vector3f scale = new Vector3f(1, 1, 1);
+
+        private @Nullable String originName;
+        private @Nullable Vector3f origin;
+
+        /**
+         * Sets the translation of the root transform.
+         *
+         * @param translation the translation
+         * @return this builder
+         * @throws NullPointerException if {@code translation} is {@code null}
+         */
+        public RootTransformBuilder translation(Vector3f translation)
+        {
+            Preconditions.checkNotNull(translation, "Translation must not be null");
+            this.translation = translation;
+            return this;
+        }
+
+        /**
+         * Sets the left rotation of the root transform.
+         *
+         * @param rotation the left rotation
+         * @return this builder
+         * @throws NullPointerException if {@code rotation} is {@code null}
+         */
+        public RootTransformBuilder rotation(Quaternion rotation)
+        {
+            Preconditions.checkNotNull(rotation, "Rotation must not be null");
+            this.leftRotation = rotation;
+            return this;
+        }
+
+        /**
+         * Sets the left rotation of the root transform.
+         *
+         * @param leftRotation the left rotation
+         * @return this builder
+         * @throws NullPointerException if {@code leftRotation} is {@code null}
+         */
+        public RootTransformBuilder leftRotation(Quaternion leftRotation)
+        {
+            return rotation(leftRotation);
+        }
+
+        /**
+         * Sets the right rotation of the root transform.
+         *
+         * @param rightRotation the right rotation
+         * @return this builder
+         * @throws NullPointerException if {@code rightRotation} is {@code null}
+         */
+        public RootTransformBuilder rightRotation(Quaternion rightRotation)
+        {
+            Preconditions.checkNotNull(rightRotation, "Rotation must not be null");
+            this.rightRotation = rightRotation;
+            return this;
+        }
+
+        /**
+         * Sets the scale of the root transform.
+         *
+         * @param scale the scale
+         * @return this builder
+         * @throws NullPointerException if {@code scale} is {@code null}
+         */
+        public RootTransformBuilder scale(float scale)
+        {
+            return scale(new Vector3f(scale, scale, scale));
+        }
+
+        /**
+         * Sets the scale of the root transform.
+         *
+         * @param scale the scale vector
+         * @return this builder
+         * @throws NullPointerException if {@code scale} is {@code null}
+         */
+        public RootTransformBuilder scale(Vector3f scale)
+        {
+            Preconditions.checkNotNull(scale, "Scale must not be null");
+            this.scale = scale;
+            return this;
+        }
+
+        /**
+         * Sets the root transform.
+         *
+         * @param transformation the transformation to use
+         * @return this builder
+         * @throws NullPointerException if {@code transformation} is {@code null}
+         */
+        public RootTransformBuilder transform(Transformation transformation)
+        {
+            Preconditions.checkNotNull(transformation, "Transformation must not be null");
+            this.translation = transformation.getTranslation();
+            this.leftRotation = transformation.getLeftRotation();
+            this.rightRotation = transformation.getRightRotation();
+            this.scale = transformation.getScale();
+            return this;
+        }
+
+        /**
+         * Sets the origi of the root transform.
+         *
+         * @param origin the origin vector
+         * @return this builder
+         * @throws NullPointerException if {@code origin} is {@code null}
+         */
+        public RootTransformBuilder origin(Vector3f origin)
+        {
+            Preconditions.checkNotNull(origin, "Origin must not be null");
+            this.origin = origin;
+            this.originName = null;
+            return this;
+        }
+
+        /**
+         * Sets the origin of the root transform.
+         *
+         * @param origin the origin name
+         * @return this builder
+         * @throws NullPointerException if {@code origin} is {@code null}
+         * @throws IllegalArgumentException if {@code origin} is not {@code center}, {@code corner} or {@code opposing-corner}
+         */
+        public RootTransformBuilder origin(String origin)
+        {
+            Preconditions.checkNotNull(origin, "Origin must not be null");
+            Preconditions.checkArgument(origin.equals("center") || origin.equals("corner") || origin.equals("opposing-corner"), "Invalid value for origin name.");
+            this.originName = origin;
+            this.origin = null;
+            return this;
+        }
+
+        /**
+         * Finish configuring the parent builder
+         * @return the parent block model builder
+         */
+        public BlockModelBuilder end()
+        {
+            return BlockModelBuilder.this;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -176,7 +176,7 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         }
 
         /**
-         * Sets the origi of the root transform.
+         * Sets the origin of the root transform.
          *
          * @param origin the origin vector
          * @return this builder
@@ -199,7 +199,7 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
          */
         public RootTransformBuilder origin(TransformOrigin origin)
         {
-            this.origin = Preconditions.checkNotNull(origin, "Origin must not be null");;
+            this.origin = Preconditions.checkNotNull(origin, "Origin must not be null");
             this.originVec = null;
             return this;
         }
@@ -270,6 +270,7 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
             }
 
             @Override
+            @NotNull
             public String getSerializedName()
             {
                 return name;

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -56,50 +56,6 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
 
     public class RootTransformBuilder
     {
-        public enum TransformOrigin implements StringRepresentable
-        {
-            CENTER(new Vector3f(), "origin"),
-            CORNER(new Vector3f(1f, 1f, 1f), "corner"),
-            OPPOSING_CORNER(new Vector3f(.5f, .5f, .5f), "opposing_corner");
-
-            private final Vector3f vec;
-            private final String name;
-
-            TransformOrigin(Vector3f vec, String name)
-            {
-                this.vec = vec;
-                this.name = name;
-            }
-
-            public Vector3f getVector()
-            {
-                return vec;
-            }
-
-            @Override
-            public String getSerializedName()
-            {
-                return name;
-            }
-
-            public static @Nullable TransformOrigin fromString(String originName)
-            {
-                if (CENTER.getSerializedName().equals(originName))
-                {
-                    return CENTER;
-                }
-                if (CORNER.getSerializedName().equals(originName))
-                {
-                    return CORNER;
-                }
-                if (OPPOSING_CORNER.getSerializedName().equals(originName))
-                {
-                    return OPPOSING_CORNER;
-                }
-                return null;
-            }
-        }
-
         private static final Vector3f ONE = new Vector3f(1, 1, 1);
 
         private Vector3f translation = Vector3f.ZERO;
@@ -291,6 +247,50 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
             }
 
             return transform;
+        }
+
+        public enum TransformOrigin implements StringRepresentable
+        {
+            CENTER(new Vector3f(), "origin"),
+            CORNER(new Vector3f(1f, 1f, 1f), "corner"),
+            OPPOSING_CORNER(new Vector3f(.5f, .5f, .5f), "opposing_corner");
+
+            private final Vector3f vec;
+            private final String name;
+
+            TransformOrigin(Vector3f vec, String name)
+            {
+                this.vec = vec;
+                this.name = name;
+            }
+
+            public Vector3f getVector()
+            {
+                return vec;
+            }
+
+            @Override
+            public String getSerializedName()
+            {
+                return name;
+            }
+
+            public static @Nullable TransformOrigin fromString(String originName)
+            {
+                if (CENTER.getSerializedName().equals(originName))
+                {
+                    return CENTER;
+                }
+                if (CORNER.getSerializedName().equals(originName))
+                {
+                    return CORNER;
+                }
+                if (OPPOSING_CORNER.getSerializedName().equals(originName))
+                {
+                    return OPPOSING_CORNER;
+                }
+                return null;
+            }
         }
 
         private JsonArray writeVec3(Vector3f vector)

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -15,8 +15,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringRepresentable;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Builder for block models, does not currently provide any additional

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -84,6 +84,20 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         }
 
         /**
+         * Sets the translation of the root transform.
+         *
+         * @param x x translation
+         * @param y y translation
+         * @param z z translation
+         * @return this builder
+         * @throws NullPointerException if {@code translation} is {@code null}
+         */
+        public RootTransformBuilder translation(float x, float y, float z)
+        {
+            return translation(new Vector3f(x, y, z));
+        }
+
+        /**
          * Sets the left rotation of the root transform.
          *
          * @param rotation the left rotation
@@ -99,6 +113,20 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         /**
          * Sets the left rotation of the root transform.
          *
+         * @param x x rotation
+         * @param y y rotation
+         * @param z z rotation
+         * @param isDegrees whether the rotation is in degrees or radians
+         * @return this builder
+         */
+        public RootTransformBuilder rotation(float x, float y, float z, boolean isDegrees)
+        {
+            return rotation(new Quaternion(x, y, z, isDegrees));
+        }
+
+        /**
+         * Sets the left rotation of the root transform.
+         *
          * @param leftRotation the left rotation
          * @return this builder
          * @throws NullPointerException if {@code leftRotation} is {@code null}
@@ -106,6 +134,20 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         public RootTransformBuilder leftRotation(Quaternion leftRotation)
         {
             return rotation(leftRotation);
+        }
+
+        /**
+         * Sets the left rotation of the root transform.
+         *
+         * @param x x rotation
+         * @param y y rotation
+         * @param z z rotation
+         * @param isDegrees whether the rotation is in degrees or radians
+         * @return this builder
+         */
+        public RootTransformBuilder leftRotation(float x, float y, float z, boolean isDegrees)
+        {
+            return leftRotation(new Quaternion(x, y, z, isDegrees));
         }
 
         /**
@@ -124,6 +166,20 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         /**
          * Sets the right rotation of the root transform.
          *
+         * @param x x rotation
+         * @param y y rotation
+         * @param z z rotation
+         * @param isDegrees whether the rotation is in degrees or radians
+         * @return this builder
+         */
+        public RootTransformBuilder rightRotation(float x, float y, float z, boolean isDegrees)
+        {
+            return rightRotation(new Quaternion(x, y, z, isDegrees));
+        }
+
+        /**
+         * Sets the right rotation of the root transform.
+         *
          * @param postRotation the right rotation
          * @return this builder
          * @throws NullPointerException if {@code rightRotation} is {@code null}
@@ -131,6 +187,20 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         public RootTransformBuilder postRotation(Quaternion postRotation)
         {
             return rightRotation(postRotation);
+        }
+
+        /**
+         * Sets the right rotation of the root transform.
+         *
+         * @param x x rotation
+         * @param y y rotation
+         * @param z z rotation
+         * @param isDegrees whether the rotation is in degrees or radians
+         * @return this builder
+         */
+        public RootTransformBuilder postRotation(float x, float y, float z, boolean isDegrees)
+        {
+            return postRotation(new Quaternion(x, y, z, isDegrees));
         }
 
         /**
@@ -143,6 +213,19 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
         public RootTransformBuilder scale(float scale)
         {
             return scale(new Vector3f(scale, scale, scale));
+        }
+
+        /**
+         * Sets the scale of the root transform.
+         *
+         * @param xScale x scale
+         * @param yScale y scale
+         * @param zScale z scale
+         * @return this builder
+         */
+        public RootTransformBuilder scale(float xScale, float yScale, float zScale)
+        {
+            return scale(new Vector3f(xScale, yScale, zScale));
         }
 
         /**

--- a/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
@@ -18,8 +18,7 @@ import com.mojang.math.Quaternion;
 import com.mojang.math.Transformation;
 import com.mojang.math.Vector3f;
 import com.mojang.math.Vector4f;
-import net.minecraftforge.client.model.generators.BlockModelBuilder;
-import net.minecraftforge.client.model.generators.BlockModelBuilder.RootTransformBuilder.Origin;
+import net.minecraftforge.client.model.generators.BlockModelBuilder.RootTransformBuilder.TransformOrigin;
 
 public final class TransformationHelper
 {
@@ -110,10 +109,6 @@ public final class TransformationHelper
 
     public static class Deserializer implements JsonDeserializer<Transformation>
     {
-        private static final Vector3f ORIGIN_CORNER = Origin.Corner.vec();
-        private static final Vector3f ORIGIN_OPPOSING_CORNER = Origin.OpposingCorner.vec();
-        private static final Vector3f ORIGIN_CENTER = Origin.Center.vec();
-
         @Override
         public Transformation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
         {
@@ -153,7 +148,7 @@ public final class TransformationHelper
             Quaternion rightRot = null;
             // TODO: Default origin is opposing corner, due to a mistake.
             // This should probably be replaced with center in future versions.
-            Vector3f origin = ORIGIN_OPPOSING_CORNER; // TODO: Changing this to ORIGIN_CENTER breaks models, function content needs changing too -C
+            Vector3f origin = TransformOrigin.OPPOSING_CORNER.getVector(); // TODO: Changing this to ORIGIN_CENTER breaks models, function content needs changing too -C
             Set<String> elements = new HashSet<>(obj.keySet());
             if (obj.has("translation"))
             {
@@ -209,10 +204,10 @@ public final class TransformationHelper
             Transformation matrix = new Transformation(translation, leftRot, scale, rightRot);
 
             // Use a different origin if needed.
-            if (!ORIGIN_CENTER.equals(origin))
+            if (!TransformOrigin.CENTER.getVector().equals(origin))
             {
                 Vector3f originFromCenter = origin.copy();
-                originFromCenter.sub(ORIGIN_CENTER);
+                originFromCenter.sub(TransformOrigin.CENTER.getVector());
                 matrix = matrix.applyOrigin(originFromCenter);
             }
             return matrix;
@@ -230,12 +225,12 @@ public final class TransformationHelper
             else if (originElement.isJsonPrimitive())
             {
                 String originString = originElement.getAsString();
-                Origin originEnum = Origin.fromString(originString);
+                TransformOrigin originEnum = TransformOrigin.fromString(originString);
                 if (originEnum == null)
                 {
                     throw new JsonParseException("Origin: expected one of 'center', 'corner', 'opposing-corner'");
                 }
-                origin = originEnum.vec();
+                origin = originEnum.getVector();
             }
             else
             {

--- a/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
@@ -18,6 +18,8 @@ import com.mojang.math.Quaternion;
 import com.mojang.math.Transformation;
 import com.mojang.math.Vector3f;
 import com.mojang.math.Vector4f;
+import net.minecraftforge.client.model.generators.BlockModelBuilder;
+import net.minecraftforge.client.model.generators.BlockModelBuilder.RootTransformBuilder.Origin;
 
 public final class TransformationHelper
 {
@@ -108,9 +110,9 @@ public final class TransformationHelper
 
     public static class Deserializer implements JsonDeserializer<Transformation>
     {
-        private static final Vector3f ORIGIN_CORNER = new Vector3f();
-        private static final Vector3f ORIGIN_OPPOSING_CORNER = new Vector3f(1f, 1f, 1f);
-        private static final Vector3f ORIGIN_CENTER = new Vector3f(.5f, .5f, .5f);
+        private static final Vector3f ORIGIN_CORNER = Origin.Corner.vec();
+        private static final Vector3f ORIGIN_OPPOSING_CORNER = Origin.OpposingCorner.vec();
+        private static final Vector3f ORIGIN_CENTER = Origin.Center.vec();
 
         @Override
         public Transformation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
@@ -219,7 +221,7 @@ public final class TransformationHelper
         private static Vector3f parseOrigin(JsonObject obj) {
             Vector3f origin = null;
 
-            // Two types supported: string ("center", "corner") and array ([x, y, z])
+            // Two types supported: string ("center", "corner", "opposing-corner") and array ([x, y, z])
             JsonElement originElement = obj.get("origin");
             if (originElement.isJsonArray())
             {
@@ -228,23 +230,12 @@ public final class TransformationHelper
             else if (originElement.isJsonPrimitive())
             {
                 String originString = originElement.getAsString();
-                if ("center".equals(originString))
-                {
-                    origin = ORIGIN_CENTER;
-                }
-                else if ("corner".equals(originString))
-                {
-                    origin = ORIGIN_CORNER;
-                }
-                else if ("opposing-corner".equals(originString))
-                {
-                    // This option can be used to not break models that were written with this origin once the default is changed
-                    origin = ORIGIN_OPPOSING_CORNER;
-                }
-                else
+                Origin originEnum = Origin.fromString(originString);
+                if (originEnum == null)
                 {
                     throw new JsonParseException("Origin: expected one of 'center', 'corner', 'opposing-corner'");
                 }
+                origin = originEnum.vec();
             }
             else
             {


### PR DESCRIPTION
Allows data generation of the root "transform" node in block model jsons (as present in `ExtendedBlockModelDeserializer`).
Use case discussed in discord: https://discord.com/channels/313125603924639766/983834532904042537/996011350990000129