### PR TITLE
Add translate key for Forge pack.mcmeta description (feature of 1.19.3)

### DIFF
--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -220,5 +220,5 @@
   "forge.experimentalsettings.tooltip": "This world uses experimental settings, which could stop working at any time.",
   "forge.selectWorld.backupWarning.experimental.additional" : "This message will not show again for this world.",
 
-  "pack.forge.description": "Forge resources pack"
+  "pack.forge.description": "Forge resource pack"
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -218,5 +218,7 @@
   "fluid_type.minecraft.flowing_milk": "Milk",
 
   "forge.experimentalsettings.tooltip": "This world uses experimental settings, which could stop working at any time.",
-  "forge.selectWorld.backupWarning.experimental.additional" : "This message will not show again for this world."
+  "forge.selectWorld.backupWarning.experimental.additional" : "This message will not show again for this world.",
+
+  "pack.forge.description": "Forge resources pack"
 }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,9 @@
 {
    "pack": {
       "pack_format": 12,
-      "description": "Forge resource pack",
+      "description": {
+         "translate": "pack.forge.description"
+      },
       "forge:resource_pack_format": 12,
       "forge:data_pack_format": 10
    }


### PR DESCRIPTION
This PR add a translation key for the description of Forge pack.mcmeta (new feature of 1.19.3).

This makes it possible to be in agreement with the other data packs which also have a translation key.