### PR TITLE
Fix Transform Origin serialized names

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -333,9 +333,9 @@ public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder>
 
         public enum TransformOrigin implements StringRepresentable
         {
-            CENTER(new Vector3f(.5f, .5f, .5f), "origin"),
+            CENTER(new Vector3f(.5f, .5f, .5f), "center"),
             CORNER(Vector3f.ZERO, "corner"),
-            OPPOSING_CORNER(ONE, "opposing_corner");
+            OPPOSING_CORNER(ONE, "opposing-corner");
 
             private final Vector3f vec;
             private final String name;


### PR DESCRIPTION
#8860 introduced an issue with deserializing models using center or opposing-center origins, as the names were erroneously set in my original PR. Issuing this to solve this, apologies for this.