### PR TITLE
Fix packet handling on play messages.

### DIFF
--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -25,7 +25,6 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.util.LogicalSidedProvider;
 import net.minecraftforge.entity.IEntityAdditionalSpawnData;
 
-import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -73,8 +72,7 @@ public class PlayMessages
             this.buf = null;
         }
 
-        private SpawnEntity(int typeId, int entityId, UUID uuid, double posX, double posY, double posZ,
-                            byte pitch, byte yaw, byte headYaw, int velX, int velY, int velZ, FriendlyByteBuf buf)
+        private SpawnEntity(int typeId, int entityId, UUID uuid, double posX, double posY, double posZ, byte pitch, byte yaw, byte headYaw, int velX, int velY, int velZ, FriendlyByteBuf buf)
         {
             this.entity = null;
             this.typeId = typeId;
@@ -125,15 +123,7 @@ public class PlayMessages
 
         public static SpawnEntity decode(FriendlyByteBuf buf)
         {
-            return new SpawnEntity(
-                    buf.readVarInt(),
-                    buf.readInt(),
-                    new UUID(buf.readLong(), buf.readLong()),
-                    buf.readDouble(), buf.readDouble(), buf.readDouble(),
-                    buf.readByte(), buf.readByte(), buf.readByte(),
-                    buf.readShort(), buf.readShort(), buf.readShort(),
-                    readSpawnDataPacket(buf)
-            );
+            return new SpawnEntity(buf.readVarInt(), buf.readInt(), new UUID(buf.readLong(), buf.readLong()), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readByte(), buf.readByte(), buf.readByte(), buf.readShort(), buf.readShort(), buf.readShort(), readSpawnDataPacket(buf));
         }
 
         private static FriendlyByteBuf readSpawnDataPacket(FriendlyByteBuf buf)
@@ -151,9 +141,9 @@ public class PlayMessages
 
         public static void handle(SpawnEntity msg, Supplier<NetworkEvent.Context> ctx)
         {
-            ctx.get().enqueueWork(() ->
-            {
-                try {
+            ctx.get().enqueueWork(() -> {
+                try
+                {
                     EntityType<?> type = Registry.ENTITY_TYPE.byId(msg.typeId);
                     Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get().getDirection().getReceptionSide());
                     Entity e = world.map(w -> type.customClientSpawn(msg, w)).orElse(null);
@@ -179,8 +169,7 @@ public class PlayMessages
                     {
                         entityAdditionalSpawnData.readSpawnData(msg.buf);
                     }
-                }
-                finally
+                } finally
                 {
                     msg.buf.release();
                 }
@@ -289,27 +278,22 @@ public class PlayMessages
 
         public static OpenContainer decode(FriendlyByteBuf buf)
         {
-            return new OpenContainer(buf.readVarInt(), buf.readVarInt(), buf.readComponent(),
-                    new FriendlyByteBuf(Unpooled.wrappedBuffer(buf.readByteArray(32600))));
+            return new OpenContainer(buf.readVarInt(), buf.readVarInt(), buf.readComponent(), new FriendlyByteBuf(Unpooled.wrappedBuffer(buf.readByteArray(32600))));
         }
 
         public static void handle(OpenContainer msg, Supplier<NetworkEvent.Context> ctx)
         {
-            ctx.get().enqueueWork(() ->
-            {
-                try {
-                    MenuScreens.getScreenFactory(msg.getType(), Minecraft.getInstance(), msg.getWindowId(), msg.getName())
-                               .ifPresent(f ->
-                               {
-                                   AbstractContainerMenu c = msg.getType().create(msg.getWindowId(), Minecraft.getInstance().player.getInventory(), msg.getAdditionalData());
+            ctx.get().enqueueWork(() -> {
+                try
+                {
+                    MenuScreens.getScreenFactory(msg.getType(), Minecraft.getInstance(), msg.getWindowId(), msg.getName()).ifPresent(f -> {
+                        AbstractContainerMenu c = msg.getType().create(msg.getWindowId(), Minecraft.getInstance().player.getInventory(), msg.getAdditionalData());
 
-                                   @SuppressWarnings("unchecked")
-                                   Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c, Minecraft.getInstance().player.getInventory(), msg.getName());
-                                   Minecraft.getInstance().player.containerMenu = ((MenuAccess<?>) s).getMenu();
-                                   Minecraft.getInstance().setScreen(s);
-                               });
-                }
-                finally
+                        @SuppressWarnings("unchecked") Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c, Minecraft.getInstance().player.getInventory(), msg.getName());
+                        Minecraft.getInstance().player.containerMenu = ((MenuAccess<?>) s).getMenu();
+                        Minecraft.getInstance().setScreen(s);
+                    });
+                } finally
                 {
                     msg.getAdditionalData().release();
                 }

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -107,11 +107,11 @@ public class PlayMessages
             buf.writeShort(msg.velX);
             buf.writeShort(msg.velY);
             buf.writeShort(msg.velZ);
-            if (msg.entity instanceof IEntityAdditionalSpawnData)
+            if (msg.entity instanceof IEntityAdditionalSpawnData entityAdditionalSpawnData)
             {
                 final FriendlyByteBuf spawnDataBuffer = new FriendlyByteBuf(Unpooled.buffer());
 
-                ((IEntityAdditionalSpawnData) msg.entity).writeSpawnData(spawnDataBuffer);
+                entityAdditionalSpawnData.writeSpawnData(spawnDataBuffer);
 
                 buf.writeVarInt(spawnDataBuffer.readableBytes());
                 buf.writeBytes(spawnDataBuffer);
@@ -153,44 +153,47 @@ public class PlayMessages
         {
             ctx.get().enqueueWork(() ->
             {
-                EntityType<?> type = Registry.ENTITY_TYPE.byId(msg.typeId);
-                if (type == null)
+                try {
+                    EntityType<?> type = Registry.ENTITY_TYPE.byId(msg.typeId);
+                    if (type == null)
+                    {
+                        throw new RuntimeException(String.format(Locale.ENGLISH, "Could not spawn entity (id %d) with " +
+                                                                                 "unknown type at (%f, %f, %f)",
+                                msg.entityId, msg.posX, msg.posY, msg.posZ));
+                    }
+
+                    Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get()
+                                                                                    .getDirection()
+                                                                                    .getReceptionSide());
+                    Entity e = world.map(w -> type.customClientSpawn(msg, w)).orElse(null);
+                    if (e == null)
+                    {
+                        return;
+                    }
+
+                    /*
+                     * Sets the postiion on the client, Mirrors what
+                     * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
+                     */
+                    e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
+                    e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
+                    e.setYHeadRot((msg.headYaw * 360) / 256.0F);
+                    e.setYBodyRot((msg.headYaw * 360) / 256.0F);
+
+                    e.setId(msg.entityId);
+                    e.setUUID(msg.uuid);
+                    world.filter(ClientLevel.class::isInstance)
+                         .ifPresent(w -> ((ClientLevel) w).putNonPlayerEntity(msg.entityId, e));
+                    e.lerpMotion(msg.velX / 8000.0, msg.velY / 8000.0, msg.velZ / 8000.0);
+                    if (e instanceof IEntityAdditionalSpawnData entityAdditionalSpawnData)
+                    {
+                        entityAdditionalSpawnData.readSpawnData(msg.buf);
+                    }
+                }
+                finally
                 {
                     msg.buf.release();
-                    throw new RuntimeException(String.format(Locale.ENGLISH, "Could not spawn entity (id %d) with " +
-                                                                             "unknown type at (%f, %f, %f)",
-                            msg.entityId, msg.posX, msg.posY, msg.posZ));
                 }
-
-                Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get()
-                                                                                .getDirection()
-                                                                                .getReceptionSide());
-                Entity e = world.map(w -> type.customClientSpawn(msg, w)).orElse(null);
-                if (e == null)
-                {
-                    msg.buf.release();
-                    return;
-                }
-
-                /*
-                 * Sets the postiion on the client, Mirrors what
-                 * Entity#recreateFromPacket and LivingEntity#recreateFromPacket does.
-                 */
-                e.syncPacketPositionCodec(msg.posX, msg.posY, msg.posZ);
-                e.absMoveTo(msg.posX, msg.posY, msg.posZ, (msg.yaw * 360) / 256.0F, (msg.pitch * 360) / 256.0F);
-                e.setYHeadRot((msg.headYaw * 360) / 256.0F);
-                e.setYBodyRot((msg.headYaw * 360) / 256.0F);
-
-                e.setId(msg.entityId);
-                e.setUUID(msg.uuid);
-                world.filter(ClientLevel.class::isInstance)
-                     .ifPresent(w -> ((ClientLevel) w).putNonPlayerEntity(msg.entityId, e));
-                e.lerpMotion(msg.velX / 8000.0, msg.velY / 8000.0, msg.velZ / 8000.0);
-                if (e instanceof IEntityAdditionalSpawnData)
-                {
-                    ((IEntityAdditionalSpawnData) e).readSpawnData(msg.buf);
-                }
-                msg.buf.release();
             });
             ctx.get().setPacketHandled(true);
         }
@@ -304,20 +307,26 @@ public class PlayMessages
         {
             ctx.get().enqueueWork(() ->
             {
-                MenuScreens.getScreenFactory(msg.getType(), Minecraft.getInstance(), msg.getWindowId(), msg.getName())
-                           .ifPresent(f ->
-                           {
-                               AbstractContainerMenu c = msg.getType()
-                                                            .create(msg.getWindowId(),
-                                                                    Minecraft.getInstance().player.getInventory(),
-                                                                    msg.getAdditionalData());
-                               msg.getAdditionalData().release();
-                               @SuppressWarnings("unchecked")
-                               Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c,
-                                       Minecraft.getInstance().player.getInventory(), msg.getName());
-                               Minecraft.getInstance().player.containerMenu = ((MenuAccess<?>) s).getMenu();
-                               Minecraft.getInstance().setScreen(s);
-                           });
+                try {
+                    MenuScreens.getScreenFactory(msg.getType(), Minecraft.getInstance(), msg.getWindowId(), msg.getName())
+                               .ifPresent(f ->
+                               {
+                                   AbstractContainerMenu c = msg.getType()
+                                                                .create(msg.getWindowId(),
+                                                                        Minecraft.getInstance().player.getInventory(),
+                                                                        msg.getAdditionalData());
+                                   @SuppressWarnings("unchecked")
+                                   Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c,
+                                           Minecraft.getInstance().player.getInventory(), msg.getName());
+                                   Minecraft.getInstance().player.containerMenu = ((MenuAccess<?>) s).getMenu();
+                                   Minecraft.getInstance().setScreen(s);
+                               });
+                }
+                finally
+                {
+                    msg.getAdditionalData().release();
+                }
+
             });
             ctx.get().setPacketHandled(true);
         }

--- a/src/main/java/net/minecraftforge/network/PlayMessages.java
+++ b/src/main/java/net/minecraftforge/network/PlayMessages.java
@@ -155,16 +155,7 @@ public class PlayMessages
             {
                 try {
                     EntityType<?> type = Registry.ENTITY_TYPE.byId(msg.typeId);
-                    if (type == null)
-                    {
-                        throw new RuntimeException(String.format(Locale.ENGLISH, "Could not spawn entity (id %d) with " +
-                                                                                 "unknown type at (%f, %f, %f)",
-                                msg.entityId, msg.posX, msg.posY, msg.posZ));
-                    }
-
-                    Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get()
-                                                                                    .getDirection()
-                                                                                    .getReceptionSide());
+                    Optional<Level> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get().getDirection().getReceptionSide());
                     Entity e = world.map(w -> type.customClientSpawn(msg, w)).orElse(null);
                     if (e == null)
                     {
@@ -182,8 +173,7 @@ public class PlayMessages
 
                     e.setId(msg.entityId);
                     e.setUUID(msg.uuid);
-                    world.filter(ClientLevel.class::isInstance)
-                         .ifPresent(w -> ((ClientLevel) w).putNonPlayerEntity(msg.entityId, e));
+                    world.filter(ClientLevel.class::isInstance).ifPresent(w -> ((ClientLevel) w).putNonPlayerEntity(msg.entityId, e));
                     e.lerpMotion(msg.velX / 8000.0, msg.velY / 8000.0, msg.velZ / 8000.0);
                     if (e instanceof IEntityAdditionalSpawnData entityAdditionalSpawnData)
                     {
@@ -311,13 +301,10 @@ public class PlayMessages
                     MenuScreens.getScreenFactory(msg.getType(), Minecraft.getInstance(), msg.getWindowId(), msg.getName())
                                .ifPresent(f ->
                                {
-                                   AbstractContainerMenu c = msg.getType()
-                                                                .create(msg.getWindowId(),
-                                                                        Minecraft.getInstance().player.getInventory(),
-                                                                        msg.getAdditionalData());
+                                   AbstractContainerMenu c = msg.getType().create(msg.getWindowId(), Minecraft.getInstance().player.getInventory(), msg.getAdditionalData());
+
                                    @SuppressWarnings("unchecked")
-                                   Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c,
-                                           Minecraft.getInstance().player.getInventory(), msg.getName());
+                                   Screen s = ((MenuScreens.ScreenConstructor<AbstractContainerMenu, ?>) f).create(c, Minecraft.getInstance().player.getInventory(), msg.getName());
                                    Minecraft.getInstance().player.containerMenu = ((MenuAccess<?>) s).getMenu();
                                    Minecraft.getInstance().setScreen(s);
                                });


### PR DESCRIPTION
This fixes forges own play messages trying to read data from a FriendlyByteBuf in an enqueueWork section after the code-flow execution of the network thread (which owns and frees said FriendlyByteBuf) has already been completed.

Fixes: #8873 