### PR TITLE
Fix deprecated & not working microsoft AWS indexes URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,13 @@ buildscript {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+        maven {
+            name = "Paladium-Public"
+            url = "http://repository.palagitium.dev/artifactory/Paladium-Public"
+        }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'fr.paladium.gradle:PalaForgeGradle:1.2.2-1.7.10'
     }
 }
 

--- a/fml/build.gradle
+++ b/fml/build.gradle
@@ -10,9 +10,13 @@ buildscript {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+        maven {
+            name = "Paladium-Public"
+            url = "http://repository.palagitium.dev/artifactory/Paladium-Public"
+        }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'fr.paladium.gradle:PalaForgeGradle:1.2.2-1.7.10'
     }
 }
 


### PR DESCRIPTION
Recently Microsoft/Mojang have down [https://s3.amazonaws.com/Minecraft.Download](https://s3.amazonaws.com/Minecraft.Download) like broadcasted in 2018 on Twitter [https://twitter.com/Dinnerbone/status/993773511469686784](https://twitter.com/Dinnerbone/status/993773511469686784).

Paladium (Minecraft Modded 1.7.10 server) built is own forked ForgeGradle with right URLs