### PR TITLE
Update to the latest JarJar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ ext {
     JETBRAINS_ANNOTATIONS_VERSION = '23.0.0'
     SLF4J_API_VERSION = '1.8.0-beta4'
     APACHE_MAVEN_ARTIFACT_VERSION = '3.8.5'
-    JARJAR_VERSION = '0.3.18'
+    JARJAR_VERSION = '0.3.19'
 
     // These versions should be kept in sync with the version manifest JSON
     // To use a version newer than the version manifest JSON, the dependency must be added to the installer configuration


### PR DESCRIPTION
### Fixed:
This fixes an issue where JarJar caused crashes because `Files.exists(...)` was invoked with the root path of the ZipFS.

@MinecraftForge/triage Please test this.

Closes #9208