### PR TITLE
[1.19.3] Add event before baked models are cached by the BlockModelShaper

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -35,6 +35,15 @@
        CompletableFuture<Map<ResourceLocation, BlockModel>> completablefuture = m_246704_(p_251134_, p_250550_);
        CompletableFuture<Map<ResourceLocation, List<ModelBakery.LoadedJson>>> completablefuture1 = m_246899_(p_251134_, p_250550_);
        CompletableFuture<ModelBakery> completablefuture2 = completablefuture.thenCombineAsync(completablefuture1, (p_251201_, p_251281_) -> {
+@@ -172,6 +_,8 @@
+             return "    " + p_248692_.m_119193_() + ":" + p_248692_.m_119203_();
+          }).collect(Collectors.joining("\n")));
+       });
++      p_252136_.m_6182_("forge_modify_baking_result");
++      net.minecraftforge.client.ForgeHooksClient.onModifyBakingResult(p_248945_.m_119251_(), p_248945_);
+       p_252136_.m_6182_("dispatch");
+       Map<ResourceLocation, BakedModel> map = p_248945_.m_119251_();
+       BakedModel bakedmodel = map.get(ModelBakery.f_119230_);
 @@ -201,6 +_,8 @@
        this.f_119397_ = modelbakery.m_119251_();
        this.f_119404_ = modelbakery.m_119355_();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -174,6 +174,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -484,7 +485,7 @@ public class ForgeHooksClient
 
     public static void onModelBake(ModelManager modelManager, Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery)
     {
-        ModLoader.get().postEvent(new ModelEvent.BakingCompleted(modelManager, models, modelBakery));
+        ModLoader.get().postEvent(new ModelEvent.BakingCompleted(modelManager, Collections.unmodifiableMap(models), modelBakery));
     }
 
     public static BakedModel handleCameraTransforms(PoseStack poseStack, BakedModel model, ItemTransforms.TransformType cameraTransformType, boolean applyLeftHandTransform)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -477,6 +477,11 @@ public class ForgeHooksClient
         return event;
     }
 
+    public static void onModifyBakingResult(Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery)
+    {
+        ModLoader.get().postEvent(new ModelEvent.ModifyBakingResult(models, modelBakery));
+    }
+
     public static void onModelBake(ModelManager modelManager, Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery)
     {
         ModLoader.get().postEvent(new ModelEvent.BakingCompleted(modelManager, models, modelBakery));

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -34,7 +34,53 @@ public abstract class ModelEvent extends Event
 
     /**
      * Fired when the {@link ModelManager} is notified of the resource manager reloading.
-     * Called after model registry is set up, but before it's passed to {@link net.minecraft.client.renderer.block.BlockModelShaper}.
+     * Called after the model registry is set up, but before it's passed to the
+     * {@link net.minecraft.client.renderer.block.BlockModelShaper}.
+     *
+     * <p>
+     * This event is fired from a worker thread and it is therefore not safe to access anything outside the
+     * model map and {@link ModelBakery} provided in this event.<br>
+     * The {@link ModelManager} firing this event is not fully set up with the latest data when this event fires and
+     * must therefore not be accessed in this event.
+     * </p>
+     *
+     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+     *
+     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
+     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     */
+    public static class ModifyBakingResult extends ModelEvent implements IModBusEvent
+    {
+        private final Map<ResourceLocation, BakedModel> models;
+        private final ModelBakery modelBakery;
+
+        @ApiStatus.Internal
+        public ModifyBakingResult(Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery)
+        {
+            this.models = models;
+            this.modelBakery = modelBakery;
+        }
+
+        /**
+         * @return the modifiable registry map of models and their model names
+         */
+        public Map<ResourceLocation, BakedModel> getModels()
+        {
+            return models;
+        }
+
+        /**
+         * @return the model loader
+         */
+        public ModelBakery getModelBakery()
+        {
+            return modelBakery;
+        }
+    }
+
+    /**
+     * Fired when the {@link ModelManager} is notified of the resource manager reloading.
+     * Called after the model registry is set up and cached in the {@link net.minecraft.client.renderer.block.BlockModelShaper}.
      *
      * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -33,13 +33,12 @@ public abstract class ModelEvent extends Event
     }
 
     /**
-     * Fired when the {@link ModelManager} is notified of the resource manager reloading.
-     * Called after the model registry is set up, but before it's passed to the
-     * {@link net.minecraft.client.renderer.block.BlockModelShaper}.
+     * Fired while the {@link ModelManager} is reloading models, after the model registry is set up, but before it's
+     * passed to the {@link net.minecraft.client.renderer.block.BlockModelShaper} for caching.
      *
      * <p>
      * This event is fired from a worker thread and it is therefore not safe to access anything outside the
-     * model map and {@link ModelBakery} provided in this event.<br>
+     * model registry and {@link ModelBakery} provided in this event.<br>
      * The {@link ModelManager} firing this event is not fully set up with the latest data when this event fires and
      * must therefore not be accessed in this event.
      * </p>
@@ -80,7 +79,9 @@ public abstract class ModelEvent extends Event
 
     /**
      * Fired when the {@link ModelManager} is notified of the resource manager reloading.
-     * Called after the model registry is set up and cached in the {@link net.minecraft.client.renderer.block.BlockModelShaper}.
+     * Called after the model registry is set up and cached in the {@link net.minecraft.client.renderer.block.BlockModelShaper}.<br>
+     * The model registry given by this event is unmodifiable. To modify the model registry, use
+     * {@link ModelEvent.ModifyBakingResult} instead.
      *
      * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
@@ -110,7 +111,7 @@ public abstract class ModelEvent extends Event
         }
 
         /**
-         * @return the modifiable registry map of models and their model names
+         * @return an unmodifiable view of the registry map of models and their model names
          */
         public Map<ResourceLocation, BakedModel> getModels()
         {


### PR DESCRIPTION
This PR adds an additional event to the model baking process right before the baked models are cached by the `BlockModelShaper` to allow listeners to modify the `Map<ResourceLocation, BakedModel>` stored in the `ModelManager` and `ModelBakery` without desyncing it from the `Map<BlockState, BakedModel>` stored in the `BlockModelShaper`.
Previously, the caching of the state->model map was done in the apply phase of the model manager after the existing `ModelEvent.BakingCompleted` was fired. Now this is done in the async prepare phase and therefore before said event fires.
Moving `ModelEvent.BakingCompleted` to the async part before the cache is built felt like a bad idea since there are cases where you only want to read from the map to cache the models, which would be best done where the event fires from now.

Being able to modify the model map after baking is an important feature in cases where the use of custom model loaders is not possible because the data deciding whether a model has to be modified is loaded from a different data source such as a texture metadata loader or when the context provided by a custom model loader is insufficient, such as a model not knowing which blockstate (if any) it is being baked for.

I have opted to make the map given to `ModelEvent.BakingCompleted` unmodifiable to make consumers aware of the inability to modify the map in that event. I have put this change in a separate commit in case it is undesired.