### PR TITLE
Rendering tweaks and fixes: Part 4

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -109,7 +109,7 @@
 +      BLOCK_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), layers);
 +   }
 +
-+   public static void setRenderLayer(Fluid fluid, RenderType type) {
++   public static synchronized void setRenderLayer(Fluid fluid, RenderType type) {
 +      com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +      checkClientLoading();
 +      FLUID_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid), type);

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
@@ -49,7 +49,7 @@
        for(BlockElement blockelement : this.m_111436_()) {
           for(BlockElementFace blockelementface : blockelement.f_111310_.values()) {
              Material material = this.m_111480_(blockelementface.f_111356_);
-@@ -181,11 +_,17 @@
+@@ -181,11 +_,18 @@
        return set1;
     }
  
@@ -62,20 +62,12 @@
 +      return net.minecraftforge.client.model.geometry.UnbakedGeometryHelper.bake(this, p_111450_, p_111451_, p_111452_, p_111453_, p_111454_, p_111455_);
 +   }
 +
-+   @Deprecated //Forge: exposed for our callbacks only. Use the above function.
++   @Deprecated(forRemoval = true, since = "1.19.2") // TODO: We cannot remove it since it's vanilla code, but make it private in 1.20
 +   public BakedModel bakeVanilla(ModelBakery p_111450_, BlockModel p_111451_, Function<Material, TextureAtlasSprite> p_111452_, ModelState p_111453_, ResourceLocation p_111454_, boolean p_111455_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
++      if (true) return net.minecraftforge.client.model.geometry.UnbakedGeometryHelper.bakeVanilla(this, p_111450_, p_111451_, p_111452_, p_111453_, p_111454_); // Redirected, in case anyone actually uses this
        TextureAtlasSprite textureatlassprite = p_111452_.apply(this.m_111480_("particle"));
        if (this.m_111490_() == ModelBakery.f_119233_) {
           return new BuiltInModel(this.m_111491_(), this.m_111446_(p_111450_, p_111451_), textureatlassprite, this.m_111479_().m_111526_());
-@@ -204,7 +_,7 @@
-             }
-          }
- 
--         return simplebakedmodel$builder.m_119533_();
-+         return simplebakedmodel$builder.build(renderTypes);
-       }
-    }
- 
 @@ -268,7 +_,18 @@
        ItemTransform itemtransform5 = this.m_111444_(ItemTransforms.TransformType.GUI);
        ItemTransform itemtransform6 = this.m_111444_(ItemTransforms.TransformType.GROUND);

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -23,10 +23,12 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.RenderTypeGroup;
@@ -167,6 +169,15 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
                 }
             }
             return ConcatenatedListView.of(quadLists);
