### PR TITLE
[1.19.3] Fix ExtendedButton not being highlighted when it's focused

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ExtendedButton.java
@@ -40,7 +40,7 @@ public class ExtendedButton extends Button
     public void renderButton(PoseStack poseStack, int mouseX, int mouseY, float partialTick)
     {
         Minecraft mc = Minecraft.getInstance();
-        int k = this.getYImage(this.isHovered);
+        int k = this.getYImage(this.isHoveredOrFocused());
         ScreenUtils.blitWithBorder(poseStack, WIDGETS_LOCATION, this.getX(), this.getY(), 0, 46 + k * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, this.getBlitOffset());
         this.renderBg(poseStack, mc, mouseX, mouseY);
 

--- a/src/main/java/net/minecraftforge/client/gui/widget/UnicodeGlyphButton.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/UnicodeGlyphButton.java
@@ -35,7 +35,7 @@ public class UnicodeGlyphButton extends ExtendedButton
         {
             Minecraft mc = Minecraft.getInstance();
             this.isHovered = mouseX >= this.getX() && mouseY >= this.getY() && mouseX < this.getX() + this.width && mouseY < this.getY() + this.height;
-            int k = this.getYImage(this.isHovered);
+            int k = this.getYImage(this.isHoveredOrFocused());
             ScreenUtils.blitWithBorder(poseStack, WIDGETS_LOCATION, this.getX(), this.getY(), 0, 46 + k * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, this.getBlitOffset());
             this.renderBg(poseStack, mc, mouseX, mouseY);
 


### PR DESCRIPTION
When a button is focused, for example when using the TAB key to navigate to it, it is usually highlighted the same way as if the cursor is hovering over it. This is not the case for ExtendedButton and UnicodeGlyphButton, and this PR fixes that.
The same fix is also included for its subclass UnicodeGlyphButton.