### PR TITLE
add allowHomonymObjectName option for OBJModel.ModelSettings

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/ObjLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjLoader.java
@@ -57,6 +57,7 @@ public class ObjLoader implements IGeometryLoader<ObjModel>, ResourceManagerRelo
         boolean flipV = GsonHelper.getAsBoolean(jsonObject, "flip_v", false);
         boolean emissiveAmbient = GsonHelper.getAsBoolean(jsonObject, "emissive_ambient", true);
         String mtlOverride = GsonHelper.getAsString(jsonObject, "mtl_override", null);
+        boolean allowHomonymObjectName = GsonHelper.getAsBoolean(jsonObject,"allow_homonym_object_name",false);
 
         // TODO: Deprecated names. To be removed in 1.20
         var deprecationWarningsBuilder = ImmutableMap.<String, String>builder();
@@ -86,7 +87,7 @@ public class ObjLoader implements IGeometryLoader<ObjModel>, ResourceManagerRelo
             deprecationWarningsBuilder.put("materialLibraryOverride", "mtl_override");
         }
 
-        return loadModel(new ObjModel.ModelSettings(new ResourceLocation(modelLocation), automaticCulling, shadeQuads, flipV, emissiveAmbient, mtlOverride), deprecationWarningsBuilder.build());
+        return loadModel(new ObjModel.ModelSettings(new ResourceLocation(modelLocation), automaticCulling, shadeQuads, flipV, emissiveAmbient, mtlOverride,allowHomonymObjectName), deprecationWarningsBuilder.build());
     }
 
     public ObjModel loadModel(ObjModel.ModelSettings settings)

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -108,6 +108,8 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
     {
         var modelLocation = settings.modelLocation;
         var materialLibraryOverrideLocation = settings.mtlOverride;
+        var allowHomonymObjectName = settings.allowHomonymObjectName;
+        var hasHomonymObjectNameAppeared = false;
         var model = new ObjModel(settings, deprecationWarnings);
 
         // for relative references to material libraries
@@ -280,6 +282,21 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
                 case "o":
                 {
                     String name = line[1];
+                    if (model.parts.containsKey(name))
+                    {
+                        hasHomonymObjectNameAppeared = true;
+                        if (allowHomonymObjectName)
+                        {
+                            int suffixNum = 0;
+                            String renamed;
+                            do
+                            {
+                                renamed = name + '_' + (suffixNum++);
+                            }
+                            while (model.parts.containsKey(renamed));
+                            name = renamed;
+                        }
+                    }
                     if (objAboveGroup || currentGroup == null)
                     {
                         objAboveGroup = true;
@@ -298,6 +315,10 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
                     break;
                 }
             }
+        }
+        if (!allowHomonymObjectName && hasHomonymObjectNameAppeared)
+        {
+            LOGGER.error("find homonym object in obj model:" + settings.modelLocation + ", use allow_homonym_object_name=true can rename them for you");
         }
         return model;
     }
@@ -687,6 +708,6 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
 
     public record ModelSettings(@NotNull ResourceLocation modelLocation,
                                 boolean automaticCulling, boolean shadeQuads, boolean flipV,
-                                boolean emissiveAmbient, @Nullable String mtlOverride)
+                                boolean emissiveAmbient, @Nullable String mtlOverride, boolean allowHomonymObjectName)
     { }
 }

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderableTest.java
@@ -115,7 +115,8 @@ public class RenderableTest
                             true,
                             true,
                             false,
-                            null
+                            null,
+                            false
                     );
                     return ObjLoader.INSTANCE.loadModel(settings);
                 }


### PR DESCRIPTION
This PR adds the ability for the OBJ Loder to load .obj file with the same part name  
this PR follows #8624, but for Minecraft version 1.19.2 and a small difference.
I don't know how to change an existing GitHub PR's source/target branch, so I just open a new one

## Why need this?

for modeling software such as BlockBench which allows homonym cube names.  When its model is exported as a .obj model file. The name subsequent to the .obj format command/keyword `o` will duplicate

Due to the current OBJ Loader implementation, the collection of the parts is a `Map<String, ModelGroup> parts`, so the latter will override the former. As a result, only the last part will remain

## Implementation

add an option bool for `OBJModel.Setting` called `allowHomonymObjectName`  which is false by default.
when reading from json file, its key is `allow_homonym_object_name`

we now will check whether the same part name occurs before, if it is and the option is true, we re-name it by plusing a char `_` and a non-negative growth number after the original name until no-repeat occurs.
In a similar way to another modeling software called Blender, it can correctly load .obj file with homonym object names

re-name only works on the `o` .obj command/keyword now

## Addition

When finding any part name that occurs before, we use a bool to record this. When load end we print an error message that indicates this and prompts this option when the option is false as this is usually not expected behavior. 