### PR TITLE
Fix `KeyMapping` Control Modifier on Mac to not be Alt

### DIFF
--- a/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
@@ -23,7 +23,7 @@ public enum KeyModifier {
             int keyCode = key.getValue();
             if (Minecraft.ON_OSX)
             {
-                return keyCode == GLFW.GLFW_KEY_LEFT_ALT || keyCode == GLFW.GLFW_KEY_RIGHT_ALT;
+                return keyCode == GLFW.GLFW_KEY_LEFT_SUPER || keyCode == GLFW.GLFW_KEY_RIGHT_SUPER;
             }
             else
             {


### PR DESCRIPTION
The `KeyModifier` control on mac (within the `#matches` method) was checked against the left and right alt keys instead of the left and right super keys, leading to control and alt key modifiers to conflict with each other. This PR fixes the check to use the left and right super keys (343 and 347), as shown in `Screen#hasControlDown`.