### PR TITLE
[1.19.x] Fix ClientChatReceivedEvent for system messages

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
@@ -19,3 +19,14 @@
                 this.m_241119_(p_242290_, component);
              }
           }
+@@ -194,7 +_,9 @@
+    }
+ 
+    boolean m_241171_(ChatType.Bound p_241518_, PlayerChatMessage p_241542_, Component p_241510_) {
+-      this.f_240348_.f_91065_.m_93076_().m_93785_(p_241510_);
++      Component forgeComponent = net.minecraftforge.client.ForgeHooksClient.onClientChat(p_241518_, p_241510_, p_241542_, p_241542_.m_241067_());
++      if (forgeComponent == null) return false;
++      this.f_240348_.f_91065_.m_93076_().m_93785_(forgeComponent);
+       this.m_241119_(p_241518_, p_241542_.m_237220_());
+       this.m_240498_(p_241510_, p_241542_.m_241109_());
+       this.f_240659_ = Util.m_137550_();

--- a/patches/minecraft/net/minecraft/client/multiplayer/resolver/AddressCheck.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/resolver/AddressCheck.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/multiplayer/resolver/AddressCheck.java
++++ b/net/minecraft/client/multiplayer/resolver/AddressCheck.java
+@@ -16,7 +_,7 @@
+    boolean m_142408_(ServerAddress p_171830_);
+ 
+    static AddressCheck m_171828_() {
+-      final ImmutableList<Predicate<String>> immutablelist = Streams.stream(ServiceLoader.load(BlockListSupplier.class)).map(BlockListSupplier::createBlockList).filter(Objects::nonNull).collect(ImmutableList.toImmutableList());
++      final ImmutableList<Predicate<String>> immutablelist = Streams.stream(ServiceLoader.load(BlockListSupplier.class, net.minecraftforge.fml.loading.FMLLoader.class.getClassLoader())).map(BlockListSupplier::createBlockList).filter(Objects::nonNull).collect(ImmutableList.toImmutableList());
+       return new AddressCheck() {
+          public boolean m_142649_(ResolvedServerAddress p_171835_) {
+             String s = p_171835_.m_142727_();


### PR DESCRIPTION
Seems to work from testing. Just a simple missed patch on my part. Easy test is set a breakpoint in `ForgeHooksClient#onClientChat`, open up a client & server, connect to server, run `/say hi` in server console, see breakpoint fire, see that `ClientChatReceivedEvent#isSystem` returns true.

Note that the narrated chat message is the undecorated server content without any server stylation, so this does not have forgeComponent patched in (as we fire the event with the decorated server content). Allowing mods to modify this would require firing two events or adding a new field to ClientChatReceivedEvent (perhaps in a subclass?). This is a viable idea but narration is niche so (insert shrug).
The logSystemMessage call also needs the original msg I think due to chat signing and reporting, etc. Would need more investigation but best left alone I think for now.

Fixes #8923.