### PR TITLE
[1.19.3] Move client-extra to the end of the list of "minecraft paths"

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/targets/CommonDevLaunchHandler.java
@@ -31,7 +31,6 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
         // The extra jar is on the classpath, so try and pull it out of the legacy classpath
         var legacyCP = Objects.requireNonNull(System.getProperty("legacyClassPath"), "Missing legacyClassPath, cannot find client-extra").split(File.pathSeparator);
         var extra = findJarOnClasspath(legacyCP, "client-extra");
-        mcstream.add(extra);
 
         // The MC code/Patcher edits are in exploded directories
         final var modstream = Stream.<List<Path>>builder();
@@ -42,6 +41,7 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
         minecraft.stream().distinct().forEach(mcstream::add);
         mods.values().forEach(modstream::add);
 
+        mcstream.add(extra);
         var mcFilter = getMcFilter(extra, minecraft, modstream);
         return new LocatedPaths(mcstream.build().toList(), mcFilter, modstream.build().toList(), getFmlStuff(legacyCP));
     }


### PR DESCRIPTION
This PR changes the ordering of the "minecraft paths" in Forgedev to fix an issue where mergeable resources (such as tags and the new atlas configs) included in Forge would overwrite the respective vanilla resources instead of being merged.

---

Forge resources are included in the `VanillaPackResources` in both Forgedev and userdev.
In userdev (`CommonUserdevLaunchHandler`), the client-extra.jar is added last, which gets re-ordered to first because `UnionFileSystem` flips the order of the `basepaths` around. When a resource is searched, the client-extra.jar is therefore considered first and vanilla resources are not overwritten by files in the same relative path in Forge resources.
In Forgedev (`CommonDevLaunchHandler`), the client-extra.jar is currently added first, which gets re-ordered to last in `UnionFileSystem`, causing Forge resources to overwrite their vanilla counterparts when accessed through `VanillaPackResources`.

Forge resources are present again in their own `PackResources` via Forge's `ResourcePackLoader`, meaning those resources will still load correctly with this fix (tested with the new atlas config and a tag).

The most likely reason why this wasn't noticed until now is that Forge itself did not add any mergeable resource (only tags until now) that is also present in vanilla and the test mods (which do append to vanilla tags) have a separate path for their built resources (`projects/forge/build/resources/test`) which is not included in the list of "minecraft paths" and therefore not present in the `basepaths` list of the `UnionFileSystem` feeding the `VanillaPackResources`.