### PR TITLE
Update Gradle to 7.5.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes some major bugs in 7.5 at the bottom of the release notes it says "We recommend users upgrade to 7.5.1 instead of 7.5."
So we should move to this Version and has no breaking changes
ChangeLog: https://docs.gradle.org/7.5.1/release-notes.html