### PR TITLE
[1.19.3] Disable guiLight3d for generated item models

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
 +++ b/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
-@@ -40,6 +_,7 @@
+@@ -40,6 +_,8 @@
        map.put("particle", p_111672_.m_111477_("particle") ? Either.left(p_111672_.m_111480_("particle")) : map.get("layer0"));
        BlockModel blockmodel = new BlockModel((ResourceLocation)null, list, map, false, p_111672_.m_111479_(), p_111672_.m_111491_(), p_111672_.m_111484_());
        blockmodel.f_111416_ = p_111672_.f_111416_;
 +      blockmodel.customData.copyFrom(p_111672_.customData);
++      blockmodel.customData.setGui3d(false);
        return blockmodel;
     }
  

--- a/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
@@ -41,6 +41,7 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
     private Transformation rootTransform;
     @Nullable
     private ResourceLocation renderTypeHint;
+    private boolean gui3d = true;
 
     @ApiStatus.Internal
     public BlockGeometryBakingContext(BlockModel owner)
@@ -93,7 +94,7 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
     @Override
     public boolean isGui3d()
     {
-        return true;
+        return gui3d;
     }
 
     @Override
@@ -141,12 +142,18 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
         this.renderTypeHint = renderTypeHint;
     }
 
+    public void setGui3d(boolean gui3d)
+    {
+        this.gui3d = gui3d;
+    }
+
     public void copyFrom(BlockGeometryBakingContext other)
     {
         this.customGeometry = other.customGeometry;
         this.rootTransform = other.rootTransform;
         this.visibilityData.copyFrom(other.visibilityData);
         this.renderTypeHint = other.renderTypeHint;
+        this.gui3d = other.gui3d;
     }
 
     public BakedModel bake(ModelBaker baker, Function<Material, TextureAtlasSprite> bakedTextureGetter, ModelState modelTransform, ItemOverrides overrides, ResourceLocation modelLocation)


### PR DESCRIPTION
This PR fixes a regression introduced by #9065 that causes generated item models to incorrectly return true from `BakedModel#isGui3d()`. The unification of how models are baked (everything going through `UnbakedGeometryHelper#bake()` uses Forge's `ElementsModel` now) caused the `guiLight3d` parameter of `UnbakedGeometryHelper#bake()` to be ignored completely and the `BlockModel#customData.isGui3d()` to be used instead, which always returns true. `BlockModel#customData.isGui3d()` always returning true was correct until now since the generated item model baking (which is the only thing that sets the parameter to false) still used a path that respected the parameter.

To fix this, the return value of `BlockModel#customData.isGui3d()` is moved to a mutable variable that defaults to true and set to false by the `ItemModelGenerator`.

Fixes #9216