### PR TITLE
IS_DESERT Biome Tag

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/generated/resources/data/forge/tags/worldgen/biome/is_desert.json
+++ b/src/generated/resources/data/forge/tags/worldgen/biome/is_desert.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:desert"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -547,12 +547,10 @@ public class Tags
         public static final TagKey<Biome> IS_HOT_OVERWORLD = tag("is_hot/overworld");
         public static final TagKey<Biome> IS_HOT_NETHER = tag("is_hot/nether");
         public static final TagKey<Biome> IS_HOT_END = tag("is_hot/end");
-
         public static final TagKey<Biome> IS_COLD = tag("is_cold");
         public static final TagKey<Biome> IS_COLD_OVERWORLD = tag("is_cold/overworld");
         public static final TagKey<Biome> IS_COLD_NETHER = tag("is_cold/nether");
         public static final TagKey<Biome> IS_COLD_END = tag("is_cold/end");
-
         public static final TagKey<Biome> IS_SPARSE = tag("is_sparse");
         public static final TagKey<Biome> IS_SPARSE_OVERWORLD = tag("is_sparse/overworld");
         public static final TagKey<Biome> IS_SPARSE_NETHER = tag("is_sparse/nether");
@@ -561,7 +559,6 @@ public class Tags
         public static final TagKey<Biome> IS_DENSE_OVERWORLD = tag("is_dense/overworld");
         public static final TagKey<Biome> IS_DENSE_NETHER = tag("is_dense/nether");
         public static final TagKey<Biome> IS_DENSE_END = tag("is_dense/end");
-
         public static final TagKey<Biome> IS_WET = tag("is_wet");
         public static final TagKey<Biome> IS_WET_OVERWORLD = tag("is_wet/overworld");
         public static final TagKey<Biome> IS_WET_NETHER = tag("is_wet/nether");
@@ -570,20 +567,19 @@ public class Tags
         public static final TagKey<Biome> IS_DRY_OVERWORLD = tag("is_dry/overworld");
         public static final TagKey<Biome> IS_DRY_NETHER = tag("is_dry/nether");
         public static final TagKey<Biome> IS_DRY_END = tag("is_dry/end");
-
         public static final TagKey<Biome> IS_CONIFEROUS = tag("is_coniferous");
-
         public static final TagKey<Biome> IS_SPOOKY = tag("is_spooky");
+
         public static final TagKey<Biome> IS_DEAD = tag("is_dead");
         public static final TagKey<Biome> IS_LUSH = tag("is_lush");
         public static final TagKey<Biome> IS_MUSHROOM = tag("is_mushroom");
+
         public static final TagKey<Biome> IS_MAGICAL = tag("is_magical");
         public static final TagKey<Biome> IS_RARE = tag("is_rare");
         public static final TagKey<Biome> IS_PLATEAU = tag("is_plateau");
+
         public static final TagKey<Biome> IS_MODIFIED = tag("is_modified");
-
         public static final TagKey<Biome> IS_WATER = tag("is_water");
-
         public static final TagKey<Biome> IS_PLAINS = tag("is_plains");
         public static final TagKey<Biome> IS_SWAMP = tag("is_swamp");
         public static final TagKey<Biome> IS_SANDY = tag("is_sandy");
@@ -591,10 +587,11 @@ public class Tags
         public static final TagKey<Biome> IS_WASTELAND = tag("is_wasteland");
         public static final TagKey<Biome> IS_VOID = tag("is_void");
         public static final TagKey<Biome> IS_UNDERGROUND = tag("is_underground");
-
         public static final TagKey<Biome> IS_PEAK = tag("is_peak");
         public static final TagKey<Biome> IS_SLOPE = tag("is_slope");
         public static final TagKey<Biome> IS_MOUNTAIN = tag("is_mountain");
+
+        public static final TagKey<Biome> IS_DESERT = tag("is_desert");
 
         private static TagKey<Biome> tag(String name)
         {

--- a/src/main/java/net/minecraftforge/common/data/ForgeBiomeTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBiomeTagsProvider.java
@@ -26,7 +26,7 @@ public final class ForgeBiomeTagsProvider extends BiomeTagsProvider
     protected void addTags()
     {
         tag(Biomes.PLAINS, Tags.Biomes.IS_PLAINS);
-        tag(Biomes.DESERT, Tags.Biomes.IS_HOT_OVERWORLD, Tags.Biomes.IS_DRY_OVERWORLD, Tags.Biomes.IS_SANDY);
+        tag(Biomes.DESERT, Tags.Biomes.IS_HOT_OVERWORLD, Tags.Biomes.IS_DRY_OVERWORLD, Tags.Biomes.IS_SANDY, Tags.Biomes.IS_DESERT);
         tag(Biomes.TAIGA, Tags.Biomes.IS_COLD_OVERWORLD, Tags.Biomes.IS_CONIFEROUS);
         tag(Biomes.SWAMP, Tags.Biomes.IS_WET_OVERWORLD, Tags.Biomes.IS_SWAMP);
         tag(Biomes.NETHER_WASTES, Tags.Biomes.IS_HOT_NETHER, Tags.Biomes.IS_DRY_NETHER);

--- a/src/main/java/net/minecraftforge/common/data/ForgeBiomeTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBiomeTagsProvider.java
@@ -77,7 +77,7 @@ public final class ForgeBiomeTagsProvider extends BiomeTagsProvider
         tag(Biomes.CRIMSON_FOREST, Tags.Biomes.IS_HOT_NETHER, Tags.Biomes.IS_DRY_NETHER);
         tag(Biomes.WARPED_FOREST, Tags.Biomes.IS_HOT_NETHER, Tags.Biomes.IS_DRY_NETHER);
         tag(Biomes.BASALT_DELTAS, Tags.Biomes.IS_HOT_NETHER, Tags.Biomes.IS_DRY_NETHER);
-        tag(Biomes.MANGROVE_SWAMP, Tags.Biomes.IS_WET, Tags.Biomes.IS_WET_OVERWORLD, Tags.Biomes.IS_HOT, Tags.Biomes.IS_HOT_OVERWORLD, Tags.Biomes.IS_SWAMP);
+        tag(Biomes.MANGROVE_SWAMP, Tags.Biomes.IS_WET_OVERWORLD, Tags.Biomes.IS_HOT_OVERWORLD, Tags.Biomes.IS_SWAMP);
         tag(Biomes.DEEP_DARK, Tags.Biomes.IS_UNDERGROUND, Tags.Biomes.IS_RARE, Tags.Biomes.IS_SPOOKY);
 
         tag(Tags.Biomes.IS_HOT).addTag(Tags.Biomes.IS_HOT_OVERWORLD).addTag(Tags.Biomes.IS_HOT_NETHER).addOptionalTag(Tags.Biomes.IS_HOT_END.location());


### PR DESCRIPTION
Is useful for datapacks and mods that add other desert biomes to have a tag so that structures can spawn along with other things like mobs.