### PR TITLE
Add optional I/O constraints to item handlers

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -392,7 +392,7 @@
        this.m_36246_(Stats.f_12982_.m_12902_(p_36186_.m_41720_()));
        p_36185_.m_6263_((Player)null, this.m_20185_(), this.m_20186_(), this.m_20189_(), SoundEvents.f_12321_, SoundSource.PLAYERS, 0.5F, p_36185_.f_46441_.m_188501_() * 0.1F + 0.9F);
        if (this instanceof ServerPlayer) {
-@@ -2032,5 +_,63 @@
+@@ -2032,5 +_,64 @@
        public Component m_36423_() {
           return this.f_36413_;
        }
@@ -422,6 +422,7 @@
 +   private final net.minecraftforge.common.util.LazyOptional<net.minecraftforge.items.IItemHandler>
 +         playerEquipmentHandler = net.minecraftforge.common.util.LazyOptional.of(
 +               () -> new net.minecraftforge.items.wrapper.CombinedInvWrapper(
++                     net.minecraftforge.items.IItemHandler.IOGuarantees.STRICT,
 +                     new net.minecraftforge.items.wrapper.PlayerArmorInvWrapper(f_36093_),
 +                     new net.minecraftforge.items.wrapper.PlayerOffhandInvWrapper(f_36093_)));
 +

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -170,7 +170,8 @@ public interface IItemHandler
          */
         NONE(false, false),
         /**
-         * The inventory is guaranteed to accurately reflect the outcome of insertion/extraction operations.
+         * The inventory is guaranteed to accurately reflect the outcome of insertion/extraction operations via
+         * {@link #getStackInSlot(int)}.
          * Additionally, all slots are guaranteed to be fully independent from each other, meaning changes to one of
          * them must not immediately affect the contents or behavior of any of the others. A delayed side effect
          * (for example, at the end of the tick or next tick) is considered valid behavior.
@@ -180,7 +181,8 @@ public interface IItemHandler
          */
         CONSISTENT(true, false),
         /**
-         * A stricter version of {@link #CONSISTENT}, providing additional guarantees on insertion and extraction.
+         * A stricter version of {@link #CONSISTENT} providing additional guarantees on insertion and extraction
+         * equivalent to an implementation of {@link Container}.
          * <p>
          * Insertion must adhere to the following:
          * <ul>
@@ -188,15 +190,15 @@ public interface IItemHandler
          *     be rejected.</li>
          *     <li>If the slot contains an item and {@link ItemHandlerHelper#canItemStacksStack(ItemStack, ItemStack)}
          *     returns false when comparing it with the provided stack, the stack must be rejected.</li>
-         *     <li>Any amount up to {@link #getMaxStackSize(int, ItemStack)} minus the current size of the stack in the
-         *     slot must be allowed to be inserted, and any additional items must be rejected.</li>
+         *     <li>Otherwise any amount up to {@link #getMaxStackSize(int, ItemStack)} minus the current size of the
+         *     stack in the slot must be allowed to be inserted, and any additional items must be rejected.</li>
          * </ul>
          * <p>
          * Extraction must adhere to the following:
          * <ul>
          *     <li>If {@link #isExtractionAllowed(int, ItemStack)} returns {@code false}, no action must be performed
          *     and an empty stack must be returned</li>
-         *     <li>Any amount up to the current size of the stack in the slot must be allowed to be extracted.</li>
+         *     <li>Otherwise any amount up to the current size of the stack in the slot must be allowed to be extracted.</li>
          * </ul>
          * <p>
          * This means that a third party may safely predict the outcome of multiple insertion/extraction operations on

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -166,6 +166,11 @@ public interface IItemHandler
          * Insertion and extraction may affect other slots, and the results of these operations may not be reflected in
          * the stack in the queried slot.
          * <p>
+         * An I/O operation may raise the guarantees to a more restrictive level, but callers do not need to concern
+         * themselves with this, as they can still safely operate assuming they get no guarantees. A case like this may
+         * show up in a block with multiple input slots where setting the first item determines what can go into the
+         * other slots, and behavior becomes consistent/strict as long as that first item remains in the inventory.
+         * <p>
          * This is how item handlers have historically worked.
          */
         NONE(false, false),

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -50,6 +50,8 @@ public interface IItemHandler
      * The ItemStack <em>should not</em> be modified in this function!
      * </p>
      * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, IFluidHandler.FluidAction)}
