### PR TITLE
[1.18] Improve extensibility of DetectorRailBlock and PoweredRailBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/BaseRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BaseRailBlock.java.patch
@@ -35,30 +35,30 @@
              p_49385_.m_46672_(p_49386_.m_7494_(), this);
           }
  
-@@ -139,6 +_,7 @@
+@@ -139,6 +_,11 @@
        return blockstate.m_61124_(this.m_7978_(), flag1 ? RailShape.EAST_WEST : RailShape.NORTH_SOUTH).m_61124_(f_152149_, Boolean.valueOf(flag));
     }
  
-+   @Deprecated //Forge: Use getRailDirection(IBlockAccess, BlockPos, IBlockState, EntityMinecart) for enhanced ability
++   /**
++    * @deprecated Forge: Use {@link BaseRailBlock#getRailDirection(BlockState, BlockGetter, BlockPos, net.minecraft.world.entity.vehicle.AbstractMinecart)} for enhanced ability
++    * If you do change this property be aware that other functions in this/subclasses may break as they can make assumptions about this property
++    */
++   @Deprecated
     public abstract Property<RailShape> m_7978_();
  
     public BlockState m_7417_(BlockState p_152151_, Direction p_152152_, BlockState p_152153_, LevelAccessor p_152154_, BlockPos p_152155_, BlockPos p_152156_) {
-@@ -152,4 +_,18 @@
+@@ -152,4 +_,14 @@
     public FluidState m_5888_(BlockState p_152158_) {
        return p_152158_.m_61143_(f_152149_) ? Fluids.f_76193_.m_76068_(false) : super.m_5888_(p_152158_);
     }
 +
-+    /* ======================================== FORGE START =====================================*/
-+
 +    @Override
-+    public boolean isFlexibleRail(BlockState state, BlockGetter world, BlockPos pos)
-+    {
-+        return  !this.f_49357_;
++    public boolean isFlexibleRail(BlockState state, BlockGetter world, BlockPos pos) {
++        return !this.f_49357_;
 +    }
 +
 +    @Override
 +    public RailShape getRailDirection(BlockState state, BlockGetter world, BlockPos pos, @javax.annotation.Nullable net.minecraft.world.entity.vehicle.AbstractMinecart cart) {
 +        return state.m_61143_(m_7978_());
 +    }
-+    /* ========================================= FORGE END ======================================*/
  }

--- a/patches/minecraft/net/minecraft/world/level/block/DetectorRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/DetectorRailBlock.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/world/level/block/DetectorRailBlock.java
 +++ b/net/minecraft/world/level/block/DetectorRailBlock.java
+@@ -31,6 +_,10 @@
+ 
+    public DetectorRailBlock(BlockBehaviour.Properties p_52431_) {
+       super(true, p_52431_);
++      this.registerDefaultState();
++   }
++
++   protected void registerDefaultState() {
+       this.m_49959_(this.f_49792_.m_61090_().m_61124_(f_52428_, Boolean.valueOf(false)).m_61124_(f_52427_, RailShape.NORTH_SOUTH).m_61124_(f_152149_, Boolean.valueOf(false)));
+    }
+ 
 @@ -135,7 +_,9 @@
              return list.get(0).m_38534_().m_45436_();
           }
@@ -11,3 +22,11 @@
           if (!list1.isEmpty()) {
              return AbstractContainerMenu.m_38938_((Container)list1.get(0));
           }
