### PR TITLE
Add event for receiving system messages

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
@@ -30,3 +30,24 @@
                 this.m_241119_(p_251766_, component);
              }
           }
+@@ -159,14 +_,16 @@
+ 
+    public void m_240494_(Component p_240522_, boolean p_240642_) {
+       if (!this.f_240348_.f_91066_.m_231833_().m_231551_() || !this.f_240348_.m_91246_(this.m_240473_(p_240522_))) {
++         Component component = net.minecraftforge.client.ForgeHooksClient.onClientSystemChat(p_240522_, p_240642_);
++         if (component == null) return;
+          if (p_240642_) {
+-            this.f_240348_.f_91065_.m_93063_(p_240522_, false);
++            this.f_240348_.f_91065_.m_93063_(component, false);
+          } else {
+-            this.f_240348_.f_91065_.m_93076_().m_93785_(p_240522_);
+-            this.m_240498_(p_240522_, Instant.now());
++            this.f_240348_.f_91065_.m_93076_().m_93785_(component);
++            this.m_240498_(component, Instant.now());
+          }
+ 
+-         this.f_240348_.m_240477_().m_263195_(p_240522_);
++         this.f_240348_.m_240477_().m_263195_(component);
+       }
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/chat/ChatListener.java.patch
@@ -30,24 +30,12 @@
                 this.m_241119_(p_251766_, component);
              }
           }
-@@ -159,14 +_,16 @@
+@@ -159,6 +_,8 @@
  
     public void m_240494_(Component p_240522_, boolean p_240642_) {
        if (!this.f_240348_.f_91066_.m_231833_().m_231551_() || !this.f_240348_.m_91246_(this.m_240473_(p_240522_))) {
-+         Component component = net.minecraftforge.client.ForgeHooksClient.onClientSystemChat(p_240522_, p_240642_);
-+         if (component == null) return;
++         p_240522_ = net.minecraftforge.client.ForgeHooksClient.onClientSystemChat(p_240522_, p_240642_);
++         if (p_240522_ == null) return;
           if (p_240642_) {
--            this.f_240348_.f_91065_.m_93063_(p_240522_, false);
-+            this.f_240348_.f_91065_.m_93063_(component, false);
+             this.f_240348_.f_91065_.m_93063_(p_240522_, false);
           } else {
--            this.f_240348_.f_91065_.m_93076_().m_93785_(p_240522_);
--            this.m_240498_(p_240522_, Instant.now());
-+            this.f_240348_.f_91065_.m_93076_().m_93785_(component);
-+            this.m_240498_(component, Instant.now());
-          }
- 
--         this.f_240348_.m_240477_().m_263195_(p_240522_);
-+         this.f_240348_.m_240477_().m_263195_(component);
-       }
-    }
- 

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -978,11 +978,12 @@ public class ForgeHooksClient
 
     private static final ChatTypeDecoration SYSTEM_CHAT_TYPE_DECORATION = new ChatTypeDecoration("forge.chatType.system", List.of(ChatTypeDecoration.Parameter.CONTENT), Style.EMPTY);
     private static final ChatType SYSTEM_CHAT_TYPE = new ChatType(SYSTEM_CHAT_TYPE_DECORATION, SYSTEM_CHAT_TYPE_DECORATION);
