### PR TITLE
Allow custom item usage animations to work for more mobs

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/AbstractZombieModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/AbstractZombieModel.java.patch
@@ -4,7 +4,7 @@
  
     public void m_6973_(T p_102001_, float p_102002_, float p_102003_, float p_102004_, float p_102005_, float p_102006_) {
        super.m_6973_(p_102001_, p_102002_, p_102003_, p_102004_, p_102005_, p_102006_);
-+      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102001_))
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102001_, this))
        AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, this.m_7134_(p_102001_), this.f_102608_, p_102004_);
     }
  

--- a/patches/minecraft/net/minecraft/client/model/AbstractZombieModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/AbstractZombieModel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/model/AbstractZombieModel.java
++++ b/net/minecraft/client/model/AbstractZombieModel.java
+@@ -13,6 +_,7 @@
+ 
+    public void m_6973_(T p_102001_, float p_102002_, float p_102003_, float p_102004_, float p_102005_, float p_102006_) {
+       super.m_6973_(p_102001_, p_102002_, p_102003_, p_102004_, p_102005_, p_102006_);
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102001_))
+       AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, this.m_7134_(p_102001_), this.f_102608_, p_102004_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
@@ -4,7 +4,7 @@
     }
  
     public void m_6839_(T p_102521_, float p_102522_, float p_102523_, float p_102524_) {
-+      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102521_, this)) {
++      if (net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102521_, this)) {
 +          super.m_6839_(p_102521_, p_102522_, p_102523_, p_102524_);
 +          return;
 +      }

--- a/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/client/model/DrownedModel.java
 +++ b/net/minecraft/client/model/DrownedModel.java
-@@ -34,6 +_,7 @@
+@@ -31,6 +_,10 @@
+    }
+ 
+    public void m_6839_(T p_102521_, float p_102522_, float p_102523_, float p_102524_) {
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_102521_, this)) {
++          super.m_6839_(p_102521_, p_102522_, p_102523_, p_102524_);
++          return;
++      }
        this.f_102816_ = HumanoidModel.ArmPose.EMPTY;
        this.f_102815_ = HumanoidModel.ArmPose.EMPTY;
        ItemStack itemstack = p_102521_.m_21120_(InteractionHand.MAIN_HAND);
