### PR TITLE
[1.19.x] Fix invalidated modded packets when on LAN

### DIFF
--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -51,5 +51,5 @@
 +
 +   @Override public int getIndex() { return Integer.MAX_VALUE; }
 +   @Override public ResourceLocation getName() { return m_132042_(); }
-+   @org.jetbrains.annotations.Nullable @Override public FriendlyByteBuf getInternalData() { return this.f_132030_; }
++   @Override public FriendlyByteBuf getInternalData() { return new FriendlyByteBuf(this.f_132030_.copy()); }
  }

--- a/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/protocol/game/ClientboundCustomPayloadPacket.java.patch
@@ -51,5 +51,5 @@
 +
 +   @Override public int getIndex() { return Integer.MAX_VALUE; }
 +   @Override public ResourceLocation getName() { return m_132042_(); }
-+   @Override public FriendlyByteBuf getInternalData() { return new FriendlyByteBuf(this.f_132030_.copy()); }
++   @Override public FriendlyByteBuf getInternalData() { return m_132045_(); }
  }


### PR DESCRIPTION
In 41deadc1e260da8730fb7543f7f037a7dee53745, the sending of modded packets on LAN was subtly broken. The implementation of custom payload packets (aka. modded packets) was changed so the internal buffer was no longer copied every time it was consumed. This leads to issues on LAN worlds where a packet is sent to two or more clients from the LAN host *including* to the LAN host themself. Depending on the order that the packet is sent by the LAN host or read by the LAN host first, the packet buffer can be consumed and produce garbage data. If the packet is read by the LAN host before it is sent, the packet buffer will be consumed and the reader index of the ByteBuf will be past the contents of the packet in the buffer. Sending to other clients after this point produces invalid garbage data as seen by this log:
```
[13:34:24] [Netty Client IO #0/ERROR] [ne.mi.ne.si.IndexedMessageCodec/SIMPLENET]: Received invalid discriminator byte 210 on channel examplemod:main
[13:34:24] [Render thread/WARN] [minecraft/ClientPacketListener]: Unknown custom packet identifier: examplemod:main
```
(The discriminator byte in use is 0). Note that this logspam *only* appears on the connected LAN client to which the packet was sent. There is no evidence of invalid packets in the logs of the LAN host, as the packet is consumed perfectly fine.

This bug can be easily reproduced with a stock MDK and a custom ExampleMod class:
<details>
<summary>ExampleMod.java</summary>

```java
package com.example.examplemod;

import net.minecraft.network.FriendlyByteBuf;
import net.minecraft.resources.ResourceLocation;
import net.minecraft.server.level.ServerPlayer;
import net.minecraftforge.common.MinecraftForge;
import net.minecraftforge.event.TickEvent;
import net.minecraftforge.eventbus.api.SubscribeEvent;
import net.minecraftforge.fml.common.Mod;
import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
import net.minecraftforge.network.NetworkDirection;
import net.minecraftforge.network.NetworkEvent;
import net.minecraftforge.network.NetworkRegistry;
import net.minecraftforge.network.PacketDistributor;
import net.minecraftforge.network.simple.SimpleChannel;

import java.util.Optional;
import java.util.function.Supplier;

@Mod(ExampleMod.MODID)
@Mod.EventBusSubscriber(modid = ExampleMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
public class ExampleMod {
    public static final String MODID = "examplemod";
    private static final String PROTOCOL_VERSION = "1.0";
    private static final int DATA_CONSTANT = 1_838_290;
    private static final SimpleChannel NETWORK_INSTANCE = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, "main"),
            () -> PROTOCOL_VERSION,
            PROTOCOL_VERSION::equals,
            PROTOCOL_VERSION::equals
    );

    public ExampleMod() {
        MinecraftForge.EVENT_BUS.addListener(this::onPlayerTick);
    }

    private void onPlayerTick(TickEvent.PlayerTickEvent event) {
        // Run at start of every tick for singleplayer owner on server LAN world
        if (event.phase != TickEvent.Phase.START || !(event.player instanceof ServerPlayer player) || !player.getLevel().getServer().isSingleplayerOwner(player.getGameProfile()))
            return;

        // Bug only occurs with more than one person online on LAN
        if (player.getLevel().getServer().getPlayerList().getPlayers().size() > 1) {
            NETWORK_INSTANCE.send(PacketDistributor.ALL.noArg(), new SendDataPacket(DATA_CONSTANT));
        }
    }

    @SubscribeEvent
    public static void onCommonSetup(FMLCommonSetupEvent event) {
        NETWORK_INSTANCE.registerMessage(0, SendDataPacket.class, SendDataPacket::encode, SendDataPacket::new,
                SendDataPacket::handle, Optional.of(NetworkDirection.PLAY_TO_CLIENT));
    }

    private record SendDataPacket(int data) {
        SendDataPacket(FriendlyByteBuf buf) {
            this(buf.readVarInt());
        }

        void encode(FriendlyByteBuf buf) {
            buf.writeVarInt(this.data);
        }

        void handle(Supplier<NetworkEvent.Context> networkContext) {
            // We don't need to do anything here. The logspam speaks for itself.
            networkContext.get().setPacketHandled(true);
        }
    }
}
```

</details>

In the `build.gradle`, you must also add `args '--username', 'Dev#####'` inside `minecraft { runs { client {} } }` (around line 54) so that you can have multiple instances open at once and connect to the same LAN world with different usernames.

To test, just run the mod on two clients, open a LAN world on one, and join from the other. See log spam on LAN client.

Using the test mod and updated forge version from this PR shows no more log spam, and that the packets are properly sent with the right data to both LAN host and LAN clients.