### PR TITLE
[1.19.3] Add support for custom CreativeModeTab implementations

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/CreativeModeTab.java
 +++ b/net/minecraft/world/item/CreativeModeTab.java
-@@ -28,14 +_,26 @@
+@@ -28,14 +_,30 @@
     private Consumer<List<ItemStack>> f_256965_;
     private final Supplier<ItemStack> f_256912_;
     private final CreativeModeTab.DisplayItemsGenerator f_256824_;
@@ -11,8 +11,8 @@
 +   private final int labelColor;
 +   private final int slotColor;
  
--   protected CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_) {
-+   protected CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor) {
+-   CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_) {
++   CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor) {
        this.f_256931_ = p_260217_;
        this.f_256967_ = p_259557_;
        this.f_40764_ = p_260100_;
@@ -25,6 +25,10 @@
 +      this.tabsImage = tabsImage;
 +      this.labelColor = labelColor;
 +      this.slotColor = slotColor;
++   }
++
++   protected CreativeModeTab(CreativeModeTab.Builder builder) {
++      this(builder.f_256796_, builder.f_256977_, builder.f_256847_, builder.f_256856_, builder.f_256981_, builder.f_256953_, builder.backgroundLocation, builder.hasSearchBar, builder.searchBarWidth, builder.tabsImage, builder.labelColor, builder.slotColor);
     }
  
     public static CreativeModeTab.Builder m_257815_(CreativeModeTab.Row p_259342_, int p_260312_) {
@@ -94,7 +98,7 @@
 +      private net.minecraft.resources.ResourceLocation tabsImage = CREATIVE_INVENTORY_TABS_IMAGE;
 +      private int labelColor = 4210752;
 +      private int slotColor = -2130706433;
-+      private TabFactory tabFactory = CreativeModeTab::new;
++      private java.util.function.Function<CreativeModeTab.Builder, CreativeModeTab> tabFactory = CreativeModeTab::new;
  
        public Builder(CreativeModeTab.Row p_259171_, int p_259661_) {
           this.f_256796_ = p_259171_;
@@ -144,17 +148,17 @@
 +          return this;
 +      }
 +
-+      public CreativeModeTab.Builder withTabFactory(TabFactory factory) {
-+         this.tabFactory = factory;
++      public CreativeModeTab.Builder withTabFactory(java.util.function.Function<CreativeModeTab.Builder, CreativeModeTab> tabFactory) {
++         this.tabFactory = tabFactory;
           return this;
        }
  
-@@ -186,13 +_,19 @@
+@@ -186,11 +_,12 @@
           if ((this.f_256847_ == CreativeModeTab.Type.HOTBAR || this.f_256847_ == CreativeModeTab.Type.INVENTORY) && this.f_256953_ != f_256756_) {
              throw new IllegalStateException("Special tabs can't have display items");
           } else {
 -            CreativeModeTab creativemodetab = new CreativeModeTab(this.f_256796_, this.f_256977_, this.f_256847_, this.f_256856_, this.f_256981_, this.f_256953_);
-+            CreativeModeTab creativemodetab = tabFactory.create(this.f_256796_, this.f_256977_, this.f_256847_, this.f_256856_, this.f_256981_, this.f_256953_, this.backgroundLocation, this.hasSearchBar, this.searchBarWidth, this.tabsImage, this.labelColor, this.slotColor);
++            CreativeModeTab creativemodetab = tabFactory.apply(this);
              creativemodetab.f_257018_ = this.f_256854_;
              creativemodetab.f_40768_ = this.f_256851_;
              creativemodetab.f_40767_ = this.f_256992_;
@@ -162,11 +166,4 @@
 +            creativemodetab.backgroundLocation = this.backgroundLocation != null ? this.backgroundLocation : new net.minecraft.resources.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.f_257036_);
              return creativemodetab;
           }
-+      }
-+
-+      @FunctionalInterface
-+      public interface TabFactory {
-+         CreativeModeTab create(CreativeModeTab.Row row, int column, CreativeModeTab.Type type, Component title, Supplier<ItemStack> iconGenerator, CreativeModeTab.DisplayItemsGenerator displayItemsGenerator, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor);
        }
-    }
- 

--- a/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -11,8 +11,8 @@
 +   private final int labelColor;
 +   private final int slotColor;
  
