### PR TITLE
Add User-Agent header to requests made by the update checker

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -119,7 +119,7 @@ public class VersionChecker
              */
             private String openUrlString(URL url) throws IOException, URISyntaxException, InterruptedException {
                 URL currentUrl = url;
-                final String userAgent = String.format("MinecraftForge/%s Java/%s", FMLLoader.versionInfo().mcAndForgeVersion(), System.getProperty("java.version"));
+                final String userAgent = String.format("Java-http-client/%s MinecraftForge/%s", System.getProperty("java.version"), FMLLoader.versionInfo().mcAndForgeVersion());
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
                     var request = HttpRequest.newBuilder()

--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -119,9 +119,9 @@ public class VersionChecker
              */
             private String openUrlString(URL url) throws IOException, URISyntaxException, InterruptedException {
                 URL currentUrl = url;
+                final String userAgent = String.format("MinecraftForge/%s Java/%s", FMLLoader.versionInfo().mcAndForgeVersion(), System.getProperty("java.version"));
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
-                    final String userAgent = String.format("MinecraftForge/%s Java/%s", FMLLoader.versionInfo().mcAndForgeVersion(), System.getProperty("java.version"));
                     var request = HttpRequest.newBuilder()
                             .uri(currentUrl.toURI())
                             .timeout(Duration.ofSeconds(HTTP_TIMEOUT_SECS))

--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -121,10 +121,12 @@ public class VersionChecker
                 URL currentUrl = url;
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
+                    final String userAgent = String.format("MinecraftForge/%s Java/%s", FMLLoader.versionInfo().mcAndForgeVersion(), System.getProperty("java.version"));
                     var request = HttpRequest.newBuilder()
                             .uri(currentUrl.toURI())
                             .timeout(Duration.ofSeconds(HTTP_TIMEOUT_SECS))
                             .setHeader("Accept-Encoding", "gzip")
+                            .setHeader("User-Agent", userAgent)
                             .GET()
                             .build();
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -119,20 +119,19 @@ public class VersionChecker
              */
             private String openUrlString(URL url, IModInfo mod) throws IOException, URISyntaxException, InterruptedException {
                 URL currentUrl = url;
-                final String userAgent = String.format(
-                        "Java-http-client/%s MinecraftForge/%s %s/%s",
-                        System.getProperty("java.version"),
-                        FMLLoader.versionInfo().mcAndForgeVersion(),
-                        mod.getModId(),
-                        mod.getVersion()
-                );
+
+                final StringBuilder userAgent = new StringBuilder();
+                userAgent.append("Java-http-client/").append(System.getProperty("java.version")).append(' ');
+                userAgent.append("MinecraftForge/").append(FMLLoader.versionInfo().mcAndForgeVersion()).append(' ');
+                userAgent.append(mod.getModId()).append('/').append(mod.getVersion());
+
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
                     var request = HttpRequest.newBuilder()
                             .uri(currentUrl.toURI())
                             .timeout(Duration.ofSeconds(HTTP_TIMEOUT_SECS))
                             .setHeader("Accept-Encoding", "gzip")
-                            .setHeader("User-Agent", userAgent)
+                            .setHeader("User-Agent", userAgent.toString())
                             .GET()
                             .build();
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -120,10 +120,11 @@ public class VersionChecker
             private String openUrlString(URL url, IModInfo mod) throws IOException, URISyntaxException, InterruptedException {
                 URL currentUrl = url;
 
-                final StringBuilder userAgent = new StringBuilder();
-                userAgent.append("Java-http-client/").append(System.getProperty("java.version")).append(' ');
-                userAgent.append("MinecraftForge/").append(FMLLoader.versionInfo().mcAndForgeVersion()).append(' ');
-                userAgent.append(mod.getModId()).append('/').append(mod.getVersion());
+                final StringBuilder sb = new StringBuilder();
+                sb.append("Java-http-client/").append(System.getProperty("java.version")).append(' ');
+                sb.append("MinecraftForge/").append(FMLLoader.versionInfo().mcAndForgeVersion()).append(' ');
+                sb.append(mod.getModId()).append('/').append(mod.getVersion());
+                final String userAgent = sb.toString();
 
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
@@ -131,7 +132,7 @@ public class VersionChecker
                             .uri(currentUrl.toURI())
                             .timeout(Duration.ofSeconds(HTTP_TIMEOUT_SECS))
                             .setHeader("Accept-Encoding", "gzip")
-                            .setHeader("User-Agent", userAgent.toString())
+                            .setHeader("User-Agent", userAgent)
                             .GET()
                             .build();
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -117,9 +117,15 @@ public class VersionChecker
             /**
              * Returns the response body as a String for the given URL while following redirects
              */
-            private String openUrlString(URL url) throws IOException, URISyntaxException, InterruptedException {
+            private String openUrlString(URL url, IModInfo mod) throws IOException, URISyntaxException, InterruptedException {
                 URL currentUrl = url;
-                final String userAgent = String.format("Java-http-client/%s MinecraftForge/%s", System.getProperty("java.version"), FMLLoader.versionInfo().mcAndForgeVersion());
+                final String userAgent = String.format(
+                        "Java-http-client/%s MinecraftForge/%s %s/%s",
+                        System.getProperty("java.version"),
+                        FMLLoader.versionInfo().mcAndForgeVersion(),
+                        mod.getModId(),
+                        mod.getVersion()
+                );
                 for (int redirects = 0; redirects < MAX_HTTP_REDIRECTS; redirects++)
                 {
                     var request = HttpRequest.newBuilder()
@@ -168,7 +174,7 @@ public class VersionChecker
                     URL url = mod.getUpdateURL().get();
                     LOGGER.info("[{}] Starting version check at {}", mod.getModId(), url.toString());
 
-                    String data = openUrlString(url);
+                    String data = openUrlString(url, mod);
 
                     LOGGER.debug("[{}] Received version check data:\n{}", mod.getModId(), data);
 


### PR DESCRIPTION
Currently the update checker sends requests with the default Java HTTP client `User-Agent` header - `Java-http-client/<Java version>`. This is rather unhelpful for a couple reasons, principally that it's so generic that it kind of goes against the purpose of a user agent.

This PR changes the user agent header to make it clear that it's a request being made by Forge.

Example: `MinecraftForge/1.19-41.0.99 Java/17.0.1`
