### PR TITLE
added string tag to buildCraftingRecipes(..) for vanilla recipe override

### DIFF
--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    private final CommandSource f_81288_;
+    public final CommandSource f_81288_;

--- a/src/generated/resources/data/minecraft/recipes/candle.json
+++ b/src/generated/resources/data/minecraft/recipes/candle.json
@@ -1,19 +1,18 @@
 {
   "type": "minecraft:crafting_shaped",
   "key": {
-    "#": {
-      "tag": "forge:rods/wooden"
+    "H": {
+      "item": "minecraft:honeycomb"
     },
-    "X": {
+    "S": {
       "tag": "forge:string"
     }
   },
   "pattern": [
-    " #X",
-    "# X",
-    " #X"
+    "S",
+    "H"
   ],
   "result": {
-    "item": "minecraft:bow"
+    "item": "minecraft:candle"
   }
 }

--- a/src/generated/resources/data/minecraft/recipes/crossbow.json
+++ b/src/generated/resources/data/minecraft/recipes/crossbow.json
@@ -11,7 +11,7 @@
       "tag": "forge:ingots/iron"
     },
     "~": {
-      "item": "minecraft:string"
+      "tag": "forge:string"
     }
   },
   "pattern": [

--- a/src/generated/resources/data/minecraft/recipes/fishing_rod.json
+++ b/src/generated/resources/data/minecraft/recipes/fishing_rod.json
@@ -5,7 +5,7 @@
       "tag": "forge:rods/wooden"
     },
     "X": {
-      "item": "minecraft:string"
+      "tag": "forge:string"
     }
   },
   "pattern": [

--- a/src/generated/resources/data/minecraft/recipes/lead.json
+++ b/src/generated/resources/data/minecraft/recipes/lead.json
@@ -1,19 +1,20 @@
 {
   "type": "minecraft:crafting_shaped",
   "key": {
-    "#": {
-      "tag": "forge:rods/wooden"
+    "O": {
+      "item": "minecraft:slime_ball"
     },
-    "X": {
+    "~": {
       "tag": "forge:string"
     }
   },
   "pattern": [
-    " #X",
-    "# X",
-    " #X"
+    "~~ ",
+    "~O ",
+    "  ~"
   ],
   "result": {
-    "item": "minecraft:bow"
+    "count": 2,
+    "item": "minecraft:lead"
   }
 }

--- a/src/generated/resources/data/minecraft/recipes/loom.json
+++ b/src/generated/resources/data/minecraft/recipes/loom.json
@@ -2,18 +2,17 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "tag": "forge:rods/wooden"
+      "tag": "minecraft:planks"
     },
-    "X": {
+    "@": {
       "tag": "forge:string"
     }
   },
   "pattern": [
-    " #X",
-    "# X",
-    " #X"
+    "@@",
+    "##"
   ],
   "result": {
-    "item": "minecraft:bow"
+    "item": "minecraft:loom"
   }
 }

--- a/src/generated/resources/data/minecraft/recipes/scaffolding.json
+++ b/src/generated/resources/data/minecraft/recipes/scaffolding.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "I": {
+      "item": "minecraft:bamboo"
+    },
+    "~": {
+      "tag": "forge:string"
+    }
+  },
+  "pattern": [
+    "I~I",
+    "I I",
+    "I I"
+  ],
+  "result": {
+    "count": 6,
+    "item": "minecraft:scaffolding"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipes/white_wool_from_string.json
+++ b/src/generated/resources/data/minecraft/recipes/white_wool_from_string.json
@@ -2,18 +2,14 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "tag": "forge:rods/wooden"
-    },
-    "X": {
       "tag": "forge:string"
     }
   },
   "pattern": [
-    " #X",
-    "# X",
-    " #X"
+    "##",
+    "##"
   ],
   "result": {
-    "item": "minecraft:bow"
+    "item": "minecraft:white_wool"
   }
 }

--- a/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
@@ -56,6 +56,7 @@ public final class ForgeRecipeProvider extends RecipeProvider
     protected void buildCraftingRecipes(Consumer<FinishedRecipe> consumer)
     {
         replace(Items.STICK, Tags.Items.RODS_WOODEN);
+        replace(Items.STRING, Tags.Items.STRING);
         replace(Items.GOLD_INGOT, Tags.Items.INGOTS_GOLD);
         replace(Items.IRON_INGOT, Tags.Items.INGOTS_IRON);
         replace(Items.NETHERITE_INGOT, Tags.Items.INGOTS_NETHERITE);


### PR DESCRIPTION
Forge currently has a tag data/forge/items/string that is not used in ForgeRecipeProvider's buildCraftingRecipes(..) method. Because of this, mods using this tag will not have their modifications applied to Vanilla crafting. Added this tag to the method so that it can be used in Vanilla recipes.