### PR TITLE
Handle payloads as empty if they have no readable bytes

### DIFF
--- a/src/main/java/net/minecraftforge/network/simple/IndexedMessageCodec.java
+++ b/src/main/java/net/minecraftforge/network/simple/IndexedMessageCodec.java
@@ -135,7 +135,7 @@ public class IndexedMessageCodec
     }
 
     void consume(FriendlyByteBuf payload, int payloadIndex, Supplier<NetworkEvent.Context> context) {
-        if (payload == null || payload.readableBytes() == 0) {
+        if (payload == null || !payload.isReadable()) {
             LOGGER.error(SIMPLENET, "Received empty payload on channel {}", Optional.ofNullable(networkInstance).map(NetworkInstance::getChannelName).map(Objects::toString).orElse("MISSING CHANNEL"));
             if (!HandshakeHandler.packetNeedsResponse(context.get().getNetworkManager(), payloadIndex))
             {

--- a/src/main/java/net/minecraftforge/network/simple/IndexedMessageCodec.java
+++ b/src/main/java/net/minecraftforge/network/simple/IndexedMessageCodec.java
@@ -135,7 +135,7 @@ public class IndexedMessageCodec
     }
 
     void consume(FriendlyByteBuf payload, int payloadIndex, Supplier<NetworkEvent.Context> context) {
-        if (payload == null) {
+        if (payload == null || payload.readableBytes() == 0) {
             LOGGER.error(SIMPLENET, "Received empty payload on channel {}", Optional.ofNullable(networkInstance).map(NetworkInstance::getChannelName).map(Objects::toString).orElse("MISSING CHANNEL"));
             if (!HandshakeHandler.packetNeedsResponse(context.get().getNetworkManager(), payloadIndex))
             {


### PR DESCRIPTION
Simple PR that makes `IndexedMessageCodec#consume` handle payloads with no readable bytes as empty, the same as it handles null payloads. I noticed this issue while trying to track down the cause of https://github.com/mekanism/Mekanism/issues/7577. It turns out the *immediate* cause of that linked issue is that the payload is empty so then a crash happens on line 146 when `consume` tries to read a byte from the payload. This change keeps it from disconnecting, and instead it just logs the error about the payload being empty.

From what I can tell (and I will probably open an issue for tomorrow when my I can think straight again and haven't been debugging packets and netty related things for 5 hours...), I believe the root of the cause is that in LAN when sending packets targeted using `PacketDistributor#ALL` (or by looping them and sending the same `ClientboundCustomPayloadPacket`' vanilla packet instance to all connections) it causes the first instance to send, and then subsequent ones to send packets with an empty payload as the `ClientboundCustomPayloadPacket`'s data is empty after the first run.