### PR TITLE
[HotFix] Fix a corner case where the UMLB can not extract a version from a library.

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -106,7 +106,7 @@ public class UniqueModListBuilder
         if (modInfoList.size() > 1) {
             LOGGER.debug("Found {} mods for first modid {}, selecting most recent based on version data", modInfoList.size(), fullList.getKey());
             modInfoList.sort(Comparator.comparing(this::getVersion).reversed());
-            LOGGER.debug("Selected file {} for modid {} with version {}", modInfoList.get(0).getFileName(), fullList.getKey(), modInfoList.get(0).getModInfos().get(0).getVersion());
+            LOGGER.debug("Selected file {} for modid {} with version {}", modInfoList.get(0).getFileName(), fullList.getKey(), this.getVersion(modInfoList.get(0)));
         }
         return modInfoList.get(0);
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -113,11 +113,7 @@ public class UniqueModListBuilder
 
     private ArtifactVersion getVersion(final ModFile mf)
     {
-        if (mf.getModFileInfo() == null) {
-            return mf.getJarVersion();
-        }
-
-        if (mf.getModInfos().isEmpty()) {
+        if (mf.getModFileInfo() == null || mf.getModInfos() == null || mf.getModInfos().isEmpty()) {
             return mf.getJarVersion();
         }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -116,6 +116,11 @@ public class UniqueModListBuilder
         if (mf.getModFileInfo() == null) {
             return mf.getJarVersion();
         }
+
+        if (mf.getModInfos().isEmpty()) {
+            return mf.getJarVersion();
+        }
+
         return mf.getModInfos().get(0).getVersion();
     }
 


### PR DESCRIPTION
## HotFix
This PR fixes an active crash that occurs when a library is loaded into the game as a gamelibrary.

Those none FML aware libraries generally don't contain mods or mod information entries which make the UniqueModListBuilder fail.

### Fix:
Check for the availability of said information first, if not available fall back on default values extracted from the jar.

_Note:_
This was already implemented in the module name check later on, but not yet on the version check which is what this handles.