--   CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_) {
-+   CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor) {
+-   protected CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_) {
++   protected CreativeModeTab(CreativeModeTab.Row p_260217_, int p_259557_, CreativeModeTab.Type p_260176_, Component p_260100_, Supplier<ItemStack> p_259543_, CreativeModeTab.DisplayItemsGenerator p_259085_, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor) {
        this.f_256931_ = p_260217_;
        this.f_256967_ = p_259557_;
        this.f_40764_ = p_260100_;
@@ -83,7 +83,7 @@
        private final CreativeModeTab.Row f_256796_;
        private final int f_256977_;
        private Component f_256856_ = Component.m_237119_();
-@@ -136,6 +_,13 @@
+@@ -136,6 +_,14 @@
        private boolean f_256854_ = false;
        private CreativeModeTab.Type f_256847_ = CreativeModeTab.Type.CATEGORY;
        private String f_257036_ = "items.png";
@@ -94,10 +94,11 @@
 +      private net.minecraft.resources.ResourceLocation tabsImage = CREATIVE_INVENTORY_TABS_IMAGE;
 +      private int labelColor = 4210752;
 +      private int slotColor = -2130706433;
++      private TabFactory tabFactory = CreativeModeTab::new;
  
        public Builder(CreativeModeTab.Row p_259171_, int p_259661_) {
           this.f_256796_ = p_259171_;
-@@ -174,23 +_,57 @@
+@@ -174,11 +_,49 @@
  
        protected CreativeModeTab.Builder m_257623_(CreativeModeTab.Type p_259283_) {
           this.f_256847_ = p_259283_;
@@ -108,7 +109,6 @@
  
        public CreativeModeTab.Builder m_257609_(String p_259981_) {
 -         this.f_257036_ = p_259981_;
--         return this;
 +         return withBackgroundLocation(new net.minecraft.resources.ResourceLocation("textures/gui/container/creative_inventory/tab_" + p_259981_));
 +      }
 +
@@ -142,14 +142,19 @@
 +      public CreativeModeTab.Builder withSlotColor(int slotColor) {
 +          this.slotColor = slotColor;
 +          return this;
++      }
++
++      public CreativeModeTab.Builder withTabFactory(TabFactory factory) {
++         this.tabFactory = factory;
+          return this;
        }
  
-       public CreativeModeTab m_257652_() {
+@@ -186,13 +_,19 @@
           if ((this.f_256847_ == CreativeModeTab.Type.HOTBAR || this.f_256847_ == CreativeModeTab.Type.INVENTORY) && this.f_256953_ != f_256756_) {
              throw new IllegalStateException("Special tabs can't have display items");
           } else {
 -            CreativeModeTab creativemodetab = new CreativeModeTab(this.f_256796_, this.f_256977_, this.f_256847_, this.f_256856_, this.f_256981_, this.f_256953_);
-+            CreativeModeTab creativemodetab = new CreativeModeTab(this.f_256796_, this.f_256977_, this.f_256847_, this.f_256856_, this.f_256981_, this.f_256953_, this.backgroundLocation, this.hasSearchBar, this.searchBarWidth, this.tabsImage, this.labelColor, this.slotColor);
++            CreativeModeTab creativemodetab = tabFactory.create(this.f_256796_, this.f_256977_, this.f_256847_, this.f_256856_, this.f_256981_, this.f_256953_, this.backgroundLocation, this.hasSearchBar, this.searchBarWidth, this.tabsImage, this.labelColor, this.slotColor);
              creativemodetab.f_257018_ = this.f_256854_;
              creativemodetab.f_40768_ = this.f_256851_;
              creativemodetab.f_40767_ = this.f_256992_;
@@ -157,4 +162,11 @@
 +            creativemodetab.backgroundLocation = this.backgroundLocation != null ? this.backgroundLocation : new net.minecraft.resources.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.f_257036_);
              return creativemodetab;
           }
++      }
++
++      @FunctionalInterface
++      public interface TabFactory {
++         CreativeModeTab create(CreativeModeTab.Row row, int column, CreativeModeTab.Type type, Component title, Supplier<ItemStack> iconGenerator, CreativeModeTab.DisplayItemsGenerator displayItemsGenerator, net.minecraft.resources.ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, net.minecraft.resources.ResourceLocation tabsImage, int labelColor, int slotColor);
        }
+    }
+ 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -258,7 +258,6 @@ public net.minecraft.world.item.CreativeModeTabs f_257028_ # REDSTONE_BLOCKS
 public net.minecraft.world.item.CreativeModeTabs f_257039_ # INVENTORY
 #group public net.minecraft.world.item.Item <init>
 public net.minecraft.world.item.AxeItem <init>(Lnet/minecraft/world/item/Tier;FFLnet/minecraft/world/item/Item$Properties;)V # constructor
-protected net.minecraft.world.item.CreativeModeTab <init>(Lnet/minecraft/world/item/CreativeModeTab$Row;ILnet/minecraft/world/item/CreativeModeTab$Type;Lnet/minecraft/network/chat/Component;Ljava/util/function/Supplier;Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;)V #constructor
 public net.minecraft.world.item.DiggerItem <init>(FFLnet/minecraft/world/item/Tier;Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/item/Item$Properties;)V # constructor
 public net.minecraft.world.item.HoeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor
 public net.minecraft.world.item.PickaxeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -258,6 +258,7 @@ public net.minecraft.world.item.CreativeModeTabs f_257028_ # REDSTONE_BLOCKS
 public net.minecraft.world.item.CreativeModeTabs f_257039_ # INVENTORY
 #group public net.minecraft.world.item.Item <init>
 public net.minecraft.world.item.AxeItem <init>(Lnet/minecraft/world/item/Tier;FFLnet/minecraft/world/item/Item$Properties;)V # constructor
+protected net.minecraft.world.item.CreativeModeTab <init>(Lnet/minecraft/world/item/CreativeModeTab$Row;ILnet/minecraft/world/item/CreativeModeTab$Type;Lnet/minecraft/network/chat/Component;Ljava/util/function/Supplier;Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;)V #constructor
 public net.minecraft.world.item.DiggerItem <init>(FFLnet/minecraft/world/item/Tier;Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/item/Item$Properties;)V # constructor
 public net.minecraft.world.item.HoeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor
 public net.minecraft.world.item.PickaxeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor

--- a/src/test/java/net/minecraftforge/debug/CreativeModeTabTest.java
+++ b/src/test/java/net/minecraftforge/debug/CreativeModeTabTest.java
@@ -6,7 +6,6 @@
 package net.minecraftforge.debug;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -108,9 +107,9 @@ public class CreativeModeTabTest
     {
         private final ItemStack[] iconItems;
 
-        public CreativeModeColorTab(Row row, int column, Type type, Component title, Supplier<ItemStack> iconGenerator, DisplayItemsGenerator displayItemsGenerator, ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, ResourceLocation tabsImage, int labelColor, int slotColor)
+        public CreativeModeColorTab(CreativeModeTab.Builder builder)
         {
-            super(row, column, type, title, iconGenerator, displayItemsGenerator, backgroundLocation, hasSearchBar, searchBarWidth, tabsImage, labelColor, slotColor);
+            super(builder);
 
             DyeColor[] colors = DyeColor.values();
             iconItems = new ItemStack[colors.length];

--- a/src/test/java/net/minecraftforge/debug/CreativeModeTabTest.java
+++ b/src/test/java/net/minecraftforge/debug/CreativeModeTabTest.java
@@ -6,11 +6,15 @@
 package net.minecraftforge.debug;
 
 import java.util.List;
+import java.util.function.Supplier;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTab.TabVisibility;
 import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Blocks;
@@ -62,6 +66,17 @@ public class CreativeModeTabTest
                     output.accept(new ItemStack(Blocks.DIORITE));
                     output.accept(new ItemStack(Blocks.ANDESITE));
                 }));
+
+        event.registerCreativeModeTab(new ResourceLocation(MOD_ID, "colors"), builder -> builder.title(Component.literal("Colors"))
+                .displayItems((features, output, hasPermissions) ->
+                {
+                    for (DyeColor color : DyeColor.values())
+                    {
+                        output.accept(DyeItem.byColor(color));
+                    }
+                })
+                .withTabFactory(CreativeModeColorTab::new)
+        );
     }
 
     private static ItemStack i(ItemLike item) { return new ItemStack(item); }
