### PR TITLE
Event for bundle technology, when items are attempted to be stacked/swapped in GUI

### DIFF
--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    private final CommandSource f_81288_;
+    public final CommandSource f_81288_;

--- a/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -12,6 +12,14 @@
           for(ContainerListener containerlistener : this.f_38848_) {
              containerlistener.m_7934_(this, p_150408_, itemstack1);
           }
+@@ -399,6 +_,7 @@
+             ItemStack itemstack10 = slot7.m_7993_();
+             ItemStack itemstack11 = this.m_142621_();
+             p_150434_.m_141945_(itemstack11, slot7.m_7993_(), clickaction);
++            if (net.minecraftforge.common.ForgeHooks.onItemStackedOn(itemstack11, itemstack10, slot7, clickaction, p_150434_, m_150446_())) { } else
+             if (!itemstack11.m_150926_(slot7, clickaction, p_150434_) && !itemstack10.m_150932_(itemstack11, slot7, clickaction, p_150434_, this.m_150446_())) {
+                if (itemstack10.m_41619_()) {
+                   if (!itemstack11.m_41619_()) {
 @@ -601,14 +_,15 @@
              ItemStack itemstack = slot.m_7993_();
              if (!itemstack.m_41619_() && ItemStack.m_150942_(p_38904_, itemstack)) {

--- a/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -16,7 +16,7 @@
              ItemStack itemstack10 = slot7.m_7993_();
              ItemStack itemstack11 = this.m_142621_();
              p_150434_.m_141945_(itemstack11, slot7.m_7993_(), clickaction);
-+            if (net.minecraftforge.common.ForgeHooks.onItemStackedOn(itemstack11, itemstack10, slot7, clickaction, p_150434_, m_150446_())) { } else
++            if (!net.minecraftforge.common.ForgeHooks.onItemStackedOn(itemstack11, itemstack10, slot7, clickaction, p_150434_, m_150446_()))
              if (!itemstack11.m_150926_(slot7, clickaction, p_150434_) && !itemstack10.m_150932_(itemstack11, slot7, clickaction, p_150434_, this.m_150446_())) {
                 if (itemstack10.m_41619_()) {
                    if (!itemstack11.m_41619_()) {

--- a/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -12,14 +12,14 @@
           for(ContainerListener containerlistener : this.f_38848_) {
              containerlistener.m_7934_(this, p_150408_, itemstack1);
           }
-@@ -399,6 +_,7 @@
-             ItemStack itemstack10 = slot7.m_7993_();
+@@ -400,6 +_,7 @@
              ItemStack itemstack11 = this.m_142621_();
              p_150434_.m_141945_(itemstack11, slot7.m_7993_(), clickaction);
-+            if (!net.minecraftforge.common.ForgeHooks.onItemStackedOn(itemstack11, itemstack10, slot7, clickaction, p_150434_, m_150446_()))
              if (!itemstack11.m_150926_(slot7, clickaction, p_150434_) && !itemstack10.m_150932_(itemstack11, slot7, clickaction, p_150434_, this.m_150446_())) {
++            if (!net.minecraftforge.common.ForgeHooks.onItemStackedOn(itemstack11, itemstack10, slot7, clickaction, p_150434_, m_150446_()))
                 if (itemstack10.m_41619_()) {
                    if (!itemstack11.m_41619_()) {
+                      int l2 = clickaction == ClickAction.PRIMARY ? itemstack11.m_41613_() : 1;
 @@ -601,14 +_,15 @@
              ItemStack itemstack = slot.m_7993_();
              if (!itemstack.m_41619_() && ItemStack.m_150942_(p_38904_, itemstack)) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -60,7 +60,10 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -115,6 +118,7 @@ import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.GrindstoneEvent;
 import net.minecraftforge.event.ItemAttributeModifierEvent;
+import net.minecraftforge.event.ItemStackedOnOtherEvent;
 import net.minecraftforge.event.ModMismatchEvent;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.RegisterStructureConversionsEvent;
@@ -263,6 +267,11 @@ public class ForgeHooks
             return true;
         }
         return false;
+    }
+
+    public static boolean onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess)
+    {
+        return MinecraftForge.EVENT_BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess));
     }
 
     public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty)

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * </ul>
  *
  *  This event is fired before either of the above are called, when a carried item is clicked on top of another in a GUI slot.
- *  This event (and item stacking on others in general) is fired on both {@linkplain LogicalSide sides}, but only on {@linkplain LogicalSide#CLIENT the client} for the creative menu.
+ *  This event (and items stacking on others in general) is fired on both {@linkplain LogicalSide sides}, but only on {@linkplain LogicalSide#CLIENT the client} in the creative menu.
  *  Practically, that means that listeners of this event should require the player to be in survival mode if using capabilities that are not synced.
  *  <p>
  *  This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -20,17 +20,18 @@ import org.jetbrains.annotations.ApiStatus;
 
 /**
  * This event provides the functionality of the pair of functions used for the Bundle, in one event:
- *  - {@link Item#overrideOtherStackedOnMe(ItemStack, ItemStack, Slot, ClickAction, Player, SlotAccess)}
- *  - {@link Item#overrideStackedOnOther(ItemStack, Slot, ClickAction, Player)}
+ * <ul>
+ *     <li>{@link Item#overrideOtherStackedOnMe(ItemStack, ItemStack, Slot, ClickAction, Player, SlotAccess)}</li>
+ *     <li>{@link Item#overrideStackedOnOther(ItemStack, Slot, ClickAction, Player)}</li>
+ * </ul>
  *
- *  This event is fired before either of those are called, when a carried item is clicked on top of another in a GUI slot.
- *  This event (and item stacking on others in general) is fired on both {@linkplain LogicalSide}, but only on {@linkplain LogicalSide#CLIENT} for the creative menu.
+ *  This event is fired before either of the above are called, when a carried item is clicked on top of another in a GUI slot.
+ *  This event (and item stacking on others in general) is fired on both {@linkplain LogicalSide sides}, but only on {@linkplain LogicalSide#CLIENT the client} for the creative menu.
  *  Practically, that means that listeners of this event should require the player to be in survival mode if using capabilities that are not synced.
  *  <p>
  *  This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
  *  If the event is cancelled, the container's logic halts, the carried item and the slot will not be swapped, and handling is assumed to have been done by the mod.
- *  This means also that the two above vanilla checks described above will not be called.
- *  * <p>
+ *  This also means that the two vanilla checks described above will not be called.
  */
 @Cancelable
 public class ItemStackedOnOtherEvent extends Event
@@ -54,7 +55,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return The stack being carried by the mouse. This may be empty!
+     * {@return the stack being carried by the mouse} This may be empty!
      */
     public ItemStack getCarriedItem()
     {
@@ -62,7 +63,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return The stack currently in the slot being clicked on. This may be empty!
+     * {@return the stack currently in the slot being clicked on} This may be empty!
      */
     public ItemStack getStackedOnItem()
     {
@@ -70,7 +71,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return The Slot being clicked on
+     * {@return the slot being clicked on}
      */
     public Slot getSlot()
     {
@@ -78,7 +79,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return The click action being used. By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
+     * {@return the click action being used} By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
      */
     public ClickAction getClickAction()
     {
@@ -86,7 +87,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return The player doing the item swap attempt
+     * {@return the player doing the item swap attempt}
      */
     public Player getPlayer()
     {
@@ -94,7 +95,7 @@ public class ItemStackedOnOtherEvent extends Event
     }
 
     /**
-     * @return This is a fake slot allowing the listener to see and change what item is being carried.
+     * {@return a fake slot allowing the listener to see and change what item is being carried}
      */
     public SlotAccess getCarriedSlotAccess()
     {

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * This event provides the functionality of the pair of functions used for the Bundle, in one event:
+ *  - {@link Item#overrideOtherStackedOnMe(ItemStack, ItemStack, Slot, ClickAction, Player, SlotAccess)}
+ *  - {@link Item#overrideStackedOnOther(ItemStack, Slot, ClickAction, Player)}
+ *
+ *  This event is fired before either of those are called, when a carried item is clicked on top of another in a GUI slot.
+ *  This event (and item stacking on others in general) is fired on both {@linkplain LogicalSide}, but only on {@linkplain LogicalSide#CLIENT} for the creative menu.
+ *  Practically, that means that listeners of this event should require the player to be in survival mode if using capabilities that are not synced.
+ *  <p>
+ *  This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+ *  If the event is cancelled, the container's logic halts, the carried item and the slot will not be swapped, and handling is assumed to have been done by the mod.
+ *  This means also that the two above vanilla checks described above will not be called.
+ *  * <p>
+ */
+@Cancelable
+public class ItemStackedOnOtherEvent extends Event
+{
+    private final ItemStack carriedItem;
+    private final ItemStack stackedOnItem;
+    private final Slot slot;
+    private final ClickAction action;
+    private final Player player;
+    private final SlotAccess carriedSlotAccess;
+
+    @ApiStatus.Internal
+    public ItemStackedOnOtherEvent(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess)
+    {
+        this.carriedItem = carriedItem;
+        this.stackedOnItem = stackedOnItem;
+        this.slot = slot;
+        this.action = action;
+        this.player = player;
+        this.carriedSlotAccess = carriedSlotAccess;
+    }
+
+    /**
+     * @return The stack being carried by the mouse. This may be empty!
+     */
+    public ItemStack getCarriedItem()
+    {
+        return carriedItem;
+    }
+
+    /**
+     * @return The stack currently in the slot being clicked on. This may be empty!
+     */
+    public ItemStack getStackedOnItem()
+    {
+        return stackedOnItem;
+    }
+
+    /**
+     * @return The Slot being clicked on
+     */
+    public Slot getSlot()
+    {
+        return slot;
+    }
+
+    /**
+     * @return The click action being used. By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
+     */
+    public ClickAction getClickAction()
+    {
+        return action;
+    }
+
+    /**
+     * @return The player doing the item swap attempt
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * @return This is a fake slot allowing the listener to see and change what item is being carried.
+     */
+    public SlotAccess getCarriedSlotAccess()
+    {
+        return carriedSlotAccess;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;

--- a/src/test/java/net/minecraftforge/debug/block/OnTreeGrowBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/OnTreeGrowBlockTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/entity/living/LivingSetAttackTargetEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/LivingSetAttackTargetEventTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.entity.living;
 
 import net.minecraft.world.entity.monster.piglin.AbstractPiglin;

--- a/src/test/java/net/minecraftforge/debug/item/ItemStackedOnOtherTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemStackedOnOtherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.item;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ItemStackedOnOtherEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(ItemStackedOnOtherTest.MODID)
+public class ItemStackedOnOtherTest
+{
+    public static final String MODID = "item_stacked_on_other_test";
+
+    private static final boolean ENABLED = true;
+
+    public ItemStackedOnOtherTest()
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.addListener(this::onStackedOn);
+        }
+    }
+
+    /**
+     * When right clicking on a damageable item with a diamond sword
+     */
+    private void onStackedOn(ItemStackedOnOtherEvent event)
+    {
+        Player player = event.getPlayer();
+        if (!player.isCreative() && event.getClickAction() == ClickAction.SECONDARY)
+        {
+            ItemStack carried = event.getCarriedItem();
+            ItemStack current = event.getStackedOnItem();
+            if (carried.is(Items.DIAMOND_SWORD) && current.isDamageableItem())
+            {
+                current.hurtAndBreak(1, player, p -> {});
+                event.setCanceled(true);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.data.worldgen.features.TreeFeatures;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -263,6 +263,8 @@ modId="custom_color_resolver_test"
 [[mods]]
 modId="custom_item_decorations_test"
 [[mods]]
+modId="item_stacked_on_other_test"
+[[mods]]
 modId="ambient_occlusion_elements_test"
 
 


### PR DESCRIPTION
So since bundles were added we've been able to use `overrideOtherStackedOnMe` as well as `overrideStackedOnOther` in `Item` to do certain special actions in GUIs. The problem with this is it's tied to the item class, so there's no good way to for example, use `overrideOtherStackedOnMe` with arbitrary items that have a certain capability.

Those two methods basically allow you to return "true" to say that you handled it in the method and stop the swap. Luckily, this is exactly how cancellable events work, so all I did in the patch is check the event before I check the two builtin methods. If cancelled, the logic falls out of the if statement the exact same way as if you had returned true in either of the builtin methods. This means we're not really breaking vanilla logic at all or introducing anything unexpected, we're just taking advantage of the existing position of the checks. It is NOT meant to be a generic "slot clicked" event (it fires in pretty specific circumstances) nor should it be used like that.