### PR TITLE
Add simple block appearance API

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/chunk/RenderChunkRegion.java
 +++ b/net/minecraft/client/renderer/chunk/RenderChunkRegion.java
-@@ -66,4 +_,9 @@
+@@ -66,4 +_,14 @@
     public int m_141928_() {
        return this.f_112908_.m_141928_();
     }
@@ -8,5 +8,10 @@
 +   @Override
 +   public float getShade(float normalX, float normalY, float normalZ, boolean shade) {
 +      return this.f_112908_.getShade(normalX, normalY, normalZ, shade);
++   }
++
++   @Override
++   public net.minecraftforge.client.model.data.ModelDataManager getModelDataManager() {
++      return f_112908_.getModelDataManager();
 +   }
  }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -924,20 +924,6 @@ public interface IForgeBlock
         return defaultColor;
     }
 
-    /*
-     * Returns the {@link BlockState} that this block looks like on the given side.
-     * Overriding this does not change how this block renders. That still needs to be done in the model. This
-     * <p>
-     * This method should be overridden by blocks that mimic the appearance of other blocks by wrapping their models,
-     * such as covers and facades used to hide cables and pipes which query the geometry and then clip it. This enables
-     * blocks with connected texture behavior to check the appearance of the block instead of the state itself, allowing
-     * them to seamlessly connect to any mimic blocks, and allowing those to connect to each other.
-     * <p>
-     * Note that this method will almost always be called from a rendering or meshing thread and level context will be
-     * limited and asynchronous. If you need any data from your {@link BlockEntity}, it is recommended you put it in
-     * {@link ModelData} and query it by calling {@code level.getModelDataManager().getAt(pos)} in this method.
-     */
-
     /**
      * Returns the {@link BlockState} that this block reports to look like on the given side for querying by other mods.
      * Note: Overriding this does not change how this block renders. That still needs to be done in the model.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -925,24 +925,29 @@ public interface IForgeBlock
     }
 
     /**
-     * Returns the {@link BlockState} that this block reports to look like on the given side for querying by other mods.
-     * Note: Overriding this does not change how this block renders. That still needs to be done in the model.
+     * Returns the {@link BlockState} that this block reports to look like on the given side, for querying by other mods.
+     * Note: Overriding this does not change how this block renders. That must still be handled in the block's model.
      * <p>
      * Common implementors would be covers and facades, or any other mimic blocks that proxy another block's model.
      * Common consumers would be models with connected textures that wish to seamlessly connect to mimic blocks.
      * <p>
-     * <b>On the client, this method may be called from a rendering or meshing thread.</b>
-     * If you need any data from your {@link BlockEntity}, make sure it can be safely accessed concurrently, or put it
-     * in {@link ModelData}. If you do the latter, note that {@link BlockGetter#getModelDataManager()} will return
-     * {@code null} if in a server context. In that case, it is safe to query your {@link BlockEntity} directly.
+     * <b>Note that this method may be called on the server, or on any of the client's meshing threads.</b><br/>
+     * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
+     * safe concurrent access to it on the client.<br/>
+     * Calling {@link BlockGetter#getModelDataManager()} will return {@code null} if in a server context, where it is
+     * safe to query your {@link BlockEntity} directly. Otherwise, {@link ModelDataManager#getAt(BlockPos)} will return
+     * the {@link ModelData} for the queried block, or {@code null} if none is present.
      *
-     * @param state The state of this block
-     * @param level The level this block is in
-     * @param pos   The block's position in the level
-     * @param side  The side of the block that is being queried
-     * @return The appearance of this block from the given side
+     * @param state      The state of this block
+     * @param level      The level this block is in
+     * @param pos        The block's position in the level
+     * @param side       The side of the block that is being queried
+     * @param queryState The state of the block that is querying the appearance, or {@code null} if not applicable
+     * @param queryPos   The position of the block that is querying the appearance, or {@code null} if not applicable
+     * @return The appearance of this block on the given side. By default, the current state
+     * @see IForgeBlockState#getAppearance(BlockAndTintGetter, BlockPos, Direction, BlockState, BlockPos)
      */
