### PR TITLE
Create a Forge EntityType Tag for Bosses

### DIFF
--- a/src/generated/resources/data/forge/tags/entity_types/bosses.json
+++ b/src/generated/resources/data/forge/tags/entity_types/bosses.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:ender_dragon",
+    "minecraft:wither"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -99,6 +99,7 @@ import net.minecraftforge.common.crafting.conditions.OrCondition;
 import net.minecraftforge.common.crafting.conditions.TagEmptyCondition;
 import net.minecraftforge.common.crafting.conditions.TrueCondition;
 import net.minecraftforge.common.data.ForgeBlockTagsProvider;
+import net.minecraftforge.common.data.ForgeEntityTypeTagsProvider;
 import net.minecraftforge.common.data.ForgeItemTagsProvider;
 import net.minecraftforge.common.data.ForgeLootTableProvider;
 import net.minecraftforge.common.data.ForgeRecipeProvider;
@@ -497,6 +498,7 @@ public class ForgeMod
         ForgeBlockTagsProvider blockTags = new ForgeBlockTagsProvider(gen, existingFileHelper);
         gen.addProvider(event.includeServer(), blockTags);
         gen.addProvider(event.includeServer(), new ForgeItemTagsProvider(gen, blockTags, existingFileHelper));
+        gen.addProvider(event.includeServer(), new ForgeEntityTypeTagsProvider(gen, existingFileHelper));
         gen.addProvider(event.includeServer(), new ForgeFluidTagsProvider(gen, existingFileHelper));
         gen.addProvider(event.includeServer(), new ForgeRecipeProvider(gen));
         gen.addProvider(event.includeServer(), new ForgeLootTableProvider(gen));

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -12,6 +12,7 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.biome.Biome;
@@ -24,6 +25,7 @@ public class Tags
     public static void init ()
     {
         Blocks.init();
+        EntityTypes.init();
         Items.init();
         Fluids.init();
         Biomes.init();
@@ -179,6 +181,19 @@ public class Tags
             return BlockTags.create(new ResourceLocation("forge", name));
         }
     }
+
+    public static class EntityTypes
+    {
+        private static void init() {}
+
+        public static final TagKey<EntityType<?>> BOSSES = tag("bosses");
+
+        private static TagKey<EntityType<?>> tag(String name)
+        {
+            return TagKey.create(Registry.ENTITY_TYPE_REGISTRY, new ResourceLocation("forge", name));
+        }
+    }
+
 
     public static class Items
     {

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -194,7 +194,6 @@ public class Tags
         }
     }
 
-
     public static class Items
     {
         private static void init(){}

--- a/src/main/java/net/minecraftforge/common/data/ForgeEntityTypeTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeEntityTypeTagsProvider.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.common.data;
+
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.tags.EntityTypeTagsProvider;
+import net.minecraft.world.entity.EntityType;
+import net.minecraftforge.common.Tags;
+
+public class ForgeEntityTypeTagsProvider extends EntityTypeTagsProvider
+{
+    
+    public ForgeEntityTypeTagsProvider(DataGenerator generator, ExistingFileHelper existingFileHelper)
+    {
+        super(generator, "forge", existingFileHelper);
+    }
+
+    @Override
+    public void addTags()
+    {
+        tag(Tags.EntityTypes.BOSSES).add(EntityType.ENDER_DRAGON, EntityType.WITHER);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Forge EntityType Tags";
+    }
+}

--- a/src/main/java/net/minecraftforge/common/data/ForgeEntityTypeTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeEntityTypeTagsProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.data;
 
 import net.minecraft.data.DataGenerator;


### PR DESCRIPTION
This is a port of the seemingly abandoned PR #8464, and it closes #8400.

A simple PR to create a forge tag for boss mobs. Willie did a good job explaining why this tag should exist in #8400, but I also have a couple specific use cases if you need more examples. 

I recently ported a mod a friend of mine made a long time ago, called Beat Down Stick. The mod adds a stick which does the same amount of damage as an entity's max health, or 10% of their health if they're considered a boss. The stick uses ``` !entity.canChangeDimensions() ``` to check if it was a boss, which, if you know what the method used to be named in MCP, makes complete sense. This leads to a couple different issues. One being that if a mod adds an entity that isn't allowed to go through portals it will be considered a boss and damaging 10% of its health would be strange to end users. The other being that something considered a boss could be allowed to go through portals, and you could easily 1 shot it with a puny stick. A proper check for this would be a godsend. 

Another mod example is a mod another friend of mine made called Boss Rifts. After you kill a boss, it will spawn a rift that you can use to bring you and any entities around you back to your spawn point. Currently the mod has a custom tag for this, so it has to be added to as more bosses are discovered, which is painful. I'm sure a tag like this would be super handy for that. 

Please let me know if there are any mistakes in my PR. I made sure I followed all of the guidelines, but this is my first time making one of these for Forge so I may have missed something. Thank you for hearing me out!