### PR TITLE
[1.18] Improve logging of missing or unsupported dependencies

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -209,10 +209,24 @@ public class ModSorter
 
         if (!missingVersions.isEmpty()) {
             if (mandatoryMissing > 0) {
-                LOGGER.error(LOADING, "Missing mandatory dependencies: {}", missingVersions.stream().filter(IModInfo.ModVersion::isMandatory).map(IModInfo.ModVersion::getModId).collect(Collectors.joining(", ")));
+                LOGGER.error(
+                        LOADING,
+                        "Missing or unsupported mandatory dependencies:\n{}",
+                        missingVersions.stream()
+                                .filter(IModInfo.ModVersion::isMandatory)
+                                .map(ver -> formatDependencyError(ver, modVersions))
+                                .collect(Collectors.joining("\n"))
+                );
             }
             if (missingVersions.size() - mandatoryMissing > 0) {
-                LOGGER.error(LOADING, "Unsupported installed optional dependencies: {}", missingVersions.stream().filter(ver -> !ver.isMandatory()).map(IModInfo.ModVersion::getModId).collect(Collectors.joining(", ")));
+                LOGGER.error(
+                        LOADING,
+                        "Unsupported installed optional dependencies:\n{}",
+                        missingVersions.stream()
+                                .filter(ver -> !ver.isMandatory())
+                                .map(ver -> formatDependencyError(ver, modVersions))
+                                .collect(Collectors.joining("\n"))
+                );
             }
 
             return missingVersions.stream()
@@ -222,6 +236,18 @@ public class ModSorter
                     .toList();
         }
         return Collections.emptyList();
+    }
+
+    private static String formatDependencyError(IModInfo.ModVersion dependency, Map<String, ArtifactVersion> modVersions)
+    {
+        ArtifactVersion installed = modVersions.get(dependency.getModId());
+        return String.format(
+                "\tMod ID: '%s', Requested by: '%s', Expected range: '%s', Actual version: '%s'",
+                dependency.getModId(),
+                dependency.getOwner().getModId(),
+                dependency.getVersionRange(),
+                installed != null ? installed.toString() : "[MISSING]"
+        );
     }
 
     private boolean modVersionNotContained(final IModInfo.ModVersion mv, final Map<String, ArtifactVersion> modVersions)


### PR DESCRIPTION
This PR improves the logging of missing or unsupported dependencies by adding additional detail about the requested version range, the "requester" and the installed version (if any).

This is the backport of #9104.

Before:
```
[20:16:21] [main/ERROR] [ne.mi.fm.lo.ModSorter/LOADING]: Missing mandatory dependencies: forge, dummy
[20:16:21] [main/ERROR] [ne.mi.fm.lo.ModSorter/LOADING]: Unsupported installed optional dependencies: forge
```

After:
```
[20:16:21] [main/ERROR] [ne.mi.fm.lo.ModSorter/LOADING]: Missing or unsupported mandatory dependencies:
	Mod ID: 'forge', Requested by: 'global_loot_test', Expected range: '[69,)', Actual version: '40.1.84-improve_dep_logging_118'
	Mod ID: 'dummy', Requested by: 'custom_plant_type_test', Expected range: '[1,)', Actual version: '[MISSING]'
[20:16:21] [main/ERROR] [ne.mi.fm.lo.ModSorter/LOADING]: Unsupported installed optional dependencies:
	Mod ID: 'forge', Requested by: 'chunk_data_event_save_null_world_test', Expected range: '[78.1.42,)', Actual version: '40.1.84-improve_dep_logging_118'
```