### PR TITLE
Fix reloading event firing during server shutdown and add explicit unloading event instead

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -68,7 +68,9 @@ public class ConfigTracker {
             LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
             // stop the filewatcher before we save the file and close it, so reload doesn't fire
             config.getHandler().unload(configBasePath, config);
-            config.fireEvent(IConfigEvent.unloading(config));
+            var unloading = IConfigEvent.unloading(config);
+            if (unloading != null)
+                config.fireEvent(unloading);
             config.save();
             config.setConfigData(null);
         }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -66,8 +66,9 @@ public class ConfigTracker {
     private void closeConfig(final ModConfig config, final Path configBasePath) {
         if (config.getConfigData() != null) {
             LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
-            config.save();
+            // stop the filewatcher before we save the file and close it, so reload doesn't fire
             config.getHandler().unload(configBasePath, config);
+            config.save();
             config.setConfigData(null);
         }
     }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -68,6 +68,7 @@ public class ConfigTracker {
             LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
             // stop the filewatcher before we save the file and close it, so reload doesn't fire
             config.getHandler().unload(configBasePath, config);
+            config.fireEvent(IConfigEvent.unloading(config));
             config.save();
             config.setConfigData(null);
         }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.Bindings;
 import java.util.function.Function;
 
 public interface IConfigEvent {
-    record ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading) {}
+    record ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading, Function<ModConfig, IConfigEvent> unloading) {}
     ConfigConfig CONFIGCONFIG = Bindings.getConfigConfiguration().get();
 
     static IConfigEvent reloading(ModConfig modConfig) {
@@ -19,6 +19,9 @@ public interface IConfigEvent {
     }
     static IConfigEvent loading(ModConfig modConfig) {
         return CONFIGCONFIG.loading().apply(modConfig);
+    }
+    static IConfigEvent unloading(ModConfig modConfig) {
+        return CONFIGCONFIG.unloading().apply(modConfig);
     }
     ModConfig getConfig();
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
@@ -10,8 +10,17 @@ import net.minecraftforge.fml.Bindings;
 
 import java.util.function.Function;
 
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
 public interface IConfigEvent {
-    record ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading, Function<ModConfig, IConfigEvent> unloading) {}
+    record ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading, @Nullable Function<ModConfig, IConfigEvent> unloading) {
+        @Deprecated(since = "1.19.3", forRemoval = true)
+        @ApiStatus.Internal
+        ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading) {
+            this(loading, reloading, null);
+        }
+    }
     ConfigConfig CONFIGCONFIG = Bindings.getConfigConfiguration().get();
 
     static IConfigEvent reloading(ModConfig modConfig) {
@@ -20,8 +29,8 @@ public interface IConfigEvent {
     static IConfigEvent loading(ModConfig modConfig) {
         return CONFIGCONFIG.loading().apply(modConfig);
     }
-    static IConfigEvent unloading(ModConfig modConfig) {
-        return CONFIGCONFIG.unloading().apply(modConfig);
+    @Nullable static IConfigEvent unloading(ModConfig modConfig) {
+        return CONFIGCONFIG.unloading() == null ? null : CONFIGCONFIG.unloading().apply(modConfig);
     }
     ModConfig getConfig();
 

--- a/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyBindings.java
+++ b/fmlonly/src/main/java/net/minecraftforge/fmlonly/FMLOnlyBindings.java
@@ -42,6 +42,6 @@ public class FMLOnlyBindings implements IBindingsProvider {
 
     @Override
     public Supplier<IConfigEvent.ConfigConfig> getConfigConfiguration() {
-        return ()->new IConfigEvent.ConfigConfig(ModConfigEvent.Loading::new, ModConfigEvent.Reloading::new);
+        return ()->new IConfigEvent.ConfigConfig(ModConfigEvent.Loading::new, ModConfigEvent.Reloading::new, ModConfigEvent.Unloading::new);
     }
 }

--- a/src/fmlcommon/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
+++ b/src/fmlcommon/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
@@ -22,14 +22,36 @@ public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent 
         return config;
     }
 
+    /**
+     * Fired during mod and server loading, depending on {@link ModConfig.Type} of config file.
+     * Any Config objects associated with this will be valid and can be queried directly.
+     */
     public static class Loading extends ModConfigEvent {
         public Loading(final ModConfig config) {
             super(config);
         }
     }
 
+    /**
+     * Fired when the configuration is changed. This can be caused by a change to the config
+     * from a UI or from editing the file itself. IMPORTANT: this can fire at any time
+     * and may not even be on the server or client threads. Ensure you properly synchronize
+     * any resultant changes.
+     */
     public static class Reloading extends ModConfigEvent {
         public Reloading(final ModConfig config) {
+            super(config);
+        }
+    }
+
+    /**
+     * Fired when a config is unloaded. This only happens when the server closes, which is
+     * probably only really relevant on the client, to reset internal mod state when the
+     * server goes away, though it will fire on the dedicated server as well.
+     * The config file will be saved after this event has fired.
+     */
+    public static class Unloading extends ModConfigEvent {
+        public Unloading(final ModConfig config) {
             super(config);
         }
     }

--- a/src/main/java/net/minecraftforge/internal/ForgeBindings.java
+++ b/src/main/java/net/minecraftforge/internal/ForgeBindings.java
@@ -38,6 +38,6 @@ public class ForgeBindings implements IBindingsProvider {
 
     @Override
     public Supplier<IConfigEvent.ConfigConfig> getConfigConfiguration() {
-        return ()->new IConfigEvent.ConfigConfig(ModConfigEvent.Loading::new, ModConfigEvent.Reloading::new);
+        return ()->new IConfigEvent.ConfigConfig(ModConfigEvent.Loading::new, ModConfigEvent.Reloading::new, ModConfigEvent.Unloading::new);
     }
 }


### PR DESCRIPTION
This fixes the problem that sometimes you might get a Reloading config event because the filewatcher notices the save _after_ the config has been unloaded during server shutdown. This can result in unwelcome "Config is in an invalid state" errors.

Added an explicit Unloading event to compensate in case anyone was somehow relying on this (they shouldn't have been?!)