### PR TITLE
[1.19.2] .isFarmland() method for blocks.

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/animal/Rabbit.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Rabbit.java.patch
@@ -9,3 +9,12 @@
                 return false;
              }
  
+@@ -556,7 +_,7 @@
+ 
+       protected boolean m_6465_(LevelReader p_29785_, BlockPos p_29786_) {
+          BlockState blockstate = p_29785_.m_8055_(p_29786_);
+-         if (blockstate.m_60713_(Blocks.f_50093_) && this.f_29779_ && !this.f_29780_) {
++         if (blockstate.isFarmland(p_29785_, p_29786_) && this.f_29779_ && !this.f_29780_) {
+             blockstate = p_29785_.m_8055_(p_29786_.m_7494_());
+             if (blockstate.m_60734_() instanceof CarrotBlock && ((CarrotBlock)blockstate.m_60734_()).m_52307_(blockstate)) {
+                this.f_29780_ = true;

--- a/patches/minecraft/net/minecraft/world/level/block/AttachedStemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/AttachedStemBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/AttachedStemBlock.java
++++ b/net/minecraft/world/level/block/AttachedStemBlock.java
+@@ -40,7 +_,7 @@
+    }
+ 
+    protected boolean m_6266_(BlockState p_48863_, BlockGetter p_48864_, BlockPos p_48865_) {
+-      return p_48863_.m_60713_(Blocks.f_50093_);
++      return p_48863_.isFarmland(p_48864_, p_48865_);
+    }
+ 
+    public ItemStack m_7397_(BlockGetter p_48838_, BlockPos p_48839_, BlockState p_48840_) {

--- a/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/Block.java.patch
@@ -141,11 +141,11 @@
 +      } else if (net.minecraftforge.common.PlantType.NETHER.equals(type)) {
 +         return this == Blocks.f_50135_;
 +      } else if (net.minecraftforge.common.PlantType.CROP.equals(type)) {
-+         return state.m_60713_(Blocks.f_50093_);
++         return state.isFarmland(world, pos);
 +      } else if (net.minecraftforge.common.PlantType.CAVE.equals(type)) {
 +         return state.m_60783_(world, pos, Direction.UP);
 +      } else if (net.minecraftforge.common.PlantType.PLAINS.equals(type)) {
-+         return this == Blocks.f_50440_ || this.m_49966_().m_204336_(BlockTags.f_144274_) || this == Blocks.f_50093_;
++         return this == Blocks.f_50440_ || this.m_49966_().m_204336_(BlockTags.f_144274_) || this.m_49966_().isFarmland(world, pos);
 +      } else if (net.minecraftforge.common.PlantType.WATER.equals(type)) {
 +         return state.m_60767_() == net.minecraft.world.level.material.Material.f_76305_; //&& state.getValue(BlockLiquidWrapper)
 +      } else if (net.minecraftforge.common.PlantType.BEACH.equals(type)) {

--- a/patches/minecraft/net/minecraft/world/level/block/BushBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BushBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/BushBlock.java
 +++ b/net/minecraft/world/level/block/BushBlock.java
-@@ -10,7 +_,7 @@
+@@ -10,13 +_,13 @@
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.pathfinder.PathComputationType;
  
@@ -9,6 +9,13 @@
     public BushBlock(BlockBehaviour.Properties p_51021_) {
        super(p_51021_);
     }
+ 
+    protected boolean m_6266_(BlockState p_51042_, BlockGetter p_51043_, BlockPos p_51044_) {
+-      return p_51042_.m_204336_(BlockTags.f_144274_) || p_51042_.m_60713_(Blocks.f_50093_);
++      return p_51042_.m_204336_(BlockTags.f_144274_) || p_51042_.isFarmland(p_51043_, p_51044_);
+    }
+ 
+    public BlockState m_7417_(BlockState p_51032_, Direction p_51033_, BlockState p_51034_, LevelAccessor p_51035_, BlockPos p_51036_, BlockPos p_51037_) {
 @@ -25,6 +_,8 @@
  
     public boolean m_7898_(BlockState p_51028_, LevelReader p_51029_, BlockPos p_51030_) {

--- a/patches/minecraft/net/minecraft/world/level/block/CropBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CropBlock.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/block/CropBlock.java
 +++ b/net/minecraft/world/level/block/CropBlock.java
+@@ -36,7 +_,7 @@
+    }
+ 
+    protected boolean m_6266_(BlockState p_52302_, BlockGetter p_52303_, BlockPos p_52304_) {
+-      return p_52302_.m_60713_(Blocks.f_50093_);
++      return p_52302_.isFarmland(p_52303_, p_52304_);
+    }
+ 
+    public IntegerProperty m_7959_() {
 @@ -64,12 +_,14 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/world/level/block/StemBlock.java
 +++ b/net/minecraft/world/level/block/StemBlock.java
-@@ -43,22 +_,24 @@
+@@ -39,26 +_,28 @@
+    }
+ 
+    protected boolean m_6266_(BlockState p_57053_, BlockGetter p_57054_, BlockPos p_57055_) {
+-      return p_57053_.m_60713_(Blocks.f_50093_);
++      return p_57053_.isFarmland(p_57054_, p_57055_);
     }
  
     public void m_213898_(BlockState p_222538_, ServerLevel p_222539_, BlockPos p_222540_, RandomSource p_222541_) {
@@ -20,7 +25,7 @@
                 BlockState blockstate = p_222539_.m_8055_(blockpos.m_7495_());
 -               if (p_222539_.m_8055_(blockpos).m_60795_() && (blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
 +               Block block = blockstate.m_60734_();
-+               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this) || block == Blocks.f_50093_ || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
++               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this) || blockstate.isFarmland(p_222539_, blockpos.m_7495_()) || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
                    p_222539_.m_46597_(blockpos, this.f_57015_.m_49966_());
                    p_222539_.m_46597_(p_222540_, this.f_57015_.m_7810_().m_49966_().m_61124_(HorizontalDirectionalBlock.f_54117_, direction));
                 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -329,6 +329,17 @@ public interface IForgeBlock
     boolean canSustainPlant(BlockState state, BlockGetter level, BlockPos pos, Direction facing, IPlantable plantable);
 
     /**
+     * Determines if the block is considered farmland, allowing certain Crops and plants to be placed on it, and for Rabbits to target it.
+     * @param blockState The current state.
+     * @param level The current level.
+     * @param pos The position of the farmland block.
+     * @return True to treat this as farmland.
+     */
+    default boolean isFarmland(BlockState blockState, BlockGetter level, BlockPos pos) {
+        return blockState.is(Blocks.FARMLAND);
+    }
+
+    /**
      * Called when a tree grows on top of this block and tries to set it to dirt by the trunk placer.
      * An override that returns true is responsible for using the place function to
      * set blocks in the world properly during generation. A modded grass block might override this method

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -278,6 +278,16 @@ public interface IForgeBlockState
     }
 
     /**
+     * Determines if the block is considered farmland, allowing certain Crops and plants to be placed on it, and for Rabbits to target it.
+     * @param level The current level.
+     * @param pos The position of the farmland block.
+     * @return True to treat this as farmland.
+     */
+    default boolean isFarmland(BlockGetter level, BlockPos pos) {
+        return self().getBlock().isFarmland(self(), level, pos);
+    }
+
+    /**
      * Called when a tree grows on top of this block and tries to set it to dirt by the trunk placer.
      * An override that returns true is responsible for using the place function to
      * set blocks in the world properly during generation. A modded grass block might override this method


### PR DESCRIPTION
Normally the behavior for allowing crops to be placed and persist on farmland is hardcoded to `Blocks.FARMLAND`. This PR makes it so the behavior is instead based on calling a method `.isFarmland()` in `IForgeBlockState` or `IForgeBlock`. This allows modded blocks to be able to override the method from `IForgeBlock` to let a block behave as farmland without issue.