### PR TITLE
Fix `Transformation` loading `PoseStack`

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/vertex/PoseStack.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/vertex/PoseStack.java.patch
@@ -1,0 +1,11 @@
+--- a/com/mojang/blaze3d/vertex/PoseStack.java
++++ b/com/mojang/blaze3d/vertex/PoseStack.java
+@@ -11,7 +_,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public class PoseStack {
++public class PoseStack implements net.minecraftforge.client.extensions.IForgePoseStack {
+    private final Deque<PoseStack.Pose> f_85834_ = Util.m_137469_(Queues.newArrayDeque(), (p_85848_) -> {
+       Matrix4f matrix4f = new Matrix4f();
+       matrix4f.m_27624_();

--- a/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/patches/minecraft/net/minecraft/commands/CommandSourceStack.java.patch
@@ -8,4 +8,4 @@
 +public class CommandSourceStack implements SharedSuggestionProvider, net.minecraftforge.common.extensions.IForgeCommandSourceStack {
     public static final SimpleCommandExceptionType f_81286_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.player"));
     public static final SimpleCommandExceptionType f_81287_ = new SimpleCommandExceptionType(Component.m_237115_("permissions.requires.entity"));
-    private final CommandSource f_81288_;
+    public final CommandSource f_81288_;

--- a/src/main/java/net/minecraftforge/client/extensions/IForgePoseStack.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgePoseStack.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.extensions;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Transformation;
+import com.mojang.math.Vector3f;
+
+/**
+ * Extension interface for {@link com.mojang.blaze3d.vertex.PoseStack}.
+ */
+public interface IForgePoseStack
+{
+    private PoseStack self()
+    {
+        return (PoseStack) this;
+    }
+
+    /**
+     * Pushes and applies the {@code transformation} to this pose stack. <br>
+     * The effects of this method can be reversed by a corresponding {@link PoseStack#popPose()} call.
+     *
+     * @param transformation the transformation to push
+     */
+    default void pushTransformation(Transformation transformation)
+    {
+        self().pushPose();
+
+        Vector3f trans = transformation.getTranslation();
+        self().translate(trans.x(), trans.y(), trans.z());
+
+        self().mulPose(transformation.getLeftRotation());
+
+        Vector3f scale = transformation.getScale();
+        self().scale(scale.x(), scale.y(), scale.z());
+
+        self().mulPose(transformation.getRightRotation());
+    }
+}

--- a/src/main/java/net/minecraftforge/client/extensions/IForgePoseStack.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgePoseStack.java
@@ -27,16 +27,17 @@ public interface IForgePoseStack
      */
     default void pushTransformation(Transformation transformation)
     {
-        self().pushPose();
+        final PoseStack self = self();
+        self.pushPose();
 
         Vector3f trans = transformation.getTranslation();
-        self().translate(trans.x(), trans.y(), trans.z());
+        self.translate(trans.x(), trans.y(), trans.z());
 
-        self().mulPose(transformation.getLeftRotation());
+        self.mulPose(transformation.getLeftRotation());
 
         Vector3f scale = transformation.getScale();
-        self().scale(scale.x(), scale.y(), scale.z());
+        self.scale(scale.x(), scale.y(), scale.z());
 
-        self().mulPose(transformation.getRightRotation());
+        self.mulPose(transformation.getRightRotation());
     }
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeTransformation.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeTransformation.java
@@ -18,6 +18,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 /**
  * Extension interface for {@link Transformation}.
  */
+// TODO - 1.20: Transformation is not client-only, move this extension outside the client package
 public interface IForgeTransformation
 {
     private Transformation self()

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeTransformation.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeTransformation.java
@@ -12,6 +12,8 @@ import com.mojang.math.Matrix4f;
 import com.mojang.math.Transformation;
 import com.mojang.math.Vector3f;
 import com.mojang.math.Vector4f;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Extension interface for {@link Transformation}.
@@ -37,22 +39,15 @@ public interface IForgeTransformation
      * Pushes and applies this transformation to the pose stack. The effects of this method can be reversed by a
      * corresponding {@link PoseStack#popPose()}.
      *
+     * @deprecated Use {@linkplain PoseStack#pushTransformation(Transformation)}, as {@linkplain Transformation} can be present in common code.
+     *
      * @param stack the pose stack to modify
      */
+    @OnlyIn(Dist.CLIENT) // TODO - 1.20: Remove in favour of client-only PoseStack extension
+    @Deprecated(forRemoval = true, since = "1.19.2")
     default void push(PoseStack stack)
     {
-        stack.pushPose();
-
-        Vector3f trans = self().getTranslation();
-        stack.translate(trans.x(), trans.y(), trans.z());
-
-        stack.mulPose(self().getLeftRotation());
-
-        Vector3f scale = self().getScale();
-        stack.scale(scale.x(), scale.y(), scale.z());
-
-        stack.mulPose(self().getRightRotation());
-
+        stack.pushTransformation(self());
     }
 
     /**


### PR DESCRIPTION
It seems like during the 1.15 port, a new method was introduced in the `Transformation` extension, `IForgeTransformation#push(PoseStack)`, which accidentally made `Transformation` client-only.
This PR adds a (temporary) `@OnlyIn(Dist.CLIENT)` on the extension method, and deprecates it for removal in 1.20, in favour of a `PoseStack` extension method: `pushTransformation`.