### PR TITLE
[1.19.x] Fixed the PlayerInteractEvent.EntityInteractSpecific not respecting cancelled status on server side

### DIFF
--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -76,7 +76,7 @@
           return !component.equals(p_238202_) ? p_238202_ : null;
        });
        completablefuture.thenAcceptAsync((p_242747_) -> {
-@@ -1532,11 +_,13 @@
+@@ -1532,9 +_,10 @@
              return;
           }
  
@@ -87,11 +87,17 @@
 +                  if(!ServerGamePacketListenerImpl.this.f_9743_.canInteractWith(entity, 1.5D)) return; //Forge: If the entity cannot be reached, do nothing. Original check was dist < 6, range is 4.5, so vanilla used padding=1.5
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
-+                  if (net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, entity.m_20182_(), p_143679_) != null) return;
                    if (interactionresult.m_19077_()) {
-                      CriteriaTriggers.f_10565_.m_61494_(ServerGamePacketListenerImpl.this.f_9743_, itemstack, entity);
-                      if (interactionresult.m_19080_()) {
-@@ -1558,6 +_,8 @@
+@@ -1551,13 +_,16 @@
+                }
+ 
+                public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
+-                  this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
++                   if (net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_) != null) return;
++                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
+                      return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
+                   });
+                }
  
                 public void m_141994_() {
                    if (!(entity instanceof ItemEntity) && !(entity instanceof ExperienceOrb) && !(entity instanceof AbstractArrow) && entity != ServerGamePacketListenerImpl.this.f_9743_) {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -88,19 +88,18 @@
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
                    if (interactionresult.m_19077_()) {
-@@ -1551,13 +_,20 @@
+@@ -1551,13 +_,19 @@
                 }
  
                 public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
 -                  this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
 -                     return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
-+
 +                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
-+                    InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
-+                    if (onInteractEntityAtResult != null) {
-+                     return onInteractEntityAtResult;
-+                    }
-+                    return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
++                       InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
++                       if (onInteractEntityAtResult != null) {
++                           return onInteractEntityAtResult;
++                       }
++                       return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
                    });
                 }
  

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -92,10 +92,9 @@
  
                 public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
                    this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
--                     return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
 +                     InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
 +                     if (onInteractEntityAtResult != null) return onInteractEntityAtResult;
-+                     return p_143686_.m_7111_(p_143686_, p_143683_, p_143688_);
+                      return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
                    });
                 }
  
@@ -106,15 +105,6 @@
                       ServerGamePacketListenerImpl.this.f_9743_.m_5706_(entity);
                    } else {
                       ServerGamePacketListenerImpl.this.m_9942_(Component.m_237115_("multiplayer.disconnect.invalid_entity_attacked"));
-@@ -1575,7 +_,7 @@
-       this.f_9743_.m_9243_();
-       ServerboundClientCommandPacket.Action serverboundclientcommandpacket$action = p_9843_.m_133850_();
-       switch (serverboundclientcommandpacket$action) {
--         case PERFORM_RESPAWN:
-+          case PERFORM_RESPAWN:
-             if (this.f_9743_.f_8944_) {
-                this.f_9743_.f_8944_ = false;
-                this.f_9743_ = this.f_9745_.m_6846_().m_11236_(this.f_9743_, true);
 @@ -1757,6 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -88,13 +88,14 @@
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
                    if (interactionresult.m_19077_()) {
-@@ -1552,12 +_,15 @@
+@@ -1552,12 +_,16 @@
  
                 public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
                    this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
 -                     return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
 +                     InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
-+                     return onInteractEntityAtResult != null ? onInteractEntityAtResult : p_143686_.m_7111_(p_143686_, p_143683_, p_143688_);
++                     if (onInteractEntityAtResult != null) return onInteractEntityAtResult;
++                     return p_143686_.m_7111_(p_143686_, p_143683_, p_143688_);
                    });
                 }
  
@@ -105,6 +106,15 @@
                       ServerGamePacketListenerImpl.this.f_9743_.m_5706_(entity);
                    } else {
                       ServerGamePacketListenerImpl.this.m_9942_(Component.m_237115_("multiplayer.disconnect.invalid_entity_attacked"));
+@@ -1575,7 +_,7 @@
+       this.f_9743_.m_9243_();
+       ServerboundClientCommandPacket.Action serverboundclientcommandpacket$action = p_9843_.m_133850_();
+       switch (serverboundclientcommandpacket$action) {
+-         case PERFORM_RESPAWN:
++          case PERFORM_RESPAWN:
+             if (this.f_9743_.f_8944_) {
+                this.f_9743_.f_8944_ = false;
+                this.f_9743_ = this.f_9745_.m_6846_().m_11236_(this.f_9743_, true);
 @@ -1757,6 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -88,18 +88,13 @@
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
                    if (interactionresult.m_19077_()) {
-@@ -1551,13 +_,19 @@
-                }
+@@ -1552,12 +_,15 @@
  
                 public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
--                  this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
+                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
 -                     return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
-+                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
-+                       InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
-+                       if (onInteractEntityAtResult != null) {
-+                           return onInteractEntityAtResult;
-+                       }
-+                       return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
++                     InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
++                     return onInteractEntityAtResult != null ? onInteractEntityAtResult : p_143686_.m_7111_(p_143686_, p_143683_, p_143688_);
                    });
                 }
  

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -88,14 +88,19 @@
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
                    if (interactionresult.m_19077_()) {
-@@ -1551,13 +_,16 @@
+@@ -1551,13 +_,20 @@
                 }
  
                 public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
 -                  this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
-+                   if (net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_) != null) return;
+-                     return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
++
 +                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
-                      return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
++                    InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
++                    if (onInteractEntityAtResult != null) {
++                     return onInteractEntityAtResult;
++                    }
++                    return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
                    });
                 }
  


### PR DESCRIPTION
This PR closes: #9040 

As mentioned by [9040#issuecomment-1248310872](https://github.com/MinecraftForge/MinecraftForge/issues/9040#issuecomment-1248310872) the event being cancelled was never respected, due to this line
```java
InteractionResult interactionresult = p_143680_.run(ServerGamePacketListenerImpl.this.player, entity, p_143679_);
```
being executed before the event, essentially running the interact action on the server.

The event check was moved out to what calls the bigger chunk. (Also the same place Fabric has placed it) [Fabric/ServerPlayNetworkHandlerMixin.java#L48](https://github.com/FabricMC/fabric/blob/bd290a2e1935096397e81d608e61c26328dd40db/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerMixin.java#L48)

Which also contains the proper local hit vector, which was also incorrect. (Also spotted by @Fuzss).

This small test code, can show it working:
```java
@SubscribeEvent
public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event)
{
  if (event.getTarget() instanceof ArmorStand) {
    System.out.println(event.getLocalPos());
    event.setCancellationResult(InteractionResult.sidedSuccess(event.getLevel().isClientSide()));
    event.setCanceled(true);
  }
}
```

_There is also the issue #8143, but I deem that as 1.18, and will provide a backport for 1.18, which would close that issue. (Unless they are seen as the same issue)_