### PR TITLE
Add support for handling chunk generators in DFU

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -61,7 +61,7 @@
        this.f_90987_ = new TextureManager(this.f_91036_);
        this.f_91036_.m_7217_(this.f_90987_);
        this.f_91050_ = new SkinManager(this.f_90987_, new File(file1, "skins"), this.f_91048_);
-+      this.f_90988_ = DataFixers.m_14512_();
++      this.f_90988_ = DataFixers.m_14512_(); // FORGE: Move DFU init to below mod loading.
 +      this.f_91000_ = new HotbarManager(this.f_91069_, this.f_90988_);
        this.f_91031_ = new LevelStorageSource(this.f_91069_.toPath().resolve("saves"), this.f_91069_.toPath().resolve("backups"), this.f_90988_);
        this.f_91043_ = new SoundManager(this.f_91036_, this.f_91066_);

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -26,6 +26,20 @@
        this.f_91033_ = p_91084_.f_101908_.f_101926_;
        this.f_91034_ = !p_91084_.f_101908_.f_101929_;
        this.f_91035_ = !p_91084_.f_101908_.f_101930_;
+@@ -422,13 +_,11 @@
+       }
+ 
+       KeybindResolver.m_237364_(KeyMapping::m_90842_);
+-      this.f_90988_ = DataFixers.m_14512_();
+       this.f_91003_ = new ToastComponent(this);
+       this.f_91018_ = Thread.currentThread();
+       this.f_91066_ = new Options(this, this.f_91069_);
+       this.f_91019_ = true;
+       this.f_91005_ = new Tutorial(this, this.f_91066_);
+-      this.f_91000_ = new HotbarManager(this.f_91069_, this.f_90988_);
+       f_90982_.info("Backend library: {}", (Object)RenderSystem.m_69517_());
+       DisplayData displaydata;
+       if (this.f_91066_.f_92129_ > 0 && this.f_91066_.f_92128_ > 0) {
 @@ -457,7 +_,7 @@
  
        this.f_90990_.m_85380_(this.f_91066_.m_232035_().m_231551_());
@@ -43,6 +57,15 @@
        this.f_91038_.m_10506_();
        this.f_91066_.m_92145_(this.f_91038_);
        this.f_91039_ = new LanguageManager(this.f_91066_.f_92075_);
+@@ -472,6 +_,8 @@
+       this.f_90987_ = new TextureManager(this.f_91036_);
+       this.f_91036_.m_7217_(this.f_90987_);
+       this.f_91050_ = new SkinManager(this.f_90987_, new File(file1, "skins"), this.f_91048_);
++      this.f_90988_ = DataFixers.m_14512_();
++      this.f_91000_ = new HotbarManager(this.f_91069_, this.f_90988_);
+       this.f_91031_ = new LevelStorageSource(this.f_91069_.toPath().resolve("saves"), this.f_91069_.toPath().resolve("backups"), this.f_90988_);
+       this.f_91043_ = new SoundManager(this.f_91036_, this.f_91066_);
+       this.f_91036_.m_7217_(this.f_91043_);
 @@ -509,10 +_,12 @@
        this.f_91063_ = new GameRenderer(this, this.f_90994_.m_234586_(), this.f_91036_, this.f_90993_);
        this.f_91036_.m_7217_(this.f_91063_);

--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -61,13 +61,12 @@
              @Nullable
              private String m_168458_(String p_168459_) {
                 return compoundtag1.m_128441_(p_168459_) ? compoundtag1.m_128461_(p_168459_) : null;
-@@ -1071,6 +_,9 @@
+@@ -1071,6 +_,8 @@
     }
  
     private CompoundTag m_92164_(CompoundTag p_92165_) {
-+      if (Minecraft.m_91087_().m_91295_() == null)
++      if (Minecraft.m_91087_().m_91295_() == null) // FORGE: Can be null when inited for the first time.
 +         return p_92165_;
-+
        int i = 0;
  
        try {

--- a/patches/minecraft/net/minecraft/client/Options.java.patch
+++ b/patches/minecraft/net/minecraft/client/Options.java.patch
@@ -61,6 +61,16 @@
              @Nullable
              private String m_168458_(String p_168459_) {
                 return compoundtag1.m_128441_(p_168459_) ? compoundtag1.m_128461_(p_168459_) : null;
+@@ -1071,6 +_,9 @@
+    }
+ 
+    private CompoundTag m_92164_(CompoundTag p_92165_) {
++      if (Minecraft.m_91087_().m_91295_() == null)
++         return p_92165_;
++
+       int i = 0;
+ 
+       try {
 @@ -1082,6 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/util/datafix/schemas/V2832.java.patch
+++ b/patches/minecraft/net/minecraft/util/datafix/schemas/V2832.java.patch
@@ -1,19 +1,11 @@
 --- a/net/minecraft/util/datafix/schemas/V2832.java
 +++ b/net/minecraft/util/datafix/schemas/V2832.java
-@@ -7,6 +_,7 @@
- import java.util.Map;
- import java.util.function.Supplier;
- import net.minecraft.util.datafix.fixes.References;
-+import net.minecraftforge.datafix.ForgeDSL;
- 
- public class V2832 extends NamespacedSchema {
-    public V2832(int p_185217_, Schema p_185218_) {
 @@ -19,7 +_,7 @@
           return DSL.fields("Level", DSL.optionalFields("Entities", DSL.list(References.f_16785_.in(p_185234_)), "TileEntities", DSL.list(DSL.or(References.f_16781_.in(p_185234_), DSL.remainder())), "TileTicks", DSL.list(DSL.fields("i", References.f_16787_.in(p_185234_))), "Sections", DSL.list(DSL.optionalFields("biomes", DSL.optionalFields("palette", DSL.list(References.f_16794_.in(p_185234_))), "block_states", DSL.optionalFields("palette", DSL.list(References.f_16783_.in(p_185234_))))), "Structures", DSL.optionalFields("Starts", DSL.compoundList(References.f_16790_.in(p_185234_)))));
        });
        p_185234_.registerType(false, References.f_16795_, () -> {
 -         return DSL.fields("dimensions", DSL.compoundList(DSL.constType(m_17310_()), DSL.fields("generator", DSL.taggedChoiceLazy("type", DSL.string(), ImmutableMap.of("minecraft:debug", DSL::remainder, "minecraft:flat", () -> {
-+         return DSL.fields("dimensions", DSL.compoundList(DSL.constType(m_17310_()), DSL.fields("generator", ForgeDSL.taggedChoiceLazy(V2832.class, "type", DSL.string(), ImmutableMap.of("minecraft:debug", DSL::remainder, "minecraft:flat", () -> {
++         return DSL.fields("dimensions", DSL.compoundList(DSL.constType(m_17310_()), DSL.fields("generator", net.minecraftforge.datafix.ForgeDSL.taggedChoiceLazy(V2832.class, "type", DSL.string(), ImmutableMap.of("minecraft:debug", DSL::remainder, "minecraft:flat", () -> {
              return DSL.optionalFields("settings", DSL.optionalFields("biome", References.f_16794_.in(p_185234_), "layers", DSL.list(DSL.optionalFields("block", References.f_16787_.in(p_185234_)))));
           }, "minecraft:noise", () -> {
              return DSL.optionalFields("biome_source", DSL.taggedChoiceLazy("type", DSL.string(), ImmutableMap.of("minecraft:fixed", () -> {

--- a/patches/minecraft/net/minecraft/util/datafix/schemas/V2832.java.patch
+++ b/patches/minecraft/net/minecraft/util/datafix/schemas/V2832.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/util/datafix/schemas/V2832.java
++++ b/net/minecraft/util/datafix/schemas/V2832.java
+@@ -7,6 +_,7 @@
+ import java.util.Map;
+ import java.util.function.Supplier;
+ import net.minecraft.util.datafix.fixes.References;
++import net.minecraftforge.datafix.ForgeDSL;
+ 
+ public class V2832 extends NamespacedSchema {
+    public V2832(int p_185217_, Schema p_185218_) {
+@@ -19,7 +_,7 @@
+          return DSL.fields("Level", DSL.optionalFields("Entities", DSL.list(References.f_16785_.in(p_185234_)), "TileEntities", DSL.list(DSL.or(References.f_16781_.in(p_185234_), DSL.remainder())), "TileTicks", DSL.list(DSL.fields("i", References.f_16787_.in(p_185234_))), "Sections", DSL.list(DSL.optionalFields("biomes", DSL.optionalFields("palette", DSL.list(References.f_16794_.in(p_185234_))), "block_states", DSL.optionalFields("palette", DSL.list(References.f_16783_.in(p_185234_))))), "Structures", DSL.optionalFields("Starts", DSL.compoundList(References.f_16790_.in(p_185234_)))));
+       });
+       p_185234_.registerType(false, References.f_16795_, () -> {
+-         return DSL.fields("dimensions", DSL.compoundList(DSL.constType(m_17310_()), DSL.fields("generator", DSL.taggedChoiceLazy("type", DSL.string(), ImmutableMap.of("minecraft:debug", DSL::remainder, "minecraft:flat", () -> {
++         return DSL.fields("dimensions", DSL.compoundList(DSL.constType(m_17310_()), DSL.fields("generator", ForgeDSL.taggedChoiceLazy(V2832.class, "type", DSL.string(), ImmutableMap.of("minecraft:debug", DSL::remainder, "minecraft:flat", () -> {
+             return DSL.optionalFields("settings", DSL.optionalFields("biome", References.f_16794_.in(p_185234_), "layers", DSL.list(DSL.optionalFields("block", References.f_16787_.in(p_185234_)))));
+          }, "minecraft:noise", () -> {
+             return DSL.optionalFields("biome_source", DSL.taggedChoiceLazy("type", DSL.string(), ImmutableMap.of("minecraft:fixed", () -> {

--- a/patches/minecraft/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/EntityType.java.patch
@@ -90,7 +90,7 @@
        private Builder(EntityType.EntityFactory<T> p_20696_, MobCategory p_20697_) {
           this.f_20685_ = p_20696_;
           this.f_20686_ = p_20697_;
-@@ -641,12 +_,36 @@
+@@ -641,12 +_,37 @@
           return this;
        }
  
@@ -119,8 +119,8 @@
 +      }
 +
        public EntityType<T> m_20712_(String p_20713_) {
--         if (this.f_20688_) {
-+         if (this.f_20688_ && false) {
++         if(false) // FORGE: Do not preinitialize DFU via static init of Bootstrap, it is not needed in production.
+          if (this.f_20688_) {
              Util.m_137456_(References.f_16785_, p_20713_);
           }
  

--- a/patches/minecraft/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/EntityType.java.patch
@@ -119,7 +119,8 @@
 +      }
 +
        public EntityType<T> m_20712_(String p_20713_) {
-          if (this.f_20688_) {
+-         if (this.f_20688_) {
++         if (this.f_20688_ && false) {
              Util.m_137456_(References.f_16785_, p_20713_);
           }
  

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -5,7 +5,7 @@
        }
  
 -      Type<?> type = Util.m_137456_(References.f_16781_, p_58957_);
-+      Type<?> type = null; //Util.fetchChoiceType(References.BLOCK_ENTITY, p_58957_);
++      Type<?> type = null; //Util.fetchChoiceType(References.BLOCK_ENTITY, p_58957_); FORGE: Do not preinitialize DFU via static init of Bootstrap, it is not needed in production.
        return Registry.m_122961_(Registry.f_122830_, p_58957_, p_58958_.m_58966_(type));
     }
  

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/entity/BlockEntityType.java
++++ b/net/minecraft/world/level/block/entity/BlockEntityType.java
+@@ -69,7 +_,7 @@
+          f_58913_.warn("Block entity type {} requires at least one valid block to be defined!", (Object)p_58957_);
+       }
+ 
+-      Type<?> type = Util.m_137456_(References.f_16781_, p_58957_);
++      Type<?> type = null; //Util.fetchChoiceType(References.BLOCK_ENTITY, p_58957_);
+       return Registry.m_122961_(Registry.f_122830_, p_58957_, p_58958_.m_58966_(type));
+    }
+ 

--- a/src/main/java/net/minecraftforge/datafix/ForgeDSL.java
+++ b/src/main/java/net/minecraftforge/datafix/ForgeDSL.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.datafix;
+
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.Type;
+import com.mojang.datafixers.types.templates.TaggedChoice;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import net.minecraftforge.datafix.event.DataFixEvent;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ForgeDSL
+{
+
+    private ForgeDSL()
+    {
+        throw new IllegalStateException("Can not instantiate an instance of: ForgeDSL. This is a utility class");
+    }
+
+    public static <K> TaggedChoice<K> taggedChoiceLazy(final Class<? extends Schema> schemaClass, final String name, final Type<K> keyType, final Map<K, Supplier<TypeTemplate>> templates) {
+        final Map<K, Supplier<TypeTemplate>> finalValues = DataFixEvent.EventFactory.fireTaggedChoiceFor(schemaClass, name, keyType, templates);
+        return DSL.taggedChoiceLazy(name, keyType, finalValues);
+    }
+}

--- a/src/main/java/net/minecraftforge/datafix/event/DataFixEvent.java
+++ b/src/main/java/net/minecraftforge/datafix/event/DataFixEvent.java
@@ -1,0 +1,94 @@
+package net.minecraftforge.datafix.event;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.Type;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModLoader;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.event.IModBusEvent;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+public class DataFixEvent extends Event implements IModBusEvent
+{
+    public static final class EventFactory {
+
+        public static <K> Map<K, Supplier<TypeTemplate>> fireTaggedChoiceFor(final Class<? extends Schema> schemaClass, final String name, final Type<K> keyType, final Map<K, Supplier<TypeTemplate>> templates) {
+            final ConfigureTaggedChoice<K> event = new ConfigureTaggedChoice<>(schemaClass, name, keyType, templates);
+
+            ModLoader.get().postEventWithWrapInModOrder(
+                    event,
+                    (mc, e) -> ModLoadingContext.get().setActiveContainer(mc),
+                    (mc, e) -> ModLoadingContext.get().setActiveContainer(null)
+            );
+
+            return event.build();
+        }
+    }
+
+    public static class SchemaConstruction extends DataFixEvent {
+        private final Class<? extends Schema> schemaClass;
+
+        public SchemaConstruction(final Class<? extends Schema> schemaClass) {this.schemaClass = schemaClass;}
+
+        public Class<? extends Schema> getSchemaClass()
+        {
+            return schemaClass;
+        }
+    }
+
+    public static class ConfigureTaggedChoice<K> extends SchemaConstruction {
+        private final String name;
+        private final Type<K> keyType;
+        private final Map<K, Supplier<TypeTemplate>> vanillaChoices;
+        private final Map<K, Supplier<TypeTemplate>> modChoices = Maps.newConcurrentMap();
+        private final Map<K, Supplier<TypeTemplate>> modChoicesView = Collections.unmodifiableMap(modChoices);
+
+        public ConfigureTaggedChoice(final Class<? extends Schema> schemaClass, final String name, final Type<K> keyType , final Map<K, Supplier<TypeTemplate>> vanillaChoices)
+        {
+            super(schemaClass);
+            this.name = name;
+            this.keyType = keyType;
+            this.vanillaChoices = Collections.unmodifiableMap(vanillaChoices);
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public Type<K> getKeyType()
+        {
+            return keyType;
+        }
+
+        public Map<K, Supplier<TypeTemplate>> getVanillaChoices()
+        {
+            return vanillaChoices;
+        }
+
+        public Map<K, Supplier<TypeTemplate>> getModChoices()
+        {
+            return modChoicesView;
+        }
+
+        public ConfigureTaggedChoice<K> register(final K name, final Supplier<TypeTemplate> builder) {
+            this.modChoices.put(name, builder);
+            return this;
+        }
+
+        private Map<K, Supplier<TypeTemplate>> build() {
+            final ImmutableMap.Builder<K, Supplier<TypeTemplate>> builder = ImmutableMap.builder();
+            builder.putAll(vanillaChoices);
+            builder.putAll(modChoices);
+            return builder.build();
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/SandboxChunkGeneratorTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/SandboxChunkGeneratorTest.java
@@ -1,0 +1,162 @@
+package net.minecraftforge.debug.world;
+
+import com.mojang.datafixers.DSL;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.util.datafix.schemas.V2832;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.NoiseColumn;
+import net.minecraft.world.level.StructureManager;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.biome.FixedBiomeSource;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.blending.Blender;
+import net.minecraft.world.level.levelgen.structure.StructureSet;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.datafix.event.DataFixEvent;
+import net.minecraftforge.eventbus.api.GenericEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+@Mod(SandboxChunkGeneratorTest.MODID)
+public class SandboxChunkGeneratorTest
+{
+    public static final String MODID = "sandbox";
+
+    private static final DeferredRegister<Codec<? extends ChunkGenerator>> CHUNK_GENERATORS = DeferredRegister.create(Registry.CHUNK_GENERATOR_REGISTRY, MODID);
+    public static final RegistryObject<Codec<? extends ChunkGenerator>> TEST_CHUNK_GENERATOR = CHUNK_GENERATORS.register("test", TestChunkGenerator::makeCodec);
+
+    public SandboxChunkGeneratorTest() // invoked by forge due to @Mod
+    {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        IEventBus forgeBus = MinecraftForge.EVENT_BUS;
+
+        CHUNK_GENERATORS.register(modBus);
+        modBus.register(new DFUConfigurator());
+    }
+
+    public static class DFUConfigurator {
+
+        @SubscribeEvent
+        public final void configueDFUSchema(final DataFixEvent.ConfigureTaggedChoice<String> event) {
+            if (event.getSchemaClass() == V2832.class && Objects.equals(event.getName(), "type")) {
+                event.register("sandbox:test", DSL::remainder);
+            }
+        }
+    }
+
+    public static class TestChunkGenerator extends ChunkGenerator
+    {
+        public static Codec<? extends ChunkGenerator> makeCodec()
+        {
+            Codec<TestChunkGenerator> codec = RecordCodecBuilder.create(builder -> builder.group(
+                                                                                                  RegistryOps.retrieveRegistry(Registry.STRUCTURE_SET_REGISTRY).forGetter(generator -> generator.structureSets),
+                                                                                                  RegistryOps.retrieveRegistry(Registry.BIOME_REGISTRY).forGetter(generator -> generator.biomes))
+                                                                                          .apply(builder, TestChunkGenerator::new));
+            return codec;
+        }
+
+        private final Registry<Biome> biomes;
+
+        public TestChunkGenerator(Registry<StructureSet> structures, Registry<Biome> biomes)
+        {
+            super(structures, Optional.empty(), new FixedBiomeSource(biomes.getOrCreateHolderOrThrow(Biomes.PLAINS)));
+            this.biomes = biomes;
+        }
+
+        @Override
+        protected Codec<? extends ChunkGenerator> codec()
+        {
+            return SandboxChunkGeneratorTest.TEST_CHUNK_GENERATOR.get();
+        }
+
+        @Override
+        public void applyCarvers(WorldGenRegion p_223043_, long p_223044_, RandomState p_223045_, BiomeManager p_223046_, StructureManager p_223047_, ChunkAccess p_223048_,
+                GenerationStep.Carving p_223049_)
+        {
+        }
+
+        @Override
+        public void buildSurface(WorldGenRegion p_223050_, StructureManager p_223051_, RandomState p_223052_, ChunkAccess p_223053_)
+        {
+        }
+
+        @Override
+        public void spawnOriginalMobs(WorldGenRegion p_62167_)
+        {
+        }
+
+        @Override
+        public int getGenDepth()
+        {
+            return 384;
+        }
+
+        @Override
+        public CompletableFuture<ChunkAccess> fillFromNoise(Executor executor, Blender blender, RandomState randomState, StructureManager structureManager, ChunkAccess chunkAccess)
+        {
+            BlockState state = Blocks.SANDSTONE.defaultBlockState();
+            for (int x=0; x<16; x++)
+            {
+                for (int z=0; z<16; z++)
+                {
+                    chunkAccess.setBlockState(new BlockPos(x, 0, z), state, false);
+                }
+            }
+            return CompletableFuture.completedFuture(chunkAccess);
+        }
+
+        @Override
+        public int getSeaLevel()
+        {
+            return 63;
+        }
+
+        @Override
+        public int getMinY()
+        {
+            return 0;
+        }
+
+        @Override
+        public int getBaseHeight(int p_223032_, int p_223033_, Heightmap.Types p_223034_, LevelHeightAccessor p_223035_, RandomState p_223036_)
+        {
+            return 0;
+        }
+
+        @Override
+        public NoiseColumn getBaseColumn(int p_223028_, int p_223029_, LevelHeightAccessor p_223030_, RandomState p_223031_)
+        {
+            return new NoiseColumn(1, new BlockState[] {Blocks.SANDSTONE.defaultBlockState()});
+        }
+
+        @Override
+        public void addDebugScreenInfo(List<String> p_223175_, RandomState p_223176_, BlockPos p_223177_)
+        {
+        }
+
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -240,7 +240,8 @@ modId="custom_transformtype_test"
 modId="mega_model_test"
 [[mods]]
 modId="emissive_elements_test"
-
+[[mods]]
+modId="sandbox"
 
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This adds an event that gets fired when DFU is loaded to register stuff to it.
Right now this only deals with the chunk generators, but could use expansion later.

Delays DFU init to after mod loading.

Closes #8915 