### PR TITLE
[1.19.2] Copy bookshelves block tag into item tag

### DIFF
--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -34,7 +34,7 @@ public final class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.BARRELS, Tags.Items.BARRELS);
         copy(Tags.Blocks.BARRELS_WOODEN, Tags.Items.BARRELS_WOODEN);
         tag(Tags.Items.BONES).add(Items.BONE);
-        tag(Tags.Items.BOOKSHELVES).add(Items.BOOKSHELF);
+        copy(Tags.Blocks.BOOKSHELVES, Tags.Items.BOOKSHELVES);
         copy(Tags.Blocks.CHESTS, Tags.Items.CHESTS);
         copy(Tags.Blocks.CHESTS_ENDER, Tags.Items.CHESTS_ENDER);
         copy(Tags.Blocks.CHESTS_TRAPPED, Tags.Items.CHESTS_TRAPPED);


### PR DESCRIPTION
Addendum to #8991.

This is a bit of a small PR and is more-so for consistency than anything else, but I thought it would be worth noting regardless. Basically, in `ForgeItemTagsProvider`, block tags are usually copied into item tags, but that was not the case with the bookshelves item tag. This means that additional blocks added to the bookshelves tag would need to have their block items manually added as well.