### PR TITLE
Fire `MobEffectEvent.Added` *after* adding effects

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -118,15 +118,21 @@
              iterator.remove();
           }
  
-@@ -904,6 +_,7 @@
-          return false;
-       } else {
-          MobEffectInstance mobeffectinstance = this.f_20945_.get(p_147208_.m_19544_());
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.MobEffectEvent.Added(this, mobeffectinstance, p_147208_, p_147209_));
+@@ -907,17 +_,21 @@
           if (mobeffectinstance == null) {
              this.f_20945_.put(p_147208_.m_19544_(), p_147208_);
              this.m_142540_(p_147208_, p_147209_);
-@@ -918,6 +_,9 @@
+-            return true;
+          } else if (mobeffectinstance.m_19558_(p_147208_)) {
+             this.m_141973_(mobeffectinstance, true, p_147209_);
+-            return true;
+          } else {
+             return false;
+          }
++
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.MobEffectEvent.Added(this, mobeffectinstance, p_147208_, p_147209_));
++         return true;
+       }
     }
  
     public boolean m_7301_(MobEffectInstance p_21197_) {


### PR DESCRIPTION
Fixes a bug where event firing is false positive when adding a weaker version
Event fires at a time more in line with its class description
Allows mod makers to change `AttributeModifier`s added due to the effect