### PR TITLE
[1.19.3] Hotfix missing null check in createUnbakedItemElements

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElement.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElement.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/renderer/block/model/BlockElement.java
 +++ b/net/minecraft/client/renderer/block/model/BlockElement.java
-@@ -28,14 +_,21 @@
+@@ -28,14 +_,22 @@
     public final Map<Direction, BlockElementFace> f_111310_;
     public final BlockElementRotation f_111311_;
     public final boolean f_111312_;
-+   private net.minecraftforge.client.model.ForgeFaceData faceData;
++   @Deprecated // TODO: 1.20 - Make private. Use getter / setter methods to access.
++   public net.minecraftforge.client.model.ForgeFaceData faceData;
  
     public BlockElement(Vector3f p_253626_, Vector3f p_254426_, Map<Direction, BlockElementFace> p_254454_, @Nullable BlockElementRotation p_254229_, boolean p_253661_) {
 +     this(p_253626_, p_254426_, p_254454_, p_254229_, p_253661_, net.minecraftforge.client.model.ForgeFaceData.DEFAULT);
@@ -43,6 +44,6 @@
 +   }
 +
 +   public void setFaceData(net.minecraftforge.client.model.ForgeFaceData faceData) {
-+      this.faceData = com.google.common.base.Preconditions.checkNotNull(faceData);
++      this.faceData = java.util.Objects.requireNonNull(faceData);
     }
  }

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElement.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElement.java.patch
@@ -4,7 +4,7 @@
     public final Map<Direction, BlockElementFace> f_111310_;
     public final BlockElementRotation f_111311_;
     public final boolean f_111312_;
-+   public net.minecraftforge.client.model.ForgeFaceData faceData;
++   private net.minecraftforge.client.model.ForgeFaceData faceData;
  
     public BlockElement(Vector3f p_253626_, Vector3f p_254426_, Map<Direction, BlockElementFace> p_254454_, @Nullable BlockElementRotation p_254229_, boolean p_253661_) {
 +     this(p_253626_, p_254426_, p_254454_, p_254229_, p_253661_, net.minecraftforge.client.model.ForgeFaceData.DEFAULT);
@@ -17,7 +17,7 @@
        this.f_111311_ = p_254229_;
        this.f_111312_ = p_253661_;
        this.m_111319_();
-+      this.faceData = faceData;
++      this.setFaceData(faceData);
 +      this.f_111310_.values().forEach(face -> face.parent = this);
     }
  
@@ -32,3 +32,17 @@
           }
        }
  
+@@ -179,5 +_,13 @@
+             return new Vector3f(afloat[0], afloat[1], afloat[2]);
+          }
+       }
++   }
++
++   public net.minecraftforge.client.model.ForgeFaceData getFaceData() {
++      return this.faceData;
++   }
++
++   public void setFaceData(net.minecraftforge.client.model.ForgeFaceData faceData) {
++      this.faceData = com.google.common.base.Preconditions.checkNotNull(faceData);
+    }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElementFace.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockElementFace.java.patch
@@ -25,7 +25,7 @@
 +      if(this.faceData != null) {
 +         return this.faceData;
 +      } else if(this.parent != null) {
-+         return this.parent.faceData;
++         return this.parent.getFaceData();
 +      }
 +      return net.minecraftforge.client.model.ForgeFaceData.DEFAULT;
     }

--- a/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
+++ b/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
@@ -1,8 +1,13 @@
 {
   "parent": "forge:item/default",
-  "emissive_layers": [
-    1
-  ],
+  "forge_data": {
+    "layers": {
+      "1": {
+        "block_light": 15,
+        "sky_light": 15
+      }
+    }
+  },
   "loader": "forge:item_layers",
   "render_types": {},
   "textures": {

--- a/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -147,7 +147,7 @@ public class UnbakedGeometryHelper
         var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, spriteContents);
         if(faceData != null)
         {
-            elements.forEach(element -> element.faceData = faceData);
+            elements.forEach(element -> element.setFaceData(faceData));
         }
         return elements;
     }

--- a/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -133,7 +133,7 @@ public class UnbakedGeometryHelper
      */
     public static List<BlockElement> createUnbakedItemElements(int layerIndex, SpriteContents spriteContents)
     {
-    	return createUnbakedItemElements(layerIndex, spriteContents, null);
+        return createUnbakedItemElements(layerIndex, spriteContents, null);
     }
 
     /**
@@ -145,7 +145,10 @@ public class UnbakedGeometryHelper
     public static List<BlockElement> createUnbakedItemElements(int layerIndex, SpriteContents spriteContents, @Nullable ForgeFaceData faceData)
     {
         var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, spriteContents);
-        elements.forEach(element -> element.faceData = faceData);
+        if(faceData != null)
+        {
+            elements.forEach(element -> element.faceData = faceData);
+        }
         return elements;
     }
 
@@ -154,7 +157,7 @@ public class UnbakedGeometryHelper
      */
     public static List<BlockElement> createUnbakedItemMaskElements(int layerIndex, SpriteContents spriteContents)
     {
-    	return createUnbakedItemMaskElements(layerIndex, spriteContents, null);
+        return createUnbakedItemMaskElements(layerIndex, spriteContents, null);
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/misc/DataPackRegistriesTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/DataPackRegistriesTest.java
@@ -57,7 +57,7 @@ import org.slf4j.Logger;
 @Mod(DataPackRegistriesTest.MODID)
 public class DataPackRegistriesTest
 {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     public static final String MODID = "data_pack_registries_test";
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final ResourceLocation TEST_RL = new ResourceLocation(MODID, "test");

--- a/src/test/java/net/minecraftforge/debug/world/BiomeModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeModifierTest.java
@@ -14,7 +14,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.HolderSet;;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.DataProvider;


### PR DESCRIPTION
`UnbakedGeometryHelper#createUnbakedItemElements` is not properly null-checking and ignoring the passed `faceData`, which causes a crash during model baking (note this only occurs when using item layer models that do not have face data generated for a particular layer).

This PR adds the null check and fixes the crash.  It also changes `BlockElement#faceData` to private and adds a getter/setter for better tracking (though this is just cleanup and would not really prevent this crash).

Finally, it updates the datagenned file `item_layers.json` to the current variant.

And then two unrelated rider changes:
* Removes an extra semicolon from `BiomeModifierTest` that is making whatever version of eclipse's compiler I have installed very upset.
* Sets `DataPackRegistriesTest.ENABLED` to false since this causes a crash when running `forge_test_data` because it is not properly implemented.