### PR TITLE
[1.18.x] Fix TileFluidHandler not invalidating the lazy optional properly

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -23,7 +23,7 @@ public class TileFluidHandler extends BlockEntity
 {
     protected FluidTank tank = new FluidTank(FluidAttributes.BUCKET_VOLUME);
     
-    private final LazyOptional<IFluidHandler> holder = LazyOptional.of(() -> tank);
+    private LazyOptional<IFluidHandler> holder = LazyOptional.of(() -> tank);
 
     public TileFluidHandler(@Nonnull BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state)
     {
@@ -51,5 +51,17 @@ public class TileFluidHandler extends BlockEntity
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
             return holder.cast();
         return super.getCapability(capability, facing);
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        holder.invalidate();
+    }
+
+    @Override
+    public void reviveCaps() {
+        super.reviveCaps();
+        holder = LazyOptional.of(() -> tank);
     }
 }


### PR DESCRIPTION
This PR is a re-do of #8345 since it was closed due to being stale.
This PR closes: #8332 

