### PR TITLE
[1.19.x] Revamp how Blocks are Determined to be Nether Portal Frame Blocks

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/nether_portal_frame_blocks.json
+++ b/src/generated/resources/data/forge/tags/blocks/nether_portal_frame_blocks.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:obsidian"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -177,6 +177,8 @@ public class Tags
         public static final TagKey<Block> NEEDS_GOLD_TOOL = tag("needs_gold_tool");
         public static final TagKey<Block> NEEDS_NETHERITE_TOOL = tag("needs_netherite_tool");
 
+        public static final TagKey<Block> NETHER_PORTAL_FRAME_BLOCKS = tag("nether_portal_frame_blocks");
+
         private static TagKey<Block> tag(String name)
         {
             return BlockTags.create(new ResourceLocation("forge", name));

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -102,6 +102,7 @@ public final class ForgeBlockTagsProvider extends BlockTagsProvider
         tag(STORAGE_BLOCKS_RAW_IRON).add(Blocks.RAW_IRON_BLOCK);
         tag(STORAGE_BLOCKS_REDSTONE).add(Blocks.REDSTONE_BLOCK);
         tag(STORAGE_BLOCKS_NETHERITE).add(Blocks.NETHERITE_BLOCK);
+        tag(NETHER_PORTAL_FRAME_BLOCKS).add(Blocks.OBSIDIAN);
     }
 
     private void addColored(Consumer<Block> consumer, TagKey<Block> group, String pattern)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -5,16 +5,13 @@
 
 package net.minecraftforge.common.extensions;
 
-import java.util.Optional;
-import java.util.function.BiConsumer;
-
 import net.minecraft.client.Camera;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.SpawnPlacements;
-import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -23,34 +20,24 @@ import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.core.Direction;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.client.ForgeHooksClient;
-import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.common.IPlantable;
-
-import net.minecraft.world.level.BlockAndTintGetter;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Explosion;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.ToolAction;
-import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.common.*;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
 
 @SuppressWarnings("deprecation")
 public interface IForgeBlock
@@ -395,7 +382,7 @@ public interface IForgeBlock
      */
     default boolean isPortalFrame(BlockState state, BlockGetter level, BlockPos pos)
     {
-        return state.is(Blocks.OBSIDIAN);
+        return state.is(Tags.Blocks.NETHER_PORTAL_FRAME_BLOCKS);
     }
 
    /**


### PR DESCRIPTION
This PR creates a new Block Tag called NETHER_PORTAL_FRAME_BLOCKS and adds Vanilla Obsidian to that tag.  Then it uses the tag in IForgeBlock#isPortalFrame to check if a block in that tag can be used as a Nether Portal Frame block.  This will help make developers lives easier when trying to make a block be able to be used in a nether portal without having to overwrite or override anything just adding the block to the tag will do.

I am open to suggestions and if there is something wrong with my implementation pls lmk.
Thank You.