### PR TITLE
[1.19] Add forge tags for tools and armors

### DIFF
--- a/src/generated/resources/data/forge/tags/items/armors.json
+++ b/src/generated/resources/data/forge/tags/items/armors.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "#forge:armors/helmets",
+    "#forge:armors/chestplates",
+    "#forge:armors/leggings",
+    "#forge:armors/boots"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armors/boots.json
+++ b/src/generated/resources/data/forge/tags/items/armors/boots.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:leather_boots",
+    "minecraft:chainmail_boots",
+    "minecraft:iron_boots",
+    "minecraft:golden_boots",
+    "minecraft:diamond_boots",
+    "minecraft:netherite_boots"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armors/chestplates.json
+++ b/src/generated/resources/data/forge/tags/items/armors/chestplates.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:leather_chestplate",
+    "minecraft:chainmail_chestplate",
+    "minecraft:iron_chestplate",
+    "minecraft:golden_chestplate",
+    "minecraft:diamond_chestplate",
+    "minecraft:netherite_chestplate"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armors/helmets.json
+++ b/src/generated/resources/data/forge/tags/items/armors/helmets.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "minecraft:leather_helmet",
+    "minecraft:turtle_helmet",
+    "minecraft:chainmail_helmet",
+    "minecraft:iron_helmet",
+    "minecraft:golden_helmet",
+    "minecraft:diamond_helmet",
+    "minecraft:netherite_helmet"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armors/leggings.json
+++ b/src/generated/resources/data/forge/tags/items/armors/leggings.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:leather_leggings",
+    "minecraft:chainmail_leggings",
+    "minecraft:iron_leggings",
+    "minecraft:golden_leggings",
+    "minecraft:diamond_leggings",
+    "minecraft:netherite_leggings"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools.json
+++ b/src/generated/resources/data/forge/tags/items/tools.json
@@ -1,0 +1,14 @@
+{
+  "values": [
+    "#forge:tools/swords",
+    "#forge:tools/axes",
+    "#forge:tools/pickaxes",
+    "#forge:tools/shovels",
+    "#forge:tools/hoes",
+    "#forge:tools/shields",
+    "#forge:tools/bows",
+    "#forge:tools/crossbows",
+    "#forge:tools/fishing_rods",
+    "#forge:tools/tridents"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/axes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/axes.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:wooden_axe",
+    "minecraft:stone_axe",
+    "minecraft:iron_axe",
+    "minecraft:golden_axe",
+    "minecraft:diamond_axe",
+    "minecraft:netherite_axe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/bows.json
+++ b/src/generated/resources/data/forge/tags/items/tools/bows.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:bow"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/crossbows.json
+++ b/src/generated/resources/data/forge/tags/items/tools/crossbows.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:crossbow"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/fishing_rods.json
+++ b/src/generated/resources/data/forge/tags/items/tools/fishing_rods.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:fishing_rod"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/hoes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/hoes.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:wooden_hoe",
+    "minecraft:stone_hoe",
+    "minecraft:iron_hoe",
+    "minecraft:golden_hoe",
+    "minecraft:diamond_hoe",
+    "minecraft:netherite_hoe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/pickaxes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/pickaxes.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:wooden_pickaxe",
+    "minecraft:stone_pickaxe",
+    "minecraft:iron_pickaxe",
+    "minecraft:golden_pickaxe",
+    "minecraft:diamond_pickaxe",
+    "minecraft:netherite_pickaxe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/shields.json
+++ b/src/generated/resources/data/forge/tags/items/tools/shields.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:shield"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/shovels.json
+++ b/src/generated/resources/data/forge/tags/items/tools/shovels.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:wooden_shovel",
+    "minecraft:stone_shovel",
+    "minecraft:iron_shovel",
+    "minecraft:golden_shovel",
+    "minecraft:diamond_shovel",
+    "minecraft:netherite_shovel"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/swords.json
+++ b/src/generated/resources/data/forge/tags/items/tools/swords.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:wooden_sword",
+    "minecraft:stone_sword",
+    "minecraft:iron_sword",
+    "minecraft:golden_sword",
+    "minecraft:diamond_sword",
+    "minecraft:netherite_sword"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/tridents.json
+++ b/src/generated/resources/data/forge/tags/items/tools/tridents.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:trident"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -394,22 +394,124 @@ public class Tags
         public static final TagKey<Item> STORAGE_BLOCKS_RAW_IRON = tag("storage_blocks/raw_iron");
         public static final TagKey<Item> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
         public static final TagKey<Item> STRING                  = tag("string");
-
+        /**
+         * A tag containing all existing tools.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS = tag("tools");
+        /**
+         * A tag containing all existing swords.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_SWORDS = tag("tools/swords");
+        /**
+         * A tag containing all existing axes.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_AXES = tag("tools/axes");
+        /**
+         * A tag containing all existing pickaxes.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_PICKAXES = tag("tools/pickaxes");
+        /**
+         * A tag containing all existing shovels.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_SHOVELS = tag("tools/shovels");
+        /**
+         * A tag containing all existing hoes.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_HOES = tag("tools/hoes");
+        /**
+         * A tag containing all existing shields.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_SHIELDS = tag("tools/shields");
+        /**
+         * A tag containing all existing bows.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_BOWS = tag("tools/bows");
+        /**
+         * A tag containing all existing crossbows.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_CROSSBOWS = tag("tools/crossbows");
+        /**
+         * A tag containing all existing fishing rods.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_FISHING_RODS = tag("tools/fishing_rods");
+        /**
+         * A tag containing all existing tridents.
+         *
+         * Note: This tag is not an alternative or a substitute to {@link net.minecraftforge.common.ToolActions}.
+         *
+         * @see net.minecraftforge.common.ToolAction
+         * @see net.minecraftforge.common.ToolActions
+         */
         public static final TagKey<Item> TOOLS_TRIDENTS = tag("tools/tridents");
+        /**
+         * A tag containing all existing armors.
+         */
         public static final TagKey<Item> ARMORS = tag("armors");
+        /**
+         * A tag containing all existing helmets.
+         */
         public static final TagKey<Item> ARMORS_HELMETS = tag("armors/helmets");
+        /**
+         * A tag containing all chestplates.
+         */
         public static final TagKey<Item> ARMORS_CHESTPLATES = tag("armors/chestplates");
+        /**
+         * A tag containing all existing leggings.
+         */
         public static final TagKey<Item> ARMORS_LEGGINGS = tag("armors/leggings");
+        /**
+         * A tag containing all existing boots.
+         */
         public static final TagKey<Item> ARMORS_BOOTS = tag("armors/boots");
 
         private static TagKey<Item> tag(String name)

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -395,6 +395,23 @@ public class Tags
         public static final TagKey<Item> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
         public static final TagKey<Item> STRING                  = tag("string");
 
+        public static final TagKey<Item> TOOLS = tag("tools");
+        public static final TagKey<Item> TOOLS_SWORDS = tag("tools/swords");
+        public static final TagKey<Item> TOOLS_AXES = tag("tools/axes");
+        public static final TagKey<Item> TOOLS_PICKAXES = tag("tools/pickaxes");
+        public static final TagKey<Item> TOOLS_SHOVELS = tag("tools/shovels");
+        public static final TagKey<Item> TOOLS_HOES = tag("tools/hoes");
+        public static final TagKey<Item> TOOLS_SHIELDS = tag("tools/shields");
+        public static final TagKey<Item> TOOLS_BOWS = tag("tools/bows");
+        public static final TagKey<Item> TOOLS_CROSSBOWS = tag("tools/crossbows");
+        public static final TagKey<Item> TOOLS_FISHING_RODS = tag("tools/fishing_rods");
+        public static final TagKey<Item> TOOLS_TRIDENTS = tag("tools/tridents");
+        public static final TagKey<Item> ARMORS = tag("armors");
+        public static final TagKey<Item> ARMORS_HELMETS = tag("armors/helmets");
+        public static final TagKey<Item> ARMORS_CHESTPLATES = tag("armors/chestplates");
+        public static final TagKey<Item> ARMORS_LEGGINGS = tag("armors/leggings");
+        public static final TagKey<Item> ARMORS_BOOTS = tag("armors/boots");
+
         private static TagKey<Item> tag(String name)
         {
             return ItemTags.create(new ResourceLocation("forge", name));

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -153,6 +153,22 @@ public final class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.STORAGE_BLOCKS_RAW_IRON, Tags.Items.STORAGE_BLOCKS_RAW_IRON);
         copy(Tags.Blocks.STORAGE_BLOCKS_NETHERITE, Tags.Items.STORAGE_BLOCKS_NETHERITE);
         tag(Tags.Items.STRING).add(Items.STRING);
+        tag(Tags.Items.TOOLS_SWORDS).add(Items.WOODEN_SWORD, Items.STONE_SWORD, Items.IRON_SWORD, Items.GOLDEN_SWORD, Items.DIAMOND_SWORD, Items.NETHERITE_SWORD);
+        tag(Tags.Items.TOOLS_AXES).add(Items.WOODEN_AXE, Items.STONE_AXE, Items.IRON_AXE, Items.GOLDEN_AXE, Items.DIAMOND_AXE, Items.NETHERITE_AXE);
+        tag(Tags.Items.TOOLS_PICKAXES).add(Items.WOODEN_PICKAXE, Items.STONE_PICKAXE, Items.IRON_PICKAXE, Items.GOLDEN_PICKAXE, Items.DIAMOND_PICKAXE, Items.NETHERITE_PICKAXE);
+        tag(Tags.Items.TOOLS_SHOVELS).add(Items.WOODEN_SHOVEL, Items.STONE_SHOVEL, Items.IRON_SHOVEL, Items.GOLDEN_SHOVEL, Items.DIAMOND_SHOVEL, Items.NETHERITE_SHOVEL);
+        tag(Tags.Items.TOOLS_HOES).add(Items.WOODEN_HOE, Items.STONE_HOE, Items.IRON_HOE, Items.GOLDEN_HOE, Items.DIAMOND_HOE, Items.NETHERITE_HOE);
+        tag(Tags.Items.TOOLS_SHIELDS).add(Items.SHIELD);
+        tag(Tags.Items.TOOLS_BOWS).add(Items.BOW);
+        tag(Tags.Items.TOOLS_CROSSBOWS).add(Items.CROSSBOW);
+        tag(Tags.Items.TOOLS_FISHING_RODS).add(Items.FISHING_ROD);
+        tag(Tags.Items.TOOLS_TRIDENTS).add(Items.TRIDENT);
+        tag(Tags.Items.TOOLS).addTags(Tags.Items.TOOLS_SWORDS, Tags.Items.TOOLS_AXES, Tags.Items.TOOLS_PICKAXES, Tags.Items.TOOLS_SHOVELS, Tags.Items.TOOLS_HOES, Tags.Items.TOOLS_SHIELDS, Tags.Items.TOOLS_BOWS, Tags.Items.TOOLS_CROSSBOWS, Tags.Items.TOOLS_FISHING_RODS, Tags.Items.TOOLS_TRIDENTS);
+        tag(Tags.Items.ARMORS_HELMETS).add(Items.LEATHER_HELMET, Items.TURTLE_HELMET, Items.CHAINMAIL_HELMET, Items.IRON_HELMET, Items.GOLDEN_HELMET, Items.DIAMOND_HELMET, Items.NETHERITE_HELMET);
+        tag(Tags.Items.ARMORS_CHESTPLATES).add(Items.LEATHER_CHESTPLATE, Items.CHAINMAIL_CHESTPLATE, Items.IRON_CHESTPLATE, Items.GOLDEN_CHESTPLATE, Items.DIAMOND_CHESTPLATE, Items.NETHERITE_CHESTPLATE);
+        tag(Tags.Items.ARMORS_LEGGINGS).add(Items.LEATHER_LEGGINGS, Items.CHAINMAIL_LEGGINGS, Items.IRON_LEGGINGS, Items.GOLDEN_LEGGINGS, Items.DIAMOND_LEGGINGS, Items.NETHERITE_LEGGINGS);
+        tag(Tags.Items.ARMORS_BOOTS).add(Items.LEATHER_BOOTS, Items.CHAINMAIL_BOOTS, Items.IRON_BOOTS, Items.GOLDEN_BOOTS, Items.DIAMOND_BOOTS, Items.NETHERITE_BOOTS);
+        tag(Tags.Items.ARMORS).addTags(Tags.Items.ARMORS_HELMETS, Tags.Items.ARMORS_CHESTPLATES, Tags.Items.ARMORS_LEGGINGS, Tags.Items.ARMORS_BOOTS);
     }
 
     private void addColored(Consumer<TagKey<Item>> consumer, TagKey<Item> group, String pattern)


### PR DESCRIPTION
This PR adds forge tags for tools and armors:
- tools: `tools`, `tools/swords`, `tools/axes`, `tools/pickaxes`, `tools/shovels`, `tools/hoes`, `tools/shields`, `tools/bows`, `tools/crossbows`, `tools/fishing_rods`, `tools/tridents`
- armors: `armors`, `armors/helmets`, `armors/chestplates`, `armors/leggings`, `armors/boots`

Please tell me if I have forgotten any item. And should I add modded tool types like paxel/aiot?