### PR TITLE
[1.19] Fix client reach checks ignoring hitResult

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -293,7 +293,7 @@
 +            var inputEvent = net.minecraftforge.client.ForgeHooksClient.onClickInput(0, this.f_91066_.f_92096_, InteractionHand.MAIN_HAND);
 +            HitResult.Type hitType = this.f_91077_.m_6662_();
 +            if (this.f_91077_ instanceof EntityHitResult entityHit) { // Forge: Perform attack range checks here, instead of in GameRenderer#pick, so extended-reach interactions work.
-+               if (f_91074_.m_146892_().m_82557_(f_91077_.m_82450_()) >= f_91074_.getAttackRange() * f_91074_.getAttackRange()) hitType = HitResult.Type.MISS; // No padding in client code.
++               if (!f_91074_.canHit(f_91077_.m_82450_(), 0)) hitType = HitResult.Type.MISS; // No padding in client code.
 +            }
 +            if (!inputEvent.isCanceled())
 +            switch(hitType) {
@@ -335,7 +335,7 @@
                             return;
                          }
  
-+                        if(f_91074_.m_146892_().m_82557_(f_91077_.m_82450_()) >= f_91074_.getReachDistance() * f_91074_.getReachDistance()) break; //Forge: Entity may be traced via attack range, but the player may not have sufficient reach.  No padding in client code.
++                        if(!f_91074_.canInteractWith(f_91077_.m_82450_(), 0)) break; //Forge: Entity may be traced via attack range, but the player may not have sufficient reach.  No padding in client code.
                          InteractionResult interactionresult = this.f_91072_.m_105230_(this.f_91074_, entity, entityhitresult, interactionhand);
                          if (!interactionresult.m_19077_()) {
                             interactionresult = this.f_91072_.m_105226_(this.f_91074_, entity, interactionhand);

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -293,7 +293,7 @@
 +            var inputEvent = net.minecraftforge.client.ForgeHooksClient.onClickInput(0, this.f_91066_.f_92096_, InteractionHand.MAIN_HAND);
 +            HitResult.Type hitType = this.f_91077_.m_6662_();
 +            if (this.f_91077_ instanceof EntityHitResult entityHit) { // Forge: Perform attack range checks here, instead of in GameRenderer#pick, so extended-reach interactions work.
-+               if (!f_91074_.canHit(entityHit.m_82443_(), 0)) hitType = HitResult.Type.MISS; // No padding in client code.
++               if (f_91074_.m_146892_().m_82557_(f_91077_.m_82450_()) >= f_91074_.getAttackRange() * f_91074_.getAttackRange()) hitType = HitResult.Type.MISS; // No padding in client code.
 +            }
 +            if (!inputEvent.isCanceled())
 +            switch(hitType) {
@@ -335,7 +335,7 @@
                             return;
                          }
  
-+                        if(!this.f_91074_.canInteractWith(entityhitresult.m_82443_(), 0)) break; //Forge: Entity may be traced via attack range, but the player may not have sufficient reach.  No padding in client code.
++                        if(f_91074_.m_146892_().m_82557_(f_91077_.m_82450_()) >= f_91074_.getReachDistance() * f_91074_.getReachDistance()) break; //Forge: Entity may be traced via attack range, but the player may not have sufficient reach.  No padding in client code.
                          InteractionResult interactionresult = this.f_91072_.m_105230_(this.f_91074_, entity, entityhitresult, interactionhand);
                          if (!interactionresult.m_19077_()) {
                             interactionresult = this.f_91072_.m_105226_(this.f_91074_, entity, interactionhand);

--- a/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
@@ -4,7 +4,7 @@
                    if (this.f_92986_.f_91076_ != null && this.f_92986_.f_91076_ instanceof LivingEntity && f >= 1.0F) {
                       flag = this.f_92986_.f_91074_.m_36333_() > 5.0F;
                       flag &= this.f_92986_.f_91076_.m_6084_();
-+                     flag &= this.f_92986_.f_91074_.canHit(this.f_92986_.f_91076_, 0);
++                     flag &= this.f_92986_.f_91074_.m_20238_(f_92986_.f_91077_.m_82450_()) < f_92986_.f_91074_.getAttackRange() * f_92986_.f_91074_.getAttackRange();
                    }
  
                    int j = this.f_92978_ / 2 - 7 + 16;

--- a/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
@@ -4,7 +4,7 @@
                    if (this.f_92986_.f_91076_ != null && this.f_92986_.f_91076_ instanceof LivingEntity && f >= 1.0F) {
                       flag = this.f_92986_.f_91074_.m_36333_() > 5.0F;
                       flag &= this.f_92986_.f_91076_.m_6084_();
-+                     flag &= this.f_92986_.f_91074_.m_20238_(f_92986_.f_91077_.m_82450_()) < f_92986_.f_91074_.getAttackRange() * f_92986_.f_91074_.getAttackRange();
++                     flag &= f_92986_.f_91074_.canHit(f_92986_.f_91077_.m_82450_(), 0);
                    }
  
                    int j = this.f_92978_ / 2 - 7 + 16;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePlayer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePlayer.java
@@ -54,6 +54,18 @@ public interface IForgePlayer
     }
 
     /**
+     * Checks if the player can attack an entity by targeting the passed vector.<br>
+     * On the server, additional leniency is added to account for movement/lag.
+     * @param vec The vector being range-checked.
+     * @param padding Extra validation distance.
+     * @return If the player can attack the entity.
+     */
+    default boolean canHit(Vec3 vec, double padding) // Do not rename to canAttack - will conflict with LivingEntity#canAttack
+    {
+        return self().getEyePosition().closerThan(vec, getAttackRange() + padding);
+    }
+
+    /**
      * Checks if the player can reach (right-click) the passed entity.<br>
      * On the server, additional leniency is added to account for movement/lag.
      * @param entity The entity being range-checked.
@@ -63,6 +75,18 @@ public interface IForgePlayer
     default boolean canInteractWith(Entity entity, double padding)
     {
         return isCloseEnough(entity, getReachDistance() + padding);
+    }
+
+    /**
+     * Checks if the player can reach (right-click) an entity by targeting the passed vector.<br>
+     * On the server, additional leniency is added to account for movement/lag.
+     * @param vec The vector being range-checked.
+     * @param padding Extra validation distance.
+     * @return If the player can interact with the entity.
+     */
+    default boolean canInteractWith(Vec3 vec, double padding)
+    {
+        return self().getEyePosition().closerThan(vec, getReachDistance() + padding);
     }
 
     /**


### PR DESCRIPTION
#8478 moved the check if an entity is in reach to be able to differentiate between attack range and interaction range. But with this change the location where hit an entity aabb is not used anymore to check if the the attack is valid. Thus the player can attack an entity by targeting parts of the entity aabb which should be out of the players attack range.

In this picture the player can only target the zombie when looking at the top or the bottom of the aabb of the zombie (in this case the top is targeted). The distance between the targeted position of the aabb and the players eyes is ~3.6 blocks. This is greater than the attack range of 3 blocks. But the player is still able to attack the zombie because the location of the hitResult is ignored. Instead it's assumed that the player is targeting the center of the zombies aabb which isn't actually possible because there are blocks in the way.
![reachIssue2](https://user-images.githubusercontent.com/27779321/188328959-f586ba86-f254-454d-ae5c-1f750b75beec.png)

This PR fixes this issue by using the location of the hitResult again when calculating if an entity attack/interaction is valid.