### PR TITLE
[1.18] Fix incorrect method name in RenderGameOverlayEvent

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -17,7 +17,7 @@ import net.minecraft.client.gui.components.LerpingBossEvent;
 @Cancelable
 public class RenderGameOverlayEvent extends Event
 {
-    public PoseStack getMatrixStack()
+    public PoseStack getPoseStack()
     {
         return mStack;
     }


### PR DESCRIPTION
Fixes the method name in RenderGameOverlayEvent, which still had `getMatrixStack`.
I did a quick Search All to look for more instances of getMatrixStack but there weren't any.