### PR TITLE
Fix connecting to certain servers

### DIFF
--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -5,14 +5,17 @@
 
 package net.minecraftforge.network;
 
+import com.mojang.logging.LogUtils;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Attribute;
+import net.minecraft.ResourceLocationException;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,6 +27,7 @@ import java.util.function.Supplier;
 
 public class MCRegisterPacketHandler
 {
+    private static final Logger LOGGER = LogUtils.getLogger();
     public static final MCRegisterPacketHandler INSTANCE = new MCRegisterPacketHandler();
 
     public static class ChannelList {
@@ -62,7 +66,11 @@ public class MCRegisterPacketHandler
             for (int cur = 0; cur < all.length; cur++) {
                 if (all[cur] == '\0') {
                     String s = new String(all, last, cur - last, StandardCharsets.UTF_8);
-                    rl.add(new ResourceLocation(s));
+                    try {
+                        rl.add(new ResourceLocation(s));
+                    } catch (ResourceLocationException ex) {
+                        LOGGER.warn("Invalid channel name received: {}. Ignoring", s);
+                    }
                     last = cur + 1;
                 }
             }


### PR DESCRIPTION
Fixes connecting to servers that send characters in channel names in the register or unregister custom packets that aren't valid in `ResourceLocation` anymore.
The issue was caused by #8703 due to the client thread simply ignoring the exception while the netty thread disconnects from the server. This doesn't happen in vanilla for the register and unregister packets since vanilla does nothing with those.