### PR TITLE
[1.19] Allow custom outline rendering on EntityRenderers and BlockEntityRenderers

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -51,6 +51,16 @@
                 ++this.f_109439_;
                 if (entity.f_19797_ == 0) {
                    entity.f_19790_ = entity.m_20185_();
+@@ -1206,6 +_,9 @@
+                   int i1 = i & 255;
+                   outlinebuffersource.m_109929_(k, l, i1, 255);
+                } else {
++                  if (this.m_109817_() && entity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++                     flag3 = true;
++                  }
+                   multibuffersource = multibuffersource$buffersource;
+                }
+ 
 @@ -1226,6 +_,7 @@
           List<BlockEntity> list = levelrenderer$renderchunkinfo.f_109839_.m_112835_().m_112773_();
           if (!list.isEmpty()) {
@@ -59,7 +69,17 @@
                 BlockPos blockpos4 = blockentity1.m_58899_();
                 MultiBufferSource multibuffersource1 = multibuffersource$buffersource;
                 p_109600_.m_85836_();
-@@ -1251,6 +_,7 @@
+@@ -1242,6 +_,9 @@
+                      };
+                   }
+                }
++               if (this.m_109817_() && blockentity1.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++                  flag3 = true;
++               }
+ 
+                this.f_172946_.m_112267_(blockentity1, p_109601_, p_109600_, multibuffersource1);
+                p_109600_.m_85849_();
+@@ -1251,9 +_,13 @@
  
        synchronized(this.f_109468_) {
           for(BlockEntity blockentity : this.f_109468_) {
@@ -67,6 +87,12 @@
              BlockPos blockpos3 = blockentity.m_58899_();
              p_109600_.m_85836_();
              p_109600_.m_85837_((double)blockpos3.m_123341_() - d0, (double)blockpos3.m_123342_() - d1, (double)blockpos3.m_123343_() - d2);
++            if (this.m_109817_() && blockentity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++               flag3 = true;
++            }
+             this.f_172946_.m_112267_(blockentity, p_109601_, p_109600_, multibuffersource$buffersource);
+             p_109600_.m_85849_();
+          }
 @@ -1290,7 +_,8 @@
                 p_109600_.m_85837_((double)blockpos2.m_123341_() - d0, (double)blockpos2.m_123342_() - d1, (double)blockpos2.m_123343_() - d2);
                 PoseStack.Pose posestack$pose = p_109600_.m_85850_();

--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -55,7 +55,7 @@
                    int i1 = i & 255;
                    outlinebuffersource.m_109929_(k, l, i1, 255);
                 } else {
-+                  if (this.m_109817_() && entity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++                  if (this.m_109817_() && entity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) { // FORGE: allow custom outline rendering
 +                     flag3 = true;
 +                  }
                    multibuffersource = multibuffersource$buffersource;
@@ -73,7 +73,7 @@
                       };
                    }
                 }
