### PR TITLE
Added Bookshelves block tag

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/bookshelves.json
+++ b/src/generated/resources/data/forge/tags/blocks/bookshelves.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:bookshelf"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -35,6 +35,7 @@ public class Tags
 
         public static final TagKey<Block> BARRELS = tag("barrels");
         public static final TagKey<Block> BARRELS_WOODEN = tag("barrels/wooden");
+        public static final TagKey<Block> BOOKSHELVES = tag("bookshelves");
         public static final TagKey<Block> CHESTS = tag("chests");
         public static final TagKey<Block> CHESTS_ENDER = tag("chests/ender");
         public static final TagKey<Block> CHESTS_TRAPPED = tag("chests/trapped");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -34,6 +34,7 @@ public final class ForgeBlockTagsProvider extends BlockTagsProvider
     {
         tag(BARRELS).addTag(BARRELS_WOODEN);
         tag(BARRELS_WOODEN).add(Blocks.BARREL);
+        tag(BOOKSHELVES).add(Blocks.BOOKSHELF);
         tag(CHESTS).addTags(CHESTS_ENDER, CHESTS_TRAPPED, CHESTS_WOODEN);
         tag(CHESTS_ENDER).add(Blocks.ENDER_CHEST);
         tag(CHESTS_TRAPPED).add(Blocks.TRAPPED_CHEST);


### PR DESCRIPTION
This tag was added during 1.13 lifecycle but went missing sometimes later. https://github.com/MinecraftForge/MinecraftForge/pull/5738
As the tag exists for items, I don't see a reason, why there shouldn't be a blocktag