### PR TITLE
[1.19.x] fix inability to run 'forge forge test client' and fix inability to load/create worlds

### DIFF
--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -117,8 +117,6 @@ modId="living_conversion_event_test"
 [[mods]]
 modId="player_game_mode_event_test"
 [[mods]]
-modId="structure_spawn_list_event_test"
-[[mods]]
 modId="forge_codecs_test"
 [[mods]]
 modId="render_local_player_test"
@@ -154,8 +152,6 @@ modId="custom_tas_test"
 modId="dimension_settings_test"
 [[mods]]
 modId="player_attack_knockback_test"
-[[mods]]
-modId="overlay_layers_test"
 [[mods]]
 modId="entity_renderer_events_test"
 [[mods]]

--- a/src/test/resources/data/server_world_creation_test/dimension_type/server_world_creation_test.json
+++ b/src/test/resources/data/server_world_creation_test/dimension_type/server_world_creation_test.json
@@ -12,6 +12,8 @@
   "logical_height": 256,
   "min_y": 0,
   "height": 256,
+  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 8,
   "infiniburn": "#minecraft:infiniburn_overworld",
   "effects": "minecraft:overworld"
 }

--- a/src/test/resources/data/server_world_creation_test/worldgen/noise_settings/server_world_creation_test_noise.json
+++ b/src/test/resources/data/server_world_creation_test/worldgen/noise_settings/server_world_creation_test_noise.json
@@ -13,6 +13,7 @@
       "level": "0"
     }
   },
+  "spawn_target" : [],
   "noise": {
     "min_y": -64,
     "height": 384,


### PR DESCRIPTION
- removes missing mods from the mod toml file (overlay_layers_test and structure_spawn_list_event_test)
- disables the DataPackRegistriesTest which prevents the creation of worlds
- fixes failing datapack validation (missing JSON keys) caused by ServerWorldCreationTest which prevents the loading of worlds