### PR TITLE
[1.18.x] Make Util.memoize thread-safe

### DIFF
--- a/patches/minecraft/net/minecraft/Util.java.patch
+++ b/patches/minecraft/net/minecraft/Util.java.patch
@@ -19,11 +19,12 @@
           if (SharedConstants.f_136183_) {
              throw illegalargumentexception;
           }
-@@ -649,7 +_,7 @@
+@@ -649,7 +_,8 @@
  
     public static <T, R> Function<T, R> m_143827_(final Function<T, R> p_143828_) {
        return new Function<T, R>() {
 -         private final Map<T, R> f_143852_ = Maps.newHashMap();
++         // FORGE: Allow using memoized functions from multiple threads.
 +         private final Map<T, R> f_143852_ = Maps.newConcurrentMap();
  
           public R apply(T p_211578_) {

--- a/patches/minecraft/net/minecraft/Util.java.patch
+++ b/patches/minecraft/net/minecraft/Util.java.patch
@@ -19,3 +19,12 @@
           if (SharedConstants.f_136183_) {
              throw illegalargumentexception;
           }
+@@ -649,7 +_,7 @@
+ 
+    public static <T, R> Function<T, R> m_143827_(final Function<T, R> p_143828_) {
+       return new Function<T, R>() {
+-         private final Map<T, R> f_143852_ = Maps.newHashMap();
++         private final Map<T, R> f_143852_ = Maps.newConcurrentMap();
+ 
+          public R apply(T p_211578_) {
+             return this.f_143852_.computeIfAbsent(p_211578_, p_143828_);


### PR DESCRIPTION
This is a backport of #9155 to 1.18. As 1.18 is also using Java 17, the performance notes from the original PR should be the same here.