### PR TITLE
[1.19.2] Make Datapack Registries support ICondition(s)

### DIFF
--- a/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/resources/RegistryLoader.java
 +++ b/net/minecraft/resources/RegistryLoader.java
+@@ -26,7 +_,7 @@
+       Map<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> map = this.f_206750_.m_214030_(p_206764_);
+       DataResult<WritableRegistry<E>> dataresult = DataResult.success(p_206763_, Lifecycle.stable());
+ 
+-      for(Map.Entry<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> entry : map.entrySet()) {
++      for(Map.Entry<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> entry : net.minecraftforge.common.crafting.conditions.ICondition.filterThunks(map)) {
+          dataresult = dataresult.flatMap((p_214227_) -> {
+             return this.m_214228_(p_214227_, p_206764_, p_206765_, entry.getKey(), Optional.of(entry.getValue()), p_206766_).map((p_206761_) -> {
+                return p_214227_;
 @@ -48,7 +_,12 @@
        if (dataresult != null) {
           return dataresult;

--- a/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryLoader.java.patch
@@ -5,7 +5,7 @@
        DataResult<WritableRegistry<E>> dataresult = DataResult.success(p_206763_, Lifecycle.stable());
  
 -      for(Map.Entry<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> entry : map.entrySet()) {
-+      for(Map.Entry<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> entry : net.minecraftforge.common.crafting.conditions.ICondition.filterThunks(map)) {
++      for(Map.Entry<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> entry : net.minecraftforge.common.ForgeHooks.filterThunks(map)) {
           dataresult = dataresult.flatMap((p_214227_) -> {
              return this.m_214228_(p_214227_, p_206764_, p_206765_, entry.getKey(), Optional.of(entry.getValue()), p_206766_).map((p_206761_) -> {
                 return p_214227_;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -8,6 +8,7 @@ package net.minecraftforge.common;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -27,6 +28,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.Lifecycle;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -107,6 +109,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.loot.LootModifierManager;
 import net.minecraftforge.common.loot.LootTableIdCondition;
@@ -171,8 +174,10 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.resources.RegistryResourceAccess;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.RegistryResourceAccess.EntryThunk;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
@@ -1651,5 +1656,13 @@ public class ForgeHooks
             return PermissionAPI.getPermission(player, ForgeMod.USE_SELECTORS_PERMISSION);
         }
         return provider.hasPermission(Commands.LEVEL_GAMEMASTERS);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> Collection<Entry<ResourceKey<E>, EntryThunk<E>>> filterThunks(Map<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> map)
+    {
+        return map.entrySet().stream().filter(e -> 
+        ((EntryThunk<Boolean>)e.getValue()).parseElement(JsonOps.INSTANCE, ICondition.DECODER)
+        .get().left().get().value()).toList(); // Validity of this .get() call is enforced by the above Decoder object, which only returns DataResult.success.
     }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -234,4 +234,14 @@ public class CraftingHelper
             throw new JsonSyntaxException("Unknown condition type: " + condition.getID().toString());
         return serializer.getJson(condition);
     }
+
+    public static JsonArray serialize(ICondition... conditions)
+    {
+        JsonArray arr = new JsonArray();
+        for(ICondition iCond : conditions)
+        {
+            arr.add(serialize(iCond));
+        }
+        return arr;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
@@ -5,22 +5,61 @@
 
 package net.minecraftforge.common.crafting.conditions;
 
+import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Decoder;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.RegistryResourceAccess;
+import net.minecraft.resources.RegistryResourceAccess.EntryThunk;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraftforge.common.crafting.CraftingHelper;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 public interface ICondition
 {
+    
+    Decoder<Boolean> DECODER = new Decoder<>() {
+        @Override
+        public <T> DataResult<Pair<Boolean, T>> decode(DynamicOps<T> ops, T input) {
+            if(input instanceof JsonObject obj && obj.has("forge:conditions")) {
+                try
+                {
+                    boolean result = CraftingHelper.processConditions(obj, "forge:conditions", IContext.EMPTY);    
+                    return DataResult.success(Pair.of(result, input));
+                } 
+                catch(Exception ex)
+                {
+                    ex.printStackTrace();
+                    return DataResult.success(Pair.of(false, input)); // Print stacktrace and do not load errored conditions.
+                }
+            }
+            return DataResult.success(Pair.of(true, input));
+        }
+    };
+    
     ResourceLocation getID();
 
     boolean test(IContext context);
+    
+    @SuppressWarnings("unchecked")
+    static <E> Collection<Entry<ResourceKey<E>, EntryThunk<E>>> filterThunks(Map<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> map)
+    {
+        return map.entrySet().stream().filter(e -> 
+        ((EntryThunk<Boolean>)e.getValue()).parseElement(JsonOps.INSTANCE, DECODER)
+        .get().left().get().value()).toList(); // Validity of this .get() call is enforced by the above Decoder object, which only returns DataResult.success.
+    }
 
     interface IContext
     {

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
@@ -36,7 +36,7 @@ public interface ICondition
             if(input instanceof JsonObject obj && obj.has("forge:conditions")) {
                 try
                 {
-                    boolean result = CraftingHelper.processConditions(obj, "forge:conditions", IContext.EMPTY);    
+                    boolean result = CraftingHelper.processConditions(obj, "forge:conditions", IContext.TAGS_INVALID);    
                     return DataResult.success(Pair.of(result, input));
                 } 
                 catch(Exception ex)
@@ -69,6 +69,15 @@ public interface ICondition
             public <T> Map<ResourceLocation, Collection<Holder<T>>> getAllTags(ResourceKey<? extends Registry<T>> registry)
             {
                 return Collections.emptyMap();
+            }
+        };
+
+        IContext TAGS_INVALID = new IContext()
+        {
+            @Override
+            public <T> Map<ResourceLocation, Collection<Holder<T>>> getAllTags(ResourceKey<? extends Registry<T>> registry)
+            {
+                throw new UnsupportedOperationException("Usage of tag-based conditions is not permitted in this context!");
             }
         };
 

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
@@ -10,12 +10,8 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.Decoder;
 import com.mojang.serialization.DynamicOps;
-import com.mojang.serialization.JsonOps;
-
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.RegistryResourceAccess;
-import net.minecraft.resources.RegistryResourceAccess.EntryThunk;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -24,16 +20,17 @@ import net.minecraftforge.common.crafting.CraftingHelper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 public interface ICondition
 {
-    
+
     Decoder<Boolean> DECODER = new Decoder<>() {
         @Override
-        public <T> DataResult<Pair<Boolean, T>> decode(DynamicOps<T> ops, T input) {
-            if(input instanceof JsonObject obj && obj.has("forge:conditions")) {
+        public <T> DataResult<Pair<Boolean, T>> decode(DynamicOps<T> ops, T input)
+        {
+            if(input instanceof JsonObject obj && obj.has("forge:conditions"))
+            {
                 try
                 {
                     boolean result = CraftingHelper.processConditions(obj, "forge:conditions", IContext.TAGS_INVALID);    
@@ -48,18 +45,10 @@ public interface ICondition
             return DataResult.success(Pair.of(true, input));
         }
     };
-    
+
     ResourceLocation getID();
 
     boolean test(IContext context);
-    
-    @SuppressWarnings("unchecked")
-    static <E> Collection<Entry<ResourceKey<E>, EntryThunk<E>>> filterThunks(Map<ResourceKey<E>, RegistryResourceAccess.EntryThunk<E>> map)
-    {
-        return map.entrySet().stream().filter(e -> 
-        ((EntryThunk<Boolean>)e.getValue()).parseElement(JsonOps.INSTANCE, DECODER)
-        .get().left().get().value()).toList(); // Validity of this .get() call is enforced by the above Decoder object, which only returns DataResult.success.
-    }
 
     interface IContext
     {

--- a/src/test/java/net/minecraftforge/debug/world/BiomeModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeModifierTest.java
@@ -33,6 +33,8 @@ import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.CountOnEveryLayerPlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraftforge.common.crafting.conditions.ICondition;
+import net.minecraftforge.common.crafting.conditions.ModLoadedCondition;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.JsonCodecProvider;
 import net.minecraftforge.common.world.BiomeModifier;
@@ -150,7 +152,7 @@ public class BiomeModifierTest
         // Create and add dataproviders.
         generator.addProvider(event.includeServer(), JsonCodecProvider.forDatapackRegistry(
             generator, existingFileHelper, MODID, ops, Registry.PLACED_FEATURE_REGISTRY, Map.of(
-                LARGE_BASALT_COLUMNS_RL, basaltFeature)));
+                LARGE_BASALT_COLUMNS_RL, basaltFeature)).setConditions(Map.of(LARGE_BASALT_COLUMNS_RL, new ICondition[] { new ModLoadedCondition("forge") })));
 
         generator.addProvider(event.includeServer(), JsonCodecProvider.forDatapackRegistry(
             generator, existingFileHelper, MODID, ops, ForgeRegistries.Keys.BIOME_MODIFIERS, Map.of(

--- a/src/test/resources/data/forge/forge/biome_modifier/test_datapackreg_conditions.json
+++ b/src/test/resources/data/forge/forge/biome_modifier/test_datapackreg_conditions.json
@@ -1,0 +1,7 @@
+{
+  "forge:conditions": [{
+    "type": "forge:mod_loaded",
+    "modid": "not_forge"
+  }],
+  "type": "irrelevant:wont_be_loaded"
+}

--- a/src/test/resources/data/forge/forge/biome_modifier/test_datapackreg_conditions_error.json
+++ b/src/test/resources/data/forge/forge/biome_modifier/test_datapackreg_conditions_error.json
@@ -1,0 +1,6 @@
+{
+  "forge:conditions": [{
+    "type": "junk:not_real_type"
+  }],
+  "type": "irrelevant:wont_be_loaded"
+}


### PR DESCRIPTION
This enables Datapack Registries to have files that only load if certain conditions are present.
This is necessary if, for example, a mod wanted to add a feature via biome modifier that only generated if another mod is present.

Conditions can be added to ANY datapack registry json file and live under the `forge:conditions` key, like so:
```json
  "forge:conditions": [{
    "type": "forge:mod_loaded",
    "modid": "not_forge"
  }],
  ```
  
  Errors (invalid conditions) will cause a stacktrace to be printed and the file will not be loaded.
  
  The logic for this can and will be simplified in 1.19.3 since the way parsing Datapack Registry json files has changed.
  
  Note: this does not and cannot support tag conditions (or anything else dependent on IContext) since Tags are not loaded yet.