### PR TITLE
Hotfix for 1.19.2 item animation bug

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
@@ -27,7 +27,7 @@
        EMPTY(false),
        ITEM(false),
        BLOCK(false),
-@@ -411,10 +_,30 @@
+@@ -411,10 +_,29 @@
  
        private ArmPose(boolean p_102896_) {
           this.f_102890_ = p_102896_;
@@ -52,8 +52,7 @@
 +      }
 +
 +      public <T extends LivingEntity> void applyTransform(HumanoidModel<T> model, T entity, net.minecraft.world.entity.HumanoidArm arm) {
-+         com.google.common.base.Preconditions.checkNotNull(this.forgeArmPose, "applyTransform() must not be called on a vanilla ArmPose!");
-+         this.forgeArmPose.applyTransform(model, entity, arm);
++         if (this.forgeArmPose != null) this.forgeArmPose.applyTransform(model, entity, arm);
 +      }
 +      // FORGE END
     }

--- a/src/test/java/net/minecraftforge/debug/entity/player/ItemUseAnimationTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/ItemUseAnimationTest.java
@@ -92,6 +92,9 @@ public class ItemUseAnimationTest
                 @Override
                 public boolean applyForgeHandTransform(PoseStack poseStack, LocalPlayer player, HumanoidArm arm, ItemStack itemInHand, float partialTick, float equipProcess, float swingProcess) {
                     applyItemArmTransform(poseStack, arm);
+                    if (player.getUseItem() != itemInHand) {
+                        return true;
+                    }
                     if (player.isUsingItem()) {
                         poseStack.translate(0.0, -0.05, 0.0);
                     }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -248,6 +248,8 @@ modId="anvil_update_event_fix"
 modId="item_use_animation_test"
 [[mods]]
 modId="custom_color_resolver_test"
+[[mods]]
+modId="custom_item_decorations_test"
 
 
 


### PR DESCRIPTION
It is essentially same as #8986 but that one is based on previously used branch, and this one is based on freshly created branch.
It fixes #8985 and additionally, also fixes test client launch issue by adding missing mod id, and test item of test mod will no longer play first person arm animation if it's not actually item in use