### PR TITLE
add woodtype to hanging sign materials

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
@@ -16,7 +16,7 @@
     }
  
     public static Material m_173381_(WoodType p_173382_) {
-@@ -190,5 +_,12 @@
+@@ -190,5 +_,13 @@
           default:
              return p_110773_;
        }
@@ -27,5 +27,6 @@
 +    */
 +   public static void addWoodType(WoodType woodType) {
 +      f_110743_.put(woodType, m_173385_(woodType));
++      f_244291_.put(woodType, m_245275_(woodType));
     }
  }

--- a/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java
@@ -6,8 +6,12 @@
 package net.minecraftforge.debug.block;
 
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
+import net.minecraft.client.renderer.blockentity.HangingSignRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.HangingSignItem;
+import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.HangingSignBlockEntity;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
@@ -27,10 +31,6 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.StandingSignBlock;
-import net.minecraft.world.level.block.WallSignBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.WoodType;
@@ -46,12 +46,16 @@ public class CustomSignsTest
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
     public static final RegistryObject<CustomStandingSignBlock> TEST_STANDING_SIGN = BLOCKS.register("test_sign", () -> new CustomStandingSignBlock(Properties.of(Material.WOOD).noCollission().strength(1.0F).sound(SoundType.WOOD), CustomSignsTest.TEST_WOOD_TYPE));
     public static final RegistryObject<CustomWallSignBlock> TEST_WALL_SIGN = BLOCKS.register("test_wall_sign", () -> new CustomWallSignBlock(Properties.of(Material.WOOD).noCollission().strength(1.0F).sound(SoundType.WOOD), CustomSignsTest.TEST_WOOD_TYPE));
+    public static final RegistryObject<CustomHangingSignBlock> TEST_HANGING_SIGN = BLOCKS.register("test_hanging_sign", () -> new CustomHangingSignBlock(Properties.of(Material.WOOD).noCollission().strength(1.0F).sound(SoundType.WOOD), CustomSignsTest.TEST_WOOD_TYPE));
+    public static final RegistryObject<CustomCeilingSignBlock> TEST_CEILING_SIGN = BLOCKS.register("test_ceiling_sign", () -> new CustomCeilingSignBlock(Properties.of(Material.WOOD).noCollission().strength(1.0F).sound(SoundType.WOOD), CustomSignsTest.TEST_WOOD_TYPE));
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
     public static final RegistryObject<SignItem> TEST_SIGN = ITEMS.register("test_sign", () -> new SignItem((new Item.Properties()).stacksTo(16), TEST_STANDING_SIGN.get(), TEST_WALL_SIGN.get()));
+    public static final RegistryObject<HangingSignItem> TEST_HANGING_SIGN_ITEM = ITEMS.register("test_hanging_sign", () -> new HangingSignItem(TEST_CEILING_SIGN.get(), TEST_HANGING_SIGN.get(), (new Item.Properties()).stacksTo(16)));
 
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
     public static final RegistryObject<BlockEntityType<CustomSignBlockEntity>> CUSTOM_SIGN = BLOCK_ENTITIES.register("custom_sign", () -> BlockEntityType.Builder.of(CustomSignBlockEntity::new, TEST_WALL_SIGN.get(), TEST_STANDING_SIGN.get()).build(null));
+    public static final RegistryObject<BlockEntityType<CustomHangingSignBlockEntity>> CUSTOM_HANGING_SIGN = BLOCK_ENTITIES.register("custom_hanging_sign", () -> BlockEntityType.Builder.of(CustomHangingSignBlockEntity::new, TEST_CEILING_SIGN.get(), TEST_HANGING_SIGN.get()).build(null));
 
     public CustomSignsTest()
     {
@@ -71,12 +75,16 @@ public class CustomSignsTest
     private void addCreative(CreativeModeTabEvent.BuildContents event)
     {
         if (event.getTab() == CreativeModeTabs.BUILDING_BLOCKS)
+        {
             event.accept(TEST_SIGN);
+//            event.accept(TEST_HANGING_SIGN_ITEM);
+        }
     }
 
     private void clientSetup(final FMLClientSetupEvent event)
     {
         BlockEntityRenderers.register(CUSTOM_SIGN.get(), SignRenderer::new);
+        BlockEntityRenderers.register(CUSTOM_HANGING_SIGN.get(), HangingSignRenderer::new);
         event.enqueueWork(() -> {
            Sheets.addWoodType(TEST_WOOD_TYPE);
         });
@@ -127,6 +135,49 @@ public class CustomSignsTest
         public BlockEntityType<CustomSignBlockEntity> getType()
         {
             return CUSTOM_SIGN.get();
+        }
+    }
+
+    public static class CustomHangingSignBlock extends WallHangingSignBlock
+    {
+
+        public CustomHangingSignBlock(Properties propertiesIn, WoodType woodTypeIn)
+        {
+            super(propertiesIn, woodTypeIn);
+        }
+
+        @Override
+        public BlockEntity newBlockEntity(BlockPos pos, BlockState state)
+        {
+            return new CustomHangingSignBlockEntity(pos, state);
+        }
+    }
+
+    public static class CustomCeilingSignBlock extends CeilingHangingSignBlock
+    {
+
+        public CustomCeilingSignBlock(Properties propertiesIn, WoodType woodTypeIn)
+        {
+            super(propertiesIn, woodTypeIn);
+        }
+
+        @Override
+        public BlockEntity newBlockEntity(BlockPos pos, BlockState state)
+        {
+            return new CustomHangingSignBlockEntity(pos, state);
+        }
+    }
+
+    public static class CustomHangingSignBlockEntity extends HangingSignBlockEntity
+    {
+        public CustomHangingSignBlockEntity(BlockPos pos, BlockState state) {
+            super(pos, state);
+        }
+
+        @Override
+        public BlockEntityType<CustomHangingSignBlockEntity> getType()
+        {
+            return CUSTOM_HANGING_SIGN.get();
         }
     }
 }

--- a/src/test/resources/assets/custom_signs_test/blockstates/test_ceiling_sign.json
+++ b/src/test/resources/assets/custom_signs_test/blockstates/test_ceiling_sign.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "": { "model": "custom_signs_test:block/test_hanging_sign" }
+    }
+}

--- a/src/test/resources/assets/custom_signs_test/blockstates/test_hanging_sign.json
+++ b/src/test/resources/assets/custom_signs_test/blockstates/test_hanging_sign.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "": { "model": "custom_signs_test:block/test_hanging_sign" }
+    }
+}

--- a/src/test/resources/assets/custom_signs_test/models/block/test_hanging_sign.json
+++ b/src/test/resources/assets/custom_signs_test/models/block/test_hanging_sign.json
@@ -1,0 +1,5 @@
+{
+    "textures": {
+        "particle": "minecraft:block/oak_planks"
+    }
+}


### PR DESCRIPTION
When adding a custom hanging sign (and using own wood type) with an `HangingSignRenderer`, the wood type needs to the `HANGING_SIGN_MATERIALS` map, too. Otherwise, rendering the hanging sign would cause a crash. This PR fixes this crash.