### PR TITLE
Add ability to Auto register capabilities via annotation

### DIFF
--- a/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModLanguageProvider.java
+++ b/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModLanguageProvider.java
@@ -51,7 +51,7 @@ public class LowCodeModLanguageProvider implements IModLanguageProvider
                     throw new ModLoadingException(info, ModLoadingStage.CONSTRUCT, "fml.modloading.failedtoloadmodclass", e);
                 }
             } catch (NoSuchMethodException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-                LOGGER.fatal(LOADING, "Unable to load FMLModContainer, wut?", e);
+                LOGGER.fatal(LOADING, "Unable to load LowCodeModContainer, wut?", e);
                 final Class<RuntimeException> mle = (Class<RuntimeException>) LamdbaExceptionUtils.uncheck(() -> Class.forName("net.minecraftforge.fml.ModLoadingException", true, Thread.currentThread().getContextClassLoader()));
                 final Class<ModLoadingStage> mls = (Class<ModLoadingStage>) LamdbaExceptionUtils.uncheck(() -> Class.forName("net.minecraftforge.fml.ModLoadingStage", true, Thread.currentThread().getContextClassLoader()));
                 throw LamdbaExceptionUtils.uncheck(() -> LamdbaExceptionUtils.uncheck(() -> mle.getConstructor(IModInfo.class, mls, String.class, Throwable.class)).newInstance(info, Enum.valueOf(mls, "CONSTRUCT"), "fml.modloading.failedtoloadmodclass", e));

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -699,7 +699,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
++      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
 +         if (facing == null) return handlers[2].cast();
 +         else if (facing.m_122434_().m_122478_()) return handlers[0].cast();
 +         else if (facing.m_122434_().m_122479_()) return handlers[1].cast();

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -38,7 +38,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && itemHandler != null)
++      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && itemHandler != null)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -431,7 +431,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
++      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
 +         if (facing == null) return playerJoinedHandler.cast();
 +         else if (facing.m_122434_().m_122478_()) return playerMainHandler.cast();
 +         else if (facing.m_122434_().m_122479_()) return playerEquipmentHandler.cast();

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
@@ -19,7 +19,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
++      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
@@ -10,7 +10,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
++      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -164,7 +164,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
++      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
 +         if (facing == Direction.UP)
 +            return handlers[0].cast();
 +         else if (facing == Direction.DOWN)

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
@@ -11,7 +11,7 @@
 +   }
 +
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
-+      if (!this.f_58859_ && cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
++      if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
 +         return itemHandler.cast();
 +      return super.getCapability(cap, side);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -62,7 +62,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
++      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
 +         if (facing == Direction.UP)
 +            return handlers[0].cast();
 +         else if (facing == Direction.DOWN)

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
@@ -17,7 +17,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, Direction side) {
-+       if (!this.f_58859_ && cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
++       if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
 +          if (this.chestHandler == null)
 +             this.chestHandler = net.minecraftforge.common.util.LazyOptional.of(this::createHandler);
 +          return this.chestHandler.cast();

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -226,7 +226,7 @@ public class ForgeMod
      * Stock holder set type that represents any/all values in a registry. Can be used in a holderset object with {@code { "type": "forge:any" }}
      */
     public static final RegistryObject<HolderSetType> ANY_HOLDER_SET = HOLDER_SET_TYPES.register("any", () -> AnyHolderSet::codec);
-   
+
     /**
      * Stock holder set type that represents an intersection of other holdersets. Can be used in a holderset object with {@code { "type": "forge:and", "values": [list of holdersets] }}
      */
@@ -242,7 +242,7 @@ public class ForgeMod
      * Can be used in a holderset object with {@code { "type": "forge:not", "value": holderset }}</p>
      */
     public static final RegistryObject<HolderSetType> NOT_HOLDER_SET = HOLDER_SET_TYPES.register("not", () -> NotHolderSet::codec);
-    
+
     private static final DeferredRegister<FluidType> VANILLA_FLUID_TYPES = DeferredRegister.create(ForgeRegistries.Keys.FLUID_TYPES, "minecraft");
 
     public static final RegistryObject<FluidType> EMPTY_TYPE = VANILLA_FLUID_TYPES.register("empty", () ->
@@ -437,7 +437,6 @@ public class ForgeMod
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
         final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-        modEventBus.addListener(this::registerCapabilities);
         modEventBus.addListener(this::preInit);
         modEventBus.addListener(this::gatherData);
         modEventBus.addListener(this::loadComplete);
@@ -468,13 +467,6 @@ public class ForgeMod
         MinecraftForge.EVENT_BUS.addListener(this::registerPermissionNodes);
 
         ForgeRegistries.ITEMS.tags().addOptionalTagDefaults(Tags.Items.ENCHANTING_FUELS, Set.of(ForgeRegistries.ITEMS.getDelegateOrThrow(Items.LAPIS_LAZULI)));
-    }
-
-    public void registerCapabilities(RegisterCapabilitiesEvent event)
-    {
-        CapabilityItemHandler.register(event);
-        CapabilityFluidHandler.register(event);
-        CapabilityEnergy.register(event);
     }
 
     public void preInit(FMLCommonSetupEvent evt)

--- a/src/main/java/net/minecraftforge/common/capabilities/AutoRegisterCapability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/AutoRegisterCapability.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.common.capabilities;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Marks a class to be automatically registered in Forge's {@link CapabilityManager}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AutoRegisterCapability {}

--- a/src/main/java/net/minecraftforge/common/capabilities/AutoRegisterCapability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/AutoRegisterCapability.java
@@ -1,10 +1,14 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.capabilities;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 
 /**
  * Marks a class to be automatically registered in Forge's {@link CapabilityManager}

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
 
+import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
 
@@ -63,14 +64,12 @@ public enum CapabilityManager
     private final IdentityHashMap<String, Capability<?>> providers = new IdentityHashMap<>();
     public void injectCapabilities(List<ModFileScanData> data)
     {
-        var event = new RegisterCapabilitiesEvent();
-
         var autos = data.stream()
             .flatMap(e -> e.getAnnotations().stream())
             .filter(a -> AUTO_REGISTER.equals(a.annotationType()))
             .map(a -> a.clazz())
             .distinct()
-            .sorted((a,b) -> a.toString().compareTo(b.toString()))
+            .sorted(Comparator.comparing(Type::toString))
             .toList();
 
         for (var auto : autos)
@@ -79,6 +78,7 @@ public enum CapabilityManager
             get(auto.getInternalName(), true);
         }
 
+        var event = new RegisterCapabilitiesEvent();
         ModLoader.get().postEvent(event);
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -73,6 +73,7 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
         this.initialized = true;
     }
 
+    @SuppressWarnings("unchecked")
     @NotNull
     B getProvider()
     {

--- a/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
@@ -15,7 +15,7 @@ import static net.minecraftforge.common.capabilities.CapabilityManager.get;
 /*
  * References to  Forge's built in capabilities.
  * Modders are recommended to use their own CapabilityTokens for 3rd party caps to maintain soft dependencies.
- * However, since nobody has a soft dependency on Forge, so we expose this as API.
+ * However, since nobody has a soft dependency on Forge, we expose this as API.
  */
 public class ForgeCapabilities
 {

--- a/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.common.capabilities;
+
+import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.items.IItemHandler;
+
+import static net.minecraftforge.common.capabilities.CapabilityManager.get;
+
+/*
+ * References to  Forge's built in capabilities.
+ * Modders are recommended to use their own CapabilityTokens for 3rd party caps to maintain soft dependencies.
+ * But, people complained so we expose this as API.
+ */
+public class ForgeCapabilities
+{
+    public static final Capability<IEnergyStorage> ENERGY = get(new CapabilityToken<>(){});
+    public static final Capability<IFluidHandler> FLUID_HANDLER = get(new CapabilityToken<>(){});
+    public static final Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM = get(new CapabilityToken<>(){});
+    public static final Capability<IItemHandler> ITEM_HANDLER = get(new CapabilityToken<>(){});
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.capabilities;
 
 import net.minecraftforge.energy.IEnergyStorage;
@@ -10,7 +15,7 @@ import static net.minecraftforge.common.capabilities.CapabilityManager.get;
 /*
  * References to  Forge's built in capabilities.
  * Modders are recommended to use their own CapabilityTokens for 3rd party caps to maintain soft dependencies.
- * But, people complained so we expose this as API.
+ * However, since nobody has a soft dependency on Forge, so we expose this as API.
  */
 public class ForgeCapabilities
 {

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProviderImpl.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProviderImpl.java
@@ -5,8 +5,10 @@
 
 package net.minecraftforge.common.capabilities;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+@ApiStatus.Internal // Modders should use ICapabilityProvider, this is for Forge
 public interface ICapabilityProviderImpl<B extends ICapabilityProviderImpl<B>> extends ICapabilityProvider
 {
     boolean areCapsCompatible(CapabilityProvider<B> other);

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -7,12 +7,10 @@ package net.minecraftforge.energy;
 
 import net.minecraftforge.common.capabilities.*;
 
+@Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityEnergy
 {
-    public static final Capability<IEnergyStorage> ENERGY = CapabilityManager.get(new CapabilityToken<>(){});;
+    public static final Capability<IEnergyStorage> ENERGY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register(RegisterCapabilitiesEvent event)
-    {
-        event.register(IEnergyStorage.class);
-    }
+    public static void register(RegisterCapabilitiesEvent event){}
 }

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -10,7 +10,6 @@ import net.minecraftforge.common.capabilities.*;
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityEnergy
 {
-    public static final Capability<IEnergyStorage> ENERGY = CapabilityManager.get(new CapabilityToken<>(){});
-
+    public static final Capability<IEnergyStorage> ENERGY = ForgeCapabilities.ENERGY;
     public static void register(RegisterCapabilitiesEvent event){}
 }

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -10,6 +10,10 @@ import net.minecraftforge.common.capabilities.*;
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityEnergy
 {
+    /**
+     * @deprecated Create your own reference using {@link CapabilityManager#get(CapabilityToken)}, or use {@link ForgeCapabilities#ENERGY}.
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static final Capability<IEnergyStorage> ENERGY = ForgeCapabilities.ENERGY;
     public static void register(RegisterCapabilitiesEvent event){}
 }

--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.energy;
 
+import net.minecraftforge.common.capabilities.AutoRegisterCapability;
+
 /**
  * An energy storage is the unit of interaction with Energy inventories.
  * <p>
@@ -14,6 +16,7 @@ package net.minecraftforge.energy;
  * Created with consent and permission of King Lemming and Team CoFH. Released with permission under LGPL 2.1 when bundled with Forge.
  *
  */
+@AutoRegisterCapability
 public interface IEnergyStorage
 {
     /**

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -24,14 +24,13 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.SoundActions;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.wrappers.BlockWrapper;
 import net.minecraftforge.fluids.capability.wrappers.BucketPickupHandlerWrapper;
 import net.minecraftforge.fluids.capability.wrappers.FluidBlockWrapper;
-import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 
@@ -91,7 +90,7 @@ public class FluidUtil
         ItemStack heldItem = player.getItemInHand(hand);
         if (!heldItem.isEmpty())
         {
-            return player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+            return player.getCapability(ForgeCapabilities.ITEM_HANDLER)
                 .map(playerInventory -> {
 
                     FluidActionResult fluidActionResult = tryFillContainerAndStow(heldItem, handler, playerInventory, Integer.MAX_VALUE, player, true);
@@ -418,7 +417,7 @@ public class FluidUtil
      */
     public static LazyOptional<IFluidHandlerItem> getFluidHandler(@NotNull ItemStack itemStack)
     {
-        return itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY);
+        return itemStack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM);
     }
 
     /**
@@ -445,14 +444,12 @@ public class FluidUtil
     public static LazyOptional<IFluidHandler> getFluidHandler(Level level, BlockPos blockPos, @Nullable Direction side)
     {
         BlockState state = level.getBlockState(blockPos);
-        Block block = state.getBlock();
-
         if (state.hasBlockEntity())
         {
             BlockEntity blockEntity = level.getBlockEntity(blockPos);
             if (blockEntity != null)
             {
-                return blockEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+                return blockEntity.getCapability(ForgeCapabilities.FLUID_HANDLER, side);
             }
         }
         return LazyOptional.empty();

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -14,7 +14,17 @@ import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityFluidHandler
 {
+    /**
+     * @deprecated Create your own reference using {@link CapabilityManager#get(CapabilityToken)}, or use
+     * {@link ForgeCapabilities#FLUID_HANDLER}.
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = ForgeCapabilities.FLUID_HANDLER;
+    /**
+     * @deprecated Create your own reference using {@link CapabilityManager#get(CapabilityToken)}, or use
+     * {@link ForgeCapabilities#FLUID_HANDLER_ITEM}.
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = ForgeCapabilities.FLUID_HANDLER_ITEM;
 
     public static void register(RegisterCapabilitiesEvent event){}

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -8,13 +8,14 @@ package net.minecraftforge.fluids.capability;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityFluidHandler
 {
-    public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
-    public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
+    public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = ForgeCapabilities.FLUID_HANDLER;
+    public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = ForgeCapabilities.FLUID_HANDLER_ITEM;
 
     public static void register(RegisterCapabilitiesEvent event){}
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -10,15 +10,11 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
+@Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityFluidHandler
 {
     public static Capability<IFluidHandler> FLUID_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     public static Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register(RegisterCapabilitiesEvent event)
-    {
-        event.register(IFluidHandler.class);
-
-        event.register(IFluidHandlerItem.class);
-    }
+    public static void register(RegisterCapabilitiesEvent event){}
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/FluidHandlerBlockEntity.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/FluidHandlerBlockEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
@@ -47,7 +48,7 @@ public class FluidHandlerBlockEntity extends BlockEntity
     @NotNull
     public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
     {
-        if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
+        if (capability == ForgeCapabilities.FLUID_HANDLER)
             return holder.cast();
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.fluids.capability;
 
+import net.minecraftforge.common.capabilities.AutoRegisterCapability;
 import net.minecraftforge.fluids.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * A reference implementation is provided {@link TileFluidHandler}.
  */
+@AutoRegisterCapability
 public interface IFluidHandler
 {
     enum FluidAction {

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
@@ -6,12 +6,15 @@
 package net.minecraftforge.fluids.capability;
 
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.AutoRegisterCapability;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
  * ItemStacks handled by an {@link IFluidHandler} may change, so this class allows
  * users of the fluid handler to get the container after it has been used.
  */
+@AutoRegisterCapability
 public interface IFluidHandlerItem extends IFluidHandler
 {
     /**

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -9,10 +9,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.*;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 import org.jetbrains.annotations.NotNull;
@@ -212,7 +212,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProv
     @NotNull
     public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
     {
-        return CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY.orEmpty(capability, holder);
+        return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -9,11 +9,11 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -189,7 +189,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
     @NotNull
     public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
     {
-        return CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY.orEmpty(capability, holder);
+        return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -9,13 +9,13 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
@@ -172,6 +172,6 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
     @NotNull
     public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
     {
-        return CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY.orEmpty(capability, holder);
+        return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
     }
 }

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -10,13 +10,11 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
+@Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityItemHandler
 {
     public static final Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register(RegisterCapabilitiesEvent event)
-    {
-        event.register(IItemHandler.class);
-    }
+    public static void register(RegisterCapabilitiesEvent event){}
 
 }

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -14,6 +14,10 @@ import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityItemHandler
 {
+    /**
+     * @deprecated Create your own reference using {@link CapabilityManager#get(CapabilityToken)}, or use {@link ForgeCapabilities#ITEM_HANDLER}.
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static final Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = ForgeCapabilities.ITEM_HANDLER;
 
     public static void register(RegisterCapabilitiesEvent event){}

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -8,12 +8,13 @@ package net.minecraftforge.items;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 @Deprecated(forRemoval = true, since = "1.19.2")
 public class CapabilityItemHandler
 {
-    public static final Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
+    public static final Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = ForgeCapabilities.ITEM_HANDLER;
 
     public static void register(RegisterCapabilitiesEvent event){}
 

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -7,10 +7,12 @@ package net.minecraftforge.items;
 
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.AutoRegisterCapability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.NotNull;
 
+@AutoRegisterCapability
 public interface IItemHandler
 {
     /**

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.entity.Hopper;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.DispenserBlockEntity;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
@@ -242,7 +243,7 @@ public class VanillaInventoryCodeHooks
             BlockEntity blockEntity = worldIn.getBlockEntity(blockpos);
             if (blockEntity != null)
             {
-                return blockEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side)
+                return blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER, side)
                     .map(capability -> ImmutablePair.<IItemHandler, Object>of(capability, blockEntity));
             }
         }

--- a/src/test/java/net/minecraftforge/debug/misc/GameTestTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GameTestTest.java
@@ -27,8 +27,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.EnergyStorage;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.RegisterGameTestsEvent;
@@ -55,6 +55,7 @@ public class GameTestTest
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
     private static final RegistryObject<Block> ENERGY_BLOCK = BLOCKS.register("energy_block",
             () -> new EnergyBlock(Properties.of(Material.STONE, MaterialColor.STONE)));
+    @SuppressWarnings("unused")
     private static final RegistryObject<Item> ENERGY_BLOCK_ITEM = ITEMS.register("energy_block",
             () -> new BlockItem(ENERGY_BLOCK.get(), new Item.Properties().tab(CreativeModeTab.TAB_MISC)));
     private static final RegistryObject<BlockEntityType<EnergyBlockEntity>> ENERGY_BLOCK_ENTITY = BLOCK_ENTITIES.register("energy",
@@ -167,7 +168,7 @@ public class GameTestTest
         helper.setBlock(energyPos, ENERGY_BLOCK.get());
 
         // Queries the energy capability
-        LazyOptional<IEnergyStorage> energyHolder = helper.getBlockEntity(energyPos).getCapability(CapabilityEnergy.ENERGY);
+        LazyOptional<IEnergyStorage> energyHolder = helper.getBlockEntity(energyPos).getCapability(ForgeCapabilities.ENERGY);
 
         // Adds 2000 FE, but our energy storage can only hold 1000 FE
         energyHolder.ifPresent(energyStorage -> energyStorage.receiveEnergy(2000, false));
@@ -212,7 +213,7 @@ public class GameTestTest
         @Override
         public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
         {
-            if (capability == CapabilityEnergy.ENERGY)
+            if (capability == ForgeCapabilities.ENERGY)
                 return energyHolder.cast();
 
             return super.getCapability(capability, facing);


### PR DESCRIPTION
The intention behind this is to allow things like LowCode mods to provide caps as API.
At the end of the day you could just make a jar with your interface. Publish it as an 'api' jar, and encourage people JarInJar it with one line in their buildscript instead of needing a dummy @Mod and mods.toml entry.

Modders *should* keep their own references to Capability keys to maintain a soft dependency but people complained ...

Anyways, just to be clear, this is a OPTIONAL annotation, it does not remove the event. So tho who care don't worry.