### PR TITLE
Multiple tweaks and fixes to the recent changes in the client refactor PR: Part 3

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -89,20 +89,20 @@
 +      }
 +   }
 +
-+   /** @deprecated Set your render type in your model's JSON or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static void setRenderLayer(Block block, RenderType type) {
 +      com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +      setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +   }
 +
-+   /** @deprecated Set your render type in your model's JSON or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +      setRenderLayer(block, createSetFromPredicate(predicate));
 +   }
 +
-+   /** @deprecated Set your render type in your model's JSON or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +      checkClientLoading();

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -89,20 +89,20 @@
 +      }
 +   }
 +
-+   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static void setRenderLayer(Block block, RenderType type) {
 +      com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +      setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +   }
 +
-+   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +      setRenderLayer(block, createSetFromPredicate(predicate));
 +   }
 +
-+   /** @deprecated Set your render type in your block model's JSON (eg. "render_type": "cutout") or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
++   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
 +   @Deprecated(forRemoval = true, since = "1.19")
 +   public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +      checkClientLoading();

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -16,32 +16,42 @@
     private static final Map<Fluid, RenderType> f_109276_ = Util.m_137469_(Maps.newHashMap(), (p_109290_) -> {
        RenderType rendertype = RenderType.m_110466_();
        p_109290_.put(Fluids.f_76192_, rendertype);
-@@ -303,6 +_,7 @@
+@@ -303,6 +_,8 @@
     });
     private static boolean f_109277_;
  
-+   @Deprecated // FORGE: Use canRenderInLayer
++   /** @deprecated Forge: Use {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
++   @Deprecated // Note: this method does NOT support model-based render types
     public static RenderType m_109282_(BlockState p_109283_) {
        Block block = p_109283_.m_60734_();
        if (block instanceof LeavesBlock) {
-@@ -313,6 +_,7 @@
+@@ -313,6 +_,8 @@
        }
     }
  
-+   @Deprecated // FORGE: Use canRenderInLayer
++   /** @deprecated Forge: Use {@link net.minecraftforge.client.RenderTypeHelper#getMovingBlockRenderType(RenderType)} while iterating through {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
++   @Deprecated // Note: this method does NOT support model-based render types
     public static RenderType m_109293_(BlockState p_109294_) {
        Block block = p_109294_.m_60734_();
        if (block instanceof LeavesBlock) {
-@@ -328,8 +_,7 @@
+@@ -327,6 +_,8 @@
+       }
     }
  
++   /** @deprecated Forge: Use {@link net.minecraftforge.client.RenderTypeHelper#getEntityRenderType(RenderType, boolean)} while iterating through {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
++   @Deprecated // Note: this method does NOT support model-based render types
     public static RenderType m_109284_(BlockState p_109285_, boolean p_109286_) {
--      RenderType rendertype = m_109282_(p_109285_);
--      if (rendertype == RenderType.m_110466_()) {
-+      if (getRenderLayers(p_109285_).contains(RenderType.m_110466_())) {
-          if (!Minecraft.m_91085_()) {
-             return Sheets.m_110792_();
-          } else {
+       RenderType rendertype = m_109282_(p_109285_);
+       if (rendertype == RenderType.m_110466_()) {
+@@ -340,6 +_,8 @@
+       }
+    }
+ 
++   /** @deprecated Forge: Use {@link net.minecraft.client.resources.model.BakedModel#getRenderPasses(ItemStack, boolean)} and {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(ItemStack, boolean)}. */
++   @Deprecated // Note: this method does NOT support model-based render types
+    public static RenderType m_109279_(ItemStack p_109280_, boolean p_109281_) {
+       Item item = p_109280_.m_41720_();
+       if (item instanceof BlockItem) {
 @@ -351,8 +_,73 @@
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -57,7 +57,7 @@
                 float f2 = (float)(i & 255) / 255.0F;
 -               this.f_110900_.m_111067_(p_110914_.m_85850_(), p_110915_.m_6299_(ItemBlockRenderTypes.m_109284_(p_110913_, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_);
 +               for (net.minecraft.client.renderer.RenderType rt : bakedmodel.getRenderTypes(p_110913_, RandomSource.m_216335_(42), modelData))
-+                  this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(renderType != null ? renderType : net.minecraftforge.client.ForgeHooksClient.getEntityRenderType(rt, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, rt);
++                  this.f_110900_.renderModel(p_110914_.m_85850_(), p_110915_.m_6299_(renderType != null ? renderType : net.minecraftforge.client.RenderTypeHelper.getEntityRenderType(rt, false)), p_110913_, bakedmodel, f, f1, f2, p_110916_, p_110917_, modelData, rt);
                 break;
              case ENTITYBLOCK_ANIMATED:
 -               this.f_173397_.m_108829_(new ItemStack(p_110913_.m_60734_()), ItemTransforms.TransformType.NONE, p_110914_, p_110915_, p_110916_, p_110917_);

--- a/patches/minecraft/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -39,7 +39,7 @@
     public boolean m_7539_() {
        return this.f_119542_.m_7539_();
     }
-@@ -54,8 +_,16 @@
+@@ -54,8 +_,23 @@
        return this.f_119542_.m_6160_();
     }
  
@@ -53,6 +53,13 @@
 +
 +   public BakedModel applyTransform(net.minecraft.client.renderer.block.model.ItemTransforms.TransformType transformType, com.mojang.blaze3d.vertex.PoseStack poseStack, boolean applyLeftHandTransform) {
 +      return this.f_119542_.applyTransform(transformType, poseStack, applyLeftHandTransform);
++   }
++
++   @Override // FORGE: Get render types based on the active weighted model
++   public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(@org.jetbrains.annotations.NotNull BlockState state, @org.jetbrains.annotations.NotNull RandomSource rand, @org.jetbrains.annotations.NotNull net.minecraftforge.client.model.data.ModelData data) {
++      return WeightedRandom.m_146314_(this.f_119541_, Math.abs((int)rand.m_188505_()) % this.f_119540_)
++              .map((p_235065_) -> p_235065_.m_146310_().getRenderTypes(state, rand, data))
++              .orElse(net.minecraftforge.client.ChunkRenderTypeSet.none());
     }
  
     public ItemOverrides m_7343_() {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -757,7 +757,7 @@ public class ForgeHooksClient
         var model = blockRenderer.getBlockModel(state);
         for (var renderType : model.getRenderTypes(state, RandomSource.create(state.getSeed(pos)), ModelData.EMPTY))
         {
-            VertexConsumer vertexConsumer = bufferSource.getBuffer(renderType == RenderType.translucent() ? RenderType.translucentMovingBlock() : renderType);
+            VertexConsumer vertexConsumer = bufferSource.getBuffer(RenderTypeHelper.getMovingBlockRenderType(renderType));
             blockRenderer.getModelRenderer().tesselateBlock(level, model, state, pos, stack, vertexConsumer, checkSides, RandomSource.create(), state.getSeed(pos), packedOverlay, ModelData.EMPTY, renderType);
         }
     }
@@ -951,20 +951,6 @@ public class ForgeHooksClient
     {
         ClientChatEvent event = new ClientChatEvent(message);
         return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
-    }
-
-    /**
-     * Mimics the behavior of {@link net.minecraft.client.renderer.ItemBlockRenderTypes#getRenderType(BlockState, boolean)}
-     * for the input {@link RenderType}.
-     */
-    @NotNull
-    public static RenderType getEntityRenderType(RenderType chunkRenderType, boolean fabulous)
-    {
-        if (chunkRenderType != RenderType.translucent())
-            return Sheets.cutoutBlockSheet();
-        if (!Minecraft.useShaderTransparency())
-            return Sheets.translucentCullBlockSheet();
-        return fabulous ? Sheets.translucentCullBlockSheet() : Sheets.translucentItemSheet();
     }
 
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid="forge", bus= Mod.EventBusSubscriber.Bus.MOD)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -953,6 +953,16 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
     }
 
+    /**
+     * Mimics the behavior of {@link net.minecraft.client.renderer.ItemBlockRenderTypes#getRenderType(BlockState, boolean)}
+     * for the input {@link RenderType}.
+     */
+    @NotNull
+    public static RenderType getEntityRenderType(RenderType chunkRenderType, boolean cull)
+    {
+        return RenderTypeHelper.getEntityRenderType(chunkRenderType, cull);
+    }
+
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid="forge", bus= Mod.EventBusSubscriber.Bus.MOD)
     public static class ClientEvents
     {

--- a/src/main/java/net/minecraftforge/client/RenderTypeHelper.java
+++ b/src/main/java/net/minecraftforge/client/RenderTypeHelper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.client;
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
@@ -48,7 +53,7 @@ public final class RenderTypeHelper
 
     /**
      * Provides a fallback {@link RenderType} for the given {@link ItemStack} in the case that none is explicitly specified.
-     * <p/>
+     * <p>
      * Mimics the behavior of vanilla's {@link ItemBlockRenderTypes#getRenderType(ItemStack, boolean)}
      * but removes the need to query the model again if the item is a {@link BlockItem}.
      */

--- a/src/main/java/net/minecraftforge/client/RenderTypeHelper.java
+++ b/src/main/java/net/minecraftforge/client/RenderTypeHelper.java
@@ -1,0 +1,71 @@
+package net.minecraftforge.client;
+
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.model.data.ModelData;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides helper functions replacing those in {@link ItemBlockRenderTypes}.
+ */
+public final class RenderTypeHelper
+{
+    /**
+     * Provides a {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY} for the given {@link DefaultVertexFormat#BLOCK} format.
+     * This should be called for each {@link RenderType} returned by {@link BakedModel#getRenderTypes(BlockState, RandomSource, ModelData)}.
+     * <p>
+     * Mimics the behavior of vanilla's {@link ItemBlockRenderTypes#getRenderType(BlockState, boolean)}.
+     */
+    @NotNull
+    public static RenderType getEntityRenderType(RenderType chunkRenderType, boolean cull)
+    {
+        if (chunkRenderType != RenderType.translucent())
+            return Sheets.cutoutBlockSheet();
+        return cull || !Minecraft.useShaderTransparency() ? Sheets.translucentCullBlockSheet() : Sheets.translucentItemSheet();
+    }
+
+    /**
+     * Provides a {@link RenderType} fit for rendering moving blocks given the specified chunk render type.
+     * This should be called for each {@link RenderType} returned by {@link BakedModel#getRenderTypes(BlockState, RandomSource, ModelData)}.
+     * <p>
+     * Mimics the behavior of vanilla's {@link ItemBlockRenderTypes#getMovingBlockRenderType(BlockState)}.
+     */
+    @NotNull
+    public static RenderType getMovingBlockRenderType(RenderType renderType)
+    {
+        if (renderType == RenderType.translucent())
+            return RenderType.translucentMovingBlock();
+        return renderType;
+    }
+
+    /**
+     * Provides a fallback {@link RenderType} for the given {@link ItemStack} in the case that none is explicitly specified.
+     * <p/>
+     * Mimics the behavior of vanilla's {@link ItemBlockRenderTypes#getRenderType(ItemStack, boolean)}
+     * but removes the need to query the model again if the item is a {@link BlockItem}.
+     */
+    @NotNull
+    public static RenderType getFallbackItemRenderType(ItemStack stack, BakedModel model, boolean cull)
+    {
+        if (stack.getItem() instanceof BlockItem blockItem)
+        {
+            var renderTypes = model.getRenderTypes(blockItem.getBlock().defaultBlockState(), RandomSource.create(42), ModelData.EMPTY);
+            if (renderTypes.contains(RenderType.translucent()))
+                return getEntityRenderType(RenderType.translucent(), cull);
+            return Sheets.cutoutBlockSheet();
+        }
+        return cull ? Sheets.translucentCullBlockSheet() : Sheets.translucentItemSheet();
+    }
+
+    private RenderTypeHelper()
+    {
+    }
+}

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.ChunkRenderTypeSet;
+import net.minecraftforge.client.RenderTypeHelper;
 import net.minecraftforge.client.model.data.ModelData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,7 +98,7 @@ public interface IForgeBakedModel
      */
     default List<RenderType> getRenderTypes(ItemStack itemStack, boolean fabulous)
     {
-        return List.of(ItemBlockRenderTypes.getRenderType(itemStack, fabulous));
+        return List.of(RenderTypeHelper.getFallbackItemRenderType(itemStack, self(), fabulous));
     }
 
     /**

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -272,14 +272,14 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
 
             private void addLayer(RenderTypeGroup renderTypes, List<BakedQuad> quads)
             {
-                var modelBuilder = IModelBuilder.of(true, isSideLit, false, transforms, overrides, particle, renderTypes);
+                var modelBuilder = IModelBuilder.of(isAmbientOcclusion, isSideLit, isGui3d, transforms, overrides, particle, renderTypes);
                 quads.forEach(modelBuilder::addUnculledFace);
                 children.add(modelBuilder.build());
             }
 
             private void flushQuads(RenderTypeGroup renderTypes)
             {
-                if (Objects.equals(renderTypes, lastRenderTypes))
+                if (!Objects.equals(renderTypes, lastRenderTypes))
                 {
                     if (quads.size() > 0)
                     {

--- a/src/main/java/net/minecraftforge/client/model/DynamicFluidContainerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/DynamicFluidContainerModel.java
@@ -128,6 +128,7 @@ public class DynamicFluidContainerModel implements IUnbakedGeometry<DynamicFluid
         TextureAtlasSprite particleSprite = particleLocation != null ? spriteGetter.apply(particleLocation) : null;
 
         if (particleSprite == null) particleSprite = fluidSprite;
+        if (particleSprite == null) particleSprite = baseSprite;
         if (particleSprite == null && !coverIsMask) particleSprite = coverSprite;
 
         // If the fluid is lighter than air, rotate 180deg to turn it upside down


### PR DESCRIPTION
### Fix weighted baked models not respecting children render types
This fixes an oversight leading to weighted blockstate models always falling back to the default render type instead of using the correct one defined by the model they proxy.

### Revise deprecations in ItemBlockRenderTypes and provide replacement helpers
Documentation improvements in `ItemBlockRenderTypes` to clarify deprecations, and a new helper class with methods that are functionally equivalent to those in IBRT, but designed around the new model-defined render types.

### Allow fluid container model to use base texture as particle
This adds yet another fallback case for no particle texture being specified, making it practically impossible to run into the case where no particle is set and causing vanilla to throw a tantrum over it despite the fact that it's an item and as such doesn't need a particle.

### Fix inverted behavior in composite model building
This inverted if statement was causing composite model building to misbehave, resulting in geometry being output out-of-order and using the incorrect `RenderType`. This fixes #8871.