### PR TITLE
Grindstone Event

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -13,13 +13,13 @@
        this.m_38897_(new Slot(this.f_39560_, 0, 49, 19) {
           public boolean m_5857_(ItemStack p_39607_) {
 -            return p_39607_.m_41763_() || p_39607_.m_150930_(Items.f_42690_) || p_39607_.m_41793_();
-+            return true;
++            return true; //Allow all items in the slot, not just repairable
           }
        });
        this.m_38897_(new Slot(this.f_39560_, 1, 49, 40) {
           public boolean m_5857_(ItemStack p_39616_) {
 -            return p_39616_.m_41763_() || p_39616_.m_150930_(Items.f_42690_) || p_39616_.m_41793_();
-+            return true;
++            return true; //Allow all items in the slot, not just repairable
           }
        });
        this.m_38897_(new Slot(this.f_39559_, 2, 129, 34) {
@@ -27,16 +27,11 @@
           }
  
           public void m_142406_(Player p_150574_, ItemStack p_150575_) {
-+            GrindstoneMenu.this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneTake(GrindstoneMenu.this.f_39560_.m_8020_(0), GrindstoneMenu.this.f_39560_.m_8020_(1), GrindstoneMenu.this.f_39560_, GrindstoneMenu.this.xp);
++            if (net.minecraftforge.common.ForgeHooks.onGrindstoneTake(GrindstoneMenu.this.f_39560_, p_39568_, this::m_39631_)) return;
              p_39568_.m_39292_((p_39634_, p_39635_) -> {
                 if (p_39634_ instanceof ServerLevel) {
                    ExperienceOrb.m_147082_((ServerLevel)p_39634_, Vec3.m_82512_(p_39635_), this.m_39631_(p_39634_));
-@@ -65,11 +_,10 @@
- 
-                p_39634_.m_46796_(1042, p_39635_, 0);
-             });
--            GrindstoneMenu.this.f_39560_.m_6836_(0, ItemStack.f_41583_);
--            GrindstoneMenu.this.f_39560_.m_6836_(1, ItemStack.f_41583_);
+@@ -70,6 +_,7 @@
           }
  
           private int m_39631_(Level p_39632_) {

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -1,5 +1,58 @@
 --- a/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/net/minecraft/world/inventory/GrindstoneMenu.java
+@@ -34,6 +_,7 @@
+       }
+    };
+    private final ContainerLevelAccess f_39561_;
++   private int xp = -1;
+ 
+    public GrindstoneMenu(int p_39563_, Inventory p_39564_) {
+       this(p_39563_, p_39564_, ContainerLevelAccess.f_39287_);
+@@ -44,12 +_,12 @@
+       this.f_39561_ = p_39568_;
+       this.m_38897_(new Slot(this.f_39560_, 0, 49, 19) {
+          public boolean m_5857_(ItemStack p_39607_) {
+-            return p_39607_.m_41763_() || p_39607_.m_150930_(Items.f_42690_) || p_39607_.m_41793_();
++            return true;
+          }
+       });
+       this.m_38897_(new Slot(this.f_39560_, 1, 49, 40) {
+          public boolean m_5857_(ItemStack p_39616_) {
+-            return p_39616_.m_41763_() || p_39616_.m_150930_(Items.f_42690_) || p_39616_.m_41793_();
++            return true;
+          }
+       });
+       this.m_38897_(new Slot(this.f_39559_, 2, 129, 34) {
+@@ -58,6 +_,7 @@
+          }
+ 
+          public void m_142406_(Player p_150574_, ItemStack p_150575_) {
++            GrindstoneMenu.this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneTake(GrindstoneMenu.this.f_39560_.m_8020_(0), GrindstoneMenu.this.f_39560_.m_8020_(1), GrindstoneMenu.this.f_39560_, GrindstoneMenu.this.xp);
+             p_39568_.m_39292_((p_39634_, p_39635_) -> {
+                if (p_39634_ instanceof ServerLevel) {
+                   ExperienceOrb.m_147082_((ServerLevel)p_39634_, Vec3.m_82512_(p_39635_), this.m_39631_(p_39634_));
+@@ -65,11 +_,10 @@
+ 
+                p_39634_.m_46796_(1042, p_39635_, 0);
+             });
+-            GrindstoneMenu.this.f_39560_.m_6836_(0, ItemStack.f_41583_);
+-            GrindstoneMenu.this.f_39560_.m_6836_(1, ItemStack.f_41583_);
+          }
+ 
+          private int m_39631_(Level p_39632_) {
++            if (xp > -1) return xp;
+             int l = 0;
+             l += this.m_39636_(GrindstoneMenu.this.f_39560_.m_8020_(0));
+             l += this.m_39636_(GrindstoneMenu.this.f_39560_.m_8020_(1));
+@@ -122,6 +_,8 @@
+       ItemStack itemstack1 = this.f_39560_.m_8020_(1);
+       boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
+       boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
++      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, this.f_39559_, this.xp);
++      if (this.xp != Integer.MIN_VALUE) return;
+       if (!flag) {
+          this.f_39559_.m_6836_(0, ItemStack.f_41583_);
+       } else {
 @@ -143,12 +_,13 @@
              }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -726,22 +726,22 @@ public class ForgeHooks
 
     public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Function<Level, Integer> xpFunction)
     {
-        AtomicInteger xp = new AtomicInteger(0);
-        access.execute((l,p) -> xp.set(xpFunction.apply(l)));
-        GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(inputSlots.getItem(0), inputSlots.getItem(1), xp.get());
-        if (MinecraftForge.EVENT_BUS.post(e)) {
-            return false;
-        }
-        access.execute((l, p) -> {
-            if (l instanceof ServerLevel) {
-                ExperienceOrb.award((ServerLevel)l, Vec3.atCenterOf(p), xp.get());
+        access.execute((l,p) -> {
+            int xp = xpFunction.apply(l);
+            GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(inputSlots.getItem(0), inputSlots.getItem(1), xp);
+            if (MinecraftForge.EVENT_BUS.post(e))
+            {
+                return;
             }
-
+            if (l instanceof ServerLevel)
+            {
+                ExperienceOrb.award((ServerLevel)l, Vec3.atCenterOf(p), e.getXp());
+            }
             l.levelEvent(1042, p, 0);
+            inputSlots.setItem(0, e.getNewTopItem());
+            inputSlots.setItem(1, e.getNewBottomItem());
+            inputSlots.setChanged();
         });
-        inputSlots.setItem(0, e.getNewTopItem());
-        inputSlots.setItem(1, e.getNewBottomItem());
-        inputSlots.setChanged();
         return true;
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -100,13 +100,7 @@ import net.minecraftforge.common.loot.LootTableIdCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
-import net.minecraftforge.event.AnvilUpdateEvent;
-import net.minecraftforge.event.DifficultyChangeEvent;
-import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.event.ItemAttributeModifierEvent;
-import net.minecraftforge.event.ServerChatEvent;
-import net.minecraftforge.event.RegisterStructureConversionsEvent;
-import net.minecraftforge.event.VanillaGameEvent;
+import net.minecraftforge.event.*;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
 import net.minecraftforge.event.entity.EntityEvent;
@@ -705,6 +699,30 @@ public class ForgeHooks
         AnvilRepairEvent e = new AnvilRepairEvent(player, left, right, output);
         MinecraftForge.EVENT_BUS.post(e);
         return e.getBreakChance();
+    }
+
+    public static int onGrindstoneChange(@NotNull ItemStack top, @NotNull ItemStack bottom, Container outputSlot, int xp)
+    {
+        GrindstoneEvent.OnplaceItem e = new GrindstoneEvent.OnplaceItem(top, bottom, xp);
+        if (MinecraftForge.EVENT_BUS.post(e)) return e.getXp();
+        if (e.getOutput().isEmpty()) return Integer.MIN_VALUE;
+
+        outputSlot.setItem(0, e.getOutput());
+        return e.getXp();
+    }
+
+    public static int onGrindstoneTake(@NotNull ItemStack top, @NotNull ItemStack bottom, Container inputSlots, int xp) {
+        GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(top, bottom, xp);
+        if (MinecraftForge.EVENT_BUS.post(e)) {
+            inputSlots.setItem(0, top);
+            inputSlots.setItem(1, bottom);
+            inputSlots.setChanged();
+            return e.getXp();
+        }
+        inputSlots.setItem(0, e.getNewTop());
+        inputSlots.setItem(1, e.getNewBottom());
+        inputSlots.setChanged();
+        return e.getXp();
     }
 
     private static ThreadLocal<Player> craftingPlayer = new ThreadLocal<Player>();

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -107,7 +107,7 @@ public abstract class GrindstoneEvent extends Event
      * This event is {@link Cancelable} <br>
      * {@link OnTakeItem} is fired when the output in a grindstone are is taken. <br>
      * It is called from {@link GrindstoneMenu#GrindstoneMenu(int, Inventory)}. <br>
-     * If the event is canceled, vanilla behavior will not run, and the input items will not be consumed. <br>
+     * If the event is canceled, vanilla behavior will run. <br>
      * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
      */
     @Cancelable

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -27,7 +27,7 @@ public abstract class GrindstoneEvent extends Event
     /**
      * @return The item in the top input grindstone slot. <br>
      */
-    public ItemStack getTop()
+    public ItemStack getTopItem()
     {
         return top;
     }
@@ -35,7 +35,7 @@ public abstract class GrindstoneEvent extends Event
     /**
      * @return The item in the bottom input grindstone slot. <br>
      */
-    public ItemStack getBottom()
+    public ItemStack getBottomItem()
     {
         return bottom;
     }
@@ -62,6 +62,7 @@ public abstract class GrindstoneEvent extends Event
     }
 
     /**
+     * This event is {@link Cancelable} <br>
      * {@link OnplaceItem} is fired when the inputs to a grindstone are changed. <br>
      * It is called from {@link GrindstoneMenu#createResult()}. <br>
      * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
@@ -74,7 +75,8 @@ public abstract class GrindstoneEvent extends Event
     {
         private ItemStack output;
 
-        public OnplaceItem(ItemStack top, ItemStack bottom, int xp) {
+        public OnplaceItem(ItemStack top, ItemStack bottom, int xp)
+        {
             super(top, bottom, xp);
             this.output = ItemStack.EMPTY;
         }
@@ -102,6 +104,7 @@ public abstract class GrindstoneEvent extends Event
     }
 
     /**
+     * This event is {@link Cancelable} <br>
      * {@link OnTakeItem} is fired when the output in a grindstone are is taken. <br>
      * It is called from {@link GrindstoneMenu#GrindstoneMenu(int, Inventory)}. <br>
      * If the event is canceled, vanilla behavior will not run, and the input items will not be consumed. <br>
@@ -113,21 +116,24 @@ public abstract class GrindstoneEvent extends Event
         private ItemStack newTop = ItemStack.EMPTY;
         private ItemStack newBottom = ItemStack.EMPTY;
 
-        public OnTakeItem(ItemStack top, ItemStack bottom, int xp) {
+        public OnTakeItem(ItemStack top, ItemStack bottom, int xp)
+        {
             super(top, bottom, xp);
         }
 
         /**
          * @return The item in that will be in the top input grindstone slot after the event. <br>
          */
-        public ItemStack getNewTop() {
+        public ItemStack getNewTopItem()
+        {
             return newTop;
         }
 
         /**
          * @return The item in that will be in the bottom input grindstone slot after the event. <br>
          */
-        public ItemStack getNewBottom() {
+        public ItemStack getNewBottomItem()
+        {
             return newBottom;
         }
 
@@ -135,7 +141,8 @@ public abstract class GrindstoneEvent extends Event
          * Sets the itemstack in the top slot. <br>
          * @param newTop
          */
-        public void setNewTop(ItemStack newTop) {
+        public void setNewTopItem(ItemStack newTop)
+        {
             this.newTop = newTop;
         }
 
@@ -143,8 +150,18 @@ public abstract class GrindstoneEvent extends Event
          * Sets the itemstack in the bottom slot. <br>
          * @param newBottom
          */
-        public void setNewBottom(ItemStack newBottom) {
+        public void setNewBottomItem(ItemStack newBottom)
+        {
             this.newBottom = newBottom;
+        }
+
+        /**
+         * This is the experience amount that would be returned by the event. <br>
+         * @return The experience amount given to the player. <br>
+         */
+        public int getXp()
+        {
+            return super.getXp();
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -107,7 +107,7 @@ public abstract class GrindstoneEvent extends Event
      * This event is {@link Cancelable} <br>
      * {@link OnTakeItem} is fired when the output in a grindstone are is taken. <br>
      * It is called from {@link GrindstoneMenu#GrindstoneMenu(int, Inventory)}. <br>
-     * If the event is canceled, vanilla behavior will run. <br>
+     * If the event is canceled, vanilla behavior will not run, and no inputs will be consumed. <br>
      * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
      */
     @Cancelable
@@ -156,7 +156,7 @@ public abstract class GrindstoneEvent extends Event
         }
 
         /**
-         * This is the experience amount that would be returned by the event. <br>
+         * This is the experience amount that will be returned by the event. <br>
          * @return The experience amount given to the player. <br>
          */
         public int getXp()

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.GrindstoneMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+public abstract class GrindstoneEvent extends Event
+{
+    private final ItemStack top;
+    private final ItemStack bottom;
+    private int xp;
+
+    protected GrindstoneEvent(ItemStack top, ItemStack bottom, int xp)
+    {
+        this.top = top;
+        this.bottom = bottom;
+        this.xp = xp;
+    }
+
+    /**
+     * @return The item in the top input grindstone slot. <br>
+     */
+    public ItemStack getTop()
+    {
+        return top;
+    }
+
+    /**
+     * @return The item in the bottom input grindstone slot. <br>
+     */
+    public ItemStack getBottom()
+    {
+        return bottom;
+    }
+
+    /**
+     * This is the experience amount determined by the event, not the vanilla behavior. <br>
+     * If you are the first receiver of this event, it is guaranteed to be -1. <br>
+     * The value must be set to a positive value to override vanilla behavior. <br>
+     * if the value is equal to -1, the vanilla behavior for calculating experience will run. <br>
+     * @return The experience amount given to the player. <br>
+     */
+    public int getXp()
+    {
+        return xp;
+    }
+
+    /**
+     * Sets the experience amount. <br>
+     * @param xp The experience amount given to the player. <br>
+     */
+    public void setXp(int xp)
+    {
+        this.xp = xp;
+    }
+
+    /**
+     * {@link OnplaceItem} is fired when the inputs to a grindstone are changed. <br>
+     * It is called from {@link GrindstoneMenu#createResult()}. <br>
+     * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
+     * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
+     * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
+     * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
+     */
+    @Cancelable
+    public static class OnplaceItem extends GrindstoneEvent
+    {
+        private ItemStack output;
+
+        public OnplaceItem(ItemStack top, ItemStack bottom, int xp) {
+            super(top, bottom, xp);
+            this.output = ItemStack.EMPTY;
+        }
+
+        /**
+         * This is the output as determined by the event, not by the vanilla behavior between these two items. <br>
+         * If you are the first receiver of this event, it is guaranteed to be empty. <br>
+         * It will only be non-empty if changed by an event handler. <br>
+         * If this event is cancelled, this output stack is discarded. <br>
+         * @return The item to set in the output grindstone slot. <br>
+         */
+        public ItemStack getOutput()
+        {
+            return output;
+        }
+
+        /**
+         * Sets the output slot to a specific itemstack.
+         * @param output The stack to change the output to.
+         */
+        public void setOutput(ItemStack output)
+        {
+            this.output = output;
+        }
+    }
+
+    /**
+     * {@link OnTakeItem} is fired when the output in a grindstone are is taken. <br>
+     * It is called from {@link GrindstoneMenu#GrindstoneMenu(int, Inventory)}. <br>
+     * If the event is canceled, vanilla behavior will not run, and the input items will not be consumed. <br>
+     * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
+     */
+    @Cancelable
+    public static class OnTakeItem extends GrindstoneEvent
+    {
+        private ItemStack newTop = ItemStack.EMPTY;
+        private ItemStack newBottom = ItemStack.EMPTY;
+
+        public OnTakeItem(ItemStack top, ItemStack bottom, int xp) {
+            super(top, bottom, xp);
+        }
+
+        /**
+         * @return The item in that will be in the top input grindstone slot after the event. <br>
+         */
+        public ItemStack getNewTop() {
+            return newTop;
+        }
+
+        /**
+         * @return The item in that will be in the bottom input grindstone slot after the event. <br>
+         */
+        public ItemStack getNewBottom() {
+            return newBottom;
+        }
+
+        /**
+         * Sets the itemstack in the top slot. <br>
+         * @param newTop
+         */
+        public void setNewTop(ItemStack newTop) {
+            this.newTop = newTop;
+        }
+
+        /**
+         * Sets the itemstack in the bottom slot. <br>
+         * @param newBottom
+         */
+        public void setNewBottom(ItemStack newBottom) {
+            this.newBottom = newBottom;
+        }
+    }
+}


### PR DESCRIPTION
Made 2 grindstone events, one to modify the output, and one to modify the input. An update of #8578 

OnplaceItem is called when an item is placed in the grindstone. This is for changing the output item and experience you get.

OnTakeItem is called when the item is taken from the grindstone. This is used for changing the input slots or experience when the output is taken.

I am aware the patch for OnTakeItem changes a lot. Maybe doing this all in `ForgeHooks` and always returning would be better? 

Test mod: https://gist.github.com/ferriarnus/806dc56b50edde6c1db925d577fa560e
 