### PR TITLE
Simplify tree grower patches

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java.patch
@@ -1,33 +1,12 @@
 --- a/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractMegaTreeGrower.java
-@@ -27,6 +_,14 @@
-       return super.m_213817_(p_222891_, p_222892_, p_222893_, p_222894_, p_222895_);
-    }
- 
-+   /**
-+    * Forge: context-sensitive version to be able to use data pack provided features
-+    */
-+   @Nullable
-+   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredMegaFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random, ResourceKey<ConfiguredFeature<?, ?>> featureKey) {
-+      return level.m_8891_().m_175515_(Registries.f_256911_).m_203636_(featureKey).orElse(null);
-+   }
-+
-    @Nullable
-    protected abstract ResourceKey<ConfiguredFeature<?, ?>> m_213566_(RandomSource p_222904_);
- 
-@@ -35,11 +_,12 @@
-       if (resourcekey == null) {
+@@ -36,6 +_,9 @@
           return false;
        } else {
--         Holder<ConfiguredFeature<?, ?>> holder = p_222897_.m_8891_().m_175515_(Registries.f_256911_).m_203636_(resourcekey).orElse((Holder.Reference<ConfiguredFeature<?, ?>>)null);
--         if (holder == null) {
-+         Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredMegaFeature(p_222897_, p_222898_, p_222899_, p_222900_, p_222901_, resourcekey);
-+         net.minecraftforge.event.level.SaplingGrowTreeEvent event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_222897_, p_222901_, p_222899_, holder);
-+         if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY) || event.getFeature() == null) {
+          Holder<ConfiguredFeature<?, ?>> holder = p_222897_.m_8891_().m_175515_(Registries.f_256911_).m_203636_(resourcekey).orElse((Holder.Reference<ConfiguredFeature<?, ?>>)null);
++         var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_222897_, p_222901_, p_222899_, holder);
++         holder = event.getFeature();
++         if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) return false;
+          if (holder == null) {
              return false;
           } else {
--            ConfiguredFeature<?, ?> configuredfeature = holder.m_203334_();
-+            ConfiguredFeature<?, ?> configuredfeature = event.getFeature().m_203334_();
-             BlockState blockstate = Blocks.f_50016_.m_49966_();
-             p_222897_.m_7731_(p_222899_.m_7918_(p_222902_, 0, p_222903_), blockstate, 4);
-             p_222897_.m_7731_(p_222899_.m_7918_(p_222902_ + 1, 0, p_222903_), blockstate, 4);

--- a/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/AbstractTreeGrower.java.patch
@@ -1,33 +1,12 @@
 --- a/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
 +++ b/net/minecraft/world/level/block/grower/AbstractTreeGrower.java
-@@ -14,6 +_,14 @@
- import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
- 
- public abstract class AbstractTreeGrower {
-+   /**
-+    * Forge: context-sensitive version to be able to use data pack provided features
-+    */
-+   @Nullable
-+   protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random, boolean hasFlowers, ResourceKey<ConfiguredFeature<?, ?>> featureKey) {
-+      return level.m_8891_().m_175515_(Registries.f_256911_).m_203636_(featureKey).orElse(null);
-+   }
-+
-    @Nullable
-    protected abstract ResourceKey<ConfiguredFeature<?, ?>> m_213888_(RandomSource p_222910_, boolean p_222911_);
- 
-@@ -22,11 +_,12 @@
-       if (resourcekey == null) {
+@@ -23,6 +_,9 @@
           return false;
        } else {
--         Holder<ConfiguredFeature<?, ?>> holder = p_222905_.m_8891_().m_175515_(Registries.f_256911_).m_203636_(resourcekey).orElse((Holder.Reference<ConfiguredFeature<?, ?>>)null);
--         if (holder == null) {
-+         Holder<? extends ConfiguredFeature<?, ?>> holder = this.getConfiguredFeature(p_222905_, p_222906_, p_222907_, p_222908_, p_222909_, this.m_60011_(p_222905_, p_222907_), resourcekey);
-+         net.minecraftforge.event.level.SaplingGrowTreeEvent event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_222905_, p_222909_, p_222907_, holder);
-+         if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY) || event.getFeature() == null) {
+          Holder<ConfiguredFeature<?, ?>> holder = p_222905_.m_8891_().m_175515_(Registries.f_256911_).m_203636_(resourcekey).orElse((Holder.Reference<ConfiguredFeature<?, ?>>)null);
++         var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_222905_, p_222909_, p_222907_, holder);
++         holder = event.getFeature();
++         if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) return false;
+          if (holder == null) {
              return false;
           } else {
--            ConfiguredFeature<?, ?> configuredfeature = holder.m_203334_();
-+            ConfiguredFeature<?, ?> configuredfeature = event.getFeature().m_203334_();
-             BlockState blockstate = p_222905_.m_6425_(p_222907_).m_76188_();
-             p_222905_.m_7731_(p_222907_, blockstate, 4);
-             if (configuredfeature.m_224953_(p_222905_, p_222906_, p_222909_, p_222907_)) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -624,7 +624,7 @@ public class ForgeEventFactory
         return !blockGrowFeature(level, randomSource, pos, null).getResult().equals(Result.DENY);
     }
 