-    default BlockState getAppearance(BlockState state, BlockGetter level, BlockPos pos, Direction side)
+    default BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side, @Nullable BlockState queryState, @Nullable BlockPos queryPos)
     {
         return state;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
@@ -37,6 +38,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IPlantable;
 
@@ -930,7 +932,8 @@ public interface IForgeBlock
      * them to seamlessly connect to any mimic blocks.
      * <p>
      * Note that this method will almost always be called from a rendering or meshing thread and level context will be
-     * limited.
+     * limited and asynchronous. If you need any data from your {@link BlockEntity}, it is recommended you put it in
+     * {@link ModelData} and query it by calling {@code level.getModelDataManager().getAt(pos)} in this method.
      *
      * @param state The state of this block
      * @param level The level this block is in

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -920,4 +920,26 @@ public interface IForgeBlock
     {
         return defaultColor;
     }
+
+    /**
+     * Returns the {@link BlockState} that this block looks like on the given side.
+     * <p>
+     * This method should be overridden by blocks that mimic the appearance of other blocks by wrapping their models,
+     * such as covers and facades used to hide cables and pipes which query the geometry and then clip it. This enables
+     * blocks with connected texture behavior to check the appearance of the block instead of the state itself, allowing
+     * them to seamlessly connect to any mimic blocks.
+     * <p>
+     * Note that this method will almost always be called from a rendering or meshing thread and level context will be
+     * limited.
+     *
+     * @param state The state of this block
+     * @param level The level this block is in
+     * @param pos   The block's position in the level
+     * @param side  The side of the block that is being queried
+     * @return The appearance of this block from the given side
+     */
+    default BlockState getAppearance(BlockState state, BlockGetter level, BlockPos pos, Direction side)
+    {
+        return state;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -933,8 +933,8 @@ public interface IForgeBlock
      * <p>
      * <b>On the client, this method may be called from a rendering or meshing thread.</b>
      * If you need any data from your {@link BlockEntity}, make sure it can be safely accessed concurrently, or put it
-     * in {@link ModelData}. If you do the latter, note that {@link BlockGetter#getModelDataManager()} manager will
-     * return {@code null} if in a server context. In that case, it is safe to query your {@link BlockEntity} directly.
+     * in {@link ModelData}. If you do the latter, note that {@link BlockGetter#getModelDataManager()} will return
+     * {@code null} if in a server context. In that case, it is safe to query your {@link BlockEntity} directly.
      *
      * @param state The state of this block
      * @param level The level this block is in

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -39,6 +39,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.model.data.ModelData;
+import net.minecraftforge.client.model.data.ModelDataManager;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IPlantable;
 
@@ -923,17 +924,31 @@ public interface IForgeBlock
         return defaultColor;
     }
 
-    /**
+    /*
      * Returns the {@link BlockState} that this block looks like on the given side.
+     * Overriding this does not change how this block renders. That still needs to be done in the model. This
      * <p>
      * This method should be overridden by blocks that mimic the appearance of other blocks by wrapping their models,
      * such as covers and facades used to hide cables and pipes which query the geometry and then clip it. This enables
      * blocks with connected texture behavior to check the appearance of the block instead of the state itself, allowing
-     * them to seamlessly connect to any mimic blocks.
+     * them to seamlessly connect to any mimic blocks, and allowing those to connect to each other.
      * <p>
      * Note that this method will almost always be called from a rendering or meshing thread and level context will be
      * limited and asynchronous. If you need any data from your {@link BlockEntity}, it is recommended you put it in
      * {@link ModelData} and query it by calling {@code level.getModelDataManager().getAt(pos)} in this method.
+     */
+
+    /**
+     * Returns the {@link BlockState} that this block reports to look like on the given side for querying by other mods.
+     * Note: Overriding this does not change how this block renders. That still needs to be done in the model.
+     * <p>
+     * Common implementors would be covers and facades, or any other mimic blocks that proxy another block's model.
+     * Common consumers would be models with connected textures that wish to seamlessly connect to mimic blocks.
+     * <p>
+     * <b>On the client, this method may be called from a rendering or meshing thread.</b>
+     * If you need any data from your {@link BlockEntity}, make sure it can be safely accessed concurrently, or put it
+     * in {@link ModelData}. If you do the latter, note that {@link BlockGetter#getModelDataManager()} manager will
+     * return {@code null} if in a server context. In that case, it is safe to query your {@link BlockEntity} directly.
      *
      * @param state The state of this block
      * @param level The level this block is in

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -751,12 +751,13 @@ public interface IForgeBlockState
     }
 
     /**
-     * Returns the {@link BlockState} that this state looks like on the given side.
+     * Returns the {@link BlockState} that this state reports to look like on the given side for querying by other mods.
      *
      * @param level The level this block is in
      * @param pos   The block's position in the level
      * @param side  The side of the block that is being queried
      * @return The appearance of this block from the given side
+     * @see IForgeBlock#getAppearance(BlockState, BlockGetter, BlockPos, Direction)
      */
     default BlockState getAppearance(BlockGetter level, BlockPos pos, Direction side)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -753,14 +753,16 @@ public interface IForgeBlockState
     /**
      * Returns the {@link BlockState} that this state reports to look like on the given side for querying by other mods.
      *
-     * @param level The level this block is in
-     * @param pos   The block's position in the level
-     * @param side  The side of the block that is being queried
+     * @param level      The level this block is in
+     * @param pos        The block's position in the level
+     * @param side       The side of the block that is being queried
+     * @param queryState The state of the block that is querying the appearance, or {@code null} if not applicable
+     * @param queryPos   The position of the block that is querying the appearance, or {@code null} if not applicable
      * @return The appearance of this block from the given side
-     * @see IForgeBlock#getAppearance(BlockState, BlockGetter, BlockPos, Direction)
+     * @see IForgeBlock#getAppearance(BlockState, BlockAndTintGetter, BlockPos, Direction, BlockState, BlockPos)
      */
-    default BlockState getAppearance(BlockGetter level, BlockPos pos, Direction side)
+    default BlockState getAppearance(BlockAndTintGetter level, BlockPos pos, Direction side, @Nullable BlockState queryState, @Nullable BlockPos queryPos)
     {
-        return self().getBlock().getAppearance(self(), level, pos, side);
+        return self().getBlock().getAppearance(self(), level, pos, side, queryState, queryPos);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -749,4 +749,17 @@ public interface IForgeBlockState
     {
         return self().getBlock().canBeHydrated(self(), getter, pos, fluid, fluidPos);
     }
+
+    /**
+     * Returns the {@link BlockState} that this state looks like on the given side.
+     *
+     * @param level The level this block is in
+     * @param pos   The block's position in the level
+     * @param side  The side of the block that is being queried
+     * @return The appearance of this block from the given side
+     */
+    default BlockState getAppearance(BlockGetter level, BlockPos pos, Direction side)
+    {
+        return self().getBlock().getAppearance(self(), level, pos, side);
+    }
 }


### PR DESCRIPTION
The proposed API allows blocks to report looking like a different block on a given face. This allows blocks with connected textures to seamlessly connect to other blocks that mimic them, such as the covers and facades often used to hide cables, without adding any extra dependencies and special-casing for each mod that adds such blocks.

An API of this style has been requested several times over the years, and has been previously denied due to the impracticality of their implementation and performance implications. However, Forge and Java have both matured plenty since then, making this a trivial addition with a negligible performance impact in the few cases it's used.

*This PR was made on request from Soaryn and the AE2 team.*