### PR TITLE
Make Model Datagens ConfiguredModel non-final

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * {@link #allYRotations(ModelFile, int, boolean)}, or created by builder via
  * {@link #builder()}.
  */
-public final class ConfiguredModel {
+public class ConfiguredModel {
 
     /**
      * The default random weight of configured models, used by convenience


### PR DESCRIPTION
This will allow mods to subclass it and customize the generated JSON if they so desire, without having to rebuild the entire blockstate definition generator themselves.