### PR TITLE
Allow FakePlayer to report its position

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -81,8 +81,6 @@ public class FakePlayer extends ServerPlayer
         this.connection = new FakePlayerNetHandler(level.getServer(), this);
     }
 
-    @Override public Vec3 position() { return new Vec3(0, 0, 0); }
-    @Override public BlockPos blockPosition() { return BlockPos.ZERO; }
     @Override public void displayClientMessage(Component chatComponent, boolean actionBar) { }
     @Override public void awardStat(Stat stat, int amount) { }
     @Override public boolean isInvulnerableTo(DamageSource source) { return true; }


### PR DESCRIPTION
FakePlayers currently cannot report their position through position() and blockPosition(), but can report it through posX()/posY()/posZ().

This means that fakeplayers cannot be used in contexts where the position of the player matters, and the underlying access to the position is through position() or blockPosition().
This limitation is fairly artificial, and I don't think there's a compelling reason for the position to be hidden.