### PR TITLE
[1.19] Fix EntityEvent.Size not being fired

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -43,14 +43,13 @@
        this.f_19847_ = p_19870_;
        this.f_19853_ = p_19871_;
        this.f_19815_ = p_19870_.m_20680_();
-@@ -250,7 +_,11 @@
+@@ -250,7 +_,10 @@
        this.f_19804_.m_135372_(f_146800_, 0);
        this.m_8097_();
        this.m_6034_(0.0D, 0.0D, 0.0D);
 -      this.f_19816_ = this.m_6380_(Pose.STANDING, this.f_19815_);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.f_19815_, this.m_6380_(Pose.STANDING, this.f_19815_));
-+      this.f_19815_ = sizeEvent.getNewSize();
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      this.f_19815_ = this.getDimensionsForge(Pose.STANDING);
++      this.f_19816_ = this.getEyeHeightForge(Pose.STANDING, this.f_19815_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
@@ -383,6 +382,15 @@
           }
        } else {
           return null;
+@@ -2375,7 +_,7 @@
+    }
+ 
+    protected Vec3 m_7643_(Direction.Axis p_20045_, BlockUtil.FoundRectangle p_20046_) {
+-      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.m_6972_(this.m_20089_()));
++      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.getDimensionsForge(this.m_20089_()));
+    }
+ 
+    protected Optional<BlockUtil.FoundRectangle> m_183318_(ServerLevel p_185935_, BlockPos p_185936_, boolean p_185937_, WorldBorder p_185938_) {
 @@ -2443,6 +_,7 @@
        return this.f_19821_;
     }
@@ -391,15 +399,25 @@
     public boolean m_6063_() {
        return true;
     }
-@@ -2560,8 +_,10 @@
+@@ -2551,17 +_,17 @@
+    @Deprecated
+    protected void m_252801_() {
+       Pose pose = this.m_20089_();
+-      EntityDimensions entitydimensions = this.m_6972_(pose);
++      EntityDimensions entitydimensions = this.getDimensionsForge(pose);
+       this.f_19815_ = entitydimensions;
+-      this.f_19816_ = this.m_6380_(pose, entitydimensions);
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions);
+    }
+ 
+    public void m_6210_() {
        EntityDimensions entitydimensions = this.f_19815_;
        Pose pose = this.m_20089_();
-       EntityDimensions entitydimensions1 = this.m_6972_(pose);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, entitydimensions, entitydimensions1, this.m_6380_(pose, entitydimensions1));
-+      entitydimensions1 = sizeEvent.getNewSize();
+-      EntityDimensions entitydimensions1 = this.m_6972_(pose);
++      EntityDimensions entitydimensions1 = this.getDimensionsForge(pose);
        this.f_19815_ = entitydimensions1;
 -      this.f_19816_ = this.m_6380_(pose, entitydimensions1);
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions1);
        this.m_20090_();
        boolean flag = (double)entitydimensions1.f_20377_ <= 4.0D && (double)entitydimensions1.f_20378_ <= 4.0D;
        if (!this.f_19853_.f_46443_ && !this.f_19803_ && !this.f_19794_ && flag && (entitydimensions1.f_20377_ > entitydimensions.f_20377_ || entitydimensions1.f_20378_ > entitydimensions.f_20378_) && !(this instanceof Player)) {
@@ -414,6 +432,33 @@
           });
        }
  
