### PR TITLE
Remove duplicate `updateNeighbourForOutputSignal` call

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -207,14 +207,6 @@
     }
  
     @Nullable
-@@ -640,6 +_,7 @@
-          this.m_46745_(p_151544_).m_8092_(true);
-       }
- 
-+      this.m_46717_(p_151544_, m_8055_(p_151544_).m_60734_()); //Notify neighbors of changes
-    }
- 
-    public int m_5736_() {
 @@ -684,7 +_,7 @@
     public int m_46681_(BlockPos p_46682_, Direction p_46683_) {
        BlockState blockstate = this.m_8055_(p_46682_);


### PR DESCRIPTION
This PR fixes #9169 by removing a duplicated `updateNeighbourForOutputSignal` call in `Level`.

As [said in the linked issue](https://github.com/MinecraftForge/MinecraftForge/issues/9169#issuecomment-1334720427), this is a patching error between 1.15 and 1.16. Forge patches `Level#removeBlockEntity` to call the above method to notify neighbors when the block entity is removed. 

However, in 1.16, a patching error caused the call to be duplicated to `Level#blockEntityChanged`. This method is called primarily by `BlockEntity#setChanged`, which already calls `updateNeighbourForOutputSignal` itself. Thus, the method is called twice for that codepath.