### PR TITLE
Revert breaking change to ForgeConfigSpec.Builder#comment

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -645,10 +645,13 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         {
             if (comment.stream().allMatch(String::isBlank))
             {
-                if (!FMLEnvironment.production)
-                    throw new IllegalStateException("Can not build comment for config option " + DOT_JOINER.join(path) + " as it comprises entirely of blank lines/whitespace");
+                if (FMLEnvironment.production)
+                    LogManager.getLogger().warn(CORE, "Detected a comment that is all whitespace for config option {}, which causes obscure bugs in Forge's config system and will cause a crash in the future. Please report this to the mod author.",
+                            DOT_JOINER.join(path));
+                else
+                    throw new IllegalStateException("Can not build comment for config option " + DOT_JOINER.join(path) + " as it comprises entirely of blank lines/whitespace. This is not allowed as it causes a \"constantly correcting config\" bug with NightConfig in Forge's config system.");
 
-                return "A developer of this mod has defined this config option with an empty comment, which will cause a crash in the future. Please report this to the mod author.";
+                return "A developer of this mod has defined this config option with a blank comment, which causes obscure bugs in Forge's config system and will cause a crash in the future. Please report this to the mod author.";
             }
 
             return LINE_JOINER.join(comment);

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -643,12 +643,12 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public String buildComment() { return buildComment(List.of("unknown", "unknown")); }
         public String buildComment(final List<String> path)
         {
-            if (!FMLEnvironment.production && comment.stream().allMatch(String::isBlank))
+            if (comment.stream().allMatch(String::isBlank))
             {
-                LogManager.getLogger().error(CORE, "Detected a comment that is all whitespace for config option {}, this is invalid and will be disallowed in the future.",
-                        DOT_JOINER.join(path));
+                if (!FMLEnvironment.production)
+                    throw new IllegalStateException("Can not build comment for config option " + DOT_JOINER.join(path) + " as it comprises entirely of blank lines/whitespace");
 
-                return "No comment";
+                return "A developer of this mod has defined this config option with an empty comment, which will cause a crash in the future. Please report this to the mod author.";
             }
 
             return LINE_JOINER.join(comment);

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -635,9 +635,6 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             // Don't use `validate` because it throws IllegalStateException, not NullPointerException
             Preconditions.checkNotNull(value, "Passed in null value for comment");
 
-            if (value.isBlank() && comment.size() == 0)
-                throw new IllegalArgumentException("Can not add zero-length comment as top-most comment");
-
             comment.add(value);
         }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -640,7 +640,13 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
 
         public void clearComment() { comment.clear(); }
         public boolean hasComment() { return this.comment.size() > 0; }
-        public String buildComment() { return LINE_JOINER.join(comment); }
+        public String buildComment()
+        {
+            if (comment.stream().allMatch(String::isBlank))
+                throw new IllegalStateException("Can not build comment that comprises entirely of blank lines/whitespace");
+
+            return LINE_JOINER.join(comment);
+        }
         public void setTranslationKey(String value) { this.langKey = value; }
         public String getTranslationKey() { return this.langKey; }
         public <V extends Comparable<? super V>> void setRange(Range<V> value)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;

--- a/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
@@ -63,6 +63,22 @@ public class ForgeConfigSpecTest
         executeSpeedTest("test.test.test.test.test.test.test.test.test.test", "deepKeyValue", "deepKeySpeedTest");
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void allEmptyCommentTest() throws IllegalStateException
+    {
+        final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        final ForgeConfigSpec.ConfigValue<String> simpleValue = builder.comment("", "").define("allEmptyCommentTest", "someDefaultValue");
+        final ForgeConfigSpec spec = builder.build();
+    }
+
+    @Test
+    public void topPaddedCommentTest() throws IllegalStateException
+    {
+        final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        final ForgeConfigSpec.ConfigValue<String> simpleValue = builder.comment("", "Test").define("topPaddedCommentTest", "someDefaultValue");
+        final ForgeConfigSpec spec = builder.build();
+    }
+
     private <T> void executeSpeedTest(final String configKey, final T defaultKeyValue, final String testName) throws IOException
     {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();

--- a/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
@@ -63,7 +63,8 @@ public class ForgeConfigSpecTest
         executeSpeedTest("test.test.test.test.test.test.test.test.test.test", "deepKeyValue", "deepKeySpeedTest");
     }
 
-    @Test(expected = IllegalStateException.class)
+    //@Test(expected = IllegalStateException.class) - uncomment when this behaviour is disallowed
+    @Test
     public void allEmptyCommentTest() throws IllegalStateException
     {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();

--- a/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
@@ -63,8 +63,7 @@ public class ForgeConfigSpecTest
         executeSpeedTest("test.test.test.test.test.test.test.test.test.test", "deepKeyValue", "deepKeySpeedTest");
     }
 
-    //@Test(expected = IllegalStateException.class) - uncomment when this behaviour is disallowed
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void allEmptyCommentTest() throws IllegalStateException
     {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();

--- a/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
+++ b/src/test/java/net/minecraftforge/commontest/ForgeConfigSpecTest.java
@@ -72,7 +72,7 @@ public class ForgeConfigSpecTest
     }
 
     @Test
-    public void topPaddedCommentTest() throws IllegalStateException
+    public void topPaddedCommentTest()
     {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
         final ForgeConfigSpec.ConfigValue<String> simpleValue = builder.comment("", "Test").define("topPaddedCommentTest", "someDefaultValue");

--- a/src/test/java/net/minecraftforge/debug/block/OnTreeGrowBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/OnTreeGrowBlockTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/entity/living/LivingSetAttackTargetEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/LivingSetAttackTargetEventTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.entity.living;
 
 import net.minecraft.world.entity.monster.piglin.AbstractPiglin;

--- a/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.data.worldgen.features.TreeFeatures;


### PR DESCRIPTION
With #9056, the config API made a breaking change that causes a crash if the first line of a config value's comment is blank.

While this makes sense for preventing `.comment("")`, it prevents mod devs from having any separation between config values in large config files, which some do to make it clearer which config value the comment is referring to.

Presumably the change was made for preventing the first scenario with the second being overlooked. Unfortunately this is a breaking change either way that wasn't announced beforehand and occurred after an RB. This PR reverts that change to fix the crashing issue with some mods (such as Create 1.19.2 0.5.0.e and It's The Little Things 1.19.x 2.0.5)