-+      if (!net.minecraftforge.client.ForgeHooksClient.setForgeArmPose(this, itemstack, p_102521_, InteractionHand.MAIN_HAND))
-       if (itemstack.m_150930_(Items.f_42713_) && p_102521_.m_5912_()) {
-          if (p_102521_.m_5737_() == HumanoidArm.RIGHT) {
-             this.f_102816_ = HumanoidModel.ArmPose.THROW_SPEAR;

--- a/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/DrownedModel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/model/DrownedModel.java
++++ b/net/minecraft/client/model/DrownedModel.java
+@@ -34,6 +_,7 @@
+       this.f_102816_ = HumanoidModel.ArmPose.EMPTY;
+       this.f_102815_ = HumanoidModel.ArmPose.EMPTY;
+       ItemStack itemstack = p_102521_.m_21120_(InteractionHand.MAIN_HAND);
++      if (!net.minecraftforge.client.ForgeHooksClient.setForgeArmPose(this, itemstack, p_102521_, InteractionHand.MAIN_HAND))
+       if (itemstack.m_150930_(Items.f_42713_) && p_102521_.m_5912_()) {
+          if (p_102521_.m_5737_() == HumanoidArm.RIGHT) {
+             this.f_102816_ = HumanoidModel.ArmPose.THROW_SPEAR;

--- a/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/HumanoidModel.java.patch
@@ -27,7 +27,7 @@
        EMPTY(false),
        ITEM(false),
        BLOCK(false),
-@@ -411,10 +_,29 @@
+@@ -411,10 +_,33 @@
  
        private ArmPose(boolean p_102896_) {
           this.f_102890_ = p_102896_;
@@ -53,6 +53,10 @@
 +
 +      public <T extends LivingEntity> void applyTransform(HumanoidModel<T> model, T entity, net.minecraft.world.entity.HumanoidArm arm) {
 +         if (this.forgeArmPose != null) this.forgeArmPose.applyTransform(model, entity, arm);
++      }
++
++      public boolean isCustom() {
++          return this.forgeArmPose != null;
 +      }
 +      // FORGE END
     }

--- a/patches/minecraft/net/minecraft/client/model/PiglinModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/PiglinModel.java.patch
@@ -1,10 +1,10 @@
 --- a/net/minecraft/client/model/PiglinModel.java
 +++ b/net/minecraft/client/model/PiglinModel.java
-@@ -81,6 +_,7 @@
-             }
-          }
-       } else if (p_103366_.m_6095_() == EntityType.f_20531_) {
-+         if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103366_))
-          AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, p_103366_.m_5912_(), this.f_102608_, p_103369_);
-       }
- 
+@@ -50,6 +_,7 @@
+       float f2 = 0.08F + p_103368_ * 0.4F;
+       this.f_170808_.f_104205_ = (-(float)Math.PI / 6F) - Mth.m_14089_(f1 * 1.2F) * f2;
+       this.f_170807_.f_104205_ = ((float)Math.PI / 6F) + Mth.m_14089_(f1) * f2;
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103366_, this))
+       if (p_103366_ instanceof AbstractPiglin abstractpiglin) {
+          PiglinArmPose piglinarmpose = abstractpiglin.m_6389_();
+          if (piglinarmpose == PiglinArmPose.DANCING) {

--- a/patches/minecraft/net/minecraft/client/model/PiglinModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/PiglinModel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/model/PiglinModel.java
++++ b/net/minecraft/client/model/PiglinModel.java
+@@ -81,6 +_,7 @@
+             }
+          }
+       } else if (p_103366_.m_6095_() == EntityType.f_20531_) {
++         if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103366_))
+          AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, p_103366_.m_5912_(), this.f_102608_, p_103369_);
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
@@ -1,18 +1,21 @@
 --- a/net/minecraft/client/model/SkeletonModel.java
 +++ b/net/minecraft/client/model/SkeletonModel.java
-@@ -38,6 +_,7 @@
+@@ -35,6 +_,10 @@
+    }
+ 
+    public void m_6839_(T p_103793_, float p_103794_, float p_103795_, float p_103796_) {
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103793_, this)) {
++          super.m_6839_(p_103793_, p_103794_, p_103795_, p_103796_);
++          return;
++      }
        this.f_102816_ = HumanoidModel.ArmPose.EMPTY;
        this.f_102815_ = HumanoidModel.ArmPose.EMPTY;
        ItemStack itemstack = p_103793_.m_21120_(InteractionHand.MAIN_HAND);
-+      if (!net.minecraftforge.client.ForgeHooksClient.setForgeArmPose(this, itemstack, p_103793_, InteractionHand.MAIN_HAND))
-       if (itemstack.m_150930_(Items.f_42411_) && p_103793_.m_5912_()) {
-          if (p_103793_.m_5737_() == HumanoidArm.RIGHT) {
-             this.f_102816_ = HumanoidModel.ArmPose.BOW_AND_ARROW;
 @@ -52,6 +_,7 @@
     public void m_6973_(T p_103798_, float p_103799_, float p_103800_, float p_103801_, float p_103802_, float p_103803_) {
        super.m_6973_(p_103798_, p_103799_, p_103800_, p_103801_, p_103802_, p_103803_);
        ItemStack itemstack = p_103798_.m_21205_();
-+      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(itemstack, p_103798_, InteractionHand.MAIN_HAND))
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103798_, this))
        if (p_103798_.m_5912_() && (itemstack.m_41619_() || !itemstack.m_150930_(Items.f_42411_))) {
           float f = Mth.m_14031_(this.f_102608_ * (float)Math.PI);
           float f1 = Mth.m_14031_((1.0F - (1.0F - this.f_102608_) * (1.0F - this.f_102608_)) * (float)Math.PI);

--- a/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
@@ -4,7 +4,7 @@
     }
  
     public void m_6839_(T p_103793_, float p_103794_, float p_103795_, float p_103796_) {
-+      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103793_, this)) {
++      if (net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_103793_, this)) {
 +          super.m_6839_(p_103793_, p_103794_, p_103795_, p_103796_);
 +          return;
 +      }

