### PR TITLE
[1.18.x] Backport #8891 to 1.18.

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -567,11 +567,30 @@
              if (!p_21065_.f_46443_ && pair.getFirst() != null && p_21065_.f_46441_.nextFloat() < pair.getSecond()) {
                 p_21066_.m_7292_(new MobEffectInstance(pair.getFirst()));
              }
-@@ -3196,6 +_,64 @@
+@@ -3196,6 +_,83 @@
        this.m_21166_(p_21191_ == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
     }
  
 +   /* ==== FORGE START ==== */
++   /**
++    * Tracks the attack strength of the player as set within {@link net.minecraft.world.entity.player.Player#attack(Entity)} for outside usage<br>
++    * The value stored in this field is considered valid within the following events in the attack sequence:<br>
++    * {@link net.minecraftforge.event.entity.living.LivingAttackEvent}<br>
++    * {@link net.minecraftforge.event.entity.living.LivingHurtEvent}<br>
++    * {@link net.minecraftforge.event.entity.living.LivingDamageEvent}<br>
++    * {@link net.minecraftforge.event.entity.living.LivingDeathEvent}<br>
++    * {@link net.minecraftforge.event.entity.living.LivingDropsEvent}<br>
++    * Use {@link net.minecraft.world.entity.player.Player#getAttackStrengthScale(float)} instead of this field for {@link net.minecraftforge.event.entity.player.AttackEntityEvent}
++    */
++    protected float cachedAttackStrength = 1.0F;
++
++    /**
++    * @see #cachedAttackStrength
++    */
++    public float getCachedAttackStrength() {
++       return this.cachedAttackStrength;
++    }
++
 +   /***
 +    * Removes all potion effects that have curativeItem as a curative item for its effect
 +    * @param curativeItem The itemstack we are using to cure potion effects

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -582,14 +582,14 @@
 +    * {@link net.minecraftforge.event.entity.living.LivingDropsEvent}<br>
 +    * Use {@link net.minecraft.world.entity.player.Player#getAttackStrengthScale(float)} instead of this field for {@link net.minecraftforge.event.entity.player.AttackEntityEvent}
 +    */
-+    protected float cachedAttackStrength = 1.0F;
++   protected float cachedAttackStrength = 1.0F;
 +
-+    /**
++   /**
 +    * @see #cachedAttackStrength
 +    */
-+    public float getCachedAttackStrength() {
-+       return this.cachedAttackStrength;
-+    }
++   public float getCachedAttackStrength() {
++      return this.cachedAttackStrength;
++   }
 +
 +   /***
 +    * Removes all potion effects that have curativeItem as a curative item for its effect

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -389,6 +389,16 @@
        return this.m_36218_(mutablecomponent);
     }
  
+@@ -1851,6 +_,9 @@
+       return (float)(1.0D / this.m_21133_(Attributes.f_22283_) * 20.0D);
+    }
+ 
++   /**
++    * @see net.minecraft.world.entity.LivingEntity#getCachedAttackStrength
++    */
+    public float m_36403_(float p_36404_) {
+       return Mth.m_14036_(((float)this.f_20922_ + p_36404_) / this.m_36333_(), 0.0F, 1.0F);
+    }
 @@ -1895,24 +_,24 @@
           Predicate<ItemStack> predicate = ((ProjectileWeaponItem)p_36349_.m_41720_()).m_6442_();
           ItemStack itemstack = ProjectileWeaponItem.m_43010_(this, predicate);

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -234,7 +234,14 @@
        if (p_36347_.m_6097_()) {
           if (!p_36347_.m_7313_(this)) {
              float f = (float)this.m_21133_(Attributes.f_22281_);
-@@ -1058,7 +_,7 @@
+@@ -1052,13 +_,14 @@
+             }
+ 
+             float f2 = this.m_36403_(0.5F);
++            this.cachedAttackStrength = f2; // Forge: Stores the player's attack strength for usage outside this method
+             f *= 0.2F + f2 * f2 * 0.8F;
+             f1 *= f2;
+             this.m_36334_();
              if (f > 0.0F || f1 > 0.0F) {
                 boolean flag = f2 > 0.9F;
                 boolean flag1 = false;


### PR DESCRIPTION
Backport the changes from the PR for the cached attack strength value (#8891).