### PR TITLE
add ShaderTransformEvent to allow multi mods to transform shader resoures together

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/shaders/Program.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/shaders/Program.java.patch
@@ -1,0 +1,10 @@
+--- a/com/mojang/blaze3d/shaders/Program.java
++++ b/com/mojang/blaze3d/shaders/Program.java
+@@ -58,6 +_,7 @@
+          throw new IOException("Could not load program " + p_166613_.m_85566_());
+       } else {
+          int i = GlStateManager.m_84447_(p_166613_.m_85571_());
++         s = net.minecraftforge.client.ForgeHooksClient.transformShader(s,p_166613_,p_166614_,p_166616_,p_166617_);
+          GlStateManager.m_157116_(i, p_166617_.m_166461_(s));
+          GlStateManager.m_84465_(i);
+          if (GlStateManager.m_84449_(i, 35713) == 0) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -8,7 +8,9 @@ package net.minecraftforge.client;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.preprocessor.GlslPreprocessor;
 import com.mojang.blaze3d.shaders.FogShape;
+import com.mojang.blaze3d.shaders.Program;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -130,6 +132,7 @@ import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
+import net.minecraftforge.client.event.ShaderTransformEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.ToastAddEvent;
 import net.minecraftforge.client.event.ViewportEvent;
@@ -286,6 +289,13 @@ public class ForgeHooksClient
         RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.fromRenderType(renderType);
         if (stage != null)
             dispatchRenderStage(stage, levelRenderer, poseStack, projectionMatrix, renderTick, camera, frustum);
+    }
+
+    public static String transformShader(String originShader, Program.Type type, String shaderName, String shaderSourceName, GlslPreprocessor glslPreprocessor)
+    {
+        ShaderTransformEvent event = new ShaderTransformEvent(originShader,type,shaderName,shaderSourceName,glslPreprocessor);
+        ModLoader.get().postEvent(event);
+        return event.getTransformedShader();
     }
 
     public static boolean renderSpecificFirstPersonHand(InteractionHand hand, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, float partialTick, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)

