### PR TITLE
Add examples to MDK build script for Jar-in-Jar system usage

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -188,6 +188,10 @@ tasks.jarJar.configure {
 // This tells ForgeGradle to reobfuscate the Jar-in-Jar .jar file
 // something that must be done in order for your mod to function
 // outside of your development workspace
+//
+// NOTE: This is currently required due to an issue in ForgeGradle itself, not automatically queuing Jar-in-Jar for reobfuscation
+//  https://github.com/MinecraftForge/ForgeGradle/issues/883
+//  If the issue is closed by the time you are reading this comment, then this reobfJarJar task registration should no longer be required
 /*
 reobf {
     jarJar { }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -11,6 +11,10 @@ archivesBaseName = 'modid'
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
+// Uncomment to enable the Jar-in-Jar system, used to pre-package external dependencies within your compiled mod jar
+// See here for more details on the Jar-in-Jar system: https://forge.gemwire.uk/wiki/Jar-in-jar
+//jarJar.enable()
+
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
     // The mappings can be changed at any time and must be in the following format.
@@ -136,6 +140,13 @@ dependencies {
     // runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
     // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${mc_version}-${registrate_version}") // Adds registrate as a dependency
 
+    // Real Jar-in-Jar inclusion example - for these to work, jarJar.enable() must be called above
+    // See here for more info on Jar-in-Jar Dependency pinning: https://forge.gemwire.uk/wiki/Jar-in-Jar#Dependency_version_pinning
+    // Includes registrate to be pre-packaged within your mod jar
+    // Note: This will only pre-package the mod, you need the above implementation line to compile & run against registrate in your workspace
+    //jarJar(group: "com.tterrag.registrate", name: "Registrate", version: "[MC${mc_version}-${registrate_version},MC${mc_version_max})")
+    //jarJar(group: "com.tterrag.registrate", name: "Registrate", version: "[MC1.19-1.1.5,MC1.20)") // Include registrate 1.19-1.1.5 & support all versions leading up to 1.20
+
     // Examples using mod jars from ./libs
     // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
 
@@ -146,6 +157,10 @@ dependencies {
 
 // Example for how to get properties into the manifest for reading at runtime.
 jar {
+    // Uncomment if you removed the default `-all` classifier from the Jar-in-Jar task below
+    // Failing to uncomment this will result in the normal jar task replacing the Jar-in-Jar file
+    //classifier 'slim'
+
     manifest {
         attributes([
                 "Specification-Title"     : "examplemod",
@@ -158,6 +173,27 @@ jar {
         ])
     }
 }
+
+// Uncomment to remove the default `-all` classifier from the Jar-in-Jar file
+// This maybe handy as the jar you would want to share around would be the Jar-in-Jar file
+// this file contains any and all dependencies you have told the system to pre-package
+// the jar file built normally, if configured above to be `-slim` would not contain any pre-packaged dependency data
+/*
+tasks.jarJar.configure {
+    classifier ''
+}
+*/
+
+// Uncomment when using the Jar-in-Jar system
+// This tells ForgeGradle to reobfuscate the Jar-in-Jar .jar file
+// something that must be done in order for your mod to function
+// outside of your development workspace
+/*
+reobf {
+    jarJar { }
+}
+tasks.jarJar.finalizedBy('reobfJarJar')
+*/
 
 // Example configuration to allow publishing using the maven-publish plugin
 // This is the preferred method to reobfuscate your jar file


### PR DESCRIPTION
This Pull Request adds very basic Jar-in-Jar examples to the MDK build script file.

This adds examples of how to
- _Enable the system_
- _Include a dependency to be pre-packaged_
- _Change jar classifiers to make the Jar-in-Jar file to the be the main jar file_
	- _Removes `-all` from Jar-in-Jar task_
	- _Adds `-slim` to normal jar task_
- _Reobfuscating the Jar-in-Jar task_

These examples should make it easier for more people to make use of the very handy Jar-in-Jar system, while also providing links to the Forge Community Wiki for more in-depth details on how the system works.

Closes #9092