### PR TITLE
[1.19.2] Fire TickEvent.LevelTickEvent on ClientLevel tick

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -342,6 +342,22 @@
        this.f_91026_.m_6180_("gui");
        this.f_240378_.m_240688_();
        this.f_91065_.m_193832_(this.f_91012_);
+@@ -1749,6 +_,7 @@
+ 
+             this.f_91005_.m_120596_();
+ 
++            net.minecraftforge.event.ForgeEventFactory.onPreLevelTick(this.f_91073_, () -> true);
+             try {
+                this.f_91073_.m_104726_(() -> {
+                   return true;
+@@ -1764,6 +_,7 @@
+ 
+                throw new ReportedException(crashreport);
+             }
++            net.minecraftforge.event.ForgeEventFactory.onPostLevelTick(this.f_91073_, () -> true);
+          }
+ 
+          this.f_91026_.m_6182_("animateTick");
 @@ -1783,6 +_,8 @@
        this.f_91026_.m_6182_("keyboard");
        this.f_91068_.m_90931_();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -812,12 +812,12 @@ public class ForgeEventFactory
 
     public static void onPreLevelTick(Level level, BooleanSupplier haveTime)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.LevelTickEvent(LogicalSide.SERVER, TickEvent.Phase.START, level, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.LevelTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.START, level, haveTime));
     }
 
     public static void onPostLevelTick(Level level, BooleanSupplier haveTime)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.LevelTickEvent(LogicalSide.SERVER, TickEvent.Phase.END, level, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.LevelTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.END, level, haveTime));
     }
 
     public static void onPreClientTick()


### PR DESCRIPTION
Backport of #9299. Fixes #9298 for Minecraft 1.19.2.