### PR TITLE
[1.19.3] Fix Race Condition in BlockStateProvider

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -99,10 +99,10 @@ public abstract class BlockStateProvider implements DataProvider {
         itemModels().clear();
         registeredBlocks.clear();
         registerStatesAndModels();
-        models().generateAll(cache);
-        itemModels().generateAll(cache);
-        CompletableFuture<?>[] futures = new CompletableFuture<?>[this.registeredBlocks.size()];
+        CompletableFuture<?>[] futures = new CompletableFuture<?>[2 + this.registeredBlocks.size()];
         int i = 0;
+        futures[i++] = models().generateAll(cache);
+        futures[i++] = itemModels().generateAll(cache);
         for (Map.Entry<Block, IGeneratedBlockState> entry : registeredBlocks.entrySet()) {
             futures[i++] = saveBlockState(cache, entry.getValue().toJson(), entry.getKey());
         }


### PR DESCRIPTION
Fixes #9195: Incorporate the futures returned by the item and block model providers into the future returned by the blockstate provider to avoid a race condition where the models would only be generated partially.