@@ -86,6 +101,30 @@ public class CreativeModeTabTest
             entries.putBefore(i(Blocks.GRANITE),  i(Blocks.POLISHED_GRANITE),  vis);
             entries.putBefore(i(Blocks.DIORITE),  i(Blocks.POLISHED_DIORITE),  vis);
             entries.putBefore(i(Blocks.ANDESITE), i(Blocks.POLISHED_ANDESITE), vis);
+        }
+    }
+
+    private static class CreativeModeColorTab extends CreativeModeTab
+    {
+        private final ItemStack[] iconItems;
+
+        public CreativeModeColorTab(Row row, int column, Type type, Component title, Supplier<ItemStack> iconGenerator, DisplayItemsGenerator displayItemsGenerator, ResourceLocation backgroundLocation, boolean hasSearchBar, int searchBarWidth, ResourceLocation tabsImage, int labelColor, int slotColor)
+        {
+            super(row, column, type, title, iconGenerator, displayItemsGenerator, backgroundLocation, hasSearchBar, searchBarWidth, tabsImage, labelColor, slotColor);
+
+            DyeColor[] colors = DyeColor.values();
+            iconItems = new ItemStack[colors.length];
+            for (int i = 0; i < colors.length; i++)
+            {
+                iconItems[i] = new ItemStack(DyeItem.byColor(colors[i]));
+            }
+        }
+
+        @Override
+        public ItemStack getIconItem()
+        {
+            int idx = (int)(System.currentTimeMillis() / 1200) % iconItems.length;
+            return iconItems[idx];
         }
     }
 }


### PR DESCRIPTION
This PR adds support for custom subclasses of `CreativeModeTab` to allow mods to add custom logic to their tabs.
In previous versions this was simple to do because every mod directly instantiated the `CreativeModeTab` class. Due to the builder design used in 1.19.3 this is not possible anymore. To regain the customizability, an option to override the `CreativeModeTab` implementation instantiated by `CreativeModeTab.Builder#build()` is added and a protected `CreativeModeTab` constructor is added to allow subclassing (consumes the builder itself to avoid exposing the full constructor as API).

One of the most prevalent use-cases for tab customization is a rotating icon item, which is currently not possible with the simple icon generator available in the builder.