### PR TITLE
[1.18.2] Fix compatibility checker task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1223,6 +1223,14 @@ project(':forge') {
         dependsOn 'setupCheckJarCompatibility'
 
         baseJar = project.tasks.named('mergeBaseForgeJar').flatMap { it.output }
+        baseLibraries.from(project.tasks.named('createJoinedSRG').flatMap { it.output })
+
+        inputJar = project.tasks.named('reobfJar').flatMap { it.output }
+        concreteLibraries.from(project.PACKED_DEPS.collect { project.rootProject.tasks.getByPath(it).archiveFile })
+
+        commonLibraries.from(project.configurations.minecraftImplementation)
+        commonLibraries.from(project.configurations.installer)
+        commonLibraries.from(project.configurations.moduleonly)
     }
 
     task checkAll(dependsOn: [checkATs, checkSAS, checkExcs, findFieldInstanceChecks, checkPatches, checkLicenses]){}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
@@ -31,17 +31,9 @@ abstract class SetupCheckJarCompatibility extends DefaultTask {
         }.toArray(Dependency[]::new))
 
         project.tasks.named('checkJarCompatibility') {
-            baseLibraries.from(project.tasks.createJoinedSRG.output)
             baseLibraries.from(project.provider {
                 fmlLibs.resolvedConfiguration.lenientConfiguration.files
             })
-
-            inputJar = project.tasks.reobfJar.output
-            concreteLibraries.from(project.PACKED_DEPS.collect { project.rootProject.tasks.getByPath(it).archiveFile })
-
-            commonLibraries.from(project.configurations.minecraftImplementation)
-            commonLibraries.from(project.configurations.installer)
-            commonLibraries.from(project.configurations.moduleonly)
         }
 
         def baseForgeUserdev = project.layout.buildDirectory.dir(name).map { it.file("forge-${inputVersion}-userdev.jar") }.get().asFile

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
@@ -18,6 +18,7 @@ abstract class SetupCheckJarCompatibility extends DefaultTask {
         onlyIf {
             inputVersion.getOrNull() != null
         }
+        outputs.upToDateWhen { false } // Never up to date, because this setup task should always run
 
         baseBinPatchesOutput.convention(project.layout.buildDirectory.dir(name).map { it.file('joined.lzma') })
     }


### PR DESCRIPTION
This PR fixes an ongoing issue where the compatibility checker task fails to run due to a misconfiguration, causing the CI validation using that checker to fail for all existing PRs.

In addition, this PR configures the setup task, `setupCheckJarCompatibility`, to never be considered as `UP-TO-DATE`.

---

_This PR is the LTS (1.18.2) backport of #9202. Please see that PR for further details and information._

