### PR TITLE
Add support for discovering modular services

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -6,21 +6,27 @@
 package net.minecraftforge.fml.loading;
 
 import com.mojang.logging.LogUtils;
+import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
 import cpw.mods.modlauncher.api.NamedPath;
 import cpw.mods.modlauncher.serviceapi.ITransformerDiscoveryService;
 import org.slf4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
+import java.lang.module.ModuleDescriptor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.ZipFile;
+import java.util.Set;
 
 public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService {
     private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Set<String> SERVICES = Set.of(
+        "cpw.mods.modlauncher.api.ITransformationService",
+        "net.minecraftforge.forgespi.locating.IModLocator",
+        "net.minecraftforge.forgespi.locating.IDependencyLocator"
+    );
 
     @Override
     public List<NamedPath> candidates(final Path gameDirectory) {
@@ -51,14 +57,11 @@ public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService
         if (!Files.isRegularFile(path)) return;
         if (!path.toString().endsWith(".jar")) return;
         if (LamdbaExceptionUtils.uncheck(() -> Files.size(path)) == 0) return;
-        try (ZipFile zf = new ZipFile(new File(path.toUri()))) {
-            if (zf.getEntry("META-INF/services/cpw.mods.modlauncher.api.ITransformationService") != null) {
-                found.add(new NamedPath(zf.getName(), path));
-            } else if (zf.getEntry("META-INF/services/net.minecraftforge.forgespi.locating.IModLocator") != null) {
-                found.add(new NamedPath(zf.getName(), path));
-            }
-        } catch (IOException ioe) {
-            LOGGER.error("Zip Error when loading jar file {}", path, ioe);
-        }
+
+        SecureJar jar = SecureJar.from(path);
+        jar.moduleDataProvider().descriptor().provides().stream()
+            .map(ModuleDescriptor.Provides::service)
+            .filter(SERVICES::contains)
+            .forEach(s -> found.add(new NamedPath(s, path)));
     }
 }


### PR DESCRIPTION
Allows the discovery of modular service jars from the `mods` folder by replacing the old, hardcoded discovery logic with `SecureJar` API.

## The issues

### Modular jars get ignored

Currently, the service locator looks for a hardcoded set of paths that point to provider configuration files in `META-INF/services`.

https://github.com/MinecraftForge/MinecraftForge/blob/bc0517a404a0d766a715887fc554bbff4a9680ce/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java#L54-L59

However, these files don't exist in modular jars. Their purpose is fulfilled by the module descriptor, which gets completely ignored by the discoverer.

### Dependency locator discovery

Discovering `IDependencyLocator` services has never been implemented. I'm unsure whether this was intentional, but it being a public SPI interface, I think it should be discoverable along with existing services.

## The proposal

We replace the old, hardcoded discovery logic with `SecureJar`, which already supports reading service providers of both legacy and modular jars. The method we're looking for is `SecureJar.ModuleDataProvider#descriptor` - it calculates the jar's module descriptor from which we can subsequently read providers from. No additional changes to SJH are needed, and it's compatible with both legacy and modular jars.

Also add `IDependencyLocator` to the list of discoverable services.

#### Unapplicable
I've considered using `SecureJar#getProviders`, which directly returns a list of the jar's providers. However, its current implementation only looks for service configuration files, which leads us back to the main issue. Furthermore, making it compatible with modular jars would require reading the module descriptor, which is already done in `ModuleDataProvider#descriptor`  anyway. At that point, the entire method feels kinda redundant.