### PR TITLE
[1.18.2] Fire TickEvent.WorldTickEvent on ClientLevel tick

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -309,6 +309,22 @@
        this.f_91026_.m_6180_("gui");
        this.f_91065_.m_193832_(this.f_91012_);
        this.f_91026_.m_7238_();
+@@ -1660,6 +_,7 @@
+ 
+             this.f_91005_.m_120596_();
+ 
++            net.minecraftforge.event.ForgeEventFactory.onPreWorldTick(this.f_91073_, () -> true);
+             try {
+                this.f_91073_.m_104726_(() -> {
+                   return true;
+@@ -1675,6 +_,7 @@
+ 
+                throw new ReportedException(crashreport);
+             }
++            net.minecraftforge.event.ForgeEventFactory.onPostWorldTick(this.f_91073_, () -> true);
+          }
+ 
+          this.f_91026_.m_6182_("animateTick");
 @@ -1694,6 +_,8 @@
        this.f_91026_.m_6182_("keyboard");
        this.f_91068_.m_90931_();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -892,7 +892,7 @@ public class ForgeEventFactory
 
     public static void onPreWorldTick(Level level, BooleanSupplier haveTime)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.WorldTickEvent(LogicalSide.SERVER, TickEvent.Phase.START, level, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.WorldTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.START, level, haveTime));
     }
 
     /**
@@ -908,7 +908,7 @@ public class ForgeEventFactory
 
     public static void onPostWorldTick(Level level, BooleanSupplier haveTime)
     {
-        MinecraftForge.EVENT_BUS.post(new TickEvent.WorldTickEvent(LogicalSide.SERVER, TickEvent.Phase.END, level, haveTime));
+        MinecraftForge.EVENT_BUS.post(new TickEvent.WorldTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.END, level, haveTime));
     }
 
     public static void onPreClientTick()


### PR DESCRIPTION
LTS Backport of #9299. Fixes #9298 for Minecraft 1.18.2.