### PR TITLE
[1.19.x] add methods with more context to tree growers

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
-@@ -26,10 +_,16 @@
+@@ -26,10 +_,17 @@
     }
  
     @Nullable
@@ -9,6 +9,7 @@
 +   }
 +
 +   /** @deprecated Forge: Use {@link #getConfiguredMegaFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource)} instead */
++   @Deprecated
 +   @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213566_(RandomSource p_222904_);
  

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
@@ -4,17 +4,17 @@
     }
  
     @Nullable
-+   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredMegaFeature(ServerLevel level, BlockPos pos, RandomSource random) {
++   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredMegaFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random) {
 +      return m_213566_(random);
 +   }
 +
-+   @Deprecated // Forge: Use get getConfiguredMegaFeature(ServerLevel, BlockPos, RandomSource) instead
++   /** @deprecated Forge: Use {@link #getConfiguredMegaFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource)} instead */
 +   @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213566_(RandomSource p_222904_);
  
     public boolean m_222896_(ServerLevel p_222897_, ChunkGenerator p_222898_, BlockPos p_222899_, BlockState p_222900_, RandomSource p_222901_, int p_222902_, int p_222903_) {
 -      Holder<? extends ConfiguredFeature<?, ?>> holder = this.m_213566_(p_222901_);
-+      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredMegaFeature(p_222897_, p_222899_, p_222901_);
++      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredMegaFeature(p_222897_, p_222898_, p_222899_, p_222900_, p_222901_);
        if (holder == null) {
           return false;
        } else {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
@@ -1,16 +1,18 @@
 --- a/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
-@@ -26,10 +_,17 @@
+@@ -25,11 +_,19 @@
+       return super.m_213817_(p_222891_, p_222892_, p_222893_, p_222894_, p_222895_);
     }
  
-    @Nullable
++   // Forge: context-sensitive version to be able to use data pack provided features
++   @Nullable
 +   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredMegaFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random) {
 +      return m_213566_(random);
 +   }
 +
 +   /** @deprecated Forge: Use {@link #getConfiguredMegaFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource)} instead */
 +   @Deprecated
-+   @Nullable
+    @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213566_(RandomSource p_222904_);
  
     public boolean m_222896_(ServerLevel p_222897_, ChunkGenerator p_222898_, BlockPos p_222899_, BlockState p_222900_, RandomSource p_222901_, int p_222902_, int p_222903_) {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
++++ b/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
+@@ -26,10 +_,16 @@
+    }
+ 
+    @Nullable
++   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredMegaFeature(ServerLevel level, BlockPos pos, RandomSource random) {
++      return m_213566_(random);
++   }
++
++   @Deprecated // Forge: Use get getConfiguredMegaFeature(ServerLevel, BlockPos, RandomSource) instead
++   @Nullable
+    protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213566_(RandomSource p_222904_);
+ 
+    public boolean m_222896_(ServerLevel p_222897_, ChunkGenerator p_222898_, BlockPos p_222899_, BlockState p_222900_, RandomSource p_222901_, int p_222902_, int p_222903_) {
+-      Holder<? extends ConfiguredFeature<?, ?>> holder = this.m_213566_(p_222901_);
++      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredMegaFeature(p_222897_, p_222899_, p_222901_);
+       if (holder == null) {
+          return false;
+       } else {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
-@@ -13,10 +_,16 @@
+@@ -13,10 +_,17 @@
  
  public abstract class AbstractTreeGrower {
     @Nullable
@@ -9,6 +9,7 @@
 +   }
 +
 +   /** @deprecated Forge: Use {@link #getConfiguredFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource, boolean)} instead */
++   @Deprecated
 +   @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213888_(RandomSource p_222910_, boolean p_222911_);
  

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
@@ -4,17 +4,17 @@
  
  public abstract class AbstractTreeGrower {
     @Nullable
-+   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, BlockPos pos, RandomSource random, boolean hasFlowers) {
++   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random, boolean hasFlowers) {
 +      return m_213888_(random, hasFlowers);
 +   }
 +
-+   @Deprecated // Forge: Use get getConfiguredMegaFeature(ServerLevel, BlockPos, RandomSource, boolean) instead
++   /** @deprecated Forge: Use {@link #getConfiguredFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource, boolean)} instead */
 +   @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213888_(RandomSource p_222910_, boolean p_222911_);
  
     public boolean m_213817_(ServerLevel p_222905_, ChunkGenerator p_222906_, BlockPos p_222907_, BlockState p_222908_, RandomSource p_222909_) {
 -      Holder<? extends ConfiguredFeature<?, ?>> holder = this.m_213888_(p_222909_, this.m_60011_(p_222905_, p_222907_));
-+      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredFeature(p_222905_, p_222907_, p_222909_, this.m_60011_(p_222905_, p_222907_));
++      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredFeature(p_222905_, p_222906_, p_222907_, p_222908_, p_222909_, this.m_60011_(p_222905_, p_222907_));
        if (holder == null) {
           return false;
        } else {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
@@ -1,16 +1,18 @@
 --- a/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
-@@ -13,10 +_,17 @@
+@@ -12,11 +_,19 @@
+ import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
  
  public abstract class AbstractTreeGrower {
-    @Nullable
++   // Forge: context-sensitive version to be able to use data pack provided features
++   @Nullable
 +   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random, boolean hasFlowers) {
 +      return m_213888_(random, hasFlowers);
 +   }
 +
 +   /** @deprecated Forge: Use {@link #getConfiguredFeature(ServerLevel, ChunkGenerator, BlockPos, BlockState, RandomSource, boolean)} instead */
 +   @Deprecated
-+   @Nullable
+    @Nullable
     protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213888_(RandomSource p_222910_, boolean p_222911_);
  
     public boolean m_213817_(ServerLevel p_222905_, ChunkGenerator p_222906_, BlockPos p_222907_, BlockState p_222908_, RandomSource p_222909_) {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
++++ b/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
+@@ -13,10 +_,16 @@
+ 
+ public abstract class AbstractTreeGrower {
+    @Nullable
++   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, BlockPos pos, RandomSource random, boolean hasFlowers) {
++      return m_213888_(random, hasFlowers);
++   }
++
++   @Deprecated // Forge: Use get getConfiguredMegaFeature(ServerLevel, BlockPos, RandomSource, boolean) instead
++   @Nullable
+    protected abstract Holder<? extends ConfiguredFeature<?, ?>> m_213888_(RandomSource p_222910_, boolean p_222911_);
+ 
+    public boolean m_213817_(ServerLevel p_222905_, ChunkGenerator p_222906_, BlockPos p_222907_, BlockState p_222908_, RandomSource p_222909_) {
+-      Holder<? extends ConfiguredFeature<?, ?>> holder = this.m_213888_(p_222909_, this.m_60011_(p_222905_, p_222907_));
++      Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredFeature(p_222905_, p_222907_, p_222909_, this.m_60011_(p_222905_, p_222907_));
+       if (holder == null) {
+          return false;
+       } else {


### PR DESCRIPTION
This PR adds a method in `AbstractTreeGrower` and `AbstractMegaTreeGrower` that allows for more control and the usage of RegistryAccess in the grower.
This PR is not intending to fix `MC-251744`