### PR TITLE
Fix certain particles not updating their bounding box when their position changes

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/EnchantmentTableParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EnchantmentTableParticle.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/particle/EnchantmentTableParticle.java
++++ b/net/minecraft/client/particle/EnchantmentTableParticle.java
+@@ -73,6 +_,7 @@
+          this.f_107212_ = this.f_106461_ + this.f_107215_ * (double)f;
+          this.f_107213_ = this.f_106462_ + this.f_107216_ * (double)f - (double)(f1 * 1.2F);
+          this.f_107214_ = this.f_106460_ + this.f_107217_ * (double)f;
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
+       }
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/particle/EnchantmentTableParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EnchantmentTableParticle.java.patch
@@ -4,7 +4,7 @@
           this.f_107212_ = this.f_106461_ + this.f_107215_ * (double)f;
           this.f_107213_ = this.f_106462_ + this.f_107216_ * (double)f - (double)(f1 * 1.2F);
           this.f_107214_ = this.f_106460_ + this.f_107217_ * (double)f;
-+         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); // FORGE: update the particle's bounding box
        }
     }
  

--- a/patches/minecraft/net/minecraft/client/particle/PortalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/PortalParticle.java.patch
@@ -4,7 +4,7 @@
           this.f_107212_ = this.f_107548_ + this.f_107215_ * (double)f2;
           this.f_107213_ = this.f_107549_ + this.f_107216_ * (double)f2 + (double)(1.0F - f);
           this.f_107214_ = this.f_107547_ + this.f_107217_ * (double)f2;
-+         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); // FORGE: update the particle's bounding box
        }
     }
  

--- a/patches/minecraft/net/minecraft/client/particle/PortalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/PortalParticle.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/particle/PortalParticle.java
++++ b/net/minecraft/client/particle/PortalParticle.java
+@@ -75,6 +_,7 @@
+          this.f_107212_ = this.f_107548_ + this.f_107215_ * (double)f2;
+          this.f_107213_ = this.f_107549_ + this.f_107216_ * (double)f2 + (double)(1.0F - f);
+          this.f_107214_ = this.f_107547_ + this.f_107217_ * (double)f2;
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
+       }
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/particle/ReversePortalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ReversePortalParticle.java.patch
@@ -4,7 +4,7 @@
           this.f_107212_ += this.f_107215_ * (double)f;
           this.f_107213_ += this.f_107216_ * (double)f;
           this.f_107214_ += this.f_107217_ * (double)f;
-+         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); // FORGE: update the particle's bounding box
        }
     }
  

--- a/patches/minecraft/net/minecraft/client/particle/ReversePortalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ReversePortalParticle.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/particle/ReversePortalParticle.java
++++ b/net/minecraft/client/particle/ReversePortalParticle.java
+@@ -29,6 +_,7 @@
+          this.f_107212_ += this.f_107215_ * (double)f;
+          this.f_107213_ += this.f_107216_ * (double)f;
+          this.f_107214_ += this.f_107217_ * (double)f;
++         this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
+       }
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/particle/VibrationSignalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/VibrationSignalParticle.java.patch
@@ -4,7 +4,7 @@
              this.f_107212_ = Mth.m_14139_(d0, this.f_107212_, vec3.m_7096_());
              this.f_107213_ = Mth.m_14139_(d0, this.f_107213_, vec3.m_7098_());
              this.f_107214_ = Mth.m_14139_(d0, this.f_107214_, vec3.m_7094_());
-+            this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
++            this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); // FORGE: update the particle's bounding box
              this.f_172460_ = this.f_172462_;
              this.f_172462_ = (float)Mth.m_14136_(this.f_107212_ - vec3.m_7096_(), this.f_107214_ - vec3.m_7094_());
           }

--- a/patches/minecraft/net/minecraft/client/particle/VibrationSignalParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/VibrationSignalParticle.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/particle/VibrationSignalParticle.java
++++ b/net/minecraft/client/particle/VibrationSignalParticle.java
+@@ -100,6 +_,7 @@
+             this.f_107212_ = Mth.m_14139_(d0, this.f_107212_, vec3.m_7096_());
+             this.f_107213_ = Mth.m_14139_(d0, this.f_107213_, vec3.m_7098_());
+             this.f_107214_ = Mth.m_14139_(d0, this.f_107214_, vec3.m_7094_());
++            this.m_107264_(this.f_107212_, this.f_107213_, this.f_107214_); //Forge: update the particle's bounding box
+             this.f_172460_ = this.f_172462_;
+             this.f_172462_ = (float)Mth.m_14136_(this.f_107212_ - vec3.m_7096_(), this.f_107214_ - vec3.m_7094_());
+          }


### PR DESCRIPTION
As discussed on Discord, this PR aims to fix the issue that some particles, namely the `EnchantmentTableParticle`, `PortalParticle`, `ReversePortalParticle` and `VibrationSignalParticle` particles, neglect to update their bounding box when their position changes. 
This is not an issue in an unmodified game, since in vanilla the bounding box of a particle is only used for in-world collision, and none of the mentioned particles are able to collide with blocks. However, due to Forge's particle culling using the particle's bounding box, a particle only gets rendered if its bounding box is within the player's frustum. This means that these particles currently don't render for a player if the bounding box of the particle (that only gets set when the particle is initialized) is not within the player's field of view, even though the particle's actual position can be seen by him. This is particularly noticeable for the `VibrationSignalParticle` due to it being able to travel up to 8 blocks while the particle's bounding box is always at the source of the vibration.
This PR adds a call to `Particle#setPos` into the `tick` methods of the mentioned particles after their positions are updated. This ensures that the bounding box gets updated when the position updates, since `Particle#setPos` automatically sets the bounding box based on the position.