### PR TITLE
[1.19.3] Specify NetworkHooks#getEntitySpawningPacket Generic Return Type

### DIFF
--- a/src/main/java/net/minecraftforge/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/network/NetworkHooks.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.fml.util.thread.EffectiveSide;
 import net.minecraftforge.network.ConnectionData.ModMismatchData;
@@ -66,9 +67,11 @@ public class NetworkHooks
         return ConnectionType.forVersionFlag(channel.attr(NetworkConstants.FML_NETVERSION).get());
     }
 
-    public static Packet<?> getEntitySpawningPacket(Entity entity)
+    @SuppressWarnings("unchecked")
+    public static Packet<ClientGamePacketListener> getEntitySpawningPacket(Entity entity)
     {
-        return NetworkConstants.playChannel.toVanillaPacket(new PlayMessages.SpawnEntity(entity), NetworkDirection.PLAY_TO_CLIENT);
+        // ClientboundCustomPayloadPacket is an instance of Packet<ClientGamePacketListener>
+        return (Packet<ClientGamePacketListener>) NetworkConstants.playChannel.toVanillaPacket(new PlayMessages.SpawnEntity(entity), NetworkDirection.PLAY_TO_CLIENT);
     }
 
     public static boolean onCustomPayload(final ICustomPacket<?> packet, final Connection manager) {


### PR DESCRIPTION
In 1.19.3, the signature for `Entity#getAddEntityPacket` changed to be a non-abstract method with a return type of `Packet<ClientGamePacketListener>`. As such, the return type of `Packet<?>` within `NetworkHooks#getEntitySpawningPacket` would now throw an error without doing an unchecked cast. It is guaranteed that the packet will be a `Packet<ClientGamePacketListener>` as that is what `ClientboundCustomPayloadPacket`, the packet used to send Forge's network system during play to client, is.

This PR simply changes the return type of `NetworkHooks#getEntitySpawningPacket`  to that specified in `Entity#getAddEntityPacket` and performs the unchecked cast itself such that those who still wish to use the system do not have to cast themselves for every single entity.