### PR TITLE
Add a cancellable event that gets fired when a Totem of Undying is used

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -209,6 +209,15 @@
              }
           }
  
+@@ -1175,7 +_,7 @@
+ 
+          for(InteractionHand interactionhand : InteractionHand.values()) {
+             ItemStack itemstack1 = this.m_21120_(interactionhand);
+-            if (itemstack1.m_150930_(Items.f_42747_)) {
++            if (itemstack1.m_150930_(Items.f_42747_) && net.minecraftforge.common.ForgeHooks.onLivingUseTotem(this, p_21263_, itemstack1, interactionhand)) {
+                itemstack = itemstack1.m_41777_();
+                itemstack1.m_41774_(1);
+                break;
 @@ -1185,7 +_,7 @@
           if (itemstack != null) {
              if (this instanceof ServerPlayer) {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -125,6 +125,7 @@ import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.LivingUseTotemEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.living.ShieldBlockEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
@@ -284,6 +285,11 @@ public class ForgeHooks
         LivingKnockBackEvent event = new LivingKnockBackEvent(target, strength, ratioX, ratioZ);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
+    }
+
+    public static boolean onLivingUseTotem(LivingEntity entity, DamageSource damageSource, ItemStack totem, InteractionHand hand)
+    {
+        return !MinecraftForge.EVENT_BUS.post(new LivingUseTotemEvent(entity, damageSource, totem, hand));
     }
 
     public static float onLivingHurt(LivingEntity entity, DamageSource src, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * Fired when an Entity attempts to use a totem to prevent its death.
+ *
+ * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+ * If this event is cancelled, the totem will not prevent the entity's death.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS Forge event bus},
+ * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
+ */
+@Cancelable
+public class LivingUseTotemEvent extends LivingEvent
+{
+    private final DamageSource source;
+    private final ItemStack totem;
+    private final InteractionHand hand;
+
+    public LivingUseTotemEvent(LivingEntity entity, DamageSource source, ItemStack totem, InteractionHand hand)
+    {
+        super(entity);
+        this.source = source;
+        this.totem = totem;
+        this.hand = hand;
+    }
+
+    /**
+     * {@return The damage source that caused the entity to die.}
+     */
+    public DamageSource getSource()
+    {
+        return source;
+    }
+
+    /**
+     * {@return The totem of undying being used from the entity's inventory.}
+     */
+    public ItemStack getTotem()
+    {
+        return totem;
+    }
+
+    /**
+     * {@return The hand holding the totem.}
+     */
+    public InteractionHand getHandHolding()
+    {
+        return hand;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
@@ -38,7 +38,7 @@ public class LivingUseTotemEvent extends LivingEvent
     }
 
     /**
-     * {@return The damage source that caused the entity to die.}
+     * {@return the damage source that caused the entity to die}
      */
     public DamageSource getSource()
     {
@@ -46,7 +46,7 @@ public class LivingUseTotemEvent extends LivingEvent
     }
 
     /**
-     * {@return The totem of undying being used from the entity's inventory.}
+     * {@return the totem of undying being used from the entity's inventory}
      */
     public ItemStack getTotem()
     {
@@ -54,7 +54,7 @@ public class LivingUseTotemEvent extends LivingEvent
     }
 
     /**
-     * {@return The hand holding the totem.}
+     * {@return the hand holding the totem}
      */
     public InteractionHand getHandHolding()
     {


### PR DESCRIPTION
My initial use case was to have a way to know when a totem of undying is used such as for custom advancement triggers that are based around dying and being able to make an alternative way to trigger these death based advancements for players in hardcore. (Dying to them but with a totem so as to not actually die).

The other primary use case I can think of and why this PR targets the line it does is to prevent usages of totems. The main case I can imagine that may be useful is for some mods that want to potentially prevent totems from working in a specific dungeon of theirs.