### PR TITLE
SwapHandItemsEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -397,6 +397,22 @@
        if (!this.f_20911_ || this.f_20913_ >= this.m_21304_() / 2 || this.f_20913_ < 0) {
           this.f_20913_ = -1;
           this.f_20911_ = true;
+@@ -1784,9 +_,12 @@
+    }
+ 
+    private void m_21312_() {
+-      ItemStack itemstack = this.m_6844_(EquipmentSlot.OFFHAND);
+-      this.m_8061_(EquipmentSlot.OFFHAND, this.m_6844_(EquipmentSlot.MAINHAND));
+-      this.m_8061_(EquipmentSlot.MAINHAND, itemstack);
++      final ItemStack offHand = this.m_6844_(EquipmentSlot.OFFHAND);
++      final ItemStack mainHand = this.m_6844_(EquipmentSlot.MAINHAND);
++      final var event = net.minecraftforge.common.ForgeHooks.onSwapHandItems(this, mainHand, offHand);
++      if (event.isCanceled()) return;
++      this.m_8061_(EquipmentSlot.OFFHAND, event.getMainHand());
++      this.m_8061_(EquipmentSlot.MAINHAND, event.getOffHand());
+    }
+ 
+    protected void m_6088_() {
 @@ -1972,14 +_,17 @@
        }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -145,6 +144,7 @@ import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.living.LivingUseTotemEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.living.ShieldBlockEvent;
+import net.minecraftforge.event.entity.living.SwapHandItemsEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
@@ -1367,6 +1367,13 @@ public class ForgeHooks
     public static ShieldBlockEvent onShieldBlock(LivingEntity blocker, DamageSource source, float blocked)
     {
         ShieldBlockEvent e = new ShieldBlockEvent(blocker, source, blocked);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e;
+    }
+
+    public static SwapHandItemsEvent onSwapHandItems(final LivingEntity entity, final ItemStack mainHand, final ItemStack offHand)
+    {
+        final SwapHandItemsEvent e = new SwapHandItemsEvent(entity, mainHand, offHand);
         MinecraftForge.EVENT_BUS.post(e);
         return e;
     }

--- a/src/main/java/net/minecraftforge/event/entity/living/SwapHandItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/SwapHandItemsEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;

--- a/src/main/java/net/minecraftforge/event/entity/living/SwapHandItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/SwapHandItemsEvent.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+@Cancelable
+public class SwapHandItemsEvent extends LivingEvent {
+
+    private ItemStack offHand;
+    private ItemStack mainHand;
+
+    public SwapHandItemsEvent(final LivingEntity entity, final ItemStack mainHand, final ItemStack offHand) {
+        super(entity);
+        this.mainHand = mainHand;
+        this.offHand = offHand;
+    }
+
+    public ItemStack getOffHand() {
+        return this.offHand;
+    }
+
+    public void setOffHand(final ItemStack newOffHand) {
+        this.offHand = newOffHand;
+    }
+
+    public ItemStack getMainHand() {
+        return this.mainHand;
+    }
+
+    public void setMainHand(final ItemStack newMainHand) {
+        this.mainHand = newMainHand;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/living/SwapHandItemsEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/SwapHandItemsEventTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.living;
+
+import com.mojang.logging.LogUtils;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.SwapHandItemsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
+
+@Mod("swap_hand_items_event_test")
+public class SwapHandItemsEventTest {
+    public static final boolean ENABLE = true;
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public SwapHandItemsEventTest() {
+        if (ENABLE) MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onSwapHandItems(final SwapHandItemsEvent event) {
+        LOGGER.info("Main hand: {}", event.getMainHand());
+        LOGGER.info("Off-hand: {}", event.getOffHand());
+        if (event.getEntity().isSprinting())
+            event.setCanceled(true);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -22,6 +22,9 @@ license="LGPL v2.1"
 [[mods]]
     modId="shader_resources_test"
 
+[[mods]]
+    modId="swap_hand_items_event_test"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
Adds an event for when someone swaps hands for an item (default keybind of F). Supplies the entity and the `ItemStack`s of each hand before the event was fired. Consumers can cancel the event to cancel the action or change the `ItemStack`s on either hand.

The test mod prevents swapping hands while sprinting.