### PR TITLE
[1.19.x] Use owner for SmallFireball mobGriefing event

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/projectile/SmallFireball.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/SmallFireball.java.patch
@@ -5,7 +5,7 @@
        if (!this.f_19853_.f_46443_) {
           Entity entity = this.m_37282_();
 -         if (!(entity instanceof Mob) || this.f_19853_.m_46469_().m_46207_(GameRules.f_46132_)) {
-+         if (!(entity instanceof Mob) || net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.f_19853_, this)) {
++         if (!(entity instanceof Mob) || net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.f_19853_, entity)) {
              BlockPos blockpos = p_37384_.m_82425_().m_121945_(p_37384_.m_82434_());
              if (this.f_19853_.m_46859_(blockpos)) {
                 this.f_19853_.m_46597_(blockpos, BaseFireBlock.m_49245_(this.f_19853_, blockpos));


### PR DESCRIPTION
The mob griefing event fired from SmallFireball uses itself as the griefing entity, this should be the owner instead.

LargeFireball and WitherSkull are examples where the owner is already used, this change makes SmallFireball act consistently.