-+               if (this.m_109817_() && blockentity1.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++               if (this.m_109817_() && blockentity1.hasCustomOutlineRendering(this.f_109461_.f_91074_)) { // FORGE: allow custom outline rendering
 +                  flag3 = true;
 +               }
  
@@ -87,7 +87,7 @@
              BlockPos blockpos3 = blockentity.m_58899_();
              p_109600_.m_85836_();
              p_109600_.m_85837_((double)blockpos3.m_123341_() - d0, (double)blockpos3.m_123342_() - d1, (double)blockpos3.m_123343_() - d2);
-+            if (this.m_109817_() && blockentity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) {
++            if (this.m_109817_() && blockentity.hasCustomOutlineRendering(this.f_109461_.f_91074_)) { // FORGE: allow custom outline rendering
 +               flag3 = true;
 +            }
              this.f_172946_.m_112267_(blockentity, p_109601_, p_109600_, multibuffersource$buffersource);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
@@ -177,9 +177,10 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
      }
 
     /**
-     * Returns whether this {@link BlockEntity} has custom outline rendering behaviour
-     * @param player The local player currently viewing this {@code BlockEntity}
-     * @return true to enable outline processing
+     * Returns whether this {@link BlockEntity} has custom outline rendering behavior.
+     *
+     * @param player the local player currently viewing this {@code BlockEntity}
+     * @return {@code true} to enable outline processing
      */
     default boolean hasCustomOutlineRendering(Player player)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -174,4 +175,14 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
      {
          return ModelData.EMPTY;
      }
+
+    /**
+     * Returns whether this {@link BlockEntity} has custom outline rendering behaviour
+     * @param player The local player currently viewing this {@code BlockEntity}
+     * @return true to enable outline processing
+     */
+    default boolean hasCustomOutlineRendering(Player player)
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -413,11 +413,12 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Returns whether this {@link Entity} has custom outline rendering behaviour which does
+     * Returns whether this {@link Entity} has custom outline rendering behavior which does
      * not use the existing automatic outline rendering based on {@link Entity#isCurrentlyGlowing()}
      * and the entity's team color.
-     * @param player The local player currently viewing this {@code Entity}
-     * @return true to enable outline processing
+     *
+     * @param player the local player currently viewing this {@code Entity}
+     * @return {@code true} to enable outline processing
      */
     default boolean hasCustomOutlineRendering(Player player)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
@@ -409,5 +410,17 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     default SoundEvent getSoundFromFluidType(FluidType type, SoundAction action)
     {
         return type.getSound(self(), action);
+    }
+
+    /**
+     * Returns whether this {@link Entity} has custom outline rendering behaviour which does
+     * not use the existing automatic outline rendering based on {@link Entity#isCurrentlyGlowing()}
+     * and the entity's team color.
+     * @param player The local player currently viewing this {@code Entity}
+     * @return true to enable outline processing
+     */
+    default boolean hasCustomOutlineRendering(Player player)
+    {
+        return false;
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -77,6 +77,7 @@ public net.minecraft.client.particle.ParticleEngine m_107381_(Lnet/minecraft/cor
 public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration
 public net.minecraft.client.player.LocalPlayer m_8088_()I # getPermissionLevel
 public net.minecraft.client.renderer.GameRenderer m_109128_(Lnet/minecraft/resources/ResourceLocation;)V # loadEffect
+public net.minecraft.client.renderer.LevelRenderer m_109817_()Z # shouldShowEntityOutlines
 protected-f net.minecraft.client.renderer.RenderStateShard f_110131_ # setupState
 public net.minecraft.client.renderer.RenderStateShard$BooleanStateShard
 public net.minecraft.client.renderer.RenderStateShard$CullStateShard


### PR DESCRIPTION
This PR allows `EntityRenderers` and `BlockEntityRenderers` to render custom glowing outlines, bypassing the heavily limited automatic outline rendering on entities based on `Entity#isCurrentlyGlowing()` and the entity's team color.

---

Without theses changes, `BlockEntityRenderer`s cannot use the outline rendering at all and `EntityRenderer`s are limited to rendering the full model into the outline buffer with the entity's team color as the outline color and for every player that can see the entity.
If the outline buffer is used in either renderer without a glowing entity being rendered, the outline buffer will produce a flat colored overlay on the rendered surfaces instead of the outlines (example: https://discord.com/channels/313125603924639766/915304642668290119/982126474423304213).

With these changes, both `BlockEntityRenderer`s and `EntityRenderer`s can do fully custom outline rendering, including controlling the color, who can see it, which elements are pushed into the outline buffer, etc.
Returning `true` from the added methods will enable the outline processing, everything else is left to the implementor.

---

Example of the `ChestBlockEntity` and `ChestRenderer` modified in Forge dev to use this:
![2022-08-03_19 25 49](https://user-images.githubusercontent.com/11262040/182676073-8c1d6417-c18c-4232-8c73-77bc4f1ceb43.png)