### PR TITLE
[1.18] Fix circular dependency in static init of RecipeBookRegistry

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -41,10 +41,11 @@
        this.f_91068_ = new KeyboardHandler(this);
        this.f_91068_.m_90887_(this.f_90990_.m_85439_());
        RenderSystem.m_69580_(this.f_91066_.f_92035_, false);
-@@ -456,6 +_,7 @@
+@@ -456,6 +_,8 @@
        this.f_91042_.m_83931_(0.0F, 0.0F, 0.0F, 0.0F);
        this.f_91042_.m_83954_(f_91002_);
        this.f_91036_ = new ReloadableResourceManager(PackType.CLIENT_RESOURCES);
++      net.minecraftforge.client.RecipeBookRegistry.initDefaultValues();
 +      net.minecraftforge.client.loading.ClientModLoader.begin(this, this.f_91038_, this.f_91036_, this.f_91037_);
        this.f_91038_.m_10506_();
        this.f_91066_.m_92145_(this.f_91038_);

--- a/src/main/java/net/minecraftforge/client/RecipeBookRegistry.java
+++ b/src/main/java/net/minecraftforge/client/RecipeBookRegistry.java
@@ -11,6 +11,7 @@ import net.minecraft.client.RecipeBookCategories;
 import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -20,8 +21,7 @@ import static net.minecraft.client.RecipeBookCategories.*;
 
 public class RecipeBookRegistry
 {
-    // The ImmutableMap is the patched out value of AGGREGATE_CATEGORIES
-    private static final Map<RecipeBookCategories, List<RecipeBookCategories>> MUTABLE_AGGREGATE_CATEGORIES = new HashMap<>(ImmutableMap.of(CRAFTING_SEARCH, ImmutableList.of(CRAFTING_EQUIPMENT, CRAFTING_BUILDING_BLOCKS, CRAFTING_MISC, CRAFTING_REDSTONE), FURNACE_SEARCH, ImmutableList.of(FURNACE_FOOD, FURNACE_BLOCKS, FURNACE_MISC), BLAST_FURNACE_SEARCH, ImmutableList.of(BLAST_FURNACE_BLOCKS, BLAST_FURNACE_MISC), SMOKER_SEARCH, ImmutableList.of(SMOKER_FOOD)));
+    private static final Map<RecipeBookCategories, List<RecipeBookCategories>> MUTABLE_AGGREGATE_CATEGORIES = new HashMap<>();
 
     private static final Map<RecipeBookType, List<RecipeBookCategories>> TYPE_TO_CATEGORIES = new HashMap<>();
     private static final Map<RecipeType<?>, Function<Recipe<?>, RecipeBookCategories>> FIND_CATEGORIES_FOR_TYPE = new HashMap<>();
@@ -49,5 +49,17 @@ public class RecipeBookRegistry
     public static RecipeBookCategories findCategories(RecipeType<?> type, Recipe<?> recipe)
     {
         return Optional.ofNullable(FIND_CATEGORIES_FOR_TYPE.get(type)).map(f -> f.apply(recipe)).orElse(null);
+    }
+
+    @ApiStatus.Internal
+    public static void initDefaultValues()
+    {
+        // The ImmutableMap is the patched out value of AGGREGATE_CATEGORIES
+        MUTABLE_AGGREGATE_CATEGORIES.putAll(ImmutableMap.of(
+                CRAFTING_SEARCH, ImmutableList.of(CRAFTING_EQUIPMENT, CRAFTING_BUILDING_BLOCKS, CRAFTING_MISC, CRAFTING_REDSTONE),
+                FURNACE_SEARCH, ImmutableList.of(FURNACE_FOOD, FURNACE_BLOCKS, FURNACE_MISC),
+                BLAST_FURNACE_SEARCH, ImmutableList.of(BLAST_FURNACE_BLOCKS, BLAST_FURNACE_MISC),
+                SMOKER_SEARCH, ImmutableList.of(SMOKER_FOOD)
+        ));
     }
 }


### PR DESCRIPTION
This PR fixes a circular dependency in the static initialization of `RecipeBookRegistry` which has the potential to lead to `RecipeBookCategories.AGGREGATE_CATEGORIES` being initialized to null.
This was discovered because the `RecipeBookCategories.AGGREGATE_CATEGORIES` field being null leads to the [this](https://gist.github.com/XFactHD/80802a53d9c7c476278f7d8c3be59093) stacktrace and the `RecipesUpdatedEvent` not firing.

---

Vanilla's `RecipeBookCategories` and Forge's `RecipeBookRegistry` have a circular dependency in their static initializers. The `RecipeBookCategories.AGGREGATE_CATEGORIES` field is initialized with `RecipeBookRegistry.AGGREGATE_CATEGORIES_VIEW` which is a view of `RecipeBookRegistry.MUTABLE_AGGREGATE_CATEGORIES` which uses the enum fields of `RecipeBookCategories` in its initialization.

This issue is fixed by initializing the `RecipeBookRegistry.MUTABLE_AGGREGATE_CATEGORIES` field with an empty map and filling it later via `RecipeBookRegistry.initDefaultValues()`.

This is not an issue in 1.19 because the 1.19 implementation already does what this PR suggests by initializing the map empty and filling it later.

---

See <https://discord.com/channels/313125603924639766/852298000042164244/1012527274446291024> for the full context.