### PR TITLE
[1.19] Fix several bugs in the original grindstone PR related to canceling the event

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -44,7 +44,7 @@
        boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
        boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
 +      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, this.f_39559_, -1);
-+      if (this.xp != Integer.MIN_VALUE) return;
++      if (this.xp == Integer.MIN_VALUE)
        if (!flag) {
           this.f_39559_.m_6836_(0, ItemStack.f_41583_);
        } else {

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -43,7 +43,7 @@
        ItemStack itemstack1 = this.f_39560_.m_8020_(1);
        boolean flag = !itemstack.m_41619_() || !itemstack1.m_41619_();
        boolean flag1 = !itemstack.m_41619_() && !itemstack1.m_41619_();
-+      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, this.f_39559_, this.xp);
++      this.xp = net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, this.f_39559_, -1);
 +      if (this.xp != Integer.MIN_VALUE) return;
        if (!flag) {
           this.f_39559_.m_6836_(0, ItemStack.f_41583_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -759,7 +759,11 @@ public class ForgeHooks
     public static int onGrindstoneChange(@NotNull ItemStack top, @NotNull ItemStack bottom, Container outputSlot, int xp)
     {
         GrindstoneEvent.OnplaceItem e = new GrindstoneEvent.OnplaceItem(top, bottom, xp);
-        if (MinecraftForge.EVENT_BUS.post(e)) return e.getXp();
+        if (MinecraftForge.EVENT_BUS.post(e))
+        {
+            outputSlot.setItem(0, ItemStack.EMPTY);
+            return -1;
+        }
         if (e.getOutput().isEmpty()) return Integer.MIN_VALUE;
 
         outputSlot.setItem(0, e.getOutput());

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -41,10 +41,10 @@ public abstract class GrindstoneEvent extends Event
     }
 
     /**
-     * This is the experience amount determined by the event, not the vanilla behavior. <br>
-     * If you are the first receiver of this event, it is guaranteed to be -1. <br>
-     * The value must be set to a positive value to override vanilla behavior. <br>
-     * if the value is equal to -1, the vanilla behavior for calculating experience will run. <br>
+     * This is the experience amount determined by the event, it will be -1 unless a mod calls {@link #setXp(int)}. <br>
+     * If set to a non-negative value, that value will be used instead of running vanilla behavior. <br>
+     * If the value is negative, the vanilla behavior for calculating experience will run. <br>
+     * Ignored if the output is empty or the event is canceled.
      * @return The experience amount given to the player. <br>
      */
     public int getXp()
@@ -67,8 +67,8 @@ public abstract class GrindstoneEvent extends Event
      * It is called from {@link GrindstoneMenu#createResult()}. <br>
      * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
      * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
-     * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
-     * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
+     * If the event is not canceled and the output is empty, and the event is not canceled, the stack will be determined using vanilla behavior. <br>
+     * if the amount of experience is larger than or equal 0, the XP will be that value instead of using the vanilla logic. Ignored if the output is empty or the event is canceled. <br>
      */
     @Cancelable
     public static class OnplaceItem extends GrindstoneEvent

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -41,10 +41,7 @@ public abstract class GrindstoneEvent extends Event
     }
 
     /**
-     * This is the experience amount determined by the event, it will be -1 unless a mod calls {@link #setXp(int)}. <br>
-     * If set to a non-negative value, that value will be used instead of running vanilla behavior. <br>
-     * If the value is negative, the vanilla behavior for calculating experience will run. <br>
-     * Ignored if the output is empty or the event is canceled.
+     * This is the experience amount determined by the event. It will be {@code -1} unless {@link #setXp(int)} is called. <br>
      * @return The experience amount given to the player. <br>
      */
     public int getXp()
@@ -64,11 +61,22 @@ public abstract class GrindstoneEvent extends Event
     /**
      * This event is {@link Cancelable} <br>
      * {@link OnplaceItem} is fired when the inputs to a grindstone are changed. <br>
-     * It is called from {@link GrindstoneMenu#createResult()}. <br>
-     * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
-     * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
-     * If the event is not canceled and the output is empty, and the event is not canceled, the stack will be determined using vanilla behavior. <br>
-     * if the amount of experience is larger than or equal 0, the XP will be that value instead of using the vanilla logic. Ignored if the output is empty or the event is canceled. <br>
+     *
+     * The following rules apply:
+     * <ul>
+     *     <li>If the event is canceled, vanilla behavior will not run, and the output will be {@linkplain ItemStack#EMPTY empty}.</li>
+     *     <li>If the event is not canceled</li>
+     *     <ul>
+     *          <li>and the output is empty, the output will be determined by vanilla.</li>
+     *          <li>and the output is not empty, the output will be set, without running vanilla behavior.</li>
+     *     </ul>
+     *     <li>Vanilla XP calculation logic will be used unless all of the following criterias are met:</li>
+     *     <ul>
+     *         <li>the amount of experience is greater than or equal to {@code 0};</li>
+     *         <li>the event is not {@linkplain #isCanceled() canceled};</li>
+     *         <li>the {@linkplain #getOutput() output} is not empty.</li>
+     *     </ul>
+     * </ul>
      */
     @Cancelable
     public static class OnplaceItem extends GrindstoneEvent

--- a/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
@@ -7,16 +7,23 @@ package net.minecraftforge.debug.misc;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.GrindstoneEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.Bindings;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod("grindstone_event_test")
-@Mod.EventBusSubscriber
 public class GrindstoneEventTest {
+    private static final boolean ENABLED = false;
+    public GrindstoneEventTest() {
+        if (ENABLED) {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
 
     @SubscribeEvent
-    public static void onGrindestonePlace(GrindstoneEvent.OnplaceItem event)
+    public void onGrindestonePlace(GrindstoneEvent.OnplaceItem event)
     {
         // all of these "recipes" are slot sensitive, the top and bottom must match exactly for the behavior to change
         // switching the order will cause the "recipe" to fail
@@ -61,7 +68,7 @@ public class GrindstoneEventTest {
     }
 
     @SubscribeEvent
-    public static void onGrindstoneTake(GrindstoneEvent.OnTakeItem event)
+    public void onGrindstoneTake(GrindstoneEvent.OnTakeItem event)
     {
         ItemStack topItem = event.getTopItem();
         ItemStack bottomItem = event.getBottomItem();

--- a/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.misc;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.event.GrindstoneEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("grindstone_event_test")
+@Mod.EventBusSubscriber
+public class GrindstoneEventTest {
+
+    @SubscribeEvent
+    public static void onGrindestonePlace(GrindstoneEvent.OnplaceItem event)
+    {
+        ItemStack topItem = event.getTopItem();
+        ItemStack bottomItem = event.getBottomItem();
+        if (topItem.is(Items.LAPIS_LAZULI) && bottomItem.is(Items.NETHERITE_INGOT))
+        {
+            event.setOutput(new ItemStack(Items.DIAMOND, 1));
+            event.setXp(5);
+        }
+
+        if (topItem.is(Items.IRON_ORE) && bottomItem.is(Items.FLINT))
+        {
+            event.setOutput(new ItemStack(Items.RAW_IRON, 3));
+            event.setXp(0);
+        }
+
+        if (topItem.is(Items.IRON_AXE) && bottomItem.is(Items.AIR))
+        {
+            event.setOutput(topItem.copy());
+            event.setXp(-1);
+        }
+
+        if (topItem.is(Items.IRON_SHOVEL) && bottomItem.is(Items.AIR))
+        {
+            event.setOutput(ItemStack.EMPTY);
+        }
+
+        if (topItem.is(Items.IRON_SWORD) && bottomItem.is(Items.AIR))
+        {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onGrindstoneTake(GrindstoneEvent.OnTakeItem event) {
+        ItemStack topItem = event.getTopItem();
+        ItemStack bottomItem = event.getBottomItem();
+        if (topItem.is(Items.LAPIS_LAZULI) && bottomItem.is(Items.NETHERITE_INGOT))
+        {
+            ItemStack top = topItem.copy();
+            ItemStack bottom = bottomItem.copy();
+            bottom.shrink(1);
+            top.shrink(1);
+            event.setNewBottomItem(bottom);
+            event.setNewTopItem(top);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
@@ -18,31 +18,42 @@ public class GrindstoneEventTest {
     @SubscribeEvent
     public static void onGrindestonePlace(GrindstoneEvent.OnplaceItem event)
     {
+        // all of these "recipes" are slot sensitive, the top and bottom must match exactly for the behavior to change
+        // switching the order will cause the "recipe" to fail
         ItemStack topItem = event.getTopItem();
         ItemStack bottomItem = event.getBottomItem();
+        // craft lapis + netherite to get diamond and 5 XP
+        // this "recipe" is handled in OnTakeItem so the inputs only shrink by 1 each time
         if (topItem.is(Items.LAPIS_LAZULI) && bottomItem.is(Items.NETHERITE_INGOT))
         {
             event.setOutput(new ItemStack(Items.DIAMOND, 1));
             event.setXp(5);
         }
 
+        // craft iron ore and flint to make raw iron ore, no XP is rewarded
+        // this "recipe" is *not* handled in OnTakeItem, so the inputs will always be set to empty regardless of stack size
         if (topItem.is(Items.IRON_ORE) && bottomItem.is(Items.FLINT))
         {
             event.setOutput(new ItemStack(Items.RAW_IRON, 3));
             event.setXp(0);
         }
 
+        // when placing an iron axe in the top slot, simply copy it to the output without change (do not remove enchants)
+        // still grant XP equivalent to all enchantments on the axe
         if (topItem.is(Items.IRON_AXE) && bottomItem.is(Items.AIR))
         {
             event.setOutput(topItem.copy());
             event.setXp(-1);
         }
 
+        // setting the output to empty will run default behavior, effectively ignoring all previous overrides to the event
+        // note this will ignore any XP value you set, effectively for this test mod this has no impact
         if (topItem.is(Items.IRON_SHOVEL) && bottomItem.is(Items.AIR))
         {
             event.setOutput(ItemStack.EMPTY);
         }
 
+        // canceling the event will prevent disenchanting an iron sword in the top slot
         if (topItem.is(Items.IRON_SWORD) && bottomItem.is(Items.AIR))
         {
             event.setCanceled(true);
@@ -50,9 +61,11 @@ public class GrindstoneEventTest {
     }
 
     @SubscribeEvent
-    public static void onGrindstoneTake(GrindstoneEvent.OnTakeItem event) {
+    public static void onGrindstoneTake(GrindstoneEvent.OnTakeItem event)
+    {
         ItemStack topItem = event.getTopItem();
         ItemStack bottomItem = event.getBottomItem();
+        // only shrink stacks by 1 for the lapis + netherite "recipe"
         if (topItem.is(Items.LAPIS_LAZULI) && bottomItem.is(Items.NETHERITE_INGOT))
         {
             ItemStack top = topItem.copy();

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -268,6 +268,8 @@ modId="custom_item_decorations_test"
 modId="item_stacked_on_other_test"
 [[mods]]
 modId="ambient_occlusion_elements_test"
+[[mods]]
+modId="grindstone_event_test"
 
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Fixes issues related to canceling the grindstone event. Includes test mod from #8578

Fix canceling the event not clearing the result item, causing it to dupe whatever the result with the previous item was
Fix canceling the event running vanilla behavior if vanilla behavior ran at all since the menu was opened and no other listener changed the XP. This also fixes the grindstone event behavior disagreeing with the javadoc (javadoc said XP will be -1 for first consumer, but instead XP was whatever the last XP was)