### PR TITLE
[1.19.x] Create Method to allow modders to easily add strippable items to STRIPPABLES

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
@@ -1,5 +1,18 @@
 --- a/net/minecraft/world/item/AxeItem.java
 +++ b/net/minecraft/world/item/AxeItem.java
+@@ -21,7 +_,11 @@
+ import net.minecraft.world.level.gameevent.GameEvent;
+ 
+ public class AxeItem extends DiggerItem {
+-   protected static final Map<Block, Block> f_150683_ = (new ImmutableMap.Builder<Block, Block>()).put(Blocks.f_50011_, Blocks.f_50044_).put(Blocks.f_49999_, Blocks.f_50010_).put(Blocks.f_50043_, Blocks.f_50049_).put(Blocks.f_50004_, Blocks.f_50009_).put(Blocks.f_50015_, Blocks.f_50048_).put(Blocks.f_50003_, Blocks.f_50008_).put(Blocks.f_50013_, Blocks.f_50046_).put(Blocks.f_50001_, Blocks.f_50006_).put(Blocks.f_50014_, Blocks.f_50047_).put(Blocks.f_50002_, Blocks.f_50007_).put(Blocks.f_50012_, Blocks.f_50045_).put(Blocks.f_50000_, Blocks.f_50005_).put(Blocks.f_50686_, Blocks.f_50687_).put(Blocks.f_50688_, Blocks.f_50689_).put(Blocks.f_50695_, Blocks.f_50696_).put(Blocks.f_50697_, Blocks.f_50698_).put(Blocks.f_220836_, Blocks.f_220837_).put(Blocks.f_220832_, Blocks.f_220835_).build();
++   protected static Map<Block, Block> f_150683_ = (new ImmutableMap.Builder<Block, Block>()).put(Blocks.f_50011_, Blocks.f_50044_).put(Blocks.f_49999_, Blocks.f_50010_).put(Blocks.f_50043_, Blocks.f_50049_).put(Blocks.f_50004_, Blocks.f_50009_).put(Blocks.f_50015_, Blocks.f_50048_).put(Blocks.f_50003_, Blocks.f_50008_).put(Blocks.f_50013_, Blocks.f_50046_).put(Blocks.f_50001_, Blocks.f_50006_).put(Blocks.f_50014_, Blocks.f_50047_).put(Blocks.f_50002_, Blocks.f_50007_).put(Blocks.f_50012_, Blocks.f_50045_).put(Blocks.f_50000_, Blocks.f_50005_).put(Blocks.f_50686_, Blocks.f_50687_).put(Blocks.f_50688_, Blocks.f_50689_).put(Blocks.f_50695_, Blocks.f_50696_).put(Blocks.f_50697_, Blocks.f_50698_).put(Blocks.f_220836_, Blocks.f_220837_).put(Blocks.f_220832_, Blocks.f_220835_).build();
++
++   public static void RegisterStrippable(Block p_41384_, Block p_41385_) {
++      f_150683_.put(p_41384_, p_41385_);
++   }
+ 
+    public AxeItem(Tier p_40521_, float p_40522_, float p_40523_, Item.Properties p_40524_) {
+       super(p_40522_, p_40523_, p_40521_, BlockTags.f_144280_, p_40524_);
 @@ -32,11 +_,9 @@
        BlockPos blockpos = p_40529_.m_8083_();
        Player player = p_40529_.m_43723_();


### PR DESCRIPTION
This will allow modders to add blocks to the strippable list of blocks without having to use an access widener.