+        }
+
+        @Override
+        public @NotNull ModelData getModelData(@NotNull BlockAndTintGetter level, @NotNull BlockPos pos, @NotNull BlockState state, @NotNull ModelData modelData)
+        {
+            var builder = Data.builder();
+            for (var entry : children.entrySet())
+                builder.with(entry.getKey(), entry.getValue().getModelData(level, pos, state, Data.resolve(modelData, entry.getKey())));
+            return modelData.derive().with(Data.PROPERTY, builder.build()).build();
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/QuadTransformers.java
+++ b/src/main/java/net/minecraftforge/client/model/QuadTransformers.java
@@ -64,7 +64,7 @@ public final class QuadTransformers {
             {
                 int offset = i * IQuadTransformer.STRIDE + IQuadTransformer.NORMAL;
                 int normalIn = vertices[offset];
-                if ((normalIn >> 8) != 0)
+                if ((normalIn & 0x00FFFFFF) != 0) // The ignored byte is padding and may be filled with user data
                 {
                     float x = ((byte) (normalIn & 0xFF)) / 127.0f;
                     float y = ((byte) ((normalIn >> 8) & 0xFF)) / 127.0f;
@@ -72,12 +72,11 @@ public final class QuadTransformers {
 
                     Vector3f pos = new Vector3f(x, y, z);
                     transform.transformNormal(pos);
-                    pos.normalize();
 
-                    vertices[offset] = (((byte) (x * 127.0f)) & 0xFF) |
-                            ((((byte) (y * 127.0f)) & 0xFF) << 8) |
-                            ((((byte) (z * 127.0f)) & 0xFF) << 16) |
-                            (normalIn & 0xFF000000);
+                    vertices[offset] = (((byte) (pos.x() * 127.0f)) & 0xFF) |
+                            ((((byte) (pos.y() * 127.0f)) & 0xFF) << 8) |
+                            ((((byte) (pos.z() * 127.0f)) & 0xFF) << 16) |
+                            (normalIn & 0xFF000000); // Restore padding, just in case
                 }
             }
         };

--- a/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -113,8 +113,10 @@ public class UnbakedGeometryHelper
      */
     @ApiStatus.Internal
     @Deprecated(forRemoval = true, since = "1.19.2")
-    public static BakedModel bakeVanilla(BlockModel blockModel, ModelBakery modelBakery, BlockModel owner, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ResourceLocation modelLocation) {
-        if (blockModel.getRootModel() == ModelBakery.BLOCK_ENTITY_MARKER) {
+    public static BakedModel bakeVanilla(BlockModel blockModel, ModelBakery modelBakery, BlockModel owner, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ResourceLocation modelLocation)
+    {
+        if (blockModel.getRootModel() == ModelBakery.BLOCK_ENTITY_MARKER)
+        {
             var particleSprite = spriteGetter.apply(blockModel.getMaterial("particle"));
             return new BuiltInModel(blockModel.getTransforms(), blockModel.getOverrides(modelBakery, owner, spriteGetter), particleSprite, blockModel.getGuiLight().lightLikeBlock());
         }

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -652,9 +652,11 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
             int tintIndex = mat.diffuseTintIndex;
             Vector4f colorTint = mat.diffuseColor;
 
+            var rootTransform = owner.getRootTransform();
+            var transform = rootTransform.isIdentity() ? modelTransform.getRotation() : modelTransform.getRotation().compose(rootTransform);
             for (int[][] face : faces)
             {
-                Pair<BakedQuad, Direction> quad = makeQuad(face, tintIndex, colorTint, mat.ambientColor, texture, modelTransform.getRotation());
+                Pair<BakedQuad, Direction> quad = makeQuad(face, tintIndex, colorTint, mat.ambientColor, texture, transform);
                 if (quad.getRight() == null)
                     modelBuilder.addUnculledFace(quad.getLeft());
                 else

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -68,7 +68,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
             new Vec2(1, 0),
     };
 
-    private final Map<String, ModelGroup> parts = Maps.newHashMap();
+    private final Map<String, ModelGroup> parts = Maps.newLinkedHashMap();
     private final Set<String> rootComponentNames = Collections.unmodifiableSet(parts.keySet());
     private Set<String> allComponentNames;
 
@@ -582,7 +582,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
 
     public class ModelGroup extends ModelObject
     {
-        final Map<String, ModelObject> parts = Maps.newHashMap();
+        final Map<String, ModelObject> parts = Maps.newLinkedHashMap();
 
         ModelGroup(String name)
         {

--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -402,8 +402,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
             faceNormal = abs;
         }
 
-        var quad = new BakedQuad[1];
-        var quadBaker = new QuadBakingVertexConsumer(q -> quad[0] = q);
+        var quadBaker = new QuadBakingVertexConsumer.Buffered();
 
         quadBaker.setSprite(texture);
         quadBaker.setTintIndex(tintIndex);
@@ -516,7 +515,7 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
             }
         }
 
-        return Pair.of(quad[0], cull);
+        return Pair.of(quadBaker.getQuad(), cull);
     }
 
     public CompositeRenderable bakeRenderable(IGeometryBakingContext configuration)

--- a/src/main/java/net/minecraftforge/client/model/pipeline/QuadBakingVertexConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/QuadBakingVertexConsumer.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.client.model.pipeline;
 
+import com.google.common.base.Preconditions;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
@@ -37,7 +38,7 @@ public class QuadBakingVertexConsumer implements VertexConsumer
 
     private final Consumer<BakedQuad> quadConsumer;
 
-    private int vertexIndex = 0;
+    int vertexIndex = 0;
     private int[] quadData = new int[QUAD_DATA_SIZE];
 
     private int tintIndex;
@@ -166,5 +167,28 @@ public class QuadBakingVertexConsumer implements VertexConsumer
     public void setHasAmbientOcclusion(boolean hasAmbientOcclusion)
     {
         this.hasAmbientOcclusion = hasAmbientOcclusion;
+    }
+
+    public static class Buffered extends QuadBakingVertexConsumer
+    {
+        private final BakedQuad[] output;
+
+        public Buffered()
+        {
+            this(new BakedQuad[1]);
+        }
+
+        private Buffered(BakedQuad[] output)
+        {
+            super(q -> output[0] = q);
+            this.output = output;
+        }
+
+        public BakedQuad getQuad()
+        {
+            var quad = Preconditions.checkNotNull(output[0], "No quad has been emitted. Vertices in buffer: " + vertexIndex);
+            output[0] = null;
+            return quad;
+        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -156,8 +156,7 @@ public class NewModelLoaderTest
         {
             TextureAtlasSprite texture = spriteGetter.apply(owner.getMaterial("particle"));
 
-            var quad = new BakedQuad[1];
-            var quadBaker = new QuadBakingVertexConsumer(q -> quad[0] = q);
+            var quadBaker = new QuadBakingVertexConsumer.Buffered();
 
             quadBaker.setDirection(Direction.UP);
             quadBaker.setSprite(texture);
@@ -167,7 +166,7 @@ public class NewModelLoaderTest
             quadBaker.vertex(1, 0, 0.5f).color(255, 255, 255, 255).uv(texture.getU(16), texture.getV(16)).uv2(0).normal(0, 0, 0).endVertex();
             quadBaker.vertex(1, 1, 0.5f).color(255, 255, 255, 255).uv(texture.getU(16), texture.getV(0)).uv2(0).normal(0, 0, 0).endVertex();
 
-            modelBuilder.addUnculledFace(quad[0]);
+            modelBuilder.addUnculledFace(quadBaker.getQuad());
         }
 
         @Override


### PR DESCRIPTION
After a few months, it's time for another round of small miscellaneous fixes, tweaks and community requests.

### Fix awkward root transform on elements models and unify baking

This one isn't exactly a bug. The original implementation of root transforms (prior to the client refactor) caused vanilla elements models to look rather broken, creating gaps and deforming quads in odd ways due to vanilla's quad generation logic not being designed to support arbitrary transforms. I kept this logic because I figured gigaherz was aware of it and deemed it okay. Developers, however, have requested that these transforms look correct for some time now, so this commit fixes it.

### Add support for root transforms to OBJ models (Fixes #9059)

Fixes OBJ models not using root transforms.

### Ensure OBJ components are stored in the order they are defined in disk

Switches OBJs from hash-based ordering (HashMap) to insertion-based ordering (LinkedHashMap). This guarantees that geometry is in the same order as in the OBJ file. Existing models should not rely on this behavior, and as such this is not a breaking change.  
Requested by Soaryn. Approved ahead of time by gigaherz.

### Allow children of composite models to update ModelData as needed

Fixes composite models not overriding the `getModelData(...)` method to allow their children to modify the data object.

### Add buffered quad-baking vertex consumer to simplify basic use cases

Adds a new buffered implementation of `QuadBakingVertexConsumer` that simplifies baking quads manually.  
Requested by tterrag.

### Fix normal handling in built-in quad transformer

Fixes the computed normals being ignored, as well as the test for the presence of any normal value.

### Add missing synchronized in ItemBlockRenderTypes

Adds `synchronized` to `ItemBlockRenderTypes#setRenderLayer(Fluid, RenderType)` to match the others and fix potential concurrency issues.