### PR TITLE
[1.19] Fix minecarts on rails not properly slowing down in water

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -110,7 +110,7 @@
        }
  
     }
-@@ -390,7 +_,8 @@
+@@ -390,33 +_,34 @@
        d1 = (double)p_38156_.m_123342_();
        boolean flag = false;
        boolean flag1 = false;
@@ -120,7 +120,11 @@
           flag = p_38157_.m_61143_(PoweredRailBlock.f_55215_);
           flag1 = !flag;
        }
-@@ -401,22 +_,22 @@
+ 
+-      double d3 = 0.0078125D;
++      double d3 = getSlopeAdjustment();
+       if (this.m_20069_()) {
+          d3 *= 0.2D;
        }
  
        Vec3 vec31 = this.m_20184_();
@@ -129,22 +133,22 @@
        switch (railshape) {
           case ASCENDING_EAST:
 -            this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
-+         this.m_20256_(vec31.m_82520_(-1 * getSlopeAdjustment(), 0.0D, 0.0D));
++         this.m_20256_(vec31.m_82520_(-1 * d3, 0.0D, 0.0D));
              ++d1;
              break;
           case ASCENDING_WEST:
 -            this.m_20256_(vec31.m_82520_(d3, 0.0D, 0.0D));
-+         this.m_20256_(vec31.m_82520_(getSlopeAdjustment(), 0.0D, 0.0D));
++         this.m_20256_(vec31.m_82520_(d3, 0.0D, 0.0D));
              ++d1;
              break;
           case ASCENDING_NORTH:
 -            this.m_20256_(vec31.m_82520_(0.0D, 0.0D, d3));
-+         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, getSlopeAdjustment()));
++         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, d3));
              ++d1;
              break;
           case ASCENDING_SOUTH:
 -            this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -d3));
-+         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -1 * getSlopeAdjustment()));
++         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -1 * d3));
              ++d1;
        }
  

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -110,7 +110,7 @@
        }
  
     }
-@@ -390,33 +_,34 @@
+@@ -390,18 +_,19 @@
        d1 = (double)p_38156_.m_123342_();
        boolean flag = false;
        boolean flag1 = false;
@@ -132,26 +132,7 @@
 +      RailShape railshape = ((BaseRailBlock)p_38157_.m_60734_()).getRailDirection(p_38157_, this.f_19853_, p_38156_, this);
        switch (railshape) {
           case ASCENDING_EAST:
--            this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
-+         this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
-             ++d1;
-             break;
-          case ASCENDING_WEST:
--            this.m_20256_(vec31.m_82520_(d3, 0.0D, 0.0D));
-+         this.m_20256_(vec31.m_82520_(d3, 0.0D, 0.0D));
-             ++d1;
-             break;
-          case ASCENDING_NORTH:
--            this.m_20256_(vec31.m_82520_(0.0D, 0.0D, d3));
-+         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, d3));
-             ++d1;
-             break;
-          case ASCENDING_SOUTH:
--            this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -d3));
-+         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -d3));
-             ++d1;
-       }
- 
+             this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
 @@ -447,7 +_,7 @@
           }
        }

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -133,7 +133,7 @@
        switch (railshape) {
           case ASCENDING_EAST:
 -            this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
-+         this.m_20256_(vec31.m_82520_(-1 * d3, 0.0D, 0.0D));
++         this.m_20256_(vec31.m_82520_(-d3, 0.0D, 0.0D));
              ++d1;
              break;
           case ASCENDING_WEST:
@@ -148,7 +148,7 @@
              break;
           case ASCENDING_SOUTH:
 -            this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -d3));
-+         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -1 * d3));
++         this.m_20256_(vec31.m_82520_(0.0D, 0.0D, -d3));
              ++d1;
        }
  


### PR DESCRIPTION
As pointed out in #9011, minecarts were not properly reducing speed when on top of waterlogged rails. This is because IForgeAbstractMinecart#getSlopeAdjustment was called in AbstractMinecart#moveAlongTrack without a check to see if the minecart was in water before calculating delta movement.

This is a simple fix that now checks if the cart is in water before setting delta movement.