### PR TITLE
remove .DS_Store from the namespaces

### DIFF
--- a/src/main/java/net/minecraftforge/resource/PathPackResources.java
+++ b/src/main/java/net/minecraftforge/resource/PathPackResources.java
@@ -157,7 +157,8 @@ public class PathPackResources extends AbstractPackResources
             return this.cacheManager.getNamespaces(type);
         }
 
-        return getNamespacesFromDisk(type);
+        Set<String> s = getNamespacesFromDisk(type);s.remove(".DS_Store");
+        return s;
     }
 
     @NotNull


### PR DESCRIPTION
The game crashes because of this issue: #8413. You can read more info there, but to keep it short: macOS automatically creates files called .DS_Store and those should be ignored by forge or else minecraft crashes with this error: `net.minecraft.ResourceLocationException: Non [a-z0-9_.-] character in namespace of location: .DS_Store:sounds.json`.

My changes fix #8413 by making it so that those files are not loaded.

I am not sure this is the right approach, because the .DS_Store files never get in the jar when building. It only crashes in a mdk environment, because you are running it from the bin folder and not a jar.