### PR TITLE
Modify ScreenEvent.RenderInventoryMobEffects to allow shifting the effect stack

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java.patch
@@ -1,12 +1,13 @@
 --- a/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java
 +++ b/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java
-@@ -42,12 +_,16 @@
+@@ -42,12 +_,17 @@
        if (!collection.isEmpty() && j >= 32) {
           RenderSystem.m_157429_(1.0F, 1.0F, 1.0F, 1.0F);
           boolean flag = j >= 120;
-+         var event = net.minecraftforge.client.ForgeHooksClient.onScreenPotionSize(this, j, !flag);
-+         if (event == 0) return; // 0 = cancel rendering
-+         flag = event == 2; // 2 = full-size / 1 = compact
++         var event = net.minecraftforge.client.ForgeHooksClient.onScreenPotionSize(this, j, !flag, i);
++         if (event.isCanceled()) return;
++         flag = !event.isCompact();
++         i = event.getHorizontalOffset();
           int k = 33;
           if (collection.size() > 5) {
              k = 132 / (collection.size() - 1);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1091,10 +1091,11 @@ public class ForgeHooksClient
         };
     }
 
-    public static int onScreenPotionSize(Screen screen, int availableSpace, boolean compact)
+    public static ScreenEvent.RenderInventoryMobEffects onScreenPotionSize(Screen screen, int availableSpace, boolean compact, int horizontalOffset)
     {
-        final ScreenEvent.RenderInventoryMobEffects event = new ScreenEvent.RenderInventoryMobEffects(screen, availableSpace, compact);
-        return MinecraftForge.EVENT_BUS.post(event) ? 0 : (event.isCompact() ? 1 : 2);
+        final ScreenEvent.RenderInventoryMobEffects event = new ScreenEvent.RenderInventoryMobEffects(screen, availableSpace, compact, horizontalOffset);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
     public static boolean isBlockInSolidLayer(BlockState state)

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -275,6 +275,7 @@ public abstract class ScreenEvent extends Event
     /**
      * Fired ahead of rendering any active mob effects in the {@link EffectRenderingInventoryScreen inventory screen}.
      * Can be used to select the size of the effects display (full or compact) or even hide or replace vanilla's rendering entirely.
+     * This event can also be used to modify the horizontal position of the stack of effects being rendered.
      *
      * <p>This event is {@linkplain Cancelable cancellable} and does not {@linkplain HasResult have a result}.
      * Cancelling this event will prevent vanilla rendering.</p>
@@ -287,13 +288,15 @@ public abstract class ScreenEvent extends Event
     {
         private final int availableSpace;
         private boolean compact;
+        private int horizontalOffset;
 
         @ApiStatus.Internal
-        public RenderInventoryMobEffects(Screen screen, int availableSpace, boolean compact)
+        public RenderInventoryMobEffects(Screen screen, int availableSpace, boolean compact, int horizontalOffset)
         {
             super(screen);
             this.availableSpace = availableSpace;
             this.compact = compact;
+            this.horizontalOffset = horizontalOffset;
         }
 
         /**
@@ -310,6 +313,30 @@ public abstract class ScreenEvent extends Event
         public boolean isCompact()
         {
             return compact;
+        }
+
+        /**
+         * The distance from the left side of the screen that the effect stack is rendered. Positive values shift this more to the right.
+         */
+        public int getHorizontalOffset()
+        {
+            return horizontalOffset;
+        }
+
+        /**
+         * Replaces the horizontal offset of the effect stack
+         */
+        public void setHorizontalOffset(int offset)
+        {
+            horizontalOffset = offset;
+        }
+
+        /**
+         * Adds to the horizontal offset of the effect stack. Negative values are acceptable.
+         */
+        public void addHorizontalOffset(int offset)
+        {
+            horizontalOffset += offset;
         }
 
         /**

--- a/src/test/java/net/minecraftforge/debug/client/PotionSizeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/PotionSizeEventTest.java
@@ -7,6 +7,7 @@ package net.minecraftforge.debug.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -49,9 +50,14 @@ public class PotionSizeEventTest
             if (player.getActiveEffects().size() <= 3)
             {
                 event.setCompact(true); // Force compact mode for 3 or less active effects
-            } else
+            }
+            else
             {
                 event.setCompact(false); // Force classic mode for 4 or more active effects
+            }
+            if (player.hasEffect(MobEffects.MOVEMENT_SLOWDOWN))
+            {
+                event.addHorizontalOffset(20); // Move the effect rendering to the right when slowness is enabled
             }
         }
     }


### PR DESCRIPTION
This lets you modders change where the stack is rendered left to right. I override a local variable that controls this which is not modified anywhere else, this is likely to be a very stable patch.

Q: Why not expose the pose stack?
A: In testing I found this doesn't manipulate the internal positions of the effect widgets, so the tooltips render in the wrong spot.

Q: What is your use case?
A: In my mod I add 'tabs' to the inventory screen on the right side, which the effects rendering renders on top of, which I don't want.