+    private static final ChatType.Bound SYSTEM_CHAT_TYPE_BOUND = SYSTEM_CHAT_TYPE.bind(Component.literal("System"));
 
     @Nullable
     public static Component onClientSystemChat(Component message, boolean overlay)
     {
-        ClientChatReceivedEvent.System event = new ClientChatReceivedEvent.System(new ChatType.Bound(SYSTEM_CHAT_TYPE, Component.literal("System"), null), message, overlay);
+        ClientChatReceivedEvent.System event = new ClientChatReceivedEvent.System(SYSTEM_CHAT_TYPE_BOUND, message, overlay);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
 

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -973,6 +973,13 @@ public class ForgeHooksClient
         ClientChatReceivedEvent.Player event = new ClientChatReceivedEvent.Player(boundChatType, message, playerChatMessage, sender);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
+    
+    @Nullable
+    public static Component onClientSystemChat(Component message, boolean overlay)
+    {
+        ClientChatReceivedEvent.System event = new ClientChatReceivedEvent.System(message, overlay);
+        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+    }
 
     @NotNull
     public static String onClientSendMessage(String message)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -72,10 +72,12 @@ import net.minecraft.core.Direction;
 import net.minecraft.locale.Language;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.ChatTypeDecoration;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.PlayerChatMessage;
+import net.minecraft.network.chat.Style;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
@@ -973,11 +975,14 @@ public class ForgeHooksClient
         ClientChatReceivedEvent.Player event = new ClientChatReceivedEvent.Player(boundChatType, message, playerChatMessage, sender);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
-    
+
+    private static final ChatTypeDecoration SYSTEM_CHAT_TYPE_DECORATION = new ChatTypeDecoration("forge.chatType.system", List.of(ChatTypeDecoration.Parameter.CONTENT), Style.EMPTY);
+    private static final ChatType SYSTEM_CHAT_TYPE = new ChatType(SYSTEM_CHAT_TYPE_DECORATION, SYSTEM_CHAT_TYPE_DECORATION);
+
     @Nullable
     public static Component onClientSystemChat(Component message, boolean overlay)
     {
-        ClientChatReceivedEvent.System event = new ClientChatReceivedEvent.System(message, overlay);
+        ClientChatReceivedEvent.System event = new ClientChatReceivedEvent.System(new ChatType.Bound(SYSTEM_CHAT_TYPE, Component.literal("System"), null), message, overlay);
         return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
 

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -151,7 +151,7 @@ public class ClientChatReceivedEvent extends Event
         /**
          * {@return whether the message goes to the overlay}
          */
-        public boolean getOverlay()
+        public boolean isOverlay()
         {
             return this.overlay;
         }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -88,8 +88,8 @@ public class ClientChatReceivedEvent extends Event
     }
 
     /**
-     * {@return {@code true} if the bound chat type is not set}
-     * This will happen when the message is sent by the server and is not disguised as a player message
+     * {@return {@code true} if the bound chat type is set}
+     * This will happen when the message is either sent by a player or is disguised as a player message
      */
     public boolean hasBoundChatType()
     {

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -88,15 +88,6 @@ public class ClientChatReceivedEvent extends Event
     }
 
     /**
-     * {@return {@code true} if the bound chat type is set}
-     * This will happen when the message is either sent by a player or is disguised as a player message
-     */
-    public boolean hasBoundChatType()
-    {
-        return this.boundChatType != null;
-    }
-
-    /**
      * Fired when a player chat message is received on the client.
      *
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
@@ -142,9 +133,9 @@ public class ClientChatReceivedEvent extends Event
         private final boolean overlay;
 
         @ApiStatus.Internal
-        public System(Component message, boolean overlay)
+        public System(ChatType.Bound boundChatType, Component message, boolean overlay)
         {
-            super(null, message, Util.NIL_UUID);
+            super(boundChatType, message, Util.NIL_UUID);
             this.overlay = overlay;
         }
 

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -88,6 +88,15 @@ public class ClientChatReceivedEvent extends Event
     }
 
     /**
+     * {@return {@code true} if the bound chat type is not set}
+     * This will happen when the message is sent by the server and is not disguised as a player message
+     */
+    public boolean hasBoundChatType()
+    {
+        return this.boundChatType != null;
+    }
+
+    /**
      * Fired when a player chat message is received on the client.
      *
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
@@ -116,6 +125,35 @@ public class ClientChatReceivedEvent extends Event
         public PlayerChatMessage getPlayerChatMessage()
         {
             return this.playerChatMessage;
+        }
+    }
+
+    /**
+     * Fired when a system chat message is received on the client.
+     *
+     * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+     * If the event is cancelled, the message is not displayed in the chat message window or in the overlay.</p>
+     *
+     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     */
+    public static class System extends ClientChatReceivedEvent
+    {
+        private final boolean overlay;
+
+        @ApiStatus.Internal
+        public System(Component message, boolean overlay)
+        {
+            super(null, message, Util.NIL_UUID);
+            this.overlay = overlay;
+        }
+
+        /**
+         * {@return whether the message goes to the overlay}
+         */
+        public boolean getOverlay()
+        {
+            return this.overlay;
         }
     }
 }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -220,5 +220,7 @@
   "forge.experimentalsettings.tooltip": "This world uses experimental settings, which could stop working at any time.",
   "forge.selectWorld.backupWarning.experimental.additional" : "This message will not show again for this world.",
 
+  "forge.chatType.system": "{0}",
+
   "pack.forge.description": "Forge resource pack"
 }


### PR DESCRIPTION
Adds an event for receiving system messages that don't use the disguised message packet.

Fixes #9267 