### PR TITLE
[1.19.3] Update link for Parchment "Getting Started" in build.gradle mdk

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -22,7 +22,7 @@ minecraft {
     // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
     //
     // Parchment is an unofficial project maintained by ParchmentMC, separate from MinecraftForge
-    // Additional setup is needed to use their mappings: https://github.com/ParchmentMC/Parchment/wiki/Getting-Started
+    // Additional setup is needed to use their mappings: https://parchmentmc.org/docs/getting-started
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.


### PR DESCRIPTION
This PR just update the link from Parchment github wiki to documentation page direcly.