### PR TITLE
Fix launch handler minecraft classpath locator

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
@@ -57,7 +57,7 @@ public class FileUtils
     
     public static boolean matchFileName(String path, String... matches) {
         // Extract file name from path
-        String name = path.substring(path.lastIndexOf(File.separatorChar) + 1);
+        String name = path.substring(Math.min(path.lastIndexOf(File.separatorChar) + 1, path.length()));
         // Check if it contains any of the desired keywords
         for (String match : matches) {
             if (name.contains(match)) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
@@ -8,6 +8,7 @@ package net.minecraftforge.fml.loading;
 import com.mojang.logging.LogUtils;
 import org.slf4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -52,5 +53,17 @@ public class FileUtils
         } else {
             return "";
         }
+    }
+    
+    public static boolean matchFileName(String path, String... matches) {
+        // Extract file name from path
+        String name = path.substring(path.lastIndexOf(File.separatorChar) + 1);
+        // Check if it contains any of the desired keywords
+        for (String match : matches) {
+            if (name.contains(match)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.fml.loading.targets;
 
 import cpw.mods.jarhandling.SecureJar;
+import net.minecraftforge.fml.loading.FileUtils;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -77,22 +78,14 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
     protected List<Path> getFmlStuff(String[] classpath) {
         // We also want the FML things, fmlcore, javafmllanguage, mclanguage, I don't like hard coding these, but hey whatever works for now.
         return Arrays.stream(classpath)
-            .filter(e -> {
-                // Extract file name from path
-                String name = e.substring(e.lastIndexOf(File.separatorChar) + 1);
-                return name.contains("fmlcore") || name.contains("javafmllanguage") || name.contains("lowcodelanguage") || name.contains("mclanguage");
-            })
+            .filter(e -> FileUtils.matchFileName(e, "fmlcore", "javafmllanguage", "lowcodelanguage", "mclanguage"))
             .map(Paths::get)
             .toList();
     }
 
     protected static Path findJarOnClasspath(String[] classpath, String match) {
         return Paths.get(Arrays.stream(classpath)
-            .filter(e -> {
-                // Extract file name from path
-                String name = e.substring(e.lastIndexOf(File.separatorChar) + 1);
-                return name.contains(match);
-            })
+            .filter(e -> FileUtils.matchFileName(e, match))
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("Could not find " + match + " in classpath")));
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
@@ -29,7 +29,7 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
 
         // The extra jar is on the classpath, so try and pull it out of the legacy classpath
         var legacyCP = Objects.requireNonNull(System.getProperty("legacyClassPath"), "Missing legacyClassPath, cannot find client-extra").split(File.pathSeparator);
-        var extra = Paths.get(Arrays.stream(legacyCP).filter(e -> e.contains("client-extra")).findFirst().orElseThrow(() -> new IllegalStateException("Could not find client-extra in legacy classpath")));
+        var extra = findJarOnClasspath(legacyCP, "client-extra");
         mcstream.add(extra);
 
         // The MC code/Patcher edits are in exploded directories
@@ -77,9 +77,24 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
     protected List<Path> getFmlStuff(String[] classpath) {
         // We also want the FML things, fmlcore, javafmllanguage, mclanguage, I don't like hard coding these, but hey whatever works for now.
         return Arrays.stream(classpath)
-            .filter(e -> e.contains("fmlcore") || e.contains("javafmllanguage") || e.contains("lowcodelanguage") || e.contains("mclanguage"))
+            .filter(e -> {
+                // Extract file name from path
+                String name = e.substring(e.lastIndexOf(File.separatorChar) + 1);
+                return name.contains("fmlcore") || name.contains("javafmllanguage") || name.contains("lowcodelanguage") || name.contains("mclanguage");
+            })
             .map(Paths::get)
             .toList();
+    }
+
+    protected static Path findJarOnClasspath(String[] classpath, String match) {
+        return Paths.get(Arrays.stream(classpath)
+            .filter(e -> {
+                // Extract file name from path
+                String name = e.substring(e.lastIndexOf(File.separatorChar) + 1);
+                return name.contains(match);
+            })
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Could not find " + match + " in classpath")));
     }
 
     protected BiPredicate<String, String> getMcFilter(Path extra, List<Path> minecraft, Stream.Builder<List<Path>> mods) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonUserdevLaunchHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonUserdevLaunchHandler.java
@@ -10,8 +10,6 @@ import net.minecraftforge.fml.loading.VersionInfo;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -41,8 +39,4 @@ public abstract class CommonUserdevLaunchHandler extends CommonDevLaunchHandler 
     }
 
     protected abstract void processStreams(String[] classpath, VersionInfo versionInfo, Stream.Builder<Path> mc, Stream.Builder<List<Path>> mods);
-
-    protected static Path findJarOnClasspath(String[] classpath, String match) {
-        return Paths.get(Arrays.stream(classpath).filter(e -> e.contains(match)).findFirst().orElseThrow(() -> new IllegalStateException("Could not find " + match + " in classpath")));
-    }
 }


### PR DESCRIPTION
### The issue

All details and reproductions steps are outlined in issue #9098.

### The proposal

- Move `findJarOnClasspath` to `CommonDevLaunchHandler` to avoid using duplicate code to locate `client-extra`
- Add an additional step to `findJarOnClasspath` and `getFmlStuff` that extracts the file name from the path before matching. This prevents the accidental selection of paths that contain the desired string in one of their parent folder names.

Closes #9098