### PR TITLE
[1.19.2] Fix config key used by resource cache

### DIFF
--- a/src/main/java/net/minecraftforge/resource/ResourceCacheManager.java
+++ b/src/main/java/net/minecraftforge/resource/ResourceCacheManager.java
@@ -108,7 +108,7 @@ public class ResourceCacheManager
      */
     public static boolean shouldUseCache()
     {
-        return ResourceManagerBootCacheConfigurationHandler.getInstance().getConfigValue("cachePackAccess", true);
+        return ResourceManagerBootCacheConfigurationHandler.getInstance().getConfigValue("cacheResources", true);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #9252 by changing the config key used in `ResourceCacheManager#shouldUseCache()` from `cachePackAccess` (the old key when it was defined in the Forge common config) to the `cacheResources` key defined in the config spec and default config file in `ResourceManagerBootCacheConfigurationHandler`.