### PR TITLE
[1.19] Allow modification of lightmap via Dimension special effects

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
@@ -4,7 +4,7 @@
                       }
                    }
  
-+                  clientlevel.m_104583_().adjustLightmapColors(p_109882_, f, f7, f8, vector3f1);
++                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, f, f7, f8, vector3f1);
 +
                    if (f5 > 0.0F) {
                       float f13 = Math.max(vector3f1.m_122239_(), Math.max(vector3f1.m_122260_(), vector3f1.m_122269_()));

--- a/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/renderer/LightTexture.java
 +++ b/net/minecraft/client/renderer/LightTexture.java
+@@ -138,6 +_,8 @@
+                      }
+                   }
+ 
++                  clientlevel.m_104583_().adjustLightmapColors(p_109882_, f, f7, f8, vector3f1);
++
+                   if (f5 > 0.0F) {
+                      float f13 = Math.max(vector3f1.m_122239_(), Math.max(vector3f1.m_122260_(), vector3f1.m_122269_()));
+                      if (f13 < 1.0F) {
 @@ -193,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
@@ -4,7 +4,7 @@
                       }
                    }
  
-+                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, f, f7, f8, vector3f1);
++                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, f, f7, f8, j, i, vector3f1);
 +
                    if (f5 > 0.0F) {
                       float f13 = Math.max(vector3f1.m_122239_(), Math.max(vector3f1.m_122260_(), vector3f1.m_122269_()));

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -67,12 +67,13 @@ public interface IForgeDimensionSpecialEffects
      * Allows for manipulating the coloring of the lightmap texture.
      * Will be called for each 16*16 combination of sky/block light values.
      *
-     * @param partialTicks  Progress between ticks.
-     * @param skyDarken     Current darkness of the sky.
-     * @param skyLight      Sky light brightness factor.
-     * @param blockLight    Block light brightness factor.
-     * @param colors        The color values that will be used: [r, g, b].
+     * @param level        The current level (client-side).
+     * @param partialTicks Progress between ticks.
+     * @param skyDarken    Current darkness of the sky.
+     * @param skyLight     Sky light brightness factor.
+     * @param blockLight   Block light brightness factor.
+     * @param colors       The color values that will be used: [r, g, b].
      * @see LightTexture#updateLightTexture(float)
      */
-    default void adjustLightmapColors(float partialTicks, float skyDarken, float skyLight, float blockLight, Vector3f colors) {}
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, Vector3f colors) {}
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -7,6 +7,7 @@ package net.minecraftforge.client.extensions;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
+import com.mojang.math.Vector3f;
 import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
@@ -61,4 +62,17 @@ public interface IForgeDimensionSpecialEffects
     {
         return false;
     }
+
+    /**
+     * Allows for manipulating the coloring of the lightmap texture.
+     * Will be called for each 16*16 combination of sky/block light values.
+     *
+     * @param partialTicks  Progress between ticks.
+     * @param skyDarken     Current darkness of the sky.
+     * @param skyLight      Sky light brightness factor.
+     * @param blockLight    Block light brightness factor.
+     * @param colors        The color values that will be used: [r, g, b].
+     * @see LightTexture#updateLightTexture(float)
+     */
+    default void adjustLightmapColors(float partialTicks, float skyDarken, float skyLight, float blockLight, Vector3f colors) {}
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -77,5 +77,5 @@ public interface IForgeDimensionSpecialEffects
      * @param colors       The color values that will be used: [r, g, b].
      * @see LightTexture#updateLightTexture(float)
      */
-    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, float pixelX, float pixelY, Vector3f colors) {}
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, int pixelX, int pixelY, Vector3f colors) {}
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -72,8 +72,10 @@ public interface IForgeDimensionSpecialEffects
      * @param skyDarken    Current darkness of the sky.
      * @param skyLight     Sky light brightness factor.
      * @param blockLight   Block light brightness factor.
+     * @param pixelX       X-coordinate of the lightmap texture.
+     * @param pixelY       Y-coordinate of the lightmap texture.
      * @param colors       The color values that will be used: [r, g, b].
      * @see LightTexture#updateLightTexture(float)
      */
-    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, Vector3f colors) {}
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, float pixelX, float pixelY, Vector3f colors) {}
 }


### PR DESCRIPTION
Successor to #7678 (1.16 PR).

Hello!

## The Problem

I'm ancient, and one of the things we used to have back when dimensions were still written in Java was that you were able to edit the lightmap via the overridable method `getLightmapColors()` in `IForgeDimension`. It was a nifty little thing that allowed us to edit the lightmap as needed for the specific dimension without needing to resort to writing an event for the event bus that would fire on every frame. However, when dimensions got nuked into JSON files in 1.16.2, that functionality had vanished. This was kind of inconvenient because when updating to a newer version, a core functionality that I used to use was missing.

## The Solution

I added it back! Well, kind of. I've noticed that the dimensions from 1.15 were (effectively) split between level stems and dimension special effects. Since a lightmap modification can be considered a "special effect" of the dimension, I have added a new method into `IForgeDimensionSpecialEffects` that allows any custom special effects to override it and modify a given `Vector3f` in the same way as it was done back in Forge 1.15 when dimensions were still written in Java. This effectively grants custom dimensions the ability to play with the lightmap as they please, without resorting to adding a new event just to modify the lightmap.

In addition, I have passed in the `ClientLevel` to conform to the other methods in `IForgeDimensionSpecialEffects`, as well as passing in the x and y coordinate for the lightmap texture pixels.

## The Caveat (with this PR)

When I wrote this PR, I referenced code directly from Forge 1.15 and thus it makes this PR a regression to a feature in Forge 1.15. I also realize that a lot of naming conventions have changed since 1.15 since we dropped MCP, so if there are any parameter names or method names you want me to revise, let me know!

## Anyways

Giving dimensions the ability to modify the lightmap gives the dimensions in question more freedom to experiment with how they want to render their environment, and I think this simple, yet effective solution helps solve this problem for everyone involved. Please, please, **please** give me your feedback with this PR regarding naming, formatting, etc. If you want me to write a test mod, I'd be more than happy to. Although since this isn't adding an event, I didn't feel the need to. If you want to chat, poke me in Discord (I am `Jonathan#6666`). Thank you for coming to my TED talk.