### PR TITLE
Check source permission level before selector permission

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -296,12 +296,12 @@ public class ForgeHooks
     {
         MinecraftForge.EVENT_BUS.post(new LivingSetAttackTargetEvent(entity, target, targetType));
     }
-
+    
     public static LivingChangeTargetEvent onLivingChangeTarget(LivingEntity entity, LivingEntity originalTarget, ILivingTargetType targetType)
     {
         LivingChangeTargetEvent event = new LivingChangeTargetEvent(entity, originalTarget, targetType);
         MinecraftForge.EVENT_BUS.post(event);
-
+        
         return event;
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -296,12 +296,12 @@ public class ForgeHooks
     {
         MinecraftForge.EVENT_BUS.post(new LivingSetAttackTargetEvent(entity, target, targetType));
     }
-    
+
     public static LivingChangeTargetEvent onLivingChangeTarget(LivingEntity entity, LivingEntity originalTarget, ILivingTargetType targetType)
     {
         LivingChangeTargetEvent event = new LivingChangeTargetEvent(entity, originalTarget, targetType);
         MinecraftForge.EVENT_BUS.post(event);
-        
+
         return event;
     }
 
@@ -1646,10 +1646,14 @@ public class ForgeHooks
 
     public static boolean canUseEntitySelectors(SharedSuggestionProvider provider)
     {
-        if (provider instanceof CommandSourceStack source && source.source instanceof ServerPlayer player)
+        if (provider.hasPermission(Commands.LEVEL_GAMEMASTERS))
+        {
+            return true;
+        }
+        else if (provider instanceof CommandSourceStack source && source.source instanceof ServerPlayer player)
         {
             return PermissionAPI.getPermission(player, ForgeMod.USE_SELECTORS_PERMISSION);
         }
-        return provider.hasPermission(Commands.LEVEL_GAMEMASTERS);
+        return false;
     }
 }


### PR DESCRIPTION
This PR fixes #9137 by moving the command source stack permission check to _before_ the Forge entity selector permission check.

In some situations, such as execution of a function by an advancement as part of its reward, a command source stack may have a backing source of a `ServerPlayer` which may lack the entity selector permission _and_ have an explicit permission level that should allow the use of entity selectors, through `CommandSourceStack#withPermission`.

This does means that an operator permission level of 2 will always override the Forge entity selector permission.

This is a major oversight on my part, as this was brought up previously[^1] during public discussions in the Discord by @LexManos, but I forgot to do that one change before my PR was merged[^2].

[^1]: "okay, ATing field and `||`ing the permission level check to the Forge permission check" ~ sciwhiz12#1286 [in `#github-discussions`](https://canary.discord.com/channels/313125603924639766/852298000042164244/1012260131733508136)
[^2]: "Shit `@sci, señor sleepy sus 🔰` I derpeed, you didn't add the || before I pulled..." ~ Lex#4688 [in `#github-discussions`](https://canary.discord.com/channels/313125603924639766/852298000042164244/1012443862305886228)