### PR TITLE
[1.19.x] Moved Player.resetAttackStrengthTicker() to the end of Player.attack()

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -280,15 +280,14 @@
                          this.m_21008_(InteractionHand.MAIN_HAND, ItemStack.f_41583_);
                       }
                    }
-@@ -1212,7 +_,7 @@
+@@ -1212,6 +_,7 @@
                    }
                 }
              }
--
-+            this.m_36334_();
++            this.m_36334_(); // FORGE: Moved from beginning of attack() so that getAttackStrengthScale() returns an accurate value during all attack events
+ 
           }
        }
-    }
 @@ -1228,7 +_,7 @@
        }
  

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -215,7 +215,11 @@
        if (p_36347_.m_6097_()) {
           if (!p_36347_.m_7313_(this)) {
              float f = (float)this.m_21133_(Attributes.f_22281_);
-@@ -1086,7 +_,7 @@
+@@ -1082,11 +_,10 @@
+             float f2 = this.m_36403_(0.5F);
+             f *= 0.2F + f2 * f2 * 0.8F;
+             f1 *= f2;
+-            this.m_36334_();
              if (f > 0.0F || f1 > 0.0F) {
                 boolean flag = f2 > 0.9F;
                 boolean flag1 = false;
@@ -276,6 +280,15 @@
                          this.m_21008_(InteractionHand.MAIN_HAND, ItemStack.f_41583_);
                       }
                    }
+@@ -1212,7 +_,7 @@
+                   }
+                }
+             }
+-
++            this.m_36334_();
+          }
+       }
+    }
 @@ -1228,7 +_,7 @@
        }
  


### PR DESCRIPTION
This is another take on solving the problem that #8891 is meant to fix. 

The problem is that the player's attack progress scale is reset before they've hurt an entity (`resetAttackStrengthTicker()` resets `attackStrengthTicker`, which is used in calculating the value gotten from `getAttackStrengthScale()`), meaning if a modder wants to know what the player's attack strength scale is *after* they've hurt an entity (through using `getAttackStrengthScale()` as is otherwise possible earlier in the attack sequence), that scale value is always zero. This is fixed by moving the call to reset the value to the end of Player.attack() after the entity hurt code has been called.

One reason a modder may want to know what the attack strength scale is by using `getAttackStrengthScale()` after an entity has been hurt is for checking if the player has performed an attack with full strength (when the attack indicator is full), but also has been verified as having hurt the entity. This could be used for performing an item ability only when a player has injured an entity with a full attack swing.

This change has been tested and does not appear to affect any vanilla behavior; the attack indicator and attack swing recharge still display the same as normal.