### PR TITLE
Fix searching using the wrong prefix for items or tags.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -18,7 +18,7 @@
           this.m_98630_();
        } else {
           (this.f_97732_).f_98639_.addAll(p_261591_);
-@@ -273,6 +_,31 @@
+@@ -273,6 +_,34 @@
     protected void m_7856_() {
        if (this.f_96541_.f_91072_.m_105290_()) {
           super.m_7856_();
@@ -47,6 +47,9 @@
 +            m_142416_(net.minecraft.client.gui.components.Button.m_253074_(Component.m_237113_(">"), b -> setCurrentPage(this.pages.get(Math.min(this.pages.indexOf(this.currentPage) + 1, this.pages.size() - 1)))).m_252794_(f_97735_ + f_97726_ - 20, f_97736_ - 50).m_253046_(20, 20).m_253136_());
 +         }
 +         this.currentPage = this.pages.stream().filter(page -> page.getVisibleTabs().contains(f_98507_)).findFirst().orElse(this.currentPage);
++         if (!this.currentPage.getVisibleTabs().contains(f_98507_)) {
++            f_98507_ = this.currentPage.getVisibleTabs().get(0);
++         }
           this.f_98510_ = new EditBox(this.f_96547_, this.f_97735_ + 82, this.f_97736_ + 6, 80, 9, Component.m_237115_("itemGroup.search"));
           this.f_98510_.m_94199_(50);
           this.f_98510_.m_94182_(false);

--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -80,11 +80,11 @@
           if (s.startsWith("#")) {
              s = s.substring(1);
 -            searchtree = this.f_96541_.m_231372_(SearchRegistry.f_119942_);
-+            searchtree = this.f_96541_.m_231372_(net.minecraftforge.client.CreativeModeTabSearchRegistry.getNameSearchKey(f_98507_));
++            searchtree = this.f_96541_.m_231372_(net.minecraftforge.client.CreativeModeTabSearchRegistry.getTagSearchKey(f_98507_));
              this.m_98619_(s);
           } else {
 -            searchtree = this.f_96541_.m_231372_(SearchRegistry.f_119941_);
-+            searchtree = this.f_96541_.m_231372_(net.minecraftforge.client.CreativeModeTabSearchRegistry.getTagSearchKey(f_98507_));
++            searchtree = this.f_96541_.m_231372_(net.minecraftforge.client.CreativeModeTabSearchRegistry.getNameSearchKey(f_98507_));
           }
  
           (this.f_97732_).f_98639_.addAll(searchtree.m_6293_(s.toLowerCase(Locale.ROOT)));

--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -18,7 +18,7 @@
           this.m_98630_();
        } else {
           (this.f_97732_).f_98639_.addAll(p_261591_);
-@@ -273,6 +_,30 @@
+@@ -273,6 +_,31 @@
     protected void m_7856_() {
        if (this.f_96541_.f_91072_.m_105290_()) {
           super.m_7856_();
@@ -46,6 +46,7 @@
 +            m_142416_(net.minecraft.client.gui.components.Button.m_253074_(Component.m_237113_("<"), b -> setCurrentPage(this.pages.get(Math.max(this.pages.indexOf(this.currentPage) - 1, 0)))).m_252794_(f_97735_,  f_97736_ - 50).m_253046_(20, 20).m_253136_());
 +            m_142416_(net.minecraft.client.gui.components.Button.m_253074_(Component.m_237113_(">"), b -> setCurrentPage(this.pages.get(Math.min(this.pages.indexOf(this.currentPage) + 1, this.pages.size() - 1)))).m_252794_(f_97735_ + f_97726_ - 20, f_97736_ - 50).m_253046_(20, 20).m_253136_());
 +         }
++         this.currentPage = this.pages.stream().filter(page -> page.getVisibleTabs().contains(f_98507_)).findFirst().orElse(this.currentPage);
           this.f_98510_ = new EditBox(this.f_96547_, this.f_97735_ + 82, this.f_97736_ + 6, 80, 9, Component.m_237115_("itemGroup.search"));
           this.f_98510_.m_94199_(50);
           this.f_98510_.m_94182_(false);

--- a/src/main/java/net/minecraftforge/client/CreativeModeTabSearchRegistry.java
+++ b/src/main/java/net/minecraftforge/client/CreativeModeTabSearchRegistry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.client;
 
 import java.util.IdentityHashMap;

--- a/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.data;
 
 import net.minecraft.Util;


### PR DESCRIPTION
Fixes #9176 
Fixes #9179 

Fixes the searching for names and tags being flipped with respect to their prefix '#'.
Fixes the current page not jumping back to what it is supposed to be.
Checks now if the previously selected page is even displayable currently.