### PR TITLE
[1.19] [HotFix] Fix the dedicated server not having access to the JiJ filesystems.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     APACHE_COMMONS_LANG3_VERSION = '3.12.0'
     JOPT_SIMPLE_VERSION = '5.0.4'
     COMMONS_IO_VERSION = '2.11.0'
-    JARJAR_VERSION = '0.3.15'
+    JARJAR_VERSION = '0.3.16'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)
@@ -261,9 +261,7 @@ def sharedDeps = {
     moduleonly "org.ow2.asm:asm-util:${ASM_VERSION}"
     moduleonly "org.ow2.asm:asm-analysis:${ASM_VERSION}"
     moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
-    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}:filesystems") {
-        transitive = false
-    }
+    moduleonly "net.minecraftforge:JarJarFileSystems:${JARJAR_VERSION}"
 
     installer "cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}"
     installer "org.ow2.asm:asm:${ASM_VERSION}"
@@ -287,7 +285,8 @@ def sharedDeps = {
     installer "org.jline:jline-terminal:${JLINE_VERSION}" // Dep of TerminalConsoleAppender
     installer "org.spongepowered:mixin:${MIXIN_VERSION}"
     installer 'org.openjdk.nashorn:nashorn-core:15.3'
-    installer "net.minecraftforge:JarJar:${JARJAR_VERSION}:all"
+    installer "net.minecraftforge:JarJarSelector:${JARJAR_VERSION}"
+    installer "net.minecraftforge:JarJarMetadata:${JARJAR_VERSION}"
 
     /*
     installer 'org.lwjgl:lwjgl:3.2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     APACHE_COMMONS_LANG3_VERSION = '3.12.0'
     JOPT_SIMPLE_VERSION = '5.0.4'
     COMMONS_IO_VERSION = '2.11.0'
-    JARJAR_VERSION = '0.3.9'
+    JARJAR_VERSION = '0.3.10'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)
@@ -261,7 +261,7 @@ def sharedDeps = {
     moduleonly "org.ow2.asm:asm-util:${ASM_VERSION}"
     moduleonly "org.ow2.asm:asm-analysis:${ASM_VERSION}"
     moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
-    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}") {
+    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}:all") {
         transitive = false
     }
 
@@ -287,7 +287,7 @@ def sharedDeps = {
     installer "org.jline:jline-terminal:${JLINE_VERSION}" // Dep of TerminalConsoleAppender
     installer "org.spongepowered:mixin:${MIXIN_VERSION}"
     installer 'org.openjdk.nashorn:nashorn-core:15.3'
-    installer "net.minecraftforge:JarJar:${JARJAR_VERSION}"
+    installer "net.minecraftforge:JarJar:${JARJAR_VERSION}:all"
 
     /*
     installer 'org.lwjgl:lwjgl:3.2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     APACHE_COMMONS_LANG3_VERSION = '3.12.0'
     JOPT_SIMPLE_VERSION = '5.0.4'
     COMMONS_IO_VERSION = '2.11.0'
-    JARJAR_VERSION = '0.3.10'
+    JARJAR_VERSION = '0.3.15'
 
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)
@@ -261,7 +261,7 @@ def sharedDeps = {
     moduleonly "org.ow2.asm:asm-util:${ASM_VERSION}"
     moduleonly "org.ow2.asm:asm-analysis:${ASM_VERSION}"
     moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
-    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}:all") {
+    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}:filesystems") {
         transitive = false
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -261,6 +261,9 @@ def sharedDeps = {
     moduleonly "org.ow2.asm:asm-util:${ASM_VERSION}"
     moduleonly "org.ow2.asm:asm-analysis:${ASM_VERSION}"
     moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
+    moduleonly ("net.minecraftforge:JarJar:${JARJAR_VERSION}") {
+        transitive = false
+    }
 
     installer "cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}"
     installer "org.ow2.asm:asm:${ASM_VERSION}"

--- a/fmlloader/build.gradle
+++ b/fmlloader/build.gradle
@@ -28,7 +28,8 @@ dependencies {
     api("cpw.mods:modlauncher:${MODLAUNCHER_VERSION}")
     api("net.minecraftforge:coremods:${COREMODS_VERSION}")
     api("com.mojang:logging:${MOJANG_LOGGING_VERSION}")
-    api "net.minecraftforge:JarJar:${JARJAR_VERSION}:all"
+    api "net.minecraftforge:JarJarSelector:${JARJAR_VERSION}"
+    api "net.minecraftforge:JarJarMetadata:${JARJAR_VERSION}"
 
     implementation("net.sf.jopt-simple:jopt-simple:${JOPT_SIMPLE_VERSION}")
     implementation("cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}")

--- a/fmlloader/build.gradle
+++ b/fmlloader/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api("cpw.mods:modlauncher:${MODLAUNCHER_VERSION}")
     api("net.minecraftforge:coremods:${COREMODS_VERSION}")
     api("com.mojang:logging:${MOJANG_LOGGING_VERSION}")
-    api "net.minecraftforge:JarJar:${JARJAR_VERSION}"
+    api "net.minecraftforge:JarJar:${JARJAR_VERSION}:all"
 
     implementation("net.sf.jopt-simple:jopt-simple:${JOPT_SIMPLE_VERSION}")
     implementation("cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}")

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -13,8 +13,8 @@ import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.ModFileLoadingException;
 import net.minecraftforge.jarjar.selection.JarSelector;
-import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.VersionRange;
+import net.minecraftforge.jarjar.thedarkside.org.apache.maven.artifact.versioning.ArtifactVersion;
+import net.minecraftforge.jarjar.thedarkside.org.apache.maven.artifact.versioning.VersionRange;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -13,8 +13,8 @@ import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.ModFileLoadingException;
 import net.minecraftforge.jarjar.selection.JarSelector;
-import net.minecraftforge.jarjar.thedarkside.org.apache.maven.artifact.versioning.ArtifactVersion;
-import net.minecraftforge.jarjar.thedarkside.org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -45,7 +45,6 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
     {
         final List<IModFile> sources = Lists.newArrayList();
         loadedMods.forEach(sources::add);
-
 
         final List<IModFile> dependenciesToLoad = JarSelector.detectAndSelect(sources, this::loadResourceFromModFile, this::loadModFileFrom, this::identifyMod, this::exception);
 

--- a/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
+++ b/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
@@ -25,6 +25,7 @@ import org.objectweb.asm.Type;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,9 @@ public class TestFramework {
     public TestFramework() {
         prepareLogger();
 
-        LOGGER.info("Preparing all event tests.");
+        //THIS IS DISABLED FOR NOW UNTILL IT ACTUALLY WORKS.
+        //THIS CRASHES THE DEDICATED TEST SERVER.
+/*        LOGGER.info("Preparing all event tests.");
 
         tests = gatherEvents();
         // Let each event set up
@@ -67,7 +70,9 @@ public class TestFramework {
 
         // Register the game shutting down listener.
         // If there are any unhandled tests after shutdown, notify of an event not fired.
-        MinecraftForge.EVENT_BUS.addListener(this::collectMissedTests);
+        MinecraftForge.EVENT_BUS.addListener(this::collectMissedTests);*/
+
+        tests = Collections.emptyList();
     }
 
     /**

--- a/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
+++ b/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
@@ -25,7 +25,6 @@ import org.objectweb.asm.Type;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,8 +55,6 @@ public class TestFramework {
     public TestFramework() {
         prepareLogger();
 
-        //THIS IS DISABLED FOR NOW UNTILL IT ACTUALLY WORKS.
-        //THIS CRASHES THE DEDICATED TEST SERVER.
         LOGGER.info("Preparing all event tests.");
 
         tests = gatherEvents();

--- a/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
+++ b/src/test/java/net/minecraftforge/eventtest/internal/TestFramework.java
@@ -58,7 +58,7 @@ public class TestFramework {
 
         //THIS IS DISABLED FOR NOW UNTILL IT ACTUALLY WORKS.
         //THIS CRASHES THE DEDICATED TEST SERVER.
-/*        LOGGER.info("Preparing all event tests.");
+        LOGGER.info("Preparing all event tests.");
 
         tests = gatherEvents();
         // Let each event set up
@@ -70,9 +70,7 @@ public class TestFramework {
 
         // Register the game shutting down listener.
         // If there are any unhandled tests after shutdown, notify of an event not fired.
-        MinecraftForge.EVENT_BUS.addListener(this::collectMissedTests);*/
-
-        tests = Collections.emptyList();
+        MinecraftForge.EVENT_BUS.addListener(this::collectMissedTests);
     }
 
     /**


### PR DESCRIPTION
This uses the new JarJar implementation which splits apart its modules into subprojects capable of being loaded in different scenarios separately.

This PR loads the FileSystems from the normal none module classpath (since that is the only place they can be loaded from) and then loads the remaining modules (metadata and selector) from the module path.

Additionally, this makes the required modifications to add the corresponding libs to the proper argument flags on a dedicated server.

Proof of working JiJ on in production dedication server:
![image](https://user-images.githubusercontent.com/5585406/182122638-f9727fa4-98df-43f6-b725-eaf474cc7386.png)

Closes #8910 