### PR TITLE
Fix worlds with removed dimension types unable to load.

### DIFF
--- a/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/resources/RegistryLoader.java
++++ b/net/minecraft/resources/RegistryLoader.java
+@@ -48,7 +_,12 @@
+       if (dataresult != null) {
+          return dataresult;
+       } else {
+-         Holder<E> holder = p_214229_.m_214121_(p_214232_);
++         // Prevents an exception from disrupting codec decoding when calling this with prematurely frozen registries - see comment in LevelStorageSource
++         DataResult<Holder<E>> maybeHolder = p_214229_.m_214185_(p_214232_);
++         if (maybeHolder.error().isPresent()) {
++            return maybeHolder;
++         }
++         Holder<E> holder = maybeHolder.result().get();
+          readcache.f_206803_.put(p_214232_, DataResult.success(holder));
+          DataResult<Holder<E>> dataresult1;
+          if (p_214233_.isEmpty()) {

--- a/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,5 +1,19 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
+@@ -96,6 +_,13 @@
+       }
+ 
+       Dynamic<T> dynamic1 = p_78206_.update(References.f_16795_, dynamic, p_78207_, SharedConstants.m_183709_().getWorldVersion());
++      // The above line is modified (via the patch in V2832), such that the data fixer upper will retain dimensions that don't exist in the schema, in the dynamic.
++      // When we parse the WorldGenSettings below, in vanilla, this uses the same call paths that can cause things to register (such as dimension types).
++      // However, since at this point all resource data will have been loaded, anything that *would* register now is going to error later, because it'll create a Holder<> reference, that is not bound to anything. This unbound reference will then throw an error when the registries are frozen.
++      // So, we freeze the registries before this call to parse(). This prevents them from leaking any new unbound holders into the registry.
++      // Attempting to register to a frozen registry throws an exception, which we resolve via a patch in RegistryLoader, causing it to return DataResult.error() instead, and prevent the faulty dimension from registering without aborting the parsing of the WorldGenSettings
++      // Finally, the resultOrPartial() promotes only the dimensions which successfully parsed, and the LenientUnboundedMapCodec which is patched into the WorldGenSettings codec ensures that *only* the invalid dimensions will fail to parse (see MC-197860), and not discard other dimensions as well.
++      if (p_78205_.getOps() instanceof net.minecraft.resources.RegistryOps<T> ops) ops.f_206806_.m_203610_().forEach(e -> e.f_206234_().m_203521_());
+       DataResult<WorldGenSettings> dataresult = WorldGenSettings.f_64600_.parse(dynamic1);
+       return Pair.of(dataresult.resultOrPartial(Util.m_137489_("WorldGenSettings: ", f_78191_::error)).orElseGet(() -> {
+          RegistryAccess registryaccess = RegistryAccess.m_206154_(dynamic1);
 @@ -372,6 +_,19 @@
           return LevelStorageSource.this.m_230817_(this.f_230867_, LevelStorageSource.m_211737_(p_211748_, p_211749_, p_211750_));
        }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -268,6 +268,7 @@ public-f net.minecraft.data.tags.TagsProvider m_6055_()Ljava/lang/String; # getN
 public net.minecraft.data.tags.TagsProvider$TagAppender f_126569_ # registry
 public net.minecraft.gametest.framework.GameTestServer <init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/util/Collection;Lnet/minecraft/core/BlockPos;)V # constructor
 public net.minecraft.network.protocol.status.ClientboundStatusResponsePacket f_134885_ # GSON
+public net.minecraft.resources.RegistryOps f_206806_ # registryAccess
 public net.minecraft.resources.ResourceLocation m_135835_(C)Z # validNamespaceChar
 public net.minecraft.resources.ResourceLocation m_135841_(Ljava/lang/String;)Z # isValidPath
 public net.minecraft.resources.ResourceLocation m_135843_(Ljava/lang/String;)Z # isValidNamespace


### PR DESCRIPTION
Tested against bumblezone (and the datapack commoble included in the linked issue), creating world, all dimensions exist, remove bumblezone, world loads, all dimensions (except bumblezone) are present.

Added a fairly extensive comment explaining how the three fixes I've done here (this, LenientUnboundedMapCodec patch, V2832 patch) interact and why freezing is necessary.

![not quite](https://user-images.githubusercontent.com/35673674/184356200-e1ed549b-ed5f-4145-8169-5dced9693af3.png)

It's not quite fifty lines but it's honest work.

cc @Commoble 

Fixes #8800