### PR TITLE
[1.19] Add hook for items to remain in the hotbar when picking blocks/entities

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -5,7 +5,7 @@
        for(int k = 0; k < 9; ++k) {
           int l = (this.f_35977_ + k) % 9;
 -         if (!this.f_35974_.get(l).m_41793_()) {
-+         if (!this.f_35974_.get(l).isStickyInHotbar(this.f_35978_, l)) {
++         if (!this.f_35974_.get(l).isNotReplaceableByPickAction(this.f_35978_, l)) {
              return l;
           }
        }

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/player/Inventory.java
 +++ b/net/minecraft/world/entity/player/Inventory.java
+@@ -129,7 +_,7 @@
+ 
+       for(int k = 0; k < 9; ++k) {
+          int l = (this.f_35977_ + k) % 9;
+-         if (!this.f_35974_.get(l).m_41793_()) {
++         if (!this.f_35974_.get(l).shouldRemainInHotbarUponPick(this.f_35978_, l)) {
+             return l;
+          }
+       }
 @@ -177,7 +_,8 @@
        int i = p_36049_.m_41613_();
        ItemStack itemstack = this.m_8020_(p_36048_);

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -5,7 +5,7 @@
        for(int k = 0; k < 9; ++k) {
           int l = (this.f_35977_ + k) % 9;
 -         if (!this.f_35974_.get(l).m_41793_()) {
-+         if (!this.f_35974_.get(l).shouldRemainInHotbarUponPick(this.f_35978_, l)) {
++         if (!this.f_35974_.get(l).isStickyInHotbar(this.f_35978_, l)) {
              return l;
           }
        }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -830,7 +830,7 @@ public interface IForgeItem
     }
 
     /**
-     * Whether this stack should be excluded (if possible) when selecting the target hotbar slot of a "pick" action.
+     * Whether the given ItemStack should be excluded (if possible) when selecting the target hotbar slot of a "pick" action.
      * By default, this returns true for enchanted stacks.
      *
      * @see Inventory#getSuitableHotbarSlot()

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -828,4 +828,9 @@ public interface IForgeItem
         return self().getFoodProperties();
     }
 
+    default boolean shouldRemainInHotbarUponPick(ItemStack stack, Player player, int inventorySlot)
+    {
+        return stack.isEnchanted();
+    }
+
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -838,7 +838,7 @@ public interface IForgeItem
      * @param inventorySlot the inventory slot of the item being up for replacement
      * @return true to leave this stack in the hotbar if possible
      */
-    default boolean isStickyInHotbar(ItemStack stack, Player player, int inventorySlot)
+    default boolean isNotReplaceableByPickAction(ItemStack stack, Player player, int inventorySlot)
     {
         return stack.isEnchanted();
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 import com.google.common.collect.Multimap;
 
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -828,7 +829,16 @@ public interface IForgeItem
         return self().getFoodProperties();
     }
 
-    default boolean shouldRemainInHotbarUponPick(ItemStack stack, Player player, int inventorySlot)
+    /**
+     * Whether this stack should be excluded (if possible) when selecting the target hotbar slot of a "pick" action.
+     * By default, this returns true for enchanted stacks.
+     *
+     * @see Inventory#getSuitableHotbarSlot()
+     * @param player the player performing the picking
+     * @param inventorySlot the inventory slot of the item being up for replacement
+     * @return true to leave this stack in the hotbar if possible
+     */
+    default boolean isStickyInHotbar(ItemStack stack, Player player, int inventorySlot)
     {
         return stack.isEnchanted();
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -567,9 +567,9 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * @param inventorySlot the inventory slot of the item being up for replacement
      * @return true to leave this stack in the hotbar if possible
      */
-    default boolean isStickyInHotbar(Player player, int inventorySlot)
+    default boolean isNotReplaceableByPickAction(Player player, int inventorySlot)
     {
-        return self().getItem().isStickyInHotbar(self(), player, inventorySlot);
+        return self().getItem().isNotReplaceableByPickAction(self(), player, inventorySlot);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -556,4 +556,10 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     {
         return self().getItem().getFoodProperties(self(), entity);
     }
+
+    default boolean shouldRemainInHotbarUponPick(Player player, int inventorySlot)
+    {
+        return self().getItem().shouldRemainInHotbarUponPick(self(), player, inventorySlot);
+    }
+
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -8,6 +8,7 @@ package net.minecraftforge.common.extensions;
 import net.minecraft.core.Registry;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
@@ -557,9 +558,18 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
         return self().getItem().getFoodProperties(self(), entity);
     }
 
-    default boolean shouldRemainInHotbarUponPick(Player player, int inventorySlot)
+    /**
+     * Whether this stack should be excluded (if possible) when selecting the target hotbar slot of a "pick" action.
+     * By default, this returns true for enchanted stacks.
+     *
+     * @see Inventory#getSuitableHotbarSlot()
+     * @param player the player performing the picking
+     * @param inventorySlot the inventory slot of the item being up for replacement
+     * @return true to leave this stack in the hotbar if possible
+     */
+    default boolean isStickyInHotbar(Player player, int inventorySlot)
     {
-        return self().getItem().shouldRemainInHotbarUponPick(self(), player, inventorySlot);
+        return self().getItem().isStickyInHotbar(self(), player, inventorySlot);
     }
 
 }


### PR DESCRIPTION
When picking an item using the middle mouse button, the game tries to keep enchanted items in the hotbar, if the hotbar is already full.
This adds a hook for items to customize this behavior and allow themselves to be excluded, even if they are not enchanted.

Closes #8869.
See also: https://github.com/SlimeKnights/TinkersConstruct/issues/4939