+@@ -270,6 +_,6 @@
+    }
+ 
+    protected void m_7926_(StateDefinition.Builder<Block, BlockState> p_52469_) {
+-      p_52469_.m_61104_(f_52427_, f_52428_, f_152149_);
++      p_52469_.m_61104_(m_7978_(), f_52428_, f_152149_);
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/level/block/PoweredRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PoweredRailBlock.java.patch
@@ -1,40 +1,62 @@
 --- a/net/minecraft/world/level/block/PoweredRailBlock.java
 +++ b/net/minecraft/world/level/block/PoweredRailBlock.java
-@@ -14,10 +_,16 @@
+@@ -14,9 +_,19 @@
  public class PoweredRailBlock extends BaseRailBlock {
     public static final EnumProperty<RailShape> f_55214_ = BlockStateProperties.f_61404_;
     public static final BooleanProperty f_55215_ = BlockStateProperties.f_61448_;
 +   private final boolean isActivator;  // TRUE for an Activator Rail, FALSE for Powered Rail
  
     public PoweredRailBlock(BlockBehaviour.Properties p_55218_) {
--      super(true, p_55218_);
 +      this(p_55218_, false);
 +   }
 +
-+   protected PoweredRailBlock(BlockBehaviour.Properties builder, boolean isPoweredRail) {
-+      super(true, builder);
-       this.m_49959_(this.f_49792_.m_61090_().m_61124_(f_55214_, RailShape.NORTH_SOUTH).m_61124_(f_55215_, Boolean.valueOf(false)).m_61124_(f_152149_, Boolean.valueOf(false)));
++   protected PoweredRailBlock(BlockBehaviour.Properties p_55218_, boolean isPoweredRail) {
+       super(true, p_55218_);
 +      this.isActivator = !isPoweredRail;
++      this.registerDefaultState();
++   }
++
++   protected void registerDefaultState() {
+       this.m_49959_(this.f_49792_.m_61090_().m_61124_(f_55214_, RailShape.NORTH_SOUTH).m_61124_(f_55215_, Boolean.valueOf(false)).m_61124_(f_152149_, Boolean.valueOf(false)));
     }
  
-    protected boolean m_55219_(Level p_55220_, BlockPos p_55221_, BlockState p_55222_, boolean p_55223_, int p_55224_) {
-@@ -99,13 +_,13 @@
+@@ -28,7 +_,7 @@
+          int j = p_55221_.m_123342_();
+          int k = p_55221_.m_123343_();
+          boolean flag = true;
+-         RailShape railshape = p_55222_.m_61143_(f_55214_);
++         RailShape railshape = p_55222_.m_61143_(m_7978_());
+          switch(railshape) {
+          case NORTH_SOUTH:
+             if (p_55223_) {
+@@ -99,14 +_,14 @@
  
     protected boolean m_55225_(Level p_55226_, BlockPos p_55227_, boolean p_55228_, int p_55229_, RailShape p_55230_) {
        BlockState blockstate = p_55226_.m_8055_(p_55227_);
 -      if (!blockstate.m_60713_(this)) {
-+      if (!(blockstate.m_60734_() instanceof PoweredRailBlock)) {
++      if (!(blockstate.m_60734_() instanceof PoweredRailBlock other)) {
           return false;
        } else {
 -         RailShape railshape = blockstate.m_61143_(f_55214_);
-+         RailShape railshape = getRailDirection(blockstate, p_55226_, p_55227_, null);
++         RailShape railshape = other.getRailDirection(blockstate, p_55226_, p_55227_, null);
           if (p_55230_ != RailShape.EAST_WEST || railshape != RailShape.NORTH_SOUTH && railshape != RailShape.ASCENDING_NORTH && railshape != RailShape.ASCENDING_SOUTH) {
              if (p_55230_ != RailShape.NORTH_SOUTH || railshape != RailShape.EAST_WEST && railshape != RailShape.ASCENDING_EAST && railshape != RailShape.ASCENDING_WEST) {
 -               if (blockstate.m_61143_(f_55215_)) {
-+               if (isActivator == (((PoweredRailBlock) blockstate.m_60734_()).isActivator)) {
-                   return p_55226_.m_46753_(p_55227_) ? true : this.m_55219_(p_55226_, p_55227_, blockstate, p_55228_, p_55229_ + 1);
+-                  return p_55226_.m_46753_(p_55227_) ? true : this.m_55219_(p_55226_, p_55227_, blockstate, p_55228_, p_55229_ + 1);
++               if (isActivatorRail() == other.isActivatorRail()) {
++                  return p_55226_.m_46753_(p_55227_) ? true : other.m_55219_(p_55226_, p_55227_, blockstate, p_55228_, p_55229_ + 1);
                 } else {
                    return false;
+                }
+@@ -125,7 +_,7 @@
+       if (flag1 != flag) {
+          p_55233_.m_7731_(p_55234_, p_55232_.m_61124_(f_55215_, Boolean.valueOf(flag1)), 3);
+          p_55233_.m_46672_(p_55234_.m_7495_(), this);
+-         if (p_55232_.m_61143_(f_55214_).m_61745_()) {
++         if (p_55232_.m_61143_(m_7978_()).m_61745_()) {
+             p_55233_.m_46672_(p_55234_.m_7494_(), this);
+          }
+       }
 @@ -156,6 +_,9 @@
              return p_55240_.m_61124_(f_55214_, RailShape.SOUTH_EAST);
           case NORTH_EAST:
@@ -45,10 +67,12 @@
           }
        case COUNTERCLOCKWISE_90:
           switch((RailShape)p_55240_.m_61143_(f_55214_)) {
-@@ -254,5 +_,9 @@
+@@ -253,6 +_,10 @@
+    }
  
     protected void m_7926_(StateDefinition.Builder<Block, BlockState> p_55243_) {
-       p_55243_.m_61104_(f_55214_, f_55215_, f_152149_);
+-      p_55243_.m_61104_(f_55214_, f_55215_, f_152149_);
++      p_55243_.m_61104_(m_7978_(), f_55215_, f_152149_);
 +   }
 +
 +   public boolean isActivatorRail() {

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -61,6 +61,7 @@ net/minecraft/world/level/LevelSettings.<init>(Ljava/lang/String;Lnet/minecraft/
 net/minecraft/world/level/block/FireBlock.tryCatchFire(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;ILjava/util/Random;ILnet/minecraft/core/Direction;)V=|p_53432_,p_53433_,p_53434_,p_53435_,p_53436_,face
 net/minecraft/world/level/block/FlowerPotBlock.<init>(Ljava/util/function/Supplier;Ljava/util/function/Supplier;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V=|emptyPot,p_53528_,properties
 net/minecraft/world/level/block/LiquidBlock.<init>(Ljava/util/function/Supplier;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V=|p_54694_,p_54695_
+net/minecraft/world/level/block/PoweredRailBlock.<init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;Z)V=|p_55218_,isPoweredRail
 net/minecraft/world/level/dimension/LevelStem.<init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/level/chunk/ChunkGenerator;Z)V=|p_204519_,p_204520_,useServerSeed
 net/minecraft/world/level/entity/PersistentEntitySectionManager.addEntityWithoutEvent(Lnet/minecraft/world/level/entity/EntityAccess;Z)Z=|p_157539_,p_157540_
 net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.processEntityInfos(Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Ljava/util/List;)Ljava/util/List;=|template,p_215387_0_,p_215387_1_,p_215387_2_,p_215387_3_

--- a/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BlockGrowFeatureTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.data.worldgen.features.TreeFeatures;


### PR DESCRIPTION
LTS backport of #9130.

This PR improves the extensibility of the `DetectorRailBlock` and `PoweredRailBlock` by:
1. Allowing the implementor to pass in the blockstate property and associated value for the default state
2. Using the shape property getter to get the shape in `PoweredRailBlock#findPoweredRailSignal()`
3. Using the correct block to get the rail direction from in `PoweredRailBlock#isSameRailWithPower()`.

The main use case for this is something like a rail slope block with "underfill" that can only use ascending shapes and therefore should use a custom `EnumProperty<RailShape>`.