### PR TITLE
[1.19.2] Do not cache default value returned by supplier in ForgeConfigSpec$ValueSpec

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -776,7 +776,6 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         private final Class<?> clazz;
         private final Supplier<?> supplier;
         private final Predicate<Object> validator;
-        private Object _default = null;
 
         private ValueSpec(Supplier<?> supplier, Predicate<Object> validator, BuilderContext context)
         {
@@ -801,12 +800,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public boolean test(Object value) { return validator.test(value); }
         public Object correct(Object value) { return range == null ? getDefault() : range.correct(value, getDefault()); }
 
-        public Object getDefault()
-        {
-            if (_default == null)
-                _default = supplier.get();
-            return _default;
-        }
+        public Object getDefault() { return supplier.get(); }
     }
 
     public static class ConfigValue<T> implements Supplier<T>


### PR DESCRIPTION
Fixes #9045