### PR TITLE
[1.19] Fix check if entity/block is in range

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgePlayer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePlayer.java
@@ -5,11 +5,11 @@
 
 package net.minecraftforge.common.extensions;
 
-import java.util.Optional;
-
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeMod;
 
@@ -74,9 +74,9 @@ public interface IForgePlayer
     default boolean isCloseEnough(Entity entity, double dist)
     {
         Vec3 eye = self().getEyePosition();
-        Vec3 targetCenter = entity.getPosition(1.0F).add(0, entity.getBbHeight() / 2, 0);
-        Optional<Vec3> hit = entity.getBoundingBox().clip(eye, targetCenter); //This hit should almost always be present, but we have a fallback just in case.  It likely indicates lag if it is not present.
-        return (hit.isPresent() ? eye.distanceToSqr(hit.get()) : self().distanceToSqr(entity)) < dist * dist;
+        AABB aabb = entity.getBoundingBox().inflate(entity.getPickRadius());
+        Vec3 target = new Vec3(Mth.clamp(eye.x, aabb.minX, aabb.maxX), Mth.clamp(eye.y, aabb.minY, aabb.maxY), Mth.clamp(eye.z, aabb.minZ, aabb.maxZ));
+        return eye.distanceToSqr(target) < dist * dist;
     }
 
     /**
@@ -89,7 +89,9 @@ public interface IForgePlayer
     default boolean canInteractWith(BlockPos pos, double padding)
     {
         double reach = getReachDistance() + padding;
-        return self().getEyePosition().distanceToSqr(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D) < reach * reach;
+        Vec3 eye = self().getEyePosition();
+        Vec3 target = new Vec3(Mth.clamp(eye.x, pos.getX(), pos.getX() + 1.0D), Mth.clamp(eye.y, pos.getY(), pos.getY() + 1.0D), Mth.clamp(eye.z, pos.getZ(), pos.getZ() + 1.0D));
+        return eye.distanceToSqr(target) < reach * reach;
     }
 
 }


### PR DESCRIPTION
#8478 introduced an issue. The check if an entity or block is in interaction/attack range always assumes that the player is looking exactly at the center of the entity or block. But a player can also look at a corner of an entity which might be a lot closer to the eyes of the player.

Here is a picture of the issue:
![reachIssue](https://user-images.githubusercontent.com/27779321/188326588-38b59a4f-d4b1-4760-8941-0b0f7e812a6e.png)

Another issue is that `Entity#getPickRadius` is ignored in the calculation.

This PR fixes this issue by calculating the distance from the eyes of the player to the nearest point of the entity bounding box inflated by `Entity#getPickRadius`/block position.