### PR TITLE
Fix mob block breaking AI when chunk 0,0 is unloaded

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
@@ -5,7 +5,15 @@
  
     public boolean m_8036_() {
 -      if (!this.f_25837_.f_19853_.m_46469_().m_46207_(GameRules.f_46132_)) {
-+      if (!net.minecraftforge.common.ForgeHooks.canEntityDestroy(this.f_25837_.f_19853_, this.f_25602_, this.f_25837_)) {
++      if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.f_25837_.f_19853_, this.f_25837_)) {
           return false;
        } else if (this.f_25600_ > 0) {
           --this.f_25600_;
+@@ -133,6 +_,7 @@
+       if (chunkaccess == null) {
+          return false;
+       } else {
++         if (!chunkaccess.m_8055_(p_25851_).canEntityDestroy(p_25850_, p_25851_, this.f_25837_)) return false;
+          return chunkaccess.m_8055_(p_25851_).m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_();
+       }
+    }

--- a/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
@@ -9,11 +9,14 @@
           return false;
        } else if (this.f_25600_ > 0) {
           --this.f_25600_;
-@@ -133,6 +_,7 @@
+@@ -133,7 +_,9 @@
        if (chunkaccess == null) {
           return false;
        } else {
-+         if (!chunkaccess.m_8055_(p_25851_).canEntityDestroy(p_25850_, p_25851_, this.f_25837_)) return false;
-          return chunkaccess.m_8055_(p_25851_).m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_();
+-         return chunkaccess.m_8055_(p_25851_).m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_();
++         net.minecraft.world.level.block.state.BlockState state = chunkaccess.m_8055_(p_25851_);
++         if (!(state.canEntityDestroy(p_25850_, p_25851_, this.f_25837_) && net.minecraftforge.event.ForgeEventFactory.onEntityDestroyBlock(this.f_25837_, p_25851_, state))) return false;
++         return state.m_60713_(this.f_25836_) && chunkaccess.m_8055_(p_25851_.m_7494_()).m_60795_() && chunkaccess.m_8055_(p_25851_.m_6630_(2)).m_60795_();
        }
     }
+ }


### PR DESCRIPTION
This PR fixes #9241 by backporting https://github.com/MinecraftForge/MinecraftForge/commit/5e8c786406d5add1a2982c212f33e9ce849b21a3 from 1.19.x. 

The fix works by moving the position-sensitive entity destroy check, which checks if the selected position is loaded, to a later point. The original position of the check meant that it fired before the position was selected (by the call to `tryFindBlock()`), which meant the position was at its default of `(0, 0, 0)`. This meant that the destroy check would fail if the chunk at `(0, 0)` was not loaded, which is the case in the Nether and other dimensions. (The Overworld is not affected because the world spawn position is near enough to the above-mentioned chunk that it is kept chunkloaded by the server itself.)

---

This PR also introduces a fix for a regression introduced the above PR, where `LivingDestroyBlockEvent` was not fired anymore (due to it being originally fired by `ForgeHooks#canEntityDestroy`). The second hunk in the patch is slightly bigger because the block state is retrieved once and used three times -- one for `BlockState#canEntityDestory`, one for firing the `LivingDestroyBlockEvent`, and one for `BlockState#is`.