### PR TITLE
Add cancellable event firing when Toasts are added (1.19)

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/client/gui/components/toasts/ToastComponent.java
++++ b/net/minecraft/client/gui/components/toasts/ToastComponent.java
+@@ -103,7 +_,9 @@
+    }
+ 
+    public void m_94922_(Toast p_94923_) {
+-      this.f_94916_.add(p_94923_);
++      var event = new net.minecraftforge.client.event.ToastAddEvent(p_94923_);
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++      this.f_94916_.add(event.getToast());
+    }
+ 
+    public Minecraft m_94929_() {

--- a/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
@@ -5,8 +5,8 @@
  
     public void m_94922_(Toast p_94923_) {
 -      this.f_94916_.add(p_94923_);
-+      var event = new net.minecraftforge.client.event.ToastAddEvent(p_94923_);
-+      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++      var event = net.minecraftforge.client.ForgeHooksClient.onToastAdd(p_94923_);
++      if (event.isCanceled()) return;
 +      this.f_94916_.add(event.getToast());
     }
  

--- a/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/toasts/ToastComponent.java.patch
@@ -1,13 +1,10 @@
 --- a/net/minecraft/client/gui/components/toasts/ToastComponent.java
 +++ b/net/minecraft/client/gui/components/toasts/ToastComponent.java
-@@ -103,7 +_,9 @@
+@@ -103,6 +_,7 @@
     }
  
     public void m_94922_(Toast p_94923_) {
--      this.f_94916_.add(p_94923_);
-+      var event = net.minecraftforge.client.ForgeHooksClient.onToastAdd(p_94923_);
-+      if (event.isCanceled()) return;
-+      this.f_94916_.add(event.getToast());
++      if (net.minecraftforge.client.ForgeHooksClient.onToastAdd(p_94923_)) return;
+       this.f_94916_.add(p_94923_);
     }
  
-    public Minecraft m_94929_() {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -27,6 +27,7 @@ import net.minecraft.client.color.item.ItemColors;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiComponent;
 import net.minecraft.client.gui.components.LerpingBossEvent;
+import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.client.gui.screens.ConfirmScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
@@ -128,6 +129,7 @@ import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.client.event.ToastAddEvent;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
@@ -1095,6 +1097,13 @@ public class ForgeHooksClient
     {
         final ScreenEvent.RenderInventoryMobEffects event = new ScreenEvent.RenderInventoryMobEffects(screen, availableSpace, compact);
         return MinecraftForge.EVENT_BUS.post(event) ? 0 : (event.isCompact() ? 1 : 2);
+    }
+
+    public static ToastAddEvent onToastAdd(Toast toast)
+    {
+        ToastAddEvent event = new ToastAddEvent(toast);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
     public static boolean isBlockInSolidLayer(BlockState state)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1099,11 +1099,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(event) ? 0 : (event.isCompact() ? 1 : 2);
     }
 
-    public static ToastAddEvent onToastAdd(Toast toast)
+    public static boolean onToastAdd(Toast toast)
     {
-        ToastAddEvent event = new ToastAddEvent(toast);
-        MinecraftForge.EVENT_BUS.post(event);
-        return event;
+        return MinecraftForge.EVENT_BUS.post(new ToastAddEvent(toast));
     }
 
     public static boolean isBlockInSolidLayer(BlockState state)

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.gui.components.toasts.Toast;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * Fired when the client queues a {@link Toast} message to be shown onscreen.
+ * Toasts are small popups that appear on the top right of the screen, for certain actions such as unlocking Advancements and Recipes.
+ *
+ * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+ * Cancelling the event stops the toast from being queued, which means it never renders.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+@Cancelable
+public class ToastAddEvent extends Event
+{
+    private final Toast toast;
+
+    public ToastAddEvent(Toast toast)
+    {
+        this.toast = toast;
+    }
+
+    public Toast getToast()
+    {
+        return toast;
+    }
+}


### PR DESCRIPTION
This is a 1.19 port of #7821

Cancelling this event just causes nothing to happen, it's a safe operation. In relation to the concerns raised by addTimedToast, that provides extra functionality with relation to auto-hiding, it's not a full-fledged second toast handler that we have to handle separately.