### PR TITLE
[1.19.3] Fix StemBlock not checking canSustainPlant using StemGrownBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
@@ -20,7 +20,7 @@
                 BlockState blockstate = p_222539_.m_8055_(blockpos.m_7495_());
 -               if (p_222539_.m_8055_(blockpos).m_60795_() && (blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
 +               Block block = blockstate.m_60734_();
-+               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this) || block == Blocks.f_50093_ || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
++               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this.f_57015_) || block == Blocks.f_50093_ || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
                    p_222539_.m_46597_(blockpos, this.f_57015_.m_49966_());
                    p_222539_.m_46597_(p_222540_, this.f_57015_.m_7810_().m_49966_().m_61124_(HorizontalDirectionalBlock.f_54117_, direction));
                 }

--- a/patches/minecraft/net/minecraft/world/level/block/StemGrownBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemGrownBlock.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/world/level/block/StemGrownBlock.java
++++ b/net/minecraft/world/level/block/StemGrownBlock.java
+@@ -2,7 +_,7 @@
+ 
+ import net.minecraft.world.level.block.state.BlockBehaviour;
+ 
+-public abstract class StemGrownBlock extends Block {
++public abstract class StemGrownBlock extends Block implements net.minecraftforge.common.IPlantable {
+    public StemGrownBlock(BlockBehaviour.Properties p_57058_) {
+       super(p_57058_);
+    }
+@@ -10,4 +_,12 @@
+    public abstract StemBlock m_7161_();
+ 
+    public abstract AttachedStemBlock m_7810_();
++
++   //FORGE START
++   @Override
++   public net.minecraft.world.level.block.state.BlockState getPlant(net.minecraft.world.level.BlockGetter world, net.minecraft.core.BlockPos pos) {
++      net.minecraft.world.level.block.state.BlockState state = world.m_8055_(pos);
++      if (state.m_60734_() != this) return m_49966_();
++      return state;
++   }
+ }


### PR DESCRIPTION
This PR fixes an issue with the StemBlock patch where it would check `canSustainPlant` for placing a StemGrownBlock with the StemBlock itself, instead of the StemGrownBlock. This meant that the check would seemingly always fail unless an adjacent block were farmland, as StemBlock is a `PlantType.CROP`.

The fix involves replacing `this` with `this.fruit` in the check for `canSustainPlant` in StemBlock, which also required making StemGrownBlock implement IPlantable.