### PR TITLE
[1.19.3] Allow using custom factories in button builders

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/components/Button.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/Button.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/client/gui/components/Button.java
++++ b/net/minecraft/client/gui/components/Button.java
+@@ -29,6 +_,11 @@
+       this.f_252416_ = p_259552_;
+    }
+ 
++   protected Button(Builder builder) {
++      this(builder.f_252538_, builder.f_252462_, builder.f_252510_, builder.f_252447_, builder.f_252401_, builder.f_252468_, builder.f_252431_);
++      m_257544_(builder.f_256855_); // Forge: Make use of the Builder tooltip
++   }
++
+    public void m_5691_() {
+       this.f_93717_.m_93750_(this);
+    }
+@@ -92,9 +_,11 @@
+       }
+ 
+       public Button m_253136_() {
+-         Button button = new Button(this.f_252538_, this.f_252462_, this.f_252510_, this.f_252447_, this.f_252401_, this.f_252468_, this.f_252431_);
+-         button.m_257544_(this.f_256855_);
+-         return button;
++         return build(Button::new);
++      }
++
++      public Button build(java.util.function.Function<Builder, Button> builder) {
++         return builder.apply(this);
+       }
+    }
+ 

--- a/src/main/java/net/minecraftforge/client/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ExtendedButton.java
@@ -33,6 +33,11 @@ public class ExtendedButton extends Button
         super(xPos, yPos, width, height, displayString, handler, createNarration);
     }
 
+    public ExtendedButton(Button.Builder builder)
+    {
+        super(builder);
+    }
+
     /**
      * Draws this button to the screen.
      */

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ScreenEvent;
+import net.minecraftforge.client.gui.widget.ExtendedButton;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -63,7 +64,7 @@ public class GuiLayeringTest
             protected void init()
             {
                 int buttonWidth = 150;
-                int buttonHeight = 20;
+                int buttonHeight = 30;
                 int buttonGap = 4;
                 int buttonSpacing = (buttonHeight + buttonGap);
                 int buttons = 3;
@@ -75,9 +76,9 @@ public class GuiLayeringTest
                 xoff = RANDOM.nextInt(xoff);
                 yoff = RANDOM.nextInt(yoff);
 
-                this.addRenderableWidget(Button.builder(Component.literal("Push New Layer"), this::pushLayerButton).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build());
-                this.addRenderableWidget(Button.builder(Component.literal("Pop Current Layer"), this::popLayerButton).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build());
-                this.addRenderableWidget(Button.builder(Component.literal("Close entire stack"), this::closeStack).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build());
+                this.addRenderableWidget(Button.builder(Component.literal("Push New Layer"), this::pushLayerButton).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build(ExtendedButton::new));
+                this.addRenderableWidget(Button.builder(Component.literal("Pop Current Layer"), this::popLayerButton).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build(ExtendedButton::new));
+                this.addRenderableWidget(Button.builder(Component.literal("Close entire stack"), this::closeStack).pos(xoff, yoff + buttonSpacing * (cnt++)).size(buttonWidth, buttonHeight).build(ExtendedButton::new));
             }
 
             private void closeStack(Button button)


### PR DESCRIPTION
This PR allows using custom factories for creating a button using `Button$Builder`. This can be used for example alongside `ExtendedButton` to create buttons of any size.