--- a/src/main/java/net/minecraftforge/client/event/ShaderTransformEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ShaderTransformEvent.java
@@ -1,0 +1,130 @@
+package net.minecraftforge.client.event;
+
+import com.mojang.blaze3d.preprocessor.GlslPreprocessor;
+import com.mojang.blaze3d.shaders.Program;
+import net.minecraft.server.packs.resources.ResourceProvider;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * Fired to allow multi-mods to transform shader sources together.
+ * This event is fired before shader sources are passed into {@linkplain com.mojang.blaze3d.platform.GlStateManager#glShaderSource(int, List)}
+ *
+ * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class ShaderTransformEvent extends Event implements IModBusEvent
+{
+    private final String originShader;
+    private final Program.Type type;
+    private final String shaderName;
+    private final String shaderSourceName;
+    private final GlslPreprocessor glslPreprocessor;
+    private String transformedShader;
+
+    public ShaderTransformEvent(String originShader, Program.Type type, String shaderName, String shaderSourceName, GlslPreprocessor glslPreprocessor)
+    {
+        this.originShader = originShader;
+        this.type = type;
+        this.transformedShader = originShader;
+        this.shaderName = shaderName;
+        this.shaderSourceName = shaderSourceName;
+        this.glslPreprocessor = glslPreprocessor;
+    }
+
+    /**
+     * get the origin shader source
+     *
+     * @return the origin shader source
+     */
+    public String getOriginShader()
+    {
+        return originShader;
+    }
+
+    /**
+     * get the shader type
+     *
+     * @return the shader type
+     */
+    public Program.Type getType()
+    {
+        return type;
+    }
+
+    /**
+     * get the shader source which may has been transformed by mods
+     *
+     * @return the shader source which may has been transformed by mods
+     */
+    public String getTransformedShader()
+    {
+        return transformedShader;
+    }
+
+    /**
+     * get the shaderName, without file location and extension
+     *
+     * @return the shaderName
+     */
+    public String getShaderName()
+    {
+        return shaderName;
+    }
+
+    /**
+     * get the shader source name
+     *
+     * @return the shader source name
+     */
+    public String getShaderSourceName()
+    {
+        return shaderSourceName;
+    }
+
+    /**
+     * get the context GlslPreprocessor instance.
+     * by this you can compile and test if this shader can be compiled successfully
+     * <p/>as the current GlslPreprocessor implementations under {@link net.minecraft.client.renderer.ShaderInstance#getOrCreate(ResourceProvider, Program.Type, String)}
+     * will record what has been imported.
+     * don't forget to change that
+     * if you directly or indirectly call {@link GlslPreprocessor#applyImport(boolean, String)}<p/>
+     *
+     * @return the context GlslPreprocessor instance
+     */
+    public GlslPreprocessor getGlslPreprocessor()
+    {
+        return glslPreprocessor;
+    }
+
+    /**
+     * set the transformed shader source
+     *
+     * @param transformedShader the transformed shader source
+     */
+    public void setTransformedShader(String transformedShader)
+    {
+        this.transformedShader = transformedShader;
+    }
+
+    /**
+     * transform the shader source by a functional way
+     *
+     * @param transformFunction the transform function.
+     *                          pass originShader and transformed shader
+     *                          and return the transformed shader
+     */
+    public void transformShader(BiFunction<String, String, String> transformFunction)
+    {
+        this.transformedShader = transformFunction.apply(originShader, transformedShader);
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/ShaderTransformEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/ShaderTransformEventTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.debug.client.rendering;
+
+import com.mojang.blaze3d.shaders.Program;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ShaderTransformEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(ShaderTransformEventTest.MOD_ID)
+@Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD , modid = ShaderTransformEventTest.MOD_ID)
+public class ShaderTransformEventTest
+{
+    public static final String MOD_ID = "shader_transform_event_test";
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void transformShader(ShaderTransformEvent event)
+    {
+        if (ENABLED && event.getType() == Program.Type.FRAGMENT && event.getShaderName().equals("rendertype_text"))
+        {
+            event.transformShader((origin,transformed) ->
+                    transformed.replace("}","\tfragColor *= vec4(sin(gl_FragCoord.xy/1800),0.5,0.2)*3;\n}")
+            );
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -264,6 +264,7 @@ modId="custom_color_resolver_test"
 modId="custom_item_decorations_test"
 [[mods]]
 modId="ambient_occlusion_elements_test"
-
+[[mods]]
+modId="shader_transform_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
add ShaderTransformEvent to allow multi mods to transform shader resources together

## implementation:
add event class `ShaderTransformEvent` which is fired before shader sources are passed to opengl
holds fields below
- private final String originShader;
- private final Program.Type type; //identify shader
- private final String shaderName; //identify shader
- private final String shaderSourceName; //identify shader
- private final GlslPreprocessor glslPreprocessor; //allow mods to shader sources’ validity
- private String transformedShader; //allow multi mods to transform shader sources

## test mod:
add a test mod called `ShaderTransformEvent`, default is disabled
can change the text's color easily 
```java
public static void transformShader(ShaderTransformEvent event)
{
    if (ENABLED && event.getType() == Program.Type.FRAGMENT && event.getShaderName().equals("rendertype_text"))
    {
        event.transformShader((origin,transformed) ->
                transformed.replace("}","\tfragColor *= vec4(sin(gl_FragCoord.xy/1800),0.5,0.2)*3;\n}")
        );
}
```
![test_mod](https://user-images.githubusercontent.com/26162862/190791205-109473ee-3269-4ccc-941b-96c715df6363.png)

though resource packs can do this too, this way allows multi mods to transform shader sources together and in a more flexible way

## performance 
almost don't affect performance

## diagnosis when the transformed shader is invalid
the log will print mods who subscribe to the event, so the range can be narrowed quickly

## improve for mod compatibility
 - for Rubidium, flywheel, and other render relative mod, some of them create shaders/programs themselves, in this way, they can provide a more common way if they would other mod to transform their shader
 - for ImmersivePortalsModForForge, shimmer, and other mods who need transforming other mods'/vanilla's shader to achieve their targets