### PR TITLE
[1.19.x] Skip step in inner loop instead of returning from spawner function

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -4,7 +4,7 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
                                      phantom.m_20035_(blockpos1, 0.0F, 0.0F);
-+                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL) == -1) return 0;
++                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL) == -1) { i--; continue; }
                                      spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
                                      p_64576_.m_47205_(phantom);
                                   }


### PR DESCRIPTION
With this fix, mods when blocking spawn of one phantom no longer block spawn of any further potential phantom for any player.

Why `continue` instead of `break`? Because mods might want to discard *some* of phantoms spawned using random number generator, etc.
