### PR TITLE
[1.19.x] Rename fluid type milk translation keys

### DIFF
--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -214,8 +214,8 @@
   "generic.attack_range": "Attack Range",
   "forge.stepHeight": "Step Height",
 
-  "fluid.minecraft.milk": "Milk",
-  "fluid.minecraft.flowing_milk": "Milk",
+  "fluid_type.minecraft.milk": "Milk",
+  "fluid_type.minecraft.flowing_milk": "Milk",
 
   "forge.experimentalsettings.tooltip": "This world uses experimental settings, which could stop working at any time.",
   "forge.selectWorld.backupWarning.experimental.additional" : "This message will not show again for this world."


### PR DESCRIPTION
Closes: #9064
By fixing the missed translations, due to the Fluid API rewrite.