### PR TITLE
Fix compatibility checker task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1241,6 +1241,14 @@ project(':forge') {
         dependsOn 'setupCheckJarCompatibility'
 
         baseJar = project.tasks.named('mergeBaseForgeJar').flatMap { it.output }
+        baseLibraries.from(project.tasks.named('createJoinedSRG').flatMap { it.output })
+
+        inputJar = project.tasks.named('reobfJar').flatMap { it.output }
+        concreteLibraries.from(project.PACKED_DEPS.collect { project.rootProject.tasks.getByPath(it).archiveFile })
+
+        commonLibraries.from(project.configurations.minecraftImplementation)
+        commonLibraries.from(project.configurations.installer)
+        commonLibraries.from(project.configurations.moduleonly)
     }
 
     task checkAll(dependsOn: [checkATs, checkSAS, checkExcs, findFieldInstanceChecks, checkPatches, checkLicenses]){}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
@@ -31,17 +31,9 @@ abstract class SetupCheckJarCompatibility extends DefaultTask {
         }.toArray(Dependency[]::new))
 
         project.tasks.named('checkJarCompatibility') {
-            baseLibraries.from(project.tasks.createJoinedSRG.output)
             baseLibraries.from(project.provider {
                 fmlLibs.resolvedConfiguration.lenientConfiguration.files
             })
-
-            inputJar = project.tasks.reobfJar.output
-            concreteLibraries.from(project.PACKED_DEPS.collect { project.rootProject.tasks.getByPath(it).archiveFile })
-
-            commonLibraries.from(project.configurations.minecraftImplementation)
-            commonLibraries.from(project.configurations.installer)
-            commonLibraries.from(project.configurations.moduleonly)
         }
 
         def baseForgeUserdev = project.layout.buildDirectory.dir(name).map { it.file("forge-${inputVersion}-userdev.jar") }.get().asFile

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
@@ -18,6 +18,7 @@ abstract class SetupCheckJarCompatibility extends DefaultTask {
         onlyIf {
             inputVersion.getOrNull() != null
         }
+        outputs.upToDateWhen { false } // Never up to date, because this setup task should always run
 
         baseBinPatchesOutput.convention(project.layout.buildDirectory.dir(name).map { it.file('joined.lzma') })
     }


### PR DESCRIPTION
This PR fixes an ongoing issue where the compatibility checker task fails to run due to a misconfiguration, causing the CI validation using that checker to fail for all existing PRs.

## Background

The `setupCheckJarCompatibility` task exists to configure the main compatibility checker task, `checkJarCompatibility`, because certain configuration steps for that task could not be done until after the configuration phase of Gradle.

However, that setup task previously held all the configuration for the main check task in its task action. This caused problems because the main check task's inputs are linked to other tasks, and the previous situation made it so its configuration (by the setup task) happened _after_ Gradle built the task dependency model/tree.

This meant that certain tasks which the main check task depended on did not run before that task, because Gradle was unaware of this inter-task dependency until it was too late (when it was already executing tasks). Specifically, the `reobfJar` task was not running before the main check task, which caused a build failure if the file did not exist from a previous run (such as during a fresh or `clean`ed environment).

This fixes the issue by moving the bulk of the configuration for the main check task from the action of the setup task to the main buildscript, therefore allowing Gradle to know about those task dependencies and factor them in to its process of determining what tasks to run and in what order.

The remaining configuration step in the setup task for the main check task is linked to the setup task, and does not affect the task's dependencies (because it uses a configuration which it resolves immediately), so it stays in the setup task.

## Testing

This was tested by doing multiple runs with the `clean` and the compatibility check tasks, removing (and reintroducing) the fix while on branches with and without a breaking change. Specifically, PR #9188 was used to test as a branch with breaking changes.

---

In addition, this PR configures the setup task, `setupCheckJarCompatibility`, to never be considered as `UP-TO-DATE`.

The setup task configures the main check task, so it should always run  before that task. However, because it has an input and output, the setup task is affected by Gradle's incremental build feature. This leads to the possibility that Gradle considers the setup task as up-to-date, therefore not executing its action and causing errors with the main check task down the line.