--- a/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/SkeletonModel.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/client/model/SkeletonModel.java
++++ b/net/minecraft/client/model/SkeletonModel.java
+@@ -38,6 +_,7 @@
+       this.f_102816_ = HumanoidModel.ArmPose.EMPTY;
+       this.f_102815_ = HumanoidModel.ArmPose.EMPTY;
+       ItemStack itemstack = p_103793_.m_21120_(InteractionHand.MAIN_HAND);
++      if (!net.minecraftforge.client.ForgeHooksClient.setForgeArmPose(this, itemstack, p_103793_, InteractionHand.MAIN_HAND))
+       if (itemstack.m_150930_(Items.f_42411_) && p_103793_.m_5912_()) {
+          if (p_103793_.m_5737_() == HumanoidArm.RIGHT) {
+             this.f_102816_ = HumanoidModel.ArmPose.BOW_AND_ARROW;
+@@ -52,6 +_,7 @@
+    public void m_6973_(T p_103798_, float p_103799_, float p_103800_, float p_103801_, float p_103802_, float p_103803_) {
+       super.m_6973_(p_103798_, p_103799_, p_103800_, p_103801_, p_103802_, p_103803_);
+       ItemStack itemstack = p_103798_.m_21205_();
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(itemstack, p_103798_, InteractionHand.MAIN_HAND))
+       if (p_103798_.m_5912_() && (itemstack.m_41619_() || !itemstack.m_150930_(Items.f_42411_))) {
+          float f = Mth.m_14031_(this.f_102608_ * (float)Math.PI);
+          float f1 = Mth.m_14031_((1.0F - (1.0F - this.f_102608_) * (1.0F - this.f_102608_)) * (float)Math.PI);

--- a/patches/minecraft/net/minecraft/client/model/ZombieVillagerModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/ZombieVillagerModel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/model/ZombieVillagerModel.java
++++ b/net/minecraft/client/model/ZombieVillagerModel.java
+@@ -46,6 +_,7 @@
+ 
+    public void m_6973_(T p_104175_, float p_104176_, float p_104177_, float p_104178_, float p_104179_, float p_104180_) {
+       super.m_6973_(p_104175_, p_104176_, p_104177_, p_104178_, p_104179_, p_104180_);
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_104175_))
+       AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, p_104175_.m_5912_(), this.f_102608_, p_104178_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/model/ZombieVillagerModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/ZombieVillagerModel.java.patch
@@ -4,7 +4,7 @@
  
     public void m_6973_(T p_104175_, float p_104176_, float p_104177_, float p_104178_, float p_104179_, float p_104180_) {
        super.m_6973_(p_104175_, p_104176_, p_104177_, p_104178_, p_104179_, p_104180_);
-+      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_104175_))
++      if (!net.minecraftforge.client.ForgeHooksClient.hasForgeArmPose(p_104175_, this))
        AnimationUtils.m_102102_(this.f_102812_, this.f_102811_, p_104175_.m_5912_(), this.f_102608_, p_104178_);
     }
  

--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    private final CommandSource f_81288_;
+    public final CommandSource f_81288_;

--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    public final CommandSource f_81288_;
+    private final CommandSource f_81288_;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -298,6 +298,34 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(new RenderArmEvent(poseStack, multiBufferSource, packedLight, player, arm));
     }
 
