### PR TITLE
[1.19.x] Fix NPE when feeding wolves and cats

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/animal/Cat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Cat.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/entity/animal/Cat.java
 +++ b/net/minecraft/world/entity/animal/Cat.java
-@@ -366,7 +_,7 @@
+@@ -365,8 +_,8 @@
+             if (this.m_21830_(p_28153_)) {
                 if (!(item instanceof DyeItem)) {
                    if (item.m_41472_() && this.m_6898_(itemstack) && this.m_21223_() < this.m_21233_()) {
++                     this.m_5634_((float)itemstack.getFoodProperties(this).m_38744_());
                       this.m_142075_(p_28153_, p_28154_, itemstack);
 -                     this.m_5634_((float)item.m_41473_().m_38744_());
-+                     this.m_5634_((float)itemstack.getFoodProperties(this).m_38744_());
                       return InteractionResult.CONSUME;
                    }
  

--- a/patches/minecraft/net/minecraft/world/entity/animal/Wolf.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Wolf.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/world/entity/animal/Wolf.java
 +++ b/net/minecraft/world/entity/animal/Wolf.java
-@@ -325,11 +_,13 @@
+@@ -325,11 +_,12 @@
        } else {
           if (this.m_21824_()) {
              if (this.m_6898_(itemstack) && this.m_21223_() < this.m_21233_()) {
 +               this.m_5634_((float)itemstack.getFoodProperties(this).m_38744_());
-+
                 if (!p_30412_.m_150110_().f_35937_) {
                    itemstack.m_41774_(1);
                 }

--- a/patches/minecraft/net/minecraft/world/entity/animal/Wolf.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Wolf.java.patch
@@ -1,11 +1,16 @@
 --- a/net/minecraft/world/entity/animal/Wolf.java
 +++ b/net/minecraft/world/entity/animal/Wolf.java
-@@ -329,7 +_,8 @@
+@@ -325,11 +_,13 @@
+       } else {
+          if (this.m_21824_()) {
+             if (this.m_6898_(itemstack) && this.m_21223_() < this.m_21233_()) {
++               this.m_5634_((float)itemstack.getFoodProperties(this).m_38744_());
++
+                if (!p_30412_.m_150110_().f_35937_) {
                    itemstack.m_41774_(1);
                 }
  
 -               this.m_5634_((float)item.m_41473_().m_38744_());
-+               this.m_5634_((float)itemstack.getFoodProperties(this).m_38744_());
 +               this.m_146852_(GameEvent.f_157806_, this);
                 return InteractionResult.SUCCESS;
              }


### PR DESCRIPTION
This PR fixes #9035
Where a NPE could occur if you weren't creative and had exactly one item in your food stack, and were feeding a wolf or a cat, due to the stack being consumed first, then returning null on the following `getFoodProperties` call.

