### PR TITLE
Fix entity selector permission check to check original source

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1498,7 +1498,7 @@ public class ForgeHooks
 
     public static boolean canUseEntitySelectors(SharedSuggestionProvider provider)
     {
-        if (provider instanceof CommandSourceStack source && source.getEntity() instanceof ServerPlayer player)
+        if (provider instanceof CommandSourceStack source && source.source instanceof ServerPlayer player)
         {
             return PermissionAPI.getPermission(player, ForgeMod.USE_SELECTORS_PERMISSION);
         }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -139,6 +139,7 @@ protected net.minecraft.client.resources.model.ModelBakery f_119243_ # resourceM
 protected net.minecraft.client.resources.model.ModelBakery m_119364_(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/BlockModel; # loadBlockModel
 public net.minecraft.client.resources.model.SimpleBakedModel$Builder <init>(ZZZLnet/minecraft/client/renderer/block/model/ItemTransforms;Lnet/minecraft/client/renderer/block/model/ItemOverrides;)V # constructor
 public net.minecraft.client.sounds.SoundEngine f_120217_ # soundManager
+public net.minecraft.commands.CommandSourceStack f_81288_ # source
 public net.minecraft.commands.arguments.selector.EntitySelectorParser m_121229_()V # finalizePredicates
 public net.minecraft.commands.arguments.selector.EntitySelectorParser m_121317_()V # parseOptions
 public net.minecraft.commands.arguments.selector.options.EntitySelectorOptions m_121453_(Ljava/lang/String;Lnet/minecraft/commands/arguments/selector/options/EntitySelectorOptions$Modifier;Ljava/util/function/Predicate;Lnet/minecraft/network/chat/Component;)V # register


### PR DESCRIPTION
This PR fixes #8994 by fixing the Forge permission check hook for the use of entity selectors to check the original command source via (the access transformed) `CommandSourceStack#source`, rather than the target entity via `CommandSourceStack#getEntity()`. As noted in the linked issue, permission checks should be done against the command source and not the target entity.