### PR TITLE
Remove structures slave map to Feature registry

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -34,7 +34,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.levelgen.DebugLevelSource;
-import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.common.ForgeHooks;
@@ -83,7 +82,6 @@ public class GameData
     private static final ResourceLocation BLOCK_TO_ITEM = new ResourceLocation("minecraft:blocktoitemmap");
     private static final ResourceLocation BLOCKSTATE_TO_ID = new ResourceLocation("minecraft:blockstatetoid");
     private static final ResourceLocation BLOCKSTATE_TO_POINT_OF_INTEREST_TYPE = new ResourceLocation("minecraft:blockstatetopointofinteresttype");
-    private static final ResourceLocation STRUCTURES = new ResourceLocation("minecraft:structures");
 
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
@@ -133,7 +131,7 @@ public class GameData
 
         // Worldgen
         makeRegistry(WORLD_CARVERS).disableSaving().disableSync().create();
-        makeRegistry(FEATURES).addCallback(FeatureCallbacks.INSTANCE).disableSaving().disableSync().create();
+        makeRegistry(FEATURES).disableSaving().disableSync().create();
         makeRegistry(CHUNK_STATUS, "empty").disableSaving().disableSync().create();
         makeRegistry(BLOCK_STATE_PROVIDER_TYPES).disableSaving().disableSync().create();
         makeRegistry(FOLIAGE_PLACER_TYPES).disableSaving().disableSync().create();
@@ -167,7 +165,7 @@ public class GameData
     {
         return makeRegistry(FLUID_TYPES).disableSaving();
     }
-    
+
     static RegistryBuilder<HolderSetType> getHolderSetTypeRegistryBuilder()
     {
         return new RegistryBuilder<HolderSetType>().disableSaving().disableSync();
@@ -531,23 +529,6 @@ public class GameData
         {
             // some stuff hard patched in can cause this to derp if it's JUST vanilla, so skip
             if (stage!=RegistryManager.VANILLA) DefaultAttributes.validate();
-        }
-    }
-
-    private static class FeatureCallbacks implements IForgeRegistry.ClearCallback<Feature<?>>, IForgeRegistry.CreateCallback<Feature<?>>
-    {
-        static final FeatureCallbacks INSTANCE = new FeatureCallbacks();
-
-        @Override
-        public void onClear(IForgeRegistryInternal<Feature<?>> owner, RegistryManager stage)
-        {
-            owner.getSlaveMap(STRUCTURES, BiMap.class).clear();
-        }
-
-        @Override
-        public void onCreate(IForgeRegistryInternal<Feature<?>> owner, RegistryManager stage)
-        {
-            owner.setSlaveMap(STRUCTURES, HashBiMap.create());
         }
     }
 

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -53,6 +53,7 @@ import net.minecraftforge.registries.holdersets.HolderSetType;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -74,6 +75,7 @@ import static net.minecraftforge.registries.ForgeRegistries.Keys.*;
  * INTERNAL ONLY
  * MODDERS SHOULD HAVE NO REASON TO USE THIS CLASS
  */
+@ApiStatus.Internal
 public class GameData
 {
     private static final Logger LOGGER = LogManager.getLogger();


### PR DESCRIPTION
This PR removes the `minecraft:structures` slave map, which is controlled by the `Feature` registry, as there is no current use of the map and I can see no possible use of the map as was intended. Accordingly, because the registry callbacks for the `Feature` registry were entirely to control that slave map[^1], the callback class has also been removed.

For reference, the slave map was added in 1.14 by 55fe7c4, but by the time of 1.16.5, the map had no more uses, with the public accessor being removed in 1.19 by 4ed9117. This finishes that process of gradual removal by altogether deleting the map.

Note that the `GameData` class, which all of these changes occur in, is considered internal-only by the javadocs, and therefore not subject to the usual backwards compatibility. To solidify this, the class has also been marked with the `@ApiStatus.Internal` annotation.

[^1]: Even then, the callbacks merely created and cleared the map without modifying its contents, which meant the map is always empty as of this version.