### PR TITLE
[1.19.2] Add the ability to handle custom stack aware item cooldowns

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -131,11 +131,16 @@
 +         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) {
 +            return InteractionResult.PASS;
 +         }
-+         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.m_41619_() && !p_233747_.m_36335_().m_41519_(itemstack.m_41720_()))) {
++         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.m_41619_() && !itemstack.isOnCooldown(p_233747_))) {
              InteractionResult interactionresult1;
              if (this.f_105197_.m_46408_()) {
                 int i = itemstack.m_41613_();
-@@ -356,10 +_,17 @@
+@@ -352,14 +_,21 @@
+          this.m_233729_(this.f_105189_.f_91073_, (p_233720_) -> {
+             ServerboundUseItemPacket serverbounduseitempacket = new ServerboundUseItemPacket(p_233723_, p_233720_);
+             ItemStack itemstack = p_233722_.m_21120_(p_233723_);
+-            if (p_233722_.m_36335_().m_41519_(itemstack.m_41720_())) {
++            if (itemstack.isOnCooldown(p_233722_)) {
                 mutableobject.setValue(InteractionResult.PASS);
                 return serverbounduseitempacket;
              } else {

--- a/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
@@ -60,6 +60,15 @@
              crashreportcategory.m_128165_("Item Damage", () -> {
                 return String.valueOf(p_174237_.m_41773_());
              });
+@@ -349,7 +_,7 @@
+          }
+ 
+          LocalPlayer localplayer = Minecraft.m_91087_().f_91074_;
+-         float f = localplayer == null ? 0.0F : localplayer.m_36335_().m_41521_(p_115176_.m_41720_(), Minecraft.m_91087_().m_91296_());
++         float f = localplayer == null ? 0.0F : p_115176_.getCooldownPercent(localplayer, Minecraft.m_91087_().m_91296_());
+          if (f > 0.0F) {
+             RenderSystem.m_69465_();
+             RenderSystem.m_69472_();
 @@ -362,6 +_,7 @@
              RenderSystem.m_69482_();
           }

--- a/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
@@ -27,8 +27,9 @@
           return p_174652_ != null && p_174652_.m_5737_() != HumanoidArm.RIGHT ? 1.0F : 0.0F;
        });
 -      m_174581_(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
+-         return p_174647_ instanceof Player ? ((Player)p_174647_).m_36335_().m_41521_(p_174645_.m_41720_(), 0.0F) : 0.0F;
 +      registerGeneric(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
-          return p_174647_ instanceof Player ? ((Player)p_174647_).m_36335_().m_41521_(p_174645_.m_41720_(), 0.0F) : 0.0F;
++         return p_174645_.getCooldownPercent(p_174647_, 0);
        });
        m_174579_((p_174640_, p_174641_, p_174642_, p_174643_) -> {
           return p_174640_.m_41782_() ? (float)p_174640_.m_41783_().m_128451_("CustomModelData") : 0.0F;

--- a/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/item/ItemProperties.java.patch
@@ -29,7 +29,7 @@
 -      m_174581_(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
 -         return p_174647_ instanceof Player ? ((Player)p_174647_).m_36335_().m_41521_(p_174645_.m_41720_(), 0.0F) : 0.0F;
 +      registerGeneric(new ResourceLocation("cooldown"), (p_174645_, p_174646_, p_174647_, p_174648_) -> {
-+         return p_174645_.getCooldownPercent(p_174647_, 0);
++         return p_174647_ instanceof Player ? p_174645_.getCooldownPercent((Player)p_174647_, 0.0F) : 0.0F;
        });
        m_174579_((p_174640_, p_174641_, p_174642_, p_174643_) -> {
           return p_174640_.m_41782_() ? (float)p_174640_.m_41783_().m_128451_("CustomModelData") : 0.0F;

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -31,7 +31,7 @@
           return false;
        } else {
           BlockEntity blockentity = this.f_9244_.m_7702_(p_9281_);
-@@ -229,30 +_,42 @@
+@@ -229,38 +_,52 @@
           if (block instanceof GameMasterBlock && !this.f_9245_.m_36337_()) {
              this.f_9244_.m_7260_(p_9281_, blockstate, blockstate, 3);
              return false;
@@ -81,8 +81,10 @@
     }
  
     public InteractionResult m_6261_(ServerPlayer p_9262_, Level p_9263_, ItemStack p_9264_, InteractionHand p_9265_) {
-@@ -261,6 +_,8 @@
-       } else if (p_9262_.m_36335_().m_41519_(p_9264_.m_41720_())) {
+       if (this.f_9247_ == GameType.SPECTATOR) {
+          return InteractionResult.PASS;
+-      } else if (p_9262_.m_36335_().m_41519_(p_9264_.m_41720_())) {
++      } else if (p_9264_.isOnCooldown(p_9262_)) {
           return InteractionResult.PASS;
        } else {
 +         InteractionResult cancelResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_9262_, p_9265_);
@@ -123,7 +125,7 @@
  
 -         if (!p_9268_.m_41619_() && !p_9266_.m_36335_().m_41519_(p_9268_.m_41720_())) {
 -            UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.m_41619_() && !p_9266_.m_36335_().m_41519_(p_9268_.m_41720_()))) {
++         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.m_41619_() && !p_9268_.isOnCooldown(p_9266_))) {
 +            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return InteractionResult.PASS;
              InteractionResult interactionresult1;
              if (this.m_9295_()) {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -34,6 +34,15 @@
     }
  
     public void m_7376_(ServerboundAcceptTeleportationPacket p_9835_) {
+@@ -1026,7 +_,7 @@
+          return false;
+       } else {
+          Item item = p_9792_.m_41720_();
+-         return (item instanceof BlockItem || item instanceof BucketItem) && !p_9791_.m_36335_().m_41519_(item);
++         return (item instanceof BlockItem || item instanceof BucketItem) && !p_9792_.isOnCooldown(p_9791_);
+       }
+    }
+ 
 @@ -1040,7 +_,7 @@
        Vec3 vec3 = blockhitresult.m_82450_();
        BlockPos blockpos = blockhitresult.m_82425_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -828,4 +828,29 @@ public interface IForgeItem
         return self().getFoodProperties();
     }
 
+    /**
+     * Check if this item is on cooldown for an entity
+     *
+     * @param entity the entity holding the item
+     * @param stack the ItemStack
+     * @return if this item is on cooldow
+     */
+    default boolean isOnCooldown(@NotNull Entity entity, @NotNull ItemStack stack)
+    {
+        return this.getCooldownPercent(entity, stack, 0) > 0;
+    }
+
+    /**
+     * get this item cooldown for an entity
+     *
+     * @param entity the entity holding the item
+     * @param stack the ItemStack
+     * @param partialTick the partial render tick
+     * @return this item cooldow  percent
+     */
+    default float getCooldownPercent(@NotNull Entity entity, @NotNull ItemStack stack, float partialTick)
+    {
+        return entity instanceof Player player ? player.getCooldowns().getCooldownPercent(self(), partialTick) : 0;
+    }
+
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -829,28 +829,29 @@ public interface IForgeItem
     }
 
     /**
-     * Check if this item is on cooldown for an entity
+     * Check if this item is on cooldown for a player
      *
-     * @param entity the entity holding the item
+     * @param player the player holding the item
      * @param stack the ItemStack
-     * @return if this item is on cooldow
+     * @return if this item is on cooldown
      */
-    default boolean isOnCooldown(@NotNull Entity entity, @NotNull ItemStack stack)
+    default boolean isOnCooldown(@NotNull Player player, @NotNull ItemStack stack)
     {
-        return this.getCooldownPercent(entity, stack, 0) > 0;
+        return this.getCooldownPercent(player, stack, 0) > 0;
     }
 
     /**
-     * get this item cooldown for an entity
+     * Get the cooldown of this item for a player.
+     * The percentage is a value between 0 and 1, where 0 is not in cooldown.
      *
-     * @param entity the entity holding the item
+     * @param player the player holding the item
      * @param stack the ItemStack
      * @param partialTick the partial render tick
-     * @return this item cooldow  percent
+     * @return a number between 0 and 1 representing the cooldown of this item.
      */
-    default float getCooldownPercent(@NotNull Entity entity, @NotNull ItemStack stack, float partialTick)
+    default float getCooldownPercent(@NotNull Player player, @NotNull ItemStack stack, float partialTick)
     {
-        return entity instanceof Player player ? player.getCooldowns().getCooldownPercent(self(), partialTick) : 0;
+        return player.getCooldowns().getCooldownPercent(self(), partialTick);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -556,4 +556,27 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     {
         return self().getItem().getFoodProperties(self(), entity);
     }
+
+    /**
+     * Check if this item stack is on cooldown for an entity
+     *
+     * @param entity the entity holding the item stack
+     * @return if this item stack is on cooldow
+     */
+    default boolean isOnCooldown(@NotNull Entity entity)
+    {
+        return self().getItem().isOnCooldown(entity, self());
+    }
+
+    /**
+     * get this item stack cooldown for an entity
+     *
+     * @param entity      the entity holding the item stack
+     * @param partialTick the partial render tick
+     * @return this item stack cooldow percent
+     */
+    default float getCooldownPercent(@NotNull Entity entity, float partialTick)
+    {
+        return self().getItem().getCooldownPercent(entity, self(), partialTick);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -558,25 +558,25 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Check if this item stack is on cooldown for an entity
+     * Check if this item stack is on cooldown for a player
      *
-     * @param entity the entity holding the item stack
-     * @return if this item stack is on cooldow
+     * @param player the player holding the item stack
+     * @return if this item stack is on cooldown
      */
-    default boolean isOnCooldown(@NotNull Entity entity)
+    default boolean isOnCooldown(@NotNull Player player)
     {
-        return self().getItem().isOnCooldown(entity, self());
+        return self().getItem().isOnCooldown(player, self());
     }
 
     /**
-     * get this item stack cooldown for an entity
+     * Get the cooldown of this item stack for a player
      *
-     * @param entity      the entity holding the item stack
+     * @param player      the player holding the item stack
      * @param partialTick the partial render tick
-     * @return this item stack cooldow percent
+     * @return a number between 0 and 1 representing the cooldown of this item stack.
      */
-    default float getCooldownPercent(@NotNull Entity entity, float partialTick)
+    default float getCooldownPercent(@NotNull Player player, float partialTick)
     {
-        return self().getItem().getCooldownPercent(entity, self(), partialTick);
+        return self().getItem().getCooldownPercent(player, self(), partialTick);
     }
 }


### PR DESCRIPTION
This is a reopen of #8013 for 1.19 as I didn't had time to update it then. This PR goal is to offers the ability for mods to add custom cooldown handling on their items. To do so it adds two new methods IForgeItem#isOnCooldown and IForgeItem#getCooldownPercent that expose the vanilla cooldown behavior.