### PR TITLE
[1.19.x] feat(ScreenEvent.Closing): Add the new screen (if any) to the event

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -187,7 +187,7 @@
 +      }
 +
 +      if (old != null && p_91153_ != old) {
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Closing(old));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Closing(old, p_91153_));
 +         old.m_7861_();
 +      }
 +

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -1056,8 +1056,7 @@ public abstract class ScreenEvent extends Event
         }
 
         /**
-         * {@return The screen that will be opened after the current screen is closed.<br>
-         * If null then the game will return to the gameplay.}
+         * {@return The screen that will be opened after the current screen is closed. If null then the game will return to the gameplay}
          */
         @Nullable
         public Screen getNewScreen()

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -1045,10 +1045,23 @@ public abstract class ScreenEvent extends Event
      */
     public static class Closing extends ScreenEvent
     {
+        @Nullable
+        private final Screen newScreen;
+
         @ApiStatus.Internal
-        public Closing(Screen screen)
+        public Closing(Screen screen, @Nullable Screen newScreen)
         {
             super(screen);
+            this.newScreen = newScreen;
+        }
+
+        /**
+         * @return The screen that will be opened after this screen is closed. May be null.
+         */
+        @Nullable
+        public Screen getNewScreen()
+        {
+            return newScreen;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -1056,7 +1056,8 @@ public abstract class ScreenEvent extends Event
         }
 
         /**
-         * @return The screen that will be opened after this screen is closed. May be null.
+         * {@return The screen that will be opened after the current screen is closed.<br>
+         * If null then the game will return to the gameplay.}
          */
         @Nullable
         public Screen getNewScreen()

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -1056,7 +1056,7 @@ public abstract class ScreenEvent extends Event
         }
 
         /**
-         * {@return The screen that will be opened after the current screen is closed. If null then the game will return to the gameplay}
+         * {@return the screen that will be opened after the current screen is closed. If null then the game will return to the gameplay}
          */
         @Nullable
         public Screen getNewScreen()


### PR DESCRIPTION
Closes: #8992 
This adds the new screen (if any) that is being set after the current screen has been closed.
The issue linked, describes some scenarios where useful, or where the opening/closing in combination does not work.

Since I'm still fairly new, does it count as breaking to modify the constructor?
Would it be better to overload it, so if any mods (not sure why) that fires this event, still has the old constructor intact?