### PR TITLE
[1.19.x] Fix broken link for update checker doc page in mods.toml (mdk)

### DIFF
--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -22,7 +22,7 @@ modId="examplemod" #mandatory
 version="${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="Example Mod" #mandatory
-# A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
+# A URL to query for updates for this mod. See the JSON update specification https://docs.minecraftforge.net/en/latest/misc/updatechecker/
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional


### PR DESCRIPTION
This PR is just a cleanup to fix the link for update checker documentation page (this page was renamed).

The reason above can also go with the recent domain change (even if there is a redirection).

https://github.com/MinecraftForge/Documentation/commits/1.19.x/docs/misc/updatechecker.md