### PR TITLE
Allow appending reloadable data to load before vanilla data in AddReloadListenerEvent

### DIFF
--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    private final CommandSource f_81288_;
+    public final CommandSource f_81288_;

--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -26,14 +26,12 @@
     }
  
     public ServerFunctionLibrary m_206860_() {
-@@ -80,7 +_,9 @@
+@@ -80,7 +_,7 @@
  
     public static CompletableFuture<ReloadableServerResources> m_206861_(ResourceManager p_206862_, RegistryAccess.Frozen p_206863_, Commands.CommandSelection p_206864_, int p_206865_, Executor p_206866_, Executor p_206867_) {
        ReloadableServerResources reloadableserverresources = new ReloadableServerResources(p_206863_, p_206864_, p_206865_);
 -      return SimpleReloadInstance.m_203834_(p_206862_, reloadableserverresources.m_206890_(), p_206866_, p_206867_, f_206846_, f_206845_.isDebugEnabled()).m_7237_().whenComplete((p_214309_, p_214310_) -> {
-+      List<PreparableReloadListener> listeners = new java.util.ArrayList<>(reloadableserverresources.m_206890_());
-+      listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources));
-+      return SimpleReloadInstance.m_203834_(p_206862_, listeners, p_206866_, p_206867_, f_206846_, f_206845_.isDebugEnabled()).m_7237_().whenComplete((p_214309_, p_214310_) -> {
++      return SimpleReloadInstance.m_203834_(p_206862_, net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources), p_206866_, p_206867_, f_206846_, f_206845_.isDebugEnabled()).m_7237_().whenComplete((p_214309_, p_214310_) -> {
           reloadableserverresources.f_214300_.m_227135_(CommandBuildContext.MissingTagAccessPolicy.FAIL);
        }).thenApply((p_214306_) -> {
           return reloadableserverresources;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -668,7 +668,7 @@ public class ForgeEventFactory
         List<PreparableReloadListener> listeners = new ArrayList<>(serverResources.listeners());
         AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources, listeners);
         MinecraftForge.EVENT_BUS.post(event);
-        return ImmutableList.copyOf(listeners);
+        return List.copyOf(listeners);
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -10,8 +10,6 @@ import java.util.*;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
-import com.google.common.collect.ImmutableList;
-
 import com.mojang.authlib.GameProfile;
 
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -10,6 +10,8 @@ import java.util.*;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
+import com.google.common.collect.ImmutableList;
+
 import com.mojang.authlib.GameProfile;
 
 import com.mojang.brigadier.CommandDispatcher;
@@ -663,9 +665,10 @@ public class ForgeEventFactory
 
     public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources)
     {
-        AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources);
+        List<PreparableReloadListener> listeners = new ArrayList<>(serverResources.listeners());
+        AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources, listeners);
         MinecraftForge.EVENT_BUS.post(event);
-        return event.getListeners();
+        return ImmutableList.copyOf(listeners);
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context)


### PR DESCRIPTION
The use case for this is I have a custom recipe type that relies on a piece of server reloadable data. It's an alloying recipe, which combines 'Metal' objects, something I construct from json.

This event preserves the idea that the event listener should not be able to mutate the list, only add to it. I also have simplified the patch by taking advantage of the list mutability.