### PR TITLE
[1.19.3] Fix datapack registries not being synced to clients

### DIFF
--- a/patches/minecraft/net/minecraft/core/RegistrySynchronization.java.patch
+++ b/patches/minecraft/net/minecraft/core/RegistrySynchronization.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/RegistrySynchronization.java
++++ b/net/minecraft/core/RegistrySynchronization.java
+@@ -23,7 +_,7 @@
+       m_245912_(builder, Registries.f_256952_, Biome.f_47430_);
+       m_245912_(builder, Registries.f_256873_, ChatType.f_237005_);
+       m_245912_(builder, Registries.f_256787_, DimensionType.f_63843_);
+-      return builder.build();
++      return net.minecraftforge.registries.DataPackRegistriesHooks.grabNetworkableRegistries(builder); // FORGE: Keep the map so custom registries can be added later
+    });
+    public static final Codec<RegistryAccess> f_244380_ = m_247146_();
+ 

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -5,15 +5,20 @@
 
 package net.minecraftforge.registries;
 
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistrySynchronization;
 import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @ApiStatus.Internal
@@ -21,18 +26,32 @@ public final class DataPackRegistriesHooks
 {
     private DataPackRegistriesHooks() {} // utility class
 
+    private static Map<ResourceKey<? extends Registry<?>>, RegistrySynchronization.NetworkedRegistryData<?>> NETWORKABLE_REGISTRIES = new LinkedHashMap<>();
     private static final List<RegistryDataLoader.RegistryData<?>> DATA_PACK_REGISTRIES = new ArrayList<>(RegistryDataLoader.WORLDGEN_REGISTRIES);
     private static final List<RegistryDataLoader.RegistryData<?>> DATA_PACK_REGISTRIES_VIEW = Collections.unmodifiableList(DATA_PACK_REGISTRIES);
     private static final Set<ResourceKey<? extends Registry<?>>> SYNCED_CUSTOM_REGISTRIES = new HashSet<>();
     private static final Set<ResourceKey<? extends Registry<?>>> SYNCED_CUSTOM_REGISTRIES_VIEW = Collections.unmodifiableSet(SYNCED_CUSTOM_REGISTRIES);
+
+    /* Internal forge hook for retaining mutable access to RegistryAccess's codec registry when it bootstraps. */
+    public static Map<ResourceKey<? extends Registry<?>>, RegistrySynchronization.NetworkedRegistryData<?>> grabNetworkableRegistries(ImmutableMap.Builder<ResourceKey<? extends Registry<?>>, RegistrySynchronization.NetworkedRegistryData<?>> builder)
+    {
+        if (!StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass().equals(RegistrySynchronization.class))
+            throw new IllegalCallerException("Attempted to call DataPackRegistriesHooks#grabNetworkableRegistries!");
+        NETWORKABLE_REGISTRIES.forEach(builder::put);
+        NETWORKABLE_REGISTRIES = new HashMap<>(builder.build());
+        SYNCED_CUSTOM_REGISTRIES.clear();
+        return Collections.unmodifiableMap(NETWORKABLE_REGISTRIES);
+    }
 
     /* Internal forge method, registers a datapack registry codec and folder. */
     static <T> void addRegistryCodec(DataPackRegistryEvent.DataPackRegistryData<T> data)
     {
         RegistryDataLoader.RegistryData<T> loaderData = data.loaderData();
         DATA_PACK_REGISTRIES.add(loaderData);
-        if (data.networkCodec() != null)
+        if (data.networkCodec() != null) {
             SYNCED_CUSTOM_REGISTRIES.add(loaderData.key());
+            NETWORKABLE_REGISTRIES.put(loaderData.key(), new RegistrySynchronization.NetworkedRegistryData<>(loaderData.key(), data.networkCodec()));
+        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -39,7 +39,6 @@ public final class DataPackRegistriesHooks
             throw new IllegalCallerException("Attempted to call DataPackRegistriesHooks#grabNetworkableRegistries!");
         NETWORKABLE_REGISTRIES.forEach(builder::put);
         NETWORKABLE_REGISTRIES = new HashMap<>(builder.build());
-        SYNCED_CUSTOM_REGISTRIES.clear();
         return Collections.unmodifiableMap(NETWORKABLE_REGISTRIES);
     }
 

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -48,7 +48,8 @@ public final class DataPackRegistriesHooks
     {
         RegistryDataLoader.RegistryData<T> loaderData = data.loaderData();
         DATA_PACK_REGISTRIES.add(loaderData);
-        if (data.networkCodec() != null) {
+        if (data.networkCodec() != null)
+        {
             SYNCED_CUSTOM_REGISTRIES.add(loaderData.key());
             NETWORKABLE_REGISTRIES.put(loaderData.key(), new RegistrySynchronization.NetworkedRegistryData<>(loaderData.key(), data.networkCodec()));
         }

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistriesHooks.java
@@ -26,7 +26,7 @@ public final class DataPackRegistriesHooks
 {
     private DataPackRegistriesHooks() {} // utility class
 
-    private static Map<ResourceKey<? extends Registry<?>>, RegistrySynchronization.NetworkedRegistryData<?>> NETWORKABLE_REGISTRIES = new LinkedHashMap<>();
+    private static final Map<ResourceKey<? extends Registry<?>>, RegistrySynchronization.NetworkedRegistryData<?>> NETWORKABLE_REGISTRIES = new LinkedHashMap<>();
     private static final List<RegistryDataLoader.RegistryData<?>> DATA_PACK_REGISTRIES = new ArrayList<>(RegistryDataLoader.WORLDGEN_REGISTRIES);
     private static final List<RegistryDataLoader.RegistryData<?>> DATA_PACK_REGISTRIES_VIEW = Collections.unmodifiableList(DATA_PACK_REGISTRIES);
     private static final Set<ResourceKey<? extends Registry<?>>> SYNCED_CUSTOM_REGISTRIES = new HashSet<>();
@@ -38,7 +38,8 @@ public final class DataPackRegistriesHooks
         if (!StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass().equals(RegistrySynchronization.class))
             throw new IllegalCallerException("Attempted to call DataPackRegistriesHooks#grabNetworkableRegistries!");
         NETWORKABLE_REGISTRIES.forEach(builder::put);
-        NETWORKABLE_REGISTRIES = new HashMap<>(builder.build());
+        NETWORKABLE_REGISTRIES.clear();
+        NETWORKABLE_REGISTRIES.putAll(builder.build());
         return Collections.unmodifiableMap(NETWORKABLE_REGISTRIES);
     }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -187,6 +187,7 @@ public net.minecraft.data.recipes.packs.VanillaRecipeProvider f_244565_ # REDSTO
 public net.minecraft.data.recipes.packs.VanillaRecipeProvider f_244628_ # LAPIS_SMELTABLES
 public net.minecraft.data.tags.IntrinsicHolderTagsProvider$IntrinsicTagAppender
 public net.minecraft.data.tags.TagsProvider$TagAppender
+public net.minecraft.core.RegistrySynchronization$NetworkedRegistryData
 protected net.minecraft.data.tags.TagsProvider f_126543_ # builders
 public-f net.minecraft.data.tags.TagsProvider m_6055_()Ljava/lang/String; # getName
 public net.minecraft.gametest.framework.GameTestServer <init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/util/Collection;Lnet/minecraft/core/BlockPos;)V # constructor

--- a/src/test/java/net/minecraftforge/debug/misc/DataPackRegistriesTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/DataPackRegistriesTest.java
@@ -34,6 +34,7 @@ import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.TagsUpdatedEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.util.thread.EffectiveSide;
@@ -53,7 +54,7 @@ import org.slf4j.Logger;
  * <li><code>data/data_pack_registries_test/tags/data_pack_registries_test/syncable/test.json</code></li>
  * </ul>
  */
-//@Mod(DataPackRegistriesTest.MODID)
+@Mod(DataPackRegistriesTest.MODID)
 public class DataPackRegistriesTest
 {
     private static final boolean ENABLED = true;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -269,6 +269,8 @@ modId="ambient_occlusion_elements_test"
 [[mods]]
 modId="grindstone_event_test"
 [[mods]]
+modId="data_pack_registries_test"
+[[mods]]
 modId="creative_mode_tab_test"
 
 


### PR DESCRIPTION
With the registry changes in 1.19.3, the patch that injected the codecs of synced custom datapack registries got lost, and as such, the contents of the registries were not synced to clients. 
This PR fixes fixes that by injecting custom registries in `RegistrySynchronization#NETWORKABLE_REGISTRIES`.

### Test Mod
This PR can be tested by seeing how the `DataPackRegistriesTest` test mod (which was commented out during the port) will crash without these changes. 