### PR TITLE
[1.18.2][Backport] Let isRemotePresent check minecraft:register for packet ids from other mod loaders

### DIFF
--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -33,7 +33,8 @@ public class MCRegisterPacketHandler
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
             Set<ResourceLocation> oldLocations = this.locations;
-            this.locations = this.remoteLocations = bytesToResLocation(data);
+            this.locations = bytesToResLocation(data);
+            this.remoteLocations = Set.copyOf(this.locations);
             // ensure all locations receive updates, old and new.
             oldLocations.addAll(this.locations);
             oldLocations.stream()

--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -28,7 +28,8 @@ public class MCRegisterPacketHandler
 
     public static class ChannelList {
         private Set<ResourceLocation> locations = new HashSet<>();
-        private Set<ResourceLocation> remoteLocations = new HashSet<>();
+        private Set<ResourceLocation> remoteLocations = Set.of();
+
         public void updateFrom(final Supplier<NetworkEvent.Context> source, FriendlyByteBuf buffer, final NetworkEvent.RegistrationChangeType changeType) {
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
@@ -71,10 +72,8 @@ public class MCRegisterPacketHandler
         }
 
         /**
-         * Provides only the registered locations that the remote side has sent.
-         * This is useful for interacting with other modloaders via the network to inspect registered network ids.
-         *
-         * @return - The remote locations
+         * {@return the unmodifiable set of channel locations sent by the remote side}
+         * This is useful for interacting with other modloaders via the network to inspect registered network channel IDs.
          */
         public Set<ResourceLocation> getRemoteLocations() {
             return this.remoteLocations;

--- a/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/MCRegisterPacketHandler.java
@@ -28,12 +28,12 @@ public class MCRegisterPacketHandler
 
     public static class ChannelList {
         private Set<ResourceLocation> locations = new HashSet<>();
-
+        private Set<ResourceLocation> remoteLocations = new HashSet<>();
         public void updateFrom(final Supplier<NetworkEvent.Context> source, FriendlyByteBuf buffer, final NetworkEvent.RegistrationChangeType changeType) {
             byte[] data = new byte[Math.max(buffer.readableBytes(), 0)];
             buffer.readBytes(data);
             Set<ResourceLocation> oldLocations = this.locations;
-            this.locations = bytesToResLocation(data);
+            this.locations = this.remoteLocations = bytesToResLocation(data);
             // ensure all locations receive updates, old and new.
             oldLocations.addAll(this.locations);
             oldLocations.stream()
@@ -67,6 +67,16 @@ public class MCRegisterPacketHandler
                 }
             }
             return rl;
+        }
+
+        /**
+         * Provides only the registered locations that the remote side has sent.
+         * This is useful for interacting with other modloaders via the network to inspect registered network ids.
+         *
+         * @return - The remote locations
+         */
+        public Set<ResourceLocation> getRemoteLocations() {
+            return this.remoteLocations;
         }
     }
 

--- a/src/main/java/net/minecraftforge/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/network/NetworkHooks.java
@@ -232,4 +232,10 @@ public class NetworkHooks
     {
         return mgr.channel().attr(NetworkConstants.FML_MOD_MISMATCH_DATA).get();
     }
+
+    @Nullable
+    public static MCRegisterPacketHandler.ChannelList getChannelList(Connection mgr)
+    {
+        return mgr.channel().attr(NetworkConstants.FML_MC_REGISTRY).get();
+    }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInstance.java
@@ -95,6 +95,9 @@ public class NetworkInstance
 
     public boolean isRemotePresent(Connection manager) {
         ConnectionData connectionData = NetworkHooks.getConnectionData(manager);
-        return connectionData != null && connectionData.getChannels().containsKey(channelName);
+        MCRegisterPacketHandler.ChannelList channelList = NetworkHooks.getChannelList(manager);
+        return (connectionData != null && connectionData.getChannels().containsKey(channelName))
+                // if it's not in the fml connection data, let's check if it's sent by another modloader.
+                || (channelList != null && channelList.getRemoteLocations().contains(channelName));
     }
 }


### PR DESCRIPTION
This is the backport of #8921