### PR TITLE
[1.19.x] Add HitResult to `EntityTeleportEvent$EnderPearl`

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/projectile/ThrownEnderpearl.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/ThrownEnderpearl.java.patch
@@ -4,7 +4,7 @@
           if (entity instanceof ServerPlayer) {
              ServerPlayer serverplayer = (ServerPlayer)entity;
              if (serverplayer.f_8906_.m_6198_().m_129536_() && serverplayer.f_19853_ == this.f_19853_ && !serverplayer.m_5803_()) {
-+               net.minecraftforge.event.entity.EntityTeleportEvent.EnderPearl event = net.minecraftforge.event.ForgeEventFactory.onEnderPearlLand(serverplayer, this.m_20185_(), this.m_20186_(), this.m_20189_(), this, 5.0F);
++               net.minecraftforge.event.entity.EntityTeleportEvent.EnderPearl event = net.minecraftforge.event.ForgeEventFactory.onEnderPearlLand(serverplayer, this.m_20185_(), this.m_20186_(), this.m_20189_(), this, 5.0F, p_37504_);
 +               if (!event.isCanceled()) { // Don't indent to lower patch size
                 if (this.f_19796_.m_188501_() < 0.05F && this.f_19853_.m_46469_().m_46207_(GameRules.f_46134_)) {
                    Endermite endermite = EntityType.f_20567_.m_20615_(this.f_19853_);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -720,7 +720,7 @@ public class ForgeEventFactory
     }
 
     /**
-     * @deprecated Use {@link #onEnderPearlLand(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult) the hit result-sensitive version}
+     * @deprecated Use {@linkplain #onEnderPearlLand(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult) the hit result-sensitive version}.
      */
     @ApiStatus.Internal
     @Deprecated(forRemoval = true, since = "1.19.2")

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -719,13 +719,17 @@ public class ForgeEventFactory
         return event;
     }
 
+    /**
+     * @deprecated Use {@link #onEnderPearlLand(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult) the hit result-sensitive version}
+     */
     @ApiStatus.Internal
+    @Deprecated(forRemoval = true, since = "1.19.2")
     public static EntityTeleportEvent.EnderPearl onEnderPearlLand(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage)
     {
         return onEnderPearlLand(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, null);
     }
 
-    @ApiStatus.Internal
+    @ApiStatus.Internal // TODO - 1.20: remove the nullable
     public static EntityTeleportEvent.EnderPearl onEnderPearlLand(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, @Nullable HitResult hitResult)
     {
         EntityTeleportEvent.EnderPearl event = new EntityTeleportEvent.EnderPearl(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, hitResult);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -719,9 +719,16 @@ public class ForgeEventFactory
         return event;
     }
 
+    @ApiStatus.Internal
     public static EntityTeleportEvent.EnderPearl onEnderPearlLand(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage)
     {
-        EntityTeleportEvent.EnderPearl event = new EntityTeleportEvent.EnderPearl(entity, targetX, targetY, targetZ, pearlEntity, attackDamage);
+        return onEnderPearlLand(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, null);
+    }
+
+    @ApiStatus.Internal
+    public static EntityTeleportEvent.EnderPearl onEnderPearlLand(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, @Nullable HitResult hitResult)
+    {
+        EntityTeleportEvent.EnderPearl event = new EntityTeleportEvent.EnderPearl(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, hitResult);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -166,7 +166,11 @@ public class EntityTeleportEvent extends EntityEvent
             this.hitResult = hitResult;
         }
 
+        /**
+         * @deprecated Use {@link #EnderPearl(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult)} the hit result-sensitive version}
+         */
         @ApiStatus.Internal
+        @Deprecated(forRemoval = true, since = "1.19.2")
         public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage)
         {
             this(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, null);

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -9,11 +9,14 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * EntityTeleportEvent is fired when an event involving any teleportation of an Entity occurs.<br>
@@ -150,13 +153,23 @@ public class EntityTeleportEvent extends EntityEvent
         private final ServerPlayer player;
         private final ThrownEnderpearl pearlEntity;
         private float attackDamage;
+        @Nullable
+        private final HitResult hitResult; // TODO - 1.20: make the hit result nonnull, remove the other constructor
 
-        public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage)
+        @ApiStatus.Internal
+        public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, @Nullable HitResult hitResult)
         {
             super(entity, targetX, targetY, targetZ);
             this.pearlEntity = pearlEntity;
             this.player = entity;
             this.attackDamage = attackDamage;
+            this.hitResult = hitResult;
+        }
+
+        @ApiStatus.Internal
+        public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage)
+        {
+            this(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, null);
         }
 
         public ThrownEnderpearl getPearlEntity()
@@ -167,6 +180,12 @@ public class EntityTeleportEvent extends EntityEvent
         public ServerPlayer getPlayer()
         {
             return player;
+        }
+
+        @Nullable
+        public HitResult getHitResult()
+        {
+            return this.hitResult;
         }
 
         public float getAttackDamage()

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -167,7 +167,7 @@ public class EntityTeleportEvent extends EntityEvent
         }
 
         /**
-         * @deprecated Use {@link #EnderPearl(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult)} the hit result-sensitive version}
+         * @deprecated Use {@linkplain #EnderPearl(ServerPlayer, double, double, double, ThrownEnderpearl, float, HitResult)} the hit result-sensitive version}.
          */
         @ApiStatus.Internal
         @Deprecated(forRemoval = true, since = "1.19.2")


### PR DESCRIPTION
This PR adds the pearl's `HitResult` to `EntityTeleportEvent$EnderPearl` allowing listeners to have different behaviour depending on the hit block / entity.

*Note:* until we can break binary compatibility (1.19.3 or 1.20), the hit result will remain `Nullable`.

Implements and closes #9131.