### PR TITLE
Introduce a `batch` parameter in @GameTestHolder

### DIFF
--- a/patches/minecraft/net/minecraft/gametest/framework/GameTest.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTest.java.patch
@@ -1,14 +1,20 @@
 --- a/net/minecraft/gametest/framework/GameTest.java
 +++ b/net/minecraft/gametest/framework/GameTest.java
-@@ -16,6 +_,11 @@
+@@ -10,11 +_,16 @@
+ public @interface GameTest {
+    int m_177042_() default 100;
+ 
+-   String m_177043_() default "defaultBatch";
++   String m_177043_() default "";
+ 
+    int m_177044_() default 0;
  
     boolean m_177045_() default true;
- 
++
 +   /**
 +    * The namespace of where to grab the structure from, generally a mod id.
 +    */
 +   String templateNamespace() default "";
-+
+ 
     String m_177046_() default "";
  
-    long m_177047_() default 0L;

--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestRegistry.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestRegistry.java.patch
@@ -47,18 +47,20 @@
           return (Collection)p_177514_.invoke(object);
        } catch (ReflectiveOperationException reflectiveoperationexception) {
           throw new RuntimeException(reflectiveoperationexception);
-@@ -115,8 +_,9 @@
+@@ -115,9 +_,10 @@
        GameTest gametest = p_177516_.getAnnotation(GameTest.class);
        String s = p_177516_.getDeclaringClass().getSimpleName();
        String s1 = s.toLowerCase();
 -      String s2 = s1 + "." + p_177516_.getName().toLowerCase();
 -      String s3 = gametest.m_177046_().isEmpty() ? s2 : s1 + "." + gametest.m_177046_();
+-      String s4 = gametest.m_177043_();
 +      boolean prefixGameTestTemplate = net.minecraftforge.gametest.ForgeGameTestHooks.prefixGameTestTemplate(p_177516_);
 +      String s2 = (prefixGameTestTemplate ? s1 + "." : "") + p_177516_.getName().toLowerCase();
 +      String s3 = net.minecraftforge.gametest.ForgeGameTestHooks.getTemplateNamespace(p_177516_) + ":" + (gametest.m_177046_().isEmpty() ? s2 : (prefixGameTestTemplate ? s1 + "." : "") + gametest.m_177046_());
-       String s4 = gametest.m_177043_();
++      String s4 = net.minecraftforge.gametest.ForgeGameTestHooks.getBatch(p_177516_);
        Rotation rotation = StructureUtils.m_127835_(gametest.m_177044_());
        return new TestFunction(s4, s2, s3, rotation, gametest.m_177042_(), gametest.m_177047_(), gametest.m_177045_(), gametest.m_177049_(), gametest.m_177048_(), (Consumer<net.minecraft.gametest.framework.GameTestHelper>)m_177519_(p_177516_));
+    }
 @@ -125,7 +_,9 @@
     private static Consumer<?> m_177519_(Method p_177520_) {
        return (p_177512_) -> {

--- a/src/main/java/net/minecraftforge/gametest/ForgeGameTestHooks.java
+++ b/src/main/java/net/minecraftforge/gametest/ForgeGameTestHooks.java
@@ -114,6 +114,25 @@ public class ForgeGameTestHooks
         return "minecraft";
     }
 
+    public static String getBatch(Method method)
+    {
+        GameTest gameTest = method.getAnnotation(GameTest.class);
+
+        if (gameTest != null && !gameTest.batch().isEmpty())
+        {
+            return gameTest.batch();
+        }
+
+        GameTestHolder gameTestHolder = method.getDeclaringClass().getAnnotation(GameTestHolder.class);
+
+        if (gameTestHolder != null)
+        {
+            return gameTestHolder.batch();
+        }
+
+        return "defaultBatch";
+    }
+
     public static boolean prefixGameTestTemplate(Method method)
     {
         PrefixGameTestTemplate annotation = method.getAnnotation(PrefixGameTestTemplate.class);

--- a/src/main/java/net/minecraftforge/gametest/GameTestHolder.java
+++ b/src/main/java/net/minecraftforge/gametest/GameTestHolder.java
@@ -25,4 +25,9 @@ public @interface GameTestHolder
      * Used as the default {@link GameTest#templateNamespace() template namespace} for any game tests in the class that do not specify one.
      */
     String value() default "minecraft";
+
+    /**
+     * Used as the default {@link GameTest#batch() batch} for any game tests in the class that do not specify one.
+     */
+    String batch() default "defaultBatch";
 }


### PR DESCRIPTION
This PR adds a `batch` parameter to the Forge's `@GameTestHolder` annotation.

## Introduction

Imagine you have a test suite with dozens of tests in it. If you decide to group them under a specific batch, you have to specify a batch for every single `@GameTest`.

This PR lets us define a common batch for all the tests under `@GameTestHolder`, so the test case becomes less crowded.

## How it works

Essentially, `@GameTestHolder#batch` will take precedence unless `@GameTest#batch` is specified. That said, you can define a custom batch per test, even if you have specified a common batch.

## Examples

### Before
```kotlin
@GameTestHolder(MOD_ID)
class TestSuite {
    @GameTest(batch = "customBatch")
    fun test1(...)

    @GameTest(batch = "customBatch")
    fun test2(...)

    @GameTest(batch = "customBatch")
    fun test3(...)
}
```

### After
```kotlin
@GameTestHolder(MOD_ID, batch = "customBatch")
class TestSuite {
    @GameTest
    fun test1(...)

    @GameTest
    fun test2(...)

    @GameTest
    fun test3(...)
}
```

## Changes

This PR invades `@GameTest` annotation, specifically it removes default batch name from the `batch` parameter. This is done in order to detect whether there is a manually specified batch.

However, as `ForgeGameTestHooks#getBatch` fallbacks to "defaultBatch" if no condition is met, this PR will not affect end-users.

## Tests

I've tested this PR on my local project in 3 different scenarios:
- No batches defined. Result: all tests are under "defaultBatch"
- Batch defined in `@GameTestHolder`. Result: all tests are under `@GameTestHolder` batch
- Batch defined in `@GameTestHolder` and `@GameTest`. Result: batches defined in `@GameTest` take precedence over those defined in `@GameTestHolder`.