### PR TITLE
[1.19.x] Add configurable validation to datagen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1059,7 +1059,7 @@ project(':forge') {
                     }
 
                     args '--flat', '--all', '--validate',
-                            // '--mod', 'data_gen_test',
+                            '--mod', 'data_gen_test',
                             '--mod', 'piston_event_test',
                             '--mod', 'global_loot_test',
                             '--mod', 'scaffolding_test',

--- a/build.gradle
+++ b/build.gradle
@@ -1059,7 +1059,7 @@ project(':forge') {
                     }
 
                     args '--flat', '--all', '--validate',
-                            '--mod', 'data_gen_test',
+                            // '--mod', 'data_gen_test',
                             '--mod', 'piston_event_test',
                             '--mod', 'global_loot_test',
                             '--mod', 'scaffolding_test',
@@ -1071,9 +1071,12 @@ project(':forge') {
                             '--mod', 'data_pack_registries_test',
                             '--mod', 'biome_modifiers_test',
                             '--mod', 'structure_modifiers_test',
+                            '--mod', 'resource_validation_test',
                             '--output', rootProject.file('src/generated_test/resources/'),
                             '--existing', sourceSets.main.resources.srcDirs[0],
-                            '--existing', sourceSets.test.resources.srcDirs[0]
+                            '--existing', sourceSets.test.resources.srcDirs[0],
+
+                            '--disableValidation', 'forge:textures'
                 }
             }
         }

--- a/patches/minecraft/net/minecraft/data/Main.java.patch
+++ b/patches/minecraft/net/minecraft/data/Main.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/Main.java
 +++ b/net/minecraft/data/Main.java
-@@ -52,8 +_,15 @@
+@@ -52,8 +_,18 @@
        OptionSpec<Void> optionspec6 = optionparser.accepts("all", "Include all generators");
        OptionSpec<String> optionspec7 = optionparser.accepts("output", "Output folder").withRequiredArg().defaultsTo("generated");
        OptionSpec<String> optionspec8 = optionparser.accepts("input", "Input folder").withRequiredArg();
@@ -11,13 +11,16 @@
 +      OptionSpec<Void> flat = optionparser.accepts("flat", "Do not append modid prefix to output directory when generating for multiple mods");
 +      OptionSpec<String> assetIndex = optionparser.accepts("assetIndex").withRequiredArg();
 +      OptionSpec<java.io.File> assetsDir = optionparser.accepts("assetsDir").withRequiredArg().ofType(java.io.File.class);
