### PR TITLE
simpleBlock method with path for block texture to be in subfolder

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -162,6 +162,11 @@ public abstract class BlockStateProvider implements DataProvider {
         return new ResourceLocation(name.getNamespace(), ModelProvider.BLOCK_FOLDER + "/" + name.getPath());
     }
 
+    public ResourceLocation blockTexture(Block block, String folder) {
+        ResourceLocation name = key(block);
+        return new ResourceLocation(name.getNamespace(), ModelProvider.BLOCK_FOLDER + "/" + folder + "/" + name.getPath());
+    }
+
     private ResourceLocation extend(ResourceLocation rl, String suffix) {
         return new ResourceLocation(rl.getNamespace(), rl.getPath() + suffix);
     }
@@ -170,8 +175,16 @@ public abstract class BlockStateProvider implements DataProvider {
         return models().cubeAll(name(block), blockTexture(block));
     }
 
+    public ModelFile cubeAll(Block block, String path) {
+        return models().cubeAll(name(block), blockTexture(block, path));
+    }
+
     public void simpleBlock(Block block) {
         simpleBlock(block, cubeAll(block));
+    }
+
+    public void simpleBlock(Block block, String path){
+        simpleBlock(block, cubeAll(block, path));
     }
 
     public void simpleBlock(Block block, Function<ModelFile, ConfiguredModel[]> expander) {


### PR DESCRIPTION
Allows modders to put block textures in subfolders while using simpleBlock without having to manually do it.  This can help with organization for modders with their textures

A use case I have in mind is putting all of my ores in block/ores/ 
without having to do             
BlockModelBuilder oreBlock = this.models().singleTexture(name, mcLoc("block/cube_all"), "all", MODID.id("block/ores/" + name));
this.simpleBlock(ore.get(), oreBlock);
simpleBlockItem(ore.get(), oreBlock);

you could just do 
simpleBlock(ore.get, "ores");
simpleBlockItem(ore.get(), this.cubeAll(ore.get(), "ores"));
