### PR TITLE
[1.19.3] Fix logspam when a root resource is requested from a DelegatingPackResources

### DIFF
--- a/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
+++ b/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
@@ -107,7 +107,7 @@ public class DelegatingPackResources extends AbstractPackResources
     public IoSupplier<InputStream> getRootResource(String... paths)
     {
         // Root resources do not make sense here
-        throw null;
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
This PR fixes logspam when a root resource (such as the pack icon) is requested from a `DelegatingPackResources`.

`PackResources#getRootResource()` previously returned an `InputStream` and had to throw to indicate that a given resource doesn't exist. In 1.19.3, this method changed to returning an `IoSupplier<InputStream>`, which indicates that a resource doesn't exist by returning `null`. The exception previously thrown by this method was removed by Mojang and the related compile error in Forge was incorrectly fixed to `throw null;` instead of `return null;`.

Fixes #9197