++      final net.minecraftforge.common.data.ResourceLocationConverter rlConverter = new net.minecraftforge.common.data.ResourceLocationConverter();
++      OptionSpec<net.minecraft.resources.ResourceLocation> enableValidation = optionparser.accepts("enableValidation", "Validation types to explicitly enable").withOptionalArg().withValuesConvertedBy(rlConverter);
++      OptionSpec<net.minecraft.resources.ResourceLocation> disableValidation = optionparser.accepts("disableValidation", "Validation types to explicitly disable").withOptionalArg().withValuesConvertedBy(rlConverter);
        OptionSet optionset = optionparser.parse(p_129669_);
 -      if (!optionset.has(optionspec) && optionset.hasOptions()) {
 +      if (!optionset.has(optionspec) && optionset.hasOptions() && !(optionset.specs().size() == 1 && optionset.has(gameDir))) {
           Path path = Paths.get(optionspec7.value(optionset));
           boolean flag = optionset.has(optionspec6);
           boolean flag1 = flag || optionset.has(optionspec2);
-@@ -61,10 +_,14 @@
+@@ -61,10 +_,22 @@
           boolean flag3 = flag || optionset.has(optionspec3);
           boolean flag4 = flag || optionset.has(optionspec4);
           boolean flag5 = flag || optionset.has(optionspec5);
@@ -30,7 +33,15 @@
 +         java.util.Set<String> existingMods = new java.util.HashSet<>(optionset.valuesOf(existingMod));
 +         java.util.Set<String> mods = new java.util.HashSet<>(optionset.valuesOf(mod));
 +         boolean isFlat = mods.isEmpty() || optionset.has(flat);
-+         net.minecraftforge.data.loading.DatagenModLoader.begin(mods, path, inputs, existingPacks, existingMods, flag2, flag1, flag3, flag4, flag5, isFlat, optionset.valueOf(assetIndex), optionset.valueOf(assetsDir));
++         final java.util.Set<net.minecraft.resources.ResourceLocation> enabledValidation = optionset.has(enableValidation) ? new java.util.HashSet<>(optionset.valuesOf(enableValidation)) : java.util.Set.of();
++         final java.util.Set<net.minecraft.resources.ResourceLocation> disabledValidation = optionset.has(disableValidation) ? new java.util.HashSet<>(optionset.valuesOf(disableValidation)) : java.util.Set.of();
++         final net.minecraftforge.common.data.ValidationPredicate validationPredicate = (validationType, requestedPath, packType) -> {
++            if (validationType == null) return flag5;
++            else if (enabledValidation.contains(validationType)) return true;
++            else if (disabledValidation.contains(validationType)) return false;
++            return flag5;
++         };
++         net.minecraftforge.data.loading.DatagenModLoader.begin(mods, path, inputs, existingPacks, existingMods, flag2, flag1, flag3, flag4, validationPredicate, isFlat, optionset.valueOf(assetIndex), optionset.valueOf(assetsDir));
 +         if (mods.contains("minecraft") || mods.isEmpty())
 +            m_236679_(isFlat ? path : path.resolve("minecraft"), inputs, flag1, flag2, flag3, flag4, flag5, SharedConstants.m_183709_(), true).m_123917_();
        } else {

--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -22,8 +22,8 @@
        this.f_126540_ = p_126547_;
 +      this.modId = modId;
 +      this.existingFileHelper = existingFileHelper;
-+      this.resourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", TagManager.m_203918_(p_126547_.m_123023_()));
-+      this.elementResourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", net.minecraftforge.common.ForgeHooks.prefixNamespace(p_126547_.m_123023_().m_135782_()));
++      this.resourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", TagManager.m_203918_(p_126547_.m_123023_()), net.minecraftforge.common.data.ValidationPredicate.TAGS_VALIDATION_TYPE);
++      this.elementResourceType = new net.minecraftforge.common.data.ExistingFileHelper.ResourceType(net.minecraft.server.packs.PackType.SERVER_DATA, ".json", net.minecraftforge.common.ForgeHooks.prefixNamespace(p_126547_.m_123023_().m_135782_()), net.minecraftforge.common.data.ValidationPredicate.TAGS_VALIDATION_TYPE);
 +   }
 +
 +   // Forge: Allow customizing the path for a given tag or returning null

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -19,21 +19,21 @@ import com.google.gson.GsonBuilder;
 
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.data.HashCache;
 import net.minecraft.data.DataProvider;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.ExistingFileHelper.ResourceType;
+import net.minecraftforge.common.data.ValidationPredicate;
 
 public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataProvider {
 
     public static final String BLOCK_FOLDER = "block";
     public static final String ITEM_FOLDER = "item";
 
-    protected static final ResourceType TEXTURE = new ResourceType(PackType.CLIENT_RESOURCES, ".png", "textures");
-    protected static final ResourceType MODEL = new ResourceType(PackType.CLIENT_RESOURCES, ".json", "models");
-    protected static final ResourceType MODEL_WITH_EXTENSION = new ResourceType(PackType.CLIENT_RESOURCES, "", "models");
+    protected static final ResourceType TEXTURE = new ResourceType(PackType.CLIENT_RESOURCES, ".png", "textures", new ResourceLocation("forge", "textures"));
+    protected static final ResourceType MODEL = new ResourceType(PackType.CLIENT_RESOURCES, ".json", "models", ValidationPredicate.MODELS_VALIDATION_TYPE);
+    protected static final ResourceType MODEL_WITH_EXTENSION = new ResourceType(PackType.CLIENT_RESOURCES, "", "models", ValidationPredicate.MODELS_VALIDATION_TYPE);
 
     private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().create();
     protected final DataGenerator generator;

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ObjModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ObjModelBuilder.java
@@ -12,6 +12,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
 import net.minecraftforge.client.model.generators.ModelBuilder;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.common.data.ValidationPredicate;
 
 public class ObjModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuilder<T>
 {
@@ -35,7 +36,7 @@ public class ObjModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuil
     public ObjModelBuilder<T> modelLocation(ResourceLocation modelLocation)
     {
         Preconditions.checkNotNull(modelLocation, "modelLocation must not be null");
-        Preconditions.checkArgument(existingFileHelper.exists(modelLocation, PackType.CLIENT_RESOURCES),
+        Preconditions.checkArgument(existingFileHelper.exists(modelLocation, PackType.CLIENT_RESOURCES, ValidationPredicate.MODELS_VALIDATION_TYPE),
                 "OBJ Model %s does not exist in any known resource pack", modelLocation);
         this.modelLocation = modelLocation;
         return this;
@@ -68,7 +69,7 @@ public class ObjModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuil
     public ObjModelBuilder<T> overrideMaterialLibrary(ResourceLocation mtlOverride)
     {
         Preconditions.checkNotNull(mtlOverride, "mtlOverride must not be null");
-        Preconditions.checkArgument(existingFileHelper.exists(mtlOverride, PackType.CLIENT_RESOURCES),
+        Preconditions.checkArgument(existingFileHelper.exists(mtlOverride, PackType.CLIENT_RESOURCES, ValidationPredicate.MODELS_VALIDATION_TYPE),
                 "OBJ Model %s does not exist in any known resource pack", mtlOverride);
         this.mtlOverride = mtlOverride;
         return this;

--- a/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
+++ b/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
@@ -22,6 +22,6 @@ public class ResourceLocationConverter implements ValueConverter<ResourceLocatio
     public String valuePattern()
     {
         // language=RegExp
-        return "^[a-z0-9_.-]+:[a-z0-9/._-]+$";
+        return "^([a-z][a-z0-9_.-]{1,63}:)?([a-z][a-z0-9/._-]{1,})$";
     }
 }

--- a/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
+++ b/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.data;
 
 import joptsimple.ValueConverter;

--- a/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
+++ b/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.common.data;
+
+import joptsimple.ValueConverter;
+import net.minecraft.resources.ResourceLocation;
+import org.intellij.lang.annotations.Language;
+
+public class ResourceLocationConverter implements ValueConverter<ResourceLocation>
+{
+    @Override
+    public ResourceLocation convert(String value)
+    {
+        return new ResourceLocation(value);
+    }
+
+    @Override
+    public Class<? extends ResourceLocation> valueType()
+    {
+        return ResourceLocation.class;
+    }
+
+    @Override
+    public String valuePattern()
+    {
+        // language=RegExp
+        return "^[a-z0-9_.-]+:[a-z0-9/._-]+$";
+    }
+}

--- a/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
+++ b/src/main/java/net/minecraftforge/common/data/ResourceLocationConverter.java
@@ -7,7 +7,6 @@ package net.minecraftforge.common.data;
 
 import joptsimple.ValueConverter;
 import net.minecraft.resources.ResourceLocation;
-import org.intellij.lang.annotations.Language;
 
 public class ResourceLocationConverter implements ValueConverter<ResourceLocation>
 {

--- a/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
+++ b/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * Interface used in order to determine if a {@link ExistingFileHelper} should validate the existence of a path.
@@ -43,5 +44,10 @@ public interface ValidationPredicate
     default ValidationPredicate not()
     {
         return (validationType, requestedPath, packType) -> !this.canValidate(validationType, requestedPath, packType);
+    }
+
+    static ValidationPredicate enableType(@Nullable ResourceLocation validationType)
+    {
+        return (type, path, pack) -> Objects.equals(type, validationType);
     }
 }

--- a/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
+++ b/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
@@ -29,4 +29,14 @@ public interface ValidationPredicate
     {
         return (validationType, requestedPath, packType) -> canValidate(validationType, requestedPath, packType) && other.canValidate(validationType, requestedPath, packType);
     }
+
+    default ValidationPredicate or(ValidationPredicate other)
+    {
+        return (validationType, requestedPath, packType) -> canValidate(validationType, requestedPath, packType) || other.canValidate(validationType, requestedPath, packType);
+    }
+
+    default ValidationPredicate not()
+    {
+        return (validationType, requestedPath, packType) -> !this.canValidate(validationType, requestedPath, packType);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
+++ b/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.common.data;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface used in order to determine if a {@link ExistingFileHelper} should validate the existence of a path.
+ */
+@FunctionalInterface
+public interface ValidationPredicate
+{
+    ValidationPredicate TRUE = (type, path, pack) -> true;
+
+    ResourceLocation MODELS_VALIDATION_TYPE = new ResourceLocation("forge", "models");
+    ResourceLocation TAGS_VALIDATION_TYPE = new ResourceLocation("forge", "tags");
+
+    /**
+     * {@return if the path should be validated}
+     *
+     * @param validationType the type of the validation
+     * @param requestedPath  the path that should be validated
+     * @param packType       the type of the resource which should be validated
+     */
+    boolean canValidate(@Nullable ResourceLocation validationType, ResourceLocation requestedPath, PackType packType);
+
+    default ValidationPredicate and(ValidationPredicate other)
+    {
+        return (validationType, requestedPath, packType) -> canValidate(validationType, requestedPath, packType) && other.canValidate(validationType, requestedPath, packType);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
+++ b/src/main/java/net/minecraftforge/common/data/ValidationPredicate.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.data;
 
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -69,7 +69,7 @@ public class GatherDataEvent extends Event implements IModBusEvent
         private final boolean client;
         private final boolean dev;
         private final boolean reports;
-        private final ValidationPredicate validationPredicate;
+        ValidationPredicate validationPredicate;
         private final boolean flat;
         private List<DataGenerator> generators = new ArrayList<>();
 
@@ -99,6 +99,9 @@ public class GatherDataEvent extends Event implements IModBusEvent
         public boolean isFlat() {
             return flat || getMods().size() == 1;
         }
+
+        public void setValidationPredicate(ValidationPredicate predicate) { this.validationPredicate = predicate; }
+        public ValidationPredicate getValidationPredicate() { return this.validationPredicate; }
 
         public DataGenerator makeGenerator(final Function<Path,Path> pathEnhancer, final boolean shouldExecute) {
             final DataGenerator generator = new DataGenerator(pathEnhancer.apply(path), inputs, DetectedVersion.tryDetectVersion(), shouldExecute);

--- a/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.data.event;
 
 import com.mojang.logging.LogUtils;

--- a/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
@@ -10,8 +10,37 @@ import net.minecraftforge.common.data.ValidationPredicate;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
 
+/**
+ * This event is fired before {@link GatherDataEvent} in order to collect {@linkplain ValidationPredicate validation predicates}
+ * which will be used to determine if the {@link net.minecraftforge.common.data.ExistingFileHelper} should actually
+ * check for the existence of a resource. <br>
+ * <strong>Important:</strong> your mod's predicates will only be appended to the list if your mod's generators are enabled.
+ * <br>
+ * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus}. <br>
+ * <br><br>
+ * Example usage for ignoring all model validations for mod {@code examplemod}:
+ * <pre>
+ * {@code
+ *   // Use andNot, as we want to disable validation if the check passes
+ *   event.andNot((validationType, requestedPath, packType) ->
+ *         // Check if the requested resource is a client resource
+ *         packType == PackType.CLIENT_RESOURCES
+ *         // Check if the validated resource is a model
+ *         && Objects.equals(validationType, ValidationPredicate.MODELS_VALIDATION_TYPE)
+ *         // Check if the requested resource is from the `examplemod` namespace
+ *         && requestedPath.getNamespace().equals("examplemod"));
+ * }
+ * </pre>
+ * Example usage for disabling model validation:
+ * <pre>
+ * {@code
+ *   event.andNot(ValidationPredicate.enableType(ValidationPredicate.MODELS_VALIDATION_TYPE));
+ * }
+ * </pre>
+ */
 public class GatherValidationPredicatesEvent extends Event implements IModBusEvent
 {
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -45,6 +74,11 @@ public class GatherValidationPredicatesEvent extends Event implements IModBusEve
     public void and(ValidationPredicate predicate)
     {
         add(Strategy.AND, predicate);
+    }
+
+    public void andNot(ValidationPredicate predicate)
+    {
+        and(predicate.not());
     }
 
     public void or(ValidationPredicate predicate)

--- a/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherValidationPredicatesEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.data.event;
+
+import com.mojang.logging.LogUtils;
+import net.minecraftforge.common.data.ValidationPredicate;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.event.IModBusEvent;
+import org.slf4j.Logger;
+
+public class GatherValidationPredicatesEvent extends Event implements IModBusEvent
+{
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private final ModContainer container;
+    private final GatherDataEvent.DataGeneratorConfig config;
+
+    public GatherValidationPredicatesEvent(final ModContainer container, final GatherDataEvent.DataGeneratorConfig config)
+    {
+        this.container = container;
+        this.config = config;
+    }
+
+    public ValidationPredicate getValidationPredicate() { return this.config.validationPredicate; }
+
+    public void add(Strategy strategy, ValidationPredicate predicate)
+    {
+        if (!config.getMods().contains(container.getModId()))
+        {
+            LOGGER.debug("Skipping validation predicate {} as mod does not have datagen enabled.", predicate);
+            return;
+        }
+
+        this.config.validationPredicate = switch (strategy)
+        {
+            case AND -> getValidationPredicate().and(predicate);
+            case OR -> getValidationPredicate().or(predicate);
+        };
+    }
+
+    public void and(ValidationPredicate predicate)
+    {
+        add(Strategy.AND, predicate);
+    }
+
+    public void or(ValidationPredicate predicate)
+    {
+        add(Strategy.OR, predicate);
+    }
+
+    public enum Strategy
+    {
+        AND, OR
+    }
+}

--- a/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
@@ -37,8 +37,7 @@ public class DatagenModLoader {
     }
 
     @ApiStatus.Internal
-    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final ValidationPredicate initialValidationPredicate, final boolean flat, final String assetIndex, final File assetsDir)
-    {
+    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final ValidationPredicate initialValidationPredicate, final boolean flat, final String assetIndex, final File assetsDir) {
         if (mods.contains("minecraft") && mods.size() == 1) return;
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;

--- a/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
@@ -7,11 +7,13 @@ package net.minecraftforge.data.loading;
 
 import net.minecraft.server.Bootstrap;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.common.data.ValidationPredicate;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModWorkManager;
 import net.minecraftforge.data.event.GatherDataEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -28,18 +30,25 @@ public class DatagenModLoader {
         return runningDataGen;
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final boolean structureValidator, final boolean flat, final String assetIndex, final File assetsDir) {
+        begin(mods, path, inputs, existingPacks, existingMods, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, ValidationPredicate.TRUE, flat, assetIndex, assetsDir);
+    }
+
+    @ApiStatus.Internal
+    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final ValidationPredicate validationPredicate, final boolean flat, final String assetIndex, final File assetsDir)
+    {
         if (mods.contains("minecraft") && mods.size() == 1) return;
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;
         Bootstrap.bootStrap();
-        dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
+        dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, validationPredicate, flat);
         ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
         if (!mods.contains("forge")) {
             //If we aren't generating data for forge, automatically add forge as an existing so mods can access forge's data
             existingMods.add("forge");
         }
-        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, structureValidator, assetIndex, assetsDir);
+        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, validationPredicate, assetIndex, assetsDir);
         ModLoader.get().runEventGenerator(mc->new GatherDataEvent(mc, dataGeneratorConfig.makeGenerator(p->dataGeneratorConfig.isFlat() ? p : p.resolve(mc.getModId()), dataGeneratorConfig.getMods().contains(mc.getModId())), dataGeneratorConfig, existingFileHelper));
         dataGeneratorConfig.runAll();
     }

--- a/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
@@ -8,6 +8,7 @@ package net.minecraftforge.data.loading;
 import net.minecraft.server.Bootstrap;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.ValidationPredicate;
+import net.minecraftforge.data.event.GatherValidationPredicatesEvent;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModWorkManager;
 import net.minecraftforge.data.event.GatherDataEvent;
@@ -36,19 +37,20 @@ public class DatagenModLoader {
     }
 
     @ApiStatus.Internal
-    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final ValidationPredicate validationPredicate, final boolean flat, final String assetIndex, final File assetsDir)
+    public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks, Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator, final ValidationPredicate initialValidationPredicate, final boolean flat, final String assetIndex, final File assetsDir)
     {
         if (mods.contains("minecraft") && mods.size() == 1) return;
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;
         Bootstrap.bootStrap();
-        dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, validationPredicate, flat);
+        dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, serverGenerators, clientGenerators, devToolGenerators, reportsGenerator, initialValidationPredicate, flat);
         ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
         if (!mods.contains("forge")) {
             //If we aren't generating data for forge, automatically add forge as an existing so mods can access forge's data
             existingMods.add("forge");
         }
-        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, validationPredicate, assetIndex, assetsDir);
+        ModLoader.get().runEventGenerator(mc -> new GatherValidationPredicatesEvent(mc, dataGeneratorConfig));
+        existingFileHelper = new ExistingFileHelper(existingPacks, existingMods, dataGeneratorConfig.getValidationPredicate(), assetIndex, assetsDir);
         ModLoader.get().runEventGenerator(mc->new GatherDataEvent(mc, dataGeneratorConfig.makeGenerator(p->dataGeneratorConfig.isFlat() ? p : p.resolve(mc.getModId()), dataGeneratorConfig.getMods().contains(mc.getModId())), dataGeneratorConfig, existingFileHelper));
         dataGeneratorConfig.runAll();
     }

--- a/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
+++ b/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.debug.datagen;
+
+import net.minecraft.core.Registry;
+import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagEntry;
+import net.minecraft.tags.TagKey;
+import net.minecraftforge.client.model.generators.ItemModelProvider;
+import net.minecraftforge.data.event.GatherDataEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+@Mod(ResourceValidationTest.MODID)
+public class ResourceValidationTest
+{
+    private static final boolean ENABLED = true;
+    public static final String MODID = "resource_validation_test";
+
+    private static final boolean ENABLE_MODELS = true;
+    private static final boolean ENABLE_TAGS = false;
+
+    public ResourceValidationTest()
+    {
+        if (!ENABLED) return;
+        FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherDataEvent event) -> {
+            if (ENABLE_MODELS)
+                event.getGenerator().addProvider(event.includeClient(), new ItemModelProvider(event.getGenerator(), MODID, event.getExistingFileHelper())
+                {
+                    @Override
+                    protected void registerModels()
+                    {
+                        basicItem(new ResourceLocation(MODID, "test"));
+                    }
+                });
+
+            if (ENABLE_TAGS)
+                event.getGenerator().addProvider(event.includeServer(), new BlockTagsProvider(event.getGenerator(), MODID, event.getExistingFileHelper())
+                {
+                    @Override
+                    protected void addTags()
+                    {
+                        tag(TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(MODID, "test")))
+                                .add(TagEntry.tag(new ResourceLocation(MODID, "test_sub")));
+                    }
+                });
+        });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
+++ b/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
@@ -2,13 +2,19 @@ package net.minecraftforge.debug.datagen;
 
 import net.minecraft.core.Registry;
 import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
 import net.minecraft.tags.TagEntry;
 import net.minecraft.tags.TagKey;
 import net.minecraftforge.client.model.generators.ItemModelProvider;
+import net.minecraftforge.common.data.ValidationPredicate;
 import net.minecraftforge.data.event.GatherDataEvent;
+import net.minecraftforge.data.event.GatherValidationPredicatesEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import java.util.Objects;
 
 @Mod(ResourceValidationTest.MODID)
 public class ResourceValidationTest
@@ -17,11 +23,22 @@ public class ResourceValidationTest
     public static final String MODID = "resource_validation_test";
 
     private static final boolean ENABLE_MODELS = true;
-    private static final boolean ENABLE_TAGS = false;
+    private static final boolean ENABLE_TAGS = true;
+    private static final boolean ERROR_TAGS = false;
 
     public ResourceValidationTest()
     {
         if (!ENABLED) return;
+
+        if (!ERROR_TAGS)
+        {
+            FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherValidationPredicatesEvent event) -> {
+                event.and(((ValidationPredicate) (validationType, requestedPath, packType) -> packType == PackType.SERVER_DATA
+                        && Objects.equals(validationType, ValidationPredicate.TAGS_VALIDATION_TYPE)
+                        && requestedPath.equals(new ResourceLocation(MODID, "tags/blocks/test_sub.json"))).not());
+            });
+        }
+
         FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherDataEvent event) -> {
             if (ENABLE_MODELS)
                 event.getGenerator().addProvider(event.includeClient(), new ItemModelProvider(event.getGenerator(), MODID, event.getExistingFileHelper())

--- a/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
+++ b/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
@@ -7,7 +7,6 @@ package net.minecraftforge.debug.datagen;
 
 import net.minecraft.core.Registry;
 import net.minecraft.data.tags.BlockTagsProvider;
-import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.tags.TagEntry;
@@ -30,19 +29,19 @@ public class ResourceValidationTest
     private static final boolean ENABLE_MODELS = true;
     private static final boolean ENABLE_TAGS = true;
     private static final boolean ERROR_TAGS = false;
+    private static final boolean ERROR_TEXTURES = false;
 
     public ResourceValidationTest()
     {
         if (!ENABLED) return;
 
-        if (!ERROR_TAGS)
-        {
-            FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherValidationPredicatesEvent event) -> {
-                event.and(((ValidationPredicate) (validationType, requestedPath, packType) -> packType == PackType.SERVER_DATA
-                        && Objects.equals(validationType, ValidationPredicate.TAGS_VALIDATION_TYPE)
-                        && requestedPath.equals(new ResourceLocation(MODID, "tags/blocks/test_sub.json"))).not());
-            });
-        }
+        FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherValidationPredicatesEvent event) -> {
+            if (ERROR_TEXTURES) event.and(ValidationPredicate.enableType(new ResourceLocation("forge:textures")));
+
+            if (!ERROR_TAGS) event.andNot((validationType, requestedPath, packType) -> packType == PackType.SERVER_DATA
+                    && Objects.equals(validationType, ValidationPredicate.TAGS_VALIDATION_TYPE)
+                    && requestedPath.equals(new ResourceLocation(MODID, "tags/blocks/test_sub.json")));
+        });
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener((final GatherDataEvent event) -> {
             if (ENABLE_MODELS)

--- a/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
+++ b/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.datagen;
 
 import net.minecraft.core.Registry;

--- a/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
+++ b/src/test/java/net/minecraftforge/debug/datagen/ResourceValidationTest.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 @Mod(ResourceValidationTest.MODID)
 public class ResourceValidationTest
 {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     public static final String MODID = "resource_validation_test";
 
     private static final boolean ENABLE_MODELS = true;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -267,6 +267,8 @@ modId="custom_item_decorations_test"
 [[mods]]
 modId="item_stacked_on_other_test"
 [[mods]]
+modId="resource_validation_test"
+[[mods]]
 modId="ambient_occlusion_elements_test"
 
 


### PR DESCRIPTION
Some data generators (notably, model providers and tag providers) use the forge-added `ExistingFileHelper` in order to validate the existence of different resources. This validation was previously enabled globally by the `validate` flag, meaning that if you wanted to disable the validation of a resource type, you would've disabled all validation.
This PR allows modders to have better control on what resources should be validated.
## Using the feature
A validation type may be specifically disabled with the `--disableValidation` flag, or enabled with the `--enableValidation` flag.
Mods may also add their own custom validation predicates using `GatherValidationPredicatesEvent` (see its javadocs or the `ResourceValidationTest` for example usage)
## Why?
A common "annoyance" with the `ItemModelProvider` (or any `ModelProvider`) is the fact that the textures need to be present when the generator is run, which may not always be true (e.g. waiting on artists, or runtime textures). This PR was designed with the idea of providing an easy way to disable texture validation in mind.