### PR TITLE
Throw aggregate exception for erroneous registry event dispatch

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -357,6 +357,7 @@ public class GameData
             LOGGER.fatal("Detected errors during registry event dispatch, rolling back to VANILLA state");
             revertTo(RegistryManager.VANILLA, false);
             LOGGER.fatal("Detected errors during registry event dispatch, roll back to VANILLA complete");
+            throw aggregate;
         } else
         {
             ForgeHooks.modifyAttributes();


### PR DESCRIPTION
This PR fixes #8720 by throwing the aggregate exception during a registry event dispatch where errors have occurred.

This means that exceptions occurring during the dispatch of the registry events, such as those from the suppliers of RegistryObjects, properly cause a crash rather than merely being logged and allowing the game to reach the main menu.

Note that the cause resulting from this is immediate, without an error screen.