### PR TITLE
[1.19] Fix Vanilla Minecart interactions with Water

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -221,8 +221,8 @@
 +   private float currentSpeedCapOnRail = getMaxCartSpeedOnRail();
 +   @Override public float getCurrentCartSpeedCapOnRail() { return currentSpeedCapOnRail; }
 +   @Override public void setCurrentCartSpeedCapOnRail(float value) { currentSpeedCapOnRail = Math.min(value, getMaxCartSpeedOnRail()); }
-+   private float maxSpeedAirLateral = DEFAULT_MAX_SPEED_AIR_LATERAL;
-+   @Override public float getMaxSpeedAirLateral() { return maxSpeedAirLateral; }
++   @org.jetbrains.annotations.Nullable private Float maxSpeedAirLateral = null;
++   @Override public float getMaxSpeedAirLateral() { return maxSpeedAirLateral == null ? (float) this.m_7097_() : maxSpeedAirLateral; }
 +   @Override public void setMaxSpeedAirLateral(float value) { maxSpeedAirLateral = value; }
 +   private float maxSpeedAirVertical = DEFAULT_MAX_SPEED_AIR_VERTICAL;
 +   @Override public float getMaxSpeedAirVertical() { return maxSpeedAirVertical; }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBaseRailBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBaseRailBlock.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import net.minecraft.world.entity.vehicle.MinecartFurnace;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.level.block.state.properties.RailShape;
@@ -60,7 +61,8 @@ public interface IForgeBaseRailBlock
      */
     default float getRailMaxSpeed(BlockState state, Level level, BlockPos pos, AbstractMinecart cart)
     {
-        return 0.4f;
+        if (cart instanceof MinecartFurnace) return cart.isInWater() ? 0.15f : 0.2f;
+        else return cart.isInWater() ? 0.2f : 0.4f;
     }
 
     /**


### PR DESCRIPTION
Closes #9011.

There are two issues that remained unsolved by #9033 when minecarts interact with water as intended by vanilla.

### On-Rail Logic

As reported by #9011, on-rail logic made vanilla interactions with minecarts in water go faster within Forge. This is due to the fact that `AbstractMinecart#getMaxSpeed` is protected, so when implementing in `IForgeBaseRailBlock#getRailMaxSpeed`, it was only left as the default value. To fix this, the logic for `#getMaxSpeed` was moved into the method (along with the furnace override).

### Off-Rail Logic

While not reported, minecarts would, when falling in water, fall faster in Forge than in vanilla due to similar reasons, though this time it was made even more complicated that the logic was stored in a field, making it difficult to maintain logic. To fix this, we adjusted the private logic (to avoid any breaking changes in the public api) to store a null value when unset to default to `#getMaxSpeed`. When set, it would use that value instead for the existence of the minecart.