+@@ -2601,7 +_,7 @@
+    }
+ 
+    protected AABB m_20217_(Pose p_20218_) {
+-      EntityDimensions entitydimensions = this.m_6972_(p_20218_);
++      EntityDimensions entitydimensions = this.getDimensionsForge(p_20218_);
+       float f = entitydimensions.f_20377_ / 2.0F;
+       Vec3 vec3 = new Vec3(this.m_20185_() - (double)f, this.m_20186_(), this.m_20189_() - (double)f);
+       Vec3 vec31 = new Vec3(this.m_20185_() + (double)f, this.m_20186_() + (double)entitydimensions.f_20378_, this.m_20189_() + (double)f);
+@@ -2612,12 +_,16 @@
+       this.f_19828_ = p_20012_;
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntitySize)} instead.
++    */
++   @Deprecated
+    protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {
+       return p_19977_.f_20378_ * 0.85F;
+    }
+ 
+    public float m_20236_(Pose p_20237_) {
+-      return this.m_6380_(p_20237_, this.m_6972_(p_20237_));
++      return this.getEyeHeightForge(p_20237_, this.getDimensionsForge(p_20237_));
+    }
+ 
+    public final float m_20192_() {
 @@ -2861,9 +_,17 @@
        this.f_19859_ = this.m_146908_();
     }
@@ -519,6 +564,17 @@
        return this.f_19799_.getDouble(p_204037_);
     }
  
+@@ -2957,6 +_,10 @@
+       return new ClientboundAddEntityPacket(this);
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getDimensionsForge(Pose)} instead.
++    */
++   @Deprecated
+    public EntityDimensions m_6972_(Pose p_19975_) {
+       return this.f_19847_.m_20680_();
+    }
 @@ -3069,6 +_,7 @@
  
           this.f_146801_.m_142044_();
@@ -595,7 +651,7 @@
 +   /**
 +    * Accessor method for {@link #getEyeHeight(Pose, EntityDimensions)}
 +    */
-+   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
++   public final float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -662,7 +662,12 @@
     }
  
     public boolean m_5830_() {
-@@ -3156,7 +_,7 @@
+@@ -3152,11 +_,11 @@
+    }
+ 
+    protected float m_6431_(Pose p_21131_, EntityDimensions p_21132_) {
+-      return super.m_6380_(p_21131_, p_21132_);
++      return this.getEyeHeightForge(p_21131_, p_21132_);
     }
  
     public ItemStack m_6298_(ItemStack p_21272_) {

--- a/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -9,3 +9,12 @@
     };
     private static final float f_256985_ = 4.0F;
     private static final double f_256802_ = 1.0D;
+@@ -207,7 +_,7 @@
+       Direction.Axis direction$axis = blockstate.m_61145_(BlockStateProperties.f_61364_).orElse(Direction.Axis.X);
+       double d0 = (double)p_259931_.f_124349_;
+       double d1 = (double)p_259931_.f_124350_;
+-      EntityDimensions entitydimensions = p_259166_.m_6972_(p_259166_.m_20089_());
++      EntityDimensions entitydimensions = p_259166_.getDimensionsForge(p_259166_.m_20089_());
+       int i = p_259901_ == direction$axis ? 0 : 90;
+       Vec3 vec3 = p_259901_ == direction$axis ? p_260043_ : new Vec3(p_260043_.f_82481_, p_260043_.f_82480_, -p_260043_.f_82479_);
+       double d2 = (double)entitydimensions.f_20377_ / 2.0D + (d0 - (double)entitydimensions.f_20377_) * p_259630_.m_7096_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -16,7 +16,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.world.item.ItemStack;
@@ -26,9 +28,11 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.SoundAction;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.entity.PartEntity;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.Nullable;
 
