### PR TITLE
[1.19.1]: Let isRemotePresent check minecraft:register for packet ids from other mod loaders. 

### DIFF
--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -37,7 +37,8 @@ public class MCRegisterPacketHandler
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
             Set<ResourceLocation> oldLocations = this.locations;
-            this.locations = this.remoteLocations = bytesToResLocation(data);
+            this.locations = bytesToResLocation(data);
+            this.remoteLocations = Set.copyOf(this.locations);
             // ensure all locations receive updates, old and new.
             oldLocations.addAll(this.locations);
             oldLocations.stream()

--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -32,7 +32,8 @@ public class MCRegisterPacketHandler
 
     public static class ChannelList {
         private Set<ResourceLocation> locations = new HashSet<>();
-        private Set<ResourceLocation> remoteLocations = new HashSet<>();
+        private Set<ResourceLocation> remoteLocations = Set.of();
+
         public void updateFrom(final Supplier<NetworkEvent.Context> source, FriendlyByteBuf buffer, final NetworkEvent.RegistrationChangeType changeType) {
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
@@ -79,10 +80,8 @@ public class MCRegisterPacketHandler
         }
 
         /**
-         * Provides only the registered locations that the remote side has sent.
-         * This is useful for interacting with other modloaders via the network to inspect registered network ids.
-         *
-         * @return - The remote locations
+         * {@return the unmodifiable set of channel locations sent by the remote side}
+         * This is useful for interacting with other modloaders via the network to inspect registered network channel IDs.
          */
         public Set<ResourceLocation> getRemoteLocations() {
             return this.remoteLocations;

--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -32,12 +32,12 @@ public class MCRegisterPacketHandler
 
     public static class ChannelList {
         private Set<ResourceLocation> locations = new HashSet<>();
-
+        private Set<ResourceLocation> remoteLocations = new HashSet<>();
         public void updateFrom(final Supplier<NetworkEvent.Context> source, FriendlyByteBuf buffer, final NetworkEvent.RegistrationChangeType changeType) {
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
             Set<ResourceLocation> oldLocations = this.locations;
-            this.locations = bytesToResLocation(data);
+            this.locations = this.remoteLocations = bytesToResLocation(data);
             // ensure all locations receive updates, old and new.
             oldLocations.addAll(this.locations);
             oldLocations.stream()
@@ -75,6 +75,16 @@ public class MCRegisterPacketHandler
                 }
             }
             return rl;
+        }
+
+        /**
+         * Provides only the registered locations that the remote side has sent.
+         * This is useful for interacting with other modloaders via the network to inspect registered network ids.
+         *
+         * @return - The remote locations
+         */
+        public Set<ResourceLocation> getRemoteLocations() {
+            return this.remoteLocations;
         }
     }
 

--- a/src/main/java/net/minecraftforge/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/network/NetworkHooks.java
@@ -231,4 +231,10 @@ public class NetworkHooks
     {
         return mgr.channel().attr(NetworkConstants.FML_MOD_MISMATCH_DATA).get();
     }
+
+    @Nullable
+    public static MCRegisterPacketHandler.ChannelList getChannelList(Connection mgr)
+    {
+        return mgr.channel().attr(NetworkConstants.FML_MC_REGISTRY).get();
+    }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInstance.java
@@ -95,6 +95,9 @@ public class NetworkInstance
 
     public boolean isRemotePresent(Connection manager) {
         ConnectionData connectionData = NetworkHooks.getConnectionData(manager);
-        return connectionData != null && connectionData.getChannels().containsKey(channelName);
+        MCRegisterPacketHandler.ChannelList channelList = NetworkHooks.getChannelList(manager);
+        return (connectionData != null && connectionData.getChannels().containsKey(channelName))
+                // if it's not in the fml connection data, let's check if it's sent by another modloader.
+                || (channelList != null && channelList.getRemoteLocations().contains(channelName));
     }
 }


### PR DESCRIPTION
Other mod loaders send the registered packet ids on the "minecraft:register" packet. 
This PR lets the SimpleChannel.isRemotePreset check that if it is not in the "fml:conndata" registry. 

I need this because my mod is both optional on the server and the client and is loader agnostic, forge clients can connect to the mod on a fabric or quilt server, fabric clients can connect to the mod if it is on a forger server. 
I do not want to send random packets if the other side does not have the mod.

I will back port this to 1.18.2 when it is ready. 