-    public static SaplingGrowTreeEvent blockGrowFeature(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<? extends ConfiguredFeature<?, ?>> holder)
+    public static SaplingGrowTreeEvent blockGrowFeature(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<ConfiguredFeature<?, ?>> holder)
     {
         SaplingGrowTreeEvent event = new SaplingGrowTreeEvent(level, randomSource, pos, holder);
         MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
@@ -40,7 +40,7 @@ public class SaplingGrowTreeEvent extends LevelEvent
     private final RandomSource randomSource;
     private final BlockPos pos;
     @Nullable
-    private Holder<? extends ConfiguredFeature<?, ?>> feature;
+    private Holder<ConfiguredFeature<?, ?>> feature;
 
     @Deprecated(forRemoval = true, since = "1.19.2")
     public SaplingGrowTreeEvent(LevelAccessor level, RandomSource randomSource, BlockPos pos)
@@ -48,7 +48,7 @@ public class SaplingGrowTreeEvent extends LevelEvent
         this(level, randomSource, pos, null);
     }
 
-    public SaplingGrowTreeEvent(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<? extends ConfiguredFeature<?, ?>> feature)
+    public SaplingGrowTreeEvent(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<ConfiguredFeature<?, ?>> feature)
     {
         super(level);
         this.randomSource = randomSource;
@@ -76,15 +76,24 @@ public class SaplingGrowTreeEvent extends LevelEvent
      * {@return the holder of the feature which will be placed, possibly null}
      */
     @Nullable
-    public Holder<? extends ConfiguredFeature<?, ?>> getFeature() {
+    public Holder<ConfiguredFeature<?, ?>> getFeature()
+    {
         return feature;
     }
 
-    public void setFeature(@Nullable Holder<? extends ConfiguredFeature<?, ?>> feature) {
+    /**
+     * @param feature a {@linkplain Holder} referencing a tree feature to be placed instead of the current feature.
+     */
+    public void setFeature(@Nullable Holder<ConfiguredFeature<?, ?>> feature)
+    {
         this.feature = feature;
     }
 
-    public void setFeature(ResourceKey<ConfiguredFeature<?, ?>> featureKey) {
+    /**
+     * @param featureKey a {@linkplain ResourceKey} referencing a tree feature to be placed instead of the current feature.
+     */
+    public void setFeature(ResourceKey<ConfiguredFeature<?, ?>> featureKey)
+    {
         this.feature = this.getLevel().registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).getHolder(featureKey).orElse(null);
     }
 }


### PR DESCRIPTION
Closes #9183

This PR removes the context sensitive method from forge for using datapack configured features in tree growers. It's important to note that this is breaking against the current 1.19.3 branch, but the signature of this method changed in 1.19.3, already breaking mods.

I have also simplified the patch to require no subtractions, only three lines of additions, with some local variable trickery. This should make the patch easier to maintain. This required me changing the type bound of the holder method in the sapling grow event to not be `? extends CF` so that the local variable could match the vanilla pattern. Since ConfiguredFeature is a record this is fine.

I also added a couple javadocs and fixed a couple brackets in the event since I'm there.

Things that could be added to this PR that are listed as todo deprecations:
* the `saplingGrowTree` event fire in ForgeEventFactory, deprecated since 1.19.2
* renaming the SaplingGrowTreeEvent (not really any good reason to do this yet though as that is more breaking than needs to be done)