+    public static <T extends LivingEntity> boolean hasForgeArmPose(ItemStack item, T entity, InteractionHand hand)
+    {
+        return IClientItemExtensions.of(item).getArmPose(entity, hand, item) != null;
+    }
+
+    public static boolean hasForgeArmPose(LivingEntity entity)
+    {
+        return IClientItemExtensions.of(entity.getMainHandItem()).getArmPose(entity, InteractionHand.MAIN_HAND, entity.getMainHandItem()) != null;
+    }
+
+    public static <T extends LivingEntity> boolean setForgeArmPose(HumanoidModel<T> model, ItemStack item, T entity, InteractionHand hand)
+    {
+        HumanoidModel.ArmPose forgeArmPose = IClientItemExtensions.of(item).getArmPose(entity, hand, item);
+        if (forgeArmPose != null)
+        {
+            if (entity.getMainArm() == HumanoidArm.RIGHT)
+            {
+                model.rightArmPose = forgeArmPose;
+            }
+            else
+            {
+                model.leftArmPose = forgeArmPose;
+            }
+            return true;
+        }
+        return false;
+    }
+
     public static void onTextureStitchedPre(TextureAtlas map, Set<ResourceLocation> resourceLocations)
     {
         StartupMessageManager.mcLoaderConsumer().ifPresent(c->c.accept("Atlas Stitching : "+map.location().toString()));

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -298,32 +298,9 @@ public class ForgeHooksClient
         return MinecraftForge.EVENT_BUS.post(new RenderArmEvent(poseStack, multiBufferSource, packedLight, player, arm));
     }
 
-    public static <T extends LivingEntity> boolean hasForgeArmPose(ItemStack item, T entity, InteractionHand hand)
+    public static <T extends LivingEntity> boolean hasForgeArmPose(T entity, HumanoidModel<T> model)
     {
-        return IClientItemExtensions.of(item).getArmPose(entity, hand, item) != null;
-    }
-
-    public static boolean hasForgeArmPose(LivingEntity entity)
-    {
-        return IClientItemExtensions.of(entity.getMainHandItem()).getArmPose(entity, InteractionHand.MAIN_HAND, entity.getMainHandItem()) != null;
-    }
-
-    public static <T extends LivingEntity> boolean setForgeArmPose(HumanoidModel<T> model, ItemStack item, T entity, InteractionHand hand)
-    {
-        HumanoidModel.ArmPose forgeArmPose = IClientItemExtensions.of(item).getArmPose(entity, hand, item);
-        if (forgeArmPose != null)
-        {
-            if (entity.getMainArm() == HumanoidArm.RIGHT)
-            {
-                model.rightArmPose = forgeArmPose;
-            }
-            else
-            {
-                model.leftArmPose = forgeArmPose;
-            }
-            return true;
-        }
-        return false;
+        return entity.getMainArm() == HumanoidArm.RIGHT ? model.rightArmPose.isCustom() : model.leftArmPose.isCustom();
     }
 
     public static void onTextureStitchedPre(TextureAtlas map, Set<ResourceLocation> resourceLocations)


### PR DESCRIPTION
So while arm poses are abstracted properly to living entities / humanoids, the model classes themselves have a lot of hardcoding (some of which is totally unavoidable) that completely override custom arm poses.

The two big issues are skeletons and drowned overriding the arm pose based on what's in the mob's hand. These are easy to just check the builtin method. The second is a few places where the 'zombie arms' animation call wipes out any arm rotations provided by an item animation. So, where it makes sense, we can patch these out when we have a custom pose.

My personal use case: I make vanilla skeletons throw a trident-like item (javelin), but the arm pose gets overridden by the model class. I need the custom pose to be persistent. The same thing applies to drowned.

This is not meant to patch out *every* place where mob anims could get in the way of custom anims (See: Illagers), just places where it super obviously gets in the way.

Note for triage testing: Just summon skeletons/drowned and observe that they actually swing the item all over the place.