### PR TITLE
[1.19.3] Fix chat offset

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
@@ -575,7 +575,7 @@ public class ForgeGui extends Gui
         minecraft.getProfiler().push("chat");
 
         Window window = minecraft.getWindow();
-        var event = new CustomizeGuiOverlayEvent.Chat(window, pStack, minecraft.getFrameTime(), 0, height - 48);
+        var event = new CustomizeGuiOverlayEvent.Chat(window, pStack, minecraft.getFrameTime(), 0, height - 40);
         MinecraftForge.EVENT_BUS.post(event);
 
         pStack.pushPose();


### PR DESCRIPTION
This PR fixes the chat offset in `ForgeGui` which was off by 8 pixels.