+     * <p>
+     * Note to implementors: this method may have additional constraints based on {@link #getIOGuarantees()}.
      *
      * @param slot     Slot to insert into.
      * @param stack    ItemStack to insert. This must not be modified by the item handler.
@@ -67,6 +69,7 @@ public interface IItemHandler
      * The returned value must be empty if nothing is extracted,
      * otherwise its stack size must be less than or equal to {@code amount} and {@link ItemStack#getMaxStackSize()}.
      * </p>
+     * Note to implementors: this method may have additional constraints based on {@link #getIOGuarantees()}.
      *
      * @param slot     Slot to extract from.
      * @param amount   Amount to extract (may be greater than the current stack's max limit)
@@ -86,6 +89,19 @@ public interface IItemHandler
     int getSlotLimit(int slot);
 
     /**
+     * Retrieves the maximum stack size allowed to exist in the given slot for a given stack.
+     * <p>
+     * This may be greater than {@link ItemStack#getMaxStackSize()} but not greater than {@link #getSlotLimit(int)}.
+     *
+     * @param slot  Slot to query
+     * @param stack Stack to query
+     * @return      The maximum size allowed in the slot for the given stack.
+     */
+    default int getMaxStackSize(int slot, @NotNull ItemStack stack) {
+        return Math.min(getSlotLimit(slot), stack.getMaxStackSize());
+    }
+
+    /**
      * <p>
      * This function re-implements the vanilla function {@link Container#canPlaceItem(int, ItemStack)}.
      * It should be used instead of simulated insertions in cases where the contents and state of the inventory are
@@ -94,15 +110,131 @@ public interface IItemHandler
      * inventory and should move on).
      * </p>
      * <ul>
-     * <li>isItemValid is false when insertion of the item is never valid.</li>
-     * <li>When isItemValid is true, no assumptions can be made and insertion must be simulated case-by-case.</li>
-     * <li>The actual items in the inventory, its fullness, or any other state are <strong>not</strong> considered by isItemValid.</li>
+     *     <li>If {@code false}, insertion of the item can never be valid.</li>
+     *     <li>If {@code true}, no assumptions can be made and insertion must be simulated case-by-case.</li>
      * </ul>
+     * The actual items in the inventory, its fullness, or any other state are <b>not</b> considered by this method.
+     *
      * @param slot    Slot to query for validity
      * @param stack   Stack to test with for validity
      *
-     * @return true if the slot can insert the ItemStack, not considering the current state of the inventory.
-     *         false if the slot can never insert the ItemStack in any situation.
+     * @return {@code true} if the ItemStack may be inserted, not considering the current state of the inventory.
+     *         {@code false} if the ItemStack can never be inserted in any situation.
      */
     boolean isItemValid(int slot, @NotNull ItemStack stack);
+
+    /**
+     * The extraction counterpart of {@link #isItemValid(int, ItemStack)}.
+     * <p>
+     * It should be used instead of simulated extractions in cases where the contents and state of the inventory are
+     * irrelevant, mainly for the purpose of automation and logic (for instance, testing if a minecart can wait to
+     * extract items from this inventory to fill its own, or if items can never be extracted and it should move on).
+     * </p>
+     * <ul>
+     *     <li>If {@code false}, extraction of the item is never possible.</li>
+     *     <li>If {@code true}, no assumptions can be made and extraction must be simulated case-by-case.</li>
+     * </ul>
+     * The actual items in the inventory, its fullness, or any other state are <b>not</b> considered by this method.
+     *
+     * @param slot  Slot to query for validity
+     * @param stack Stack to test for validity
+     * @return {@code true} if extraction of the item from the given slot may be possible.
+     *         {@code false} if no extraction is possible under any circumstances.
+     */
+    default boolean isExtractionAllowed(int slot, @NotNull ItemStack stack)
+    {
+        return true; // TODO: 1.20 - Remove default, forcing users to explicitly choose, widening adoption
+    }
+
+    /**
+     * Queries the extended contract terms for {@link #insertItem(int, ItemStack, boolean)} and
+     * {@link #extractItem(int, int, boolean)}.
+     *
+     * @return The I/O guarantees of this item handler
+     */
+    default IOGuarantees getIOGuarantees()
+    {
+        return IOGuarantees.NONE; // TODO: 1.20 - Remove default, forcing users to explicitly choose, widening adoption
+    }
+
+    /**
+     * Enum describing the guarantees provided by insertion and extraction operations.
+     */
+    enum IOGuarantees
+    {
+        /**
+         * Insertion and extraction may affect other slots, and the results of these operations may not be reflected in
+         * the stack in the queried slot.
+         * <p>
+         * This is how item handlers have historically worked.
+         */
+        NONE(false, false),
+        /**
+         * The inventory is guaranteed to accurately reflect the outcome of insertion/extraction operations.
+         * Additionally, all slots are guaranteed to be fully independent from each other, meaning changes to one of
+         * them must not immediately affect the contents or behavior of any of the others. A delayed side effect
+         * (for example, at the end of the tick or next tick) is considered valid behavior.
+         * <p>
+         * This means that a third party may safely operate on multiple slots guaranteeing the independence of such
+         * operations.
+         */
+        CONSISTENT(true, false),
+        /**
+         * A stricter version of {@link #CONSISTENT}, providing additional guarantees on insertion and extraction.
+         * <p>
+         * Insertion must adhere to the following:
+         * <ul>
+         *     <li>If {@link #isItemValid(int, ItemStack)} returns {@code false} for the provided stack, the stack must
+         *     be rejected.</li>
+         *     <li>If the slot contains an item and {@link ItemHandlerHelper#canItemStacksStack(ItemStack, ItemStack)}
+         *     returns false when comparing it with the provided stack, the stack must be rejected.</li>
+         *     <li>Any amount up to {@link #getMaxStackSize(int, ItemStack)} minus the current size of the stack in the
+         *     slot must be allowed to be inserted, and any additional items must be rejected.</li>
+         * </ul>
+         * <p>
+         * Extraction must adhere to the following:
+         * <ul>
+         *     <li>If {@link #isExtractionAllowed(int, ItemStack)} returns {@code false}, no action must be performed
+         *     and an empty stack must be returned</li>
+         *     <li>Any amount up to the current size of the stack in the slot must be allowed to be extracted.</li>
+         * </ul>
+         * <p>
+         * This means that a third party may safely predict the outcome of multiple insertion/extraction operations on
+         * the same slot and collapse them down to one or two operations. They may also do this across multiple slots,
+         * since they are guaranteed to be independent.
+         */
+        STRICT(true, true);
+
+        private final boolean consistent, strict;
+
+        IOGuarantees(boolean consistent, boolean strict)
+        {
+            this.consistent = consistent;
+            this.strict = strict;
+        }
+
+        /**
+         * {@return {@code false} if the contract described in {@link #CONSISTENT} applies, {@code false} otherwise}
+         */
+        public boolean isConsistent()
+        {
+            return consistent;
+        }
+
+        /**
+         * {@return {@code false} if the contract described in {@link #STRICT} applies, {@code false} otherwise}
+         */
+        public boolean isStrict()
+        {
+            return strict;
+        }
+
+        /**
+         * {@return the least strict of the two guarantees}
+         */
+        public static IOGuarantees leastStrict(IOGuarantees first, IOGuarantees second)
+        {
+            return first.ordinal() < second.ordinal() ? first : second;
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -206,7 +206,7 @@ public class ItemHandlerHelper
 
                 if (!itemstack.isEmpty())
                 {
-                    proportion += (float)itemstack.getCount() / (float)Math.min(inv.getSlotLimit(j), itemstack.getMaxStackSize());
+                    proportion += (float)itemstack.getCount() / (float)inv.getMaxStackSize(j, itemstack);
                     ++itemsFound;
                 }
             }

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -73,7 +73,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
 
         ItemStack existing = this.stacks.get(slot);
 
-        int limit = getStackLimit(slot, stack);
+        int limit = getMaxStackSize(slot, stack);
 
         if (!existing.isEmpty())
         {
@@ -115,7 +115,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
 
         ItemStack existing = this.stacks.get(slot);
 
-        if (existing.isEmpty())
+        if (existing.isEmpty() || !isExtractionAllowed(slot, existing))
             return ItemStack.EMPTY;
 
         int toExtract = Math.min(amount, existing.getMaxStackSize());
@@ -151,6 +151,16 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         return 64;
     }
 
+    @Override
+    public int getMaxStackSize(int slot, @NotNull ItemStack stack)
+    {
+        return getStackLimit(slot, stack);
+    }
+
+    /**
+     * @deprecated Use {@link #getMaxStackSize(int, ItemStack)}
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     protected int getStackLimit(int slot, @NotNull ItemStack stack)
     {
         return Math.min(getSlotLimit(slot), stack.getMaxStackSize());
@@ -160,6 +170,12 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
     public boolean isItemValid(int slot, @NotNull ItemStack stack)
     {
         return true;
+    }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        return IOGuarantees.STRICT;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -209,7 +209,7 @@ public class VanillaInventoryCodeHooks
         for (int slot = 0; slot < itemHandler.getSlots(); slot++)
         {
             ItemStack stackInSlot = itemHandler.getStackInSlot(slot);
-            if (stackInSlot.isEmpty() || stackInSlot.getCount() < itemHandler.getSlotLimit(slot))
+            if (stackInSlot.isEmpty() || stackInSlot.getCount() < itemHandler.getMaxStackSize(slot, stackInSlot))
             {
                 return false;
             }

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -31,6 +31,7 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
         this.slotCount = index;
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public CombinedInvWrapper(IItemHandlerModifiable... itemHandler)
     {
         this(IOGuarantees.NONE, itemHandler);

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -119,11 +119,29 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
     }
 
     @Override
+    public int getMaxStackSize(int slot, @NotNull ItemStack stack)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        int localSlot = getSlotFromIndex(slot, index);
+        return handler.getMaxStackSize(localSlot, stack);
+    }
+
+    @Override
     public boolean isItemValid(int slot, @NotNull ItemStack stack)
     {
         int index = getIndexForSlot(slot);
         IItemHandlerModifiable handler = getHandlerFromIndex(index);
         int localSlot = getSlotFromIndex(slot, index);
         return handler.isItemValid(localSlot, stack);
+    }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        var guarantees = IOGuarantees.STRICT;
+        for (var handler : itemHandler)
+            guarantees = IOGuarantees.leastStrict(guarantees, handler.getIOGuarantees());
+        return guarantees;
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -12,13 +12,14 @@ import org.jetbrains.annotations.NotNull;
 // combines multiple IItemHandlerModifiable into one interface
 public class CombinedInvWrapper implements IItemHandlerModifiable
 {
-
+    protected final IOGuarantees ioGuarantees;
     protected final IItemHandlerModifiable[] itemHandler; // the handlers
     protected final int[] baseIndex; // index-offsets of the different handlers
     protected final int slotCount; // number of total slots
 
-    public CombinedInvWrapper(IItemHandlerModifiable... itemHandler)
+    public CombinedInvWrapper(IOGuarantees ioGuarantees, IItemHandlerModifiable... itemHandler)
     {
+        this.ioGuarantees = ioGuarantees;
         this.itemHandler = itemHandler;
         this.baseIndex = new int[itemHandler.length];
         int index = 0;
@@ -28,6 +29,11 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
             baseIndex[i] = index;
         }
         this.slotCount = index;
+    }
+
+    public CombinedInvWrapper(IItemHandlerModifiable... itemHandler)
+    {
+        this(IOGuarantees.NONE, itemHandler);
     }
 
     // returns the handler index for the slot
@@ -139,9 +145,6 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
     @Override
     public IOGuarantees getIOGuarantees()
     {
-        var guarantees = IOGuarantees.STRICT;
-        for (var handler : itemHandler)
-            guarantees = IOGuarantees.leastStrict(guarantees, handler.getIOGuarantees());
-        return guarantees;
+        return ioGuarantees;
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
@@ -58,4 +58,10 @@ public class EmptyHandler implements IItemHandlerModifiable
     {
         return false;
     }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        return IOGuarantees.STRICT;
+    }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -195,7 +195,7 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
         LazyOptional<IItemHandlerModifiable>[] ret = new LazyOptional[3];
         ret[0] = LazyOptional.of(() -> new EntityHandsInvWrapper(entity));
         ret[1] = LazyOptional.of(() -> new EntityArmorInvWrapper(entity));
-        ret[2] = LazyOptional.of(() -> new CombinedInvWrapper(ret[0].orElse(null), ret[1].orElse(null)));
+        ret[2] = LazyOptional.of(() -> new CombinedInvWrapper(IOGuarantees.STRICT, ret[0].orElse(null), ret[1].orElse(null)));
         return ret;
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -78,7 +78,7 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
 
         final ItemStack existing = entity.getItemBySlot(equipmentSlot);
 
-        int limit = getStackLimit(slot, stack);
+        int limit = getMaxStackSize(slot, stack);
 
         if (!existing.isEmpty())
         {
@@ -151,6 +151,16 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
         return equipmentSlot.getType() == EquipmentSlot.Type.ARMOR ? 1 : 64;
     }
 
+    @Override
+    public int getMaxStackSize(int slot, @NotNull ItemStack stack)
+    {
+        return getStackLimit(slot, stack);
+    }
+
+    /**
+     * @deprecated Use {@link #getMaxStackSize(int, ItemStack)}
+     */
+    @Deprecated(forRemoval = true, since = "1.19.2")
     protected int getStackLimit(final int slot, @NotNull final ItemStack stack)
     {
         return Math.min(getSlotLimit(slot), stack.getMaxStackSize());

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -65,7 +65,7 @@ public class InvWrapper implements IItemHandlerModifiable
         int m;
         if (!stackInSlot.isEmpty())
         {
-            if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
+            if (stackInSlot.getCount() >= getMaxStackSize(slot, stackInSlot))
                 return stack;
 
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
@@ -74,7 +74,7 @@ public class InvWrapper implements IItemHandlerModifiable
             if (!getInv().canPlaceItem(slot, stack))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
+            m = getMaxStackSize(slot, stack) - stackInSlot.getCount();
 
             if (stack.getCount() <= m)
             {
@@ -112,7 +112,7 @@ public class InvWrapper implements IItemHandlerModifiable
             if (!getInv().canPlaceItem(slot, stack))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
+            m = getMaxStackSize(slot, stack);
             if (m < stack.getCount())
             {
                 // copy the stack to not modify the original one
@@ -193,6 +193,12 @@ public class InvWrapper implements IItemHandlerModifiable
     public boolean isItemValid(int slot, @NotNull ItemStack stack)
     {
         return getInv().canPlaceItem(slot, stack);
+    }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        return IOGuarantees.STRICT;
     }
 
     public Container getInv()

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
@@ -24,21 +24,22 @@ public class PlayerArmorInvWrapper extends RangedWrapper
     @NotNull
     public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
     {
-        EquipmentSlot equ = null;
+        if (stack.isEmpty() || !isItemValid(slot, stack))
+            return stack;
+        return super.insertItem(slot, stack, simulate);
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack)
+    {
+        if (slot >= inventoryPlayer.armor.size() || !super.isItemValid(slot, stack) || stack.isEmpty())
+            return false;
+
         for (EquipmentSlot s : EquipmentSlot.values())
-        {
             if (s.getType() == EquipmentSlot.Type.ARMOR && s.getIndex() == slot)
-            {
-                equ = s;
-                break;
-            }
-        }
-        // check if it's valid for the armor slot
-        if (equ != null && slot < 4 && !stack.isEmpty() && stack.canEquip(equ, getInventoryPlayer().player))
-        {
-            return super.insertItem(slot, stack, simulate);
-        }
-        return stack;
+                return stack.canEquip(s, inventoryPlayer.player);
+
+        return false;
     }
 
     public Inventory getInventoryPlayer()

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
@@ -11,6 +11,6 @@ public class PlayerInvWrapper extends CombinedInvWrapper
 {
     public PlayerInvWrapper(Inventory inv)
     {
-        super(new PlayerMainInvWrapper(inv), new PlayerArmorInvWrapper(inv), new PlayerOffhandInvWrapper(inv));
+        super(IOGuarantees.STRICT, new PlayerMainInvWrapper(inv), new PlayerArmorInvWrapper(inv), new PlayerOffhandInvWrapper(inv));
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -91,6 +91,12 @@ public class RangedWrapper implements IItemHandlerModifiable {
     }
 
     @Override
+    public int getMaxStackSize(int slot, @NotNull ItemStack stack)
+    {
+        return checkSlot(slot) ? compose.getMaxStackSize(slot + minSlot, stack) : 0;
+    }
+
+    @Override
     public boolean isItemValid(int slot, @NotNull ItemStack stack)
     {
         if (checkSlot(slot))
@@ -99,6 +105,12 @@ public class RangedWrapper implements IItemHandlerModifiable {
         }
 
         return false;
+    }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        return compose.getIOGuarantees();
     }
 
     private boolean checkSlot(int localSlot)

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -96,7 +96,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         int m;
         if (!stackInSlot.isEmpty())
         {
-            if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
+            if (stackInSlot.getCount() >= getMaxStackSize(slot, stackInSlot))
                 return stack;
 
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
@@ -105,7 +105,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
             if (!inv.canPlaceItemThroughFace(slot1, stack, side) || !inv.canPlaceItem(slot1, stack))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
+            m = getMaxStackSize(slot, stack) - stackInSlot.getCount();
 
             if (stack.getCount() <= m)
             {
@@ -141,7 +141,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
             if (!inv.canPlaceItemThroughFace(slot1, stack, side) || !inv.canPlaceItem(slot1, stack))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
+            m = getMaxStackSize(slot, stack);
             if (m < stack.getCount())
             {
                 // copy the stack to not modify the original one
@@ -233,6 +233,19 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     public boolean isItemValid(int slot, @NotNull ItemStack stack)
     {
         int slot1 = getSlot(inv, slot, side);
-        return slot1 == -1 ? false : inv.canPlaceItem(slot1, stack);
+        return slot1 == -1 ? false : inv.canPlaceItem(slot1, stack); // TODO: 1.20 - Change this to the face-aware method
+    }
+
+    @Override
+    public boolean isExtractionAllowed(int slot, @NotNull ItemStack stack)
+    {
+        int slot1 = getSlot(inv, slot, side);
+        return slot1 == -1 ? false : inv.canTakeItemThroughFace(slot1, stack, side);
+    }
+
+    @Override
+    public IOGuarantees getIOGuarantees()
+    {
+        return IOGuarantees.STRICT;
     }
 }


### PR DESCRIPTION
This PR aims to extend the `IItemHandler` specification with opt-in constraints on insertion and extraction operations that provide additional guarantees to callers, greatly expanding their capabilities at no real cost for implementors.

## Motivation

Introducing advanced functionality to item handlers such as transactions has always been a point of contention. While it can provide huge benefits to the API users that want/need that behavior, it also comes with a sizable implementation and runtime cost, and those who don't benefit from it generally have to adapt their code, carrying over some of the complexity of these APIs. Additionally, they may introduce certain potentially unsafe behavior (requiring rollbacks for simulated/cancelled operations, which may be easily missed or forgotten), and require special attention in cases where side effects must be propagated to other systems, or where multiple views of the same underlying storage are exposed and operated on at once to name a few.

## Objective

The goal of this PR is to provide additional contract terms to the insertion and extraction methods in `IItemHandler` on an opt-in basis, affording callers certain guarantees about how these methods will behave and what their side effects will be.

It is, however, **NOT** a goal of this PR to introduce any explicit transactional helpers or behavior, or to support interfacing with multiple item handlers at once.

## I/O Guarantees

There are three proposed levels of I/O guarantees that item handlers may expose:

### None

This reflects the current contract and is returned by default.

Insertion and extraction may affect slots other than the one specified, and the results of these operations may not be reflected in the stack in the queried slot.

*For example, a trash can may immediately void any items put into it.*

### Consistent

The inventory is guaranteed to accurately reflect the outcome of insertion/extraction operations.

Additionally, all slots are guaranteed to be fully independent from each other, meaning changes to one of them must not immediately affect the contents or behavior of any of the others. A delayed side effect (for example, at the end of the tick or next tick) is considered valid behavior.

This means that a third party may safely operate on multiple slots at once guaranteeing the independence of such operations.

*For example, this ensures that, if presented with an empty two-slot inventory, inserting 5 cobblestone into the first slot does not interfere with inserting 8 planks into the second.*

### Strict

This behavior inherits from the previous and is equivalent to that of vanilla's `Container`. Additionally:

Insertion must adhere to the following:
 - If `isItemValid(int, ItemStack)` returns `false` for the provided stack, the stack must be rejected
 - If the slot contains an item and `ItemHandlerHelper#canItemStacksStack(...)` returns `false` when comparing it with the provided stack, the stack must be rejected
 - Otherwise any amount up to `getMaxStackSize(int, ItemStack)` minus the current size of the stack in the slot must be allowed to be inserted, and any additional items must be rejected

Extraction must adhere to the following:
 - If `isExtractionAllowed(int, ItemStack)` returns `false`, no action must be performed and an empty stack must be returned
 - Otherwise any amount up to the current size of the stack in the slot must be allowed to be extracted.

This essentially turns the insertion and extraction methods into a checked version of `set(...)`.

This means that a third party may safely predict the outcome of multiple insertion/extraction operations on the same slot and collapse them down to one or two operations. They may also do this across multiple slots, since they are guaranteed to be independent.

*For example, the slots in a chest are fully independent from each other and follow these insertion and extraction rules.*

## Cost

It's an enum! Implementors just have to pick one of the values for their item handler based on what guarantees they can provide to external callers (defaults to no guarantees).

Code calling into the item handler API doesn't need to be changed, but can be enhanced by querying the I/O guarantees to ensure the safety of certain operations.

## Request for Comments

This is an open call to anyone interested in such a system to leave their feedback and suggestions.

However, there are some key points that should warrant special attention:
 - Should I/O guarantees be per-slot instead of affecting the whole inventory? Note the additional cost for API callers and any inconsistencies that may be introduced with this change
 - Are the 3 provided levels enough to satisfy people's *general* needs? Understand that some behaviors, while nice, might be too niche for their implementation cost

We also have a thread in the github discussions channel of the ForgeCord, which you can find here:
https://discord.com/channels/313125603924639766/1010529560707739689