### PR TITLE
[1.19.x] (RecipeType, Item)->RecipeBookCategories table to manually sort recipes into categories

### DIFF
--- a/patches/minecraft/net/minecraft/client/ClientRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/ClientRecipeBook.java.patch
@@ -9,6 +9,17 @@
              if (s.isEmpty()) {
                 map.computeIfAbsent(recipebookcategories, (p_90645_) -> {
                    return Lists.newArrayList();
+@@ -76,6 +_,10 @@
+ 
+    private static RecipeBookCategories m_90646_(Recipe<?> p_90647_) {
+       RecipeType<?> recipetype = p_90647_.m_6671_();
++      RecipeBookCategories category = net.minecraftforge.client.RecipeBookManager.getCategoryForItem(p_90647_.m_8043_().m_41720_()); // FORGE: Returns if item has been manually assigned to a specific category
++      if (category != null) {
++         return category;
++      }
+       if (recipetype == RecipeType.f_44107_) {
+          ItemStack itemstack = p_90647_.m_8043_();
+          CreativeModeTab creativemodetab = itemstack.m_41720_().m_41471_();
 @@ -103,6 +_,8 @@
        } else if (recipetype == RecipeType.f_44113_) {
           return RecipeBookCategories.SMITHING;

--- a/patches/minecraft/net/minecraft/client/ClientRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/ClientRecipeBook.java.patch
@@ -13,7 +13,7 @@
  
     private static RecipeBookCategories m_90646_(Recipe<?> p_90647_) {
        RecipeType<?> recipetype = p_90647_.m_6671_();
-+      RecipeBookCategories category = net.minecraftforge.client.RecipeBookManager.getCategoryForItem(p_90647_.m_8043_().m_41720_()); // FORGE: Returns if item has been manually assigned to a specific category
++      RecipeBookCategories category = net.minecraftforge.client.RecipeBookManager.getCategoryForItem(recipetype, p_90647_.m_8043_().m_41720_()); // FORGE: Returns if item has been manually assigned to a specific category
 +      if (category != null) {
 +         return category;
 +      }

--- a/src/main/java/net/minecraftforge/client/RecipeBookManager.java
+++ b/src/main/java/net/minecraftforge/client/RecipeBookManager.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.RecipeBookCategories;
 import net.minecraft.world.inventory.RecipeBookType;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.client.event.RegisterRecipeBookCategoriesEvent;
@@ -37,6 +38,7 @@ public final class RecipeBookManager
     private static final Map<RecipeBookType, List<RecipeBookCategories>> TYPE_CATEGORIES = new HashMap<>();
     private static final Map<RecipeType<?>, Function<Recipe<?>, RecipeBookCategories>> RECIPE_CATEGORY_LOOKUPS = new HashMap<>();
     private static final Map<RecipeBookCategories, List<RecipeBookCategories>> AGGREGATE_CATEGORIES_VIEW = Collections.unmodifiableMap(AGGREGATE_CATEGORIES);
+    private static final Map<Item, RecipeBookCategories> ITEMS_CATEGORIES_STORAGE = new HashMap<>();
 
     /**
      * Finds the category the specified recipe should display in, or null if none.
@@ -58,6 +60,20 @@ public final class RecipeBookManager
     public static List<RecipeBookCategories> getCustomCategoriesOrEmpty(RecipeBookType recipeBookType)
     {
         return TYPE_CATEGORIES.getOrDefault(recipeBookType, List.of());
+    }
+
+    @Nullable
+    public static RecipeBookCategories getCategoryForItem(Item item)
+    {
+        return ITEMS_CATEGORIES_STORAGE.get(item);
+    }
+
+    public static void addItemToCategory(RecipeBookCategories category, Item... items)
+    {
+        for (Item item : items)
+        {
+            ITEMS_CATEGORIES_STORAGE.putIfAbsent(item, category);
+        }
     }
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/RecipeBookManager.java
+++ b/src/main/java/net/minecraftforge/client/RecipeBookManager.java
@@ -5,8 +5,10 @@
 
 package net.minecraftforge.client;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Table;
 import net.minecraft.client.RecipeBookCategories;
 import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.item.Item;
@@ -38,7 +40,7 @@ public final class RecipeBookManager
     private static final Map<RecipeBookType, List<RecipeBookCategories>> TYPE_CATEGORIES = new HashMap<>();
     private static final Map<RecipeType<?>, Function<Recipe<?>, RecipeBookCategories>> RECIPE_CATEGORY_LOOKUPS = new HashMap<>();
     private static final Map<RecipeBookCategories, List<RecipeBookCategories>> AGGREGATE_CATEGORIES_VIEW = Collections.unmodifiableMap(AGGREGATE_CATEGORIES);
-    private static final Map<Item, RecipeBookCategories> ITEMS_CATEGORIES_STORAGE = new HashMap<>();
+    private static final Table<RecipeType<?>, Item, RecipeBookCategories> ITEMS_CATEGORIES_STORAGE = HashBasedTable.create();
 
     /**
      * Finds the category the specified recipe should display in, or null if none.
@@ -63,16 +65,19 @@ public final class RecipeBookManager
     }
 
     @Nullable
-    public static RecipeBookCategories getCategoryForItem(Item item)
+    public static RecipeBookCategories getCategoryForItem(RecipeType<?> type, Item item)
     {
-        return ITEMS_CATEGORIES_STORAGE.get(item);
+        return ITEMS_CATEGORIES_STORAGE.get(type, item);
     }
 
-    public static void addItemToCategory(RecipeBookCategories category, Item... items)
+    public static void addItemToCategory(RecipeType<?> type, RecipeBookCategories category, Item... items)
     {
         for (Item item : items)
         {
-            ITEMS_CATEGORIES_STORAGE.putIfAbsent(item, category);
+            if (!ITEMS_CATEGORIES_STORAGE.contains(type, item))
+            {
+                ITEMS_CATEGORIES_STORAGE.put(type, item, category);
+            }
         }
     }
 


### PR DESCRIPTION
In vanilla, `ClientRecipeBook` determines what recipe book category (the tabs on the side of the recipe book) that a recipe should be sorted into through fairly hardcoded means, especially the crafting table. Recipes are sorted into categories in the crafting table's recipe book based on the result item's creative tab, e.g. if a block is in the vanilla redstone creative tab, it gets sorted into the redstone category in the recipe book. This becomes an issue for mods that use their own creative tabs to store their items, as since they don't belong to a vanilla creative tab, their recipes automatically get sorted into the miscellaneous category.

This PR solves this by adding in a table that correlates RecipeBookCategories to modded items and recipe types, so when `ClientRecipeBook` looks for where to sort a recipe based on its result item and recipe type, it'll check if those first exist in the map and then return the category set by the modder. This is mainly meant to fix the issue in the case of the crafting table menu, but it is capable of working for other recipe categories and types if a modder desires.

The implementation of this is just handled by calling `RecipeBookManager.addItemToCategory(RecipeType<?>, RecipeBookCategories, Item...)` any stage after registry (`FMLCommonSetup` works just fine).