@@ -423,5 +427,21 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     default boolean hasCustomOutlineRendering(Player player)
     {
         return false;
+    }
+
+    default EntityDimensions getDimensionsForge(Pose pose)
+    {
+        EntityDimensions size = self().getDimensions(pose);
+        EntityEvent.Size evt = new EntityEvent.Size(self(), pose, size);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewSize();
+    }
+
+    default float getEyeHeightForge(Pose pose, EntityDimensions size)
+    {
+        float eyeHeight = self().getEyeHeightAccess(pose, size);
+        EntityEvent.EyeHeight evt = new EntityEvent.EyeHeight(self(), pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewEyeHeight();
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -38,9 +38,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.SpawnGroupData;
-import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
@@ -89,7 +87,6 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
-import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityMobGriefingEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
@@ -724,20 +721,6 @@ public class ForgeEventFactory
     {
         RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment, context);
         MinecraftForge.EVENT_BUS.post(event);
-    }
-
-    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
-    {
-        EntityEvent.Size evt = new EntityEvent.Size(entity, pose, size, eyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
-    }
-
-    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float newEyeHeight)
-    {
-        EntityEvent.Size evt = new EntityEvent.Size(entity, pose, oldSize, newSize, entity.getEyeHeight(), newEyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
     }
 
     public static boolean canLivingConvert(LivingEntity entity, EntityType<? extends LivingEntity> outcome, Consumer<Integer> timer)

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.Pose;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -127,7 +128,7 @@ public class EntityEvent extends Event
     }
 
     /**
-     * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios.<br>
+     * This event is fired whenever {@link IForgeEntity#getDimensionsForge(Pose)} gets called.<br>
      * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
      * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
@@ -140,48 +141,53 @@ public class EntityEvent extends Event
     public static class Size extends EntityEvent
     {
         private final Pose pose;
-        private final EntityDimensions oldSize;
+        private final EntityDimensions originalSize;
         private EntityDimensions newSize;
-        private final float oldEyeHeight;
-        private float newEyeHeight;
 
-        public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight)
-        {
-            this(entity, pose, size, size, defaultEyeHeight, defaultEyeHeight);
-        }
-
-        public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight)
+        public Size(Entity entity, Pose pose, EntityDimensions size)
         {
             super(entity);
             this.pose = pose;
-            this.oldSize = oldSize;
-            this.newSize = newSize;
-            this.oldEyeHeight = oldEyeHeight;
-            this.newEyeHeight = newEyeHeight;
+            this.originalSize = size;
+            this.newSize = size;
         }
-
 
         public Pose getPose() { return pose; }
-        public EntityDimensions getOldSize() { return oldSize; }
+        public EntityDimensions getOriginalSize() { return originalSize; }
         public EntityDimensions getNewSize() { return newSize; }
-        public void setNewSize(EntityDimensions size)
+        public void setNewSize(EntityDimensions newSize) { this.newSize = newSize; }
+    }
+
+    /**
+     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose)} gets called.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class EyeHeight extends EntityEvent
+    {
+        private final Pose pose;
+        private final EntityDimensions size;
+        private final float originalEyeHeight;
+        private float newEyeHeight;
+
+        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
         {
-            setNewSize(size, false);
+            super(entity);
+            this.pose = pose;
+            this.size = size;
+            this.originalEyeHeight = eyeHeight;
+            this.newEyeHeight = eyeHeight;
         }
 
-        /**
-         * Set the new size of the entity. Set updateEyeHeight to true to also update the eye height according to the new size.
-         */
-        public void setNewSize(EntityDimensions size, boolean updateEyeHeight)
-        {
-            this.newSize = size;
-            if (updateEyeHeight)
-            {
-                this.newEyeHeight = this.getEntity().getEyeHeightAccess(this.getPose(), this.newSize);
-            }
-        }
-        public float getOldEyeHeight() { return oldEyeHeight; }
+        public Pose getPose() { return pose; }
+        public EntityDimensions getSize() { return size; }
+        public float getOriginalEyeHeight() { return originalEyeHeight; }
         public float getNewEyeHeight() { return newEyeHeight; }
-        public void setNewEyeHeight(float newHeight) { this.newEyeHeight = newHeight; }
+        public void setNewEyeHeight(float newEyeHeight) { this.newEyeHeight = newEyeHeight; }
     }
 }


### PR DESCRIPTION
Continuation of #8667

This is not a direct port of the old PR and instead as described previously I split the `EntityEvent.Size` into `EntityEvent.Size` and `EntityEvent.EyeHeight`.