### PR TITLE
[1.19.3] Address ITeleporter.getPortalInfo() nullability issues when attempting to change dimension

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -8,13 +8,15 @@
        boolean flag = this.f_19853_.m_46469_().m_46207_(GameRules.f_46142_);
        if (flag) {
           Component component = this.m_21231_().m_19293_();
-@@ -707,11 +_,12 @@
+@@ -707,11 +_,14 @@
     }
  
     @Nullable
 -   public Entity m_5489_(ServerLevel p_9180_) {
 +   public Entity changeDimension(ServerLevel p_9180_, net.minecraftforge.common.util.ITeleporter teleporter) {
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_9180_.m_46472_())) return null;
++      PortalInfo portalinfo = teleporter.getPortalInfo(this, p_9180_, this::m_7937_);
++      if (portalinfo == null) return null;
        this.f_8927_ = true;
        ServerLevel serverlevel = this.m_9236_();
        ResourceKey<Level> resourcekey = serverlevel.m_46472_();
@@ -23,14 +25,13 @@
           this.m_19877_();
           this.m_9236_().m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
           if (!this.f_8944_) {
-@@ -728,13 +_,14 @@
+@@ -728,13 +_,13 @@
           PlayerList playerlist = this.f_8924_.m_6846_();
           playerlist.m_11289_(this);
           serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
 -         this.m_146912_();
 -         PortalInfo portalinfo = this.m_7937_(p_9180_);
 +         this.revive();
-+         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_9180_, this::m_7937_);
           if (portalinfo != null) {
 +            Entity e = teleporter.placeEntity(this, serverlevel, p_9180_, this.m_146908_(), spawnPortal -> {//Forge: Start vanilla logic
              serverlevel.m_46473_().m_6180_("moving");

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -8,15 +8,13 @@
        boolean flag = this.f_19853_.m_46469_().m_46207_(GameRules.f_46142_);
        if (flag) {
           Component component = this.m_21231_().m_19293_();
-@@ -707,11 +_,14 @@
+@@ -707,11 +_,12 @@
     }
  
     @Nullable
 -   public Entity m_5489_(ServerLevel p_9180_) {
 +   public Entity changeDimension(ServerLevel p_9180_, net.minecraftforge.common.util.ITeleporter teleporter) {
-+      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_9180_.m_46472_())) return null;
-+      PortalInfo portalinfo = teleporter.getPortalInfo(this, p_9180_, this::m_7937_);
-+      if (portalinfo == null) return null;
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_9180_.m_46472_()) || !teleporter.canTeleport(this, p_9180_.m_46472_())) return null;
        this.f_8927_ = true;
        ServerLevel serverlevel = this.m_9236_();
        ResourceKey<Level> resourcekey = serverlevel.m_46472_();
@@ -25,13 +23,14 @@
           this.m_19877_();
           this.m_9236_().m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
           if (!this.f_8944_) {
-@@ -728,13 +_,13 @@
+@@ -728,13 +_,14 @@
           PlayerList playerlist = this.f_8924_.m_6846_();
           playerlist.m_11289_(this);
           serverlevel.m_143261_(this, Entity.RemovalReason.CHANGED_DIMENSION);
 -         this.m_146912_();
 -         PortalInfo portalinfo = this.m_7937_(p_9180_);
 +         this.revive();
++         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_9180_, this::m_7937_);
           if (portalinfo != null) {
 +            Entity e = teleporter.placeEntity(this, serverlevel, p_9180_, this.m_146908_(), spawnPortal -> {//Forge: Start vanilla logic
              serverlevel.m_46473_().m_6180_("moving");

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -349,14 +349,17 @@
 +   public Entity changeDimension(ServerLevel p_20118_, net.minecraftforge.common.util.ITeleporter teleporter) {
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_20118_.m_46472_())) return null;
        if (this.f_19853_ instanceof ServerLevel && !this.m_213877_()) {
-          this.f_19853_.m_46473_().m_6180_("changeDimension");
-          this.m_19877_();
-          this.f_19853_.m_46473_().m_6180_("reposition");
+-         this.f_19853_.m_46473_().m_6180_("changeDimension");
+-         this.m_19877_();
+-         this.f_19853_.m_46473_().m_6180_("reposition");
 -         PortalInfo portalinfo = this.m_7937_(p_20118_);
 +         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_20118_, this::m_7937_);
           if (portalinfo == null) {
              return null;
           } else {
++            this.f_19853_.m_46473_().m_6180_("changeDimension");
++            this.m_19877_();
++            this.f_19853_.m_46473_().m_6180_("reposition");
 +            Entity transportedEntity = teleporter.placeEntity(this, (ServerLevel) this.f_19853_, p_20118_, this.f_19857_, spawnPortal -> { //Forge: Start vanilla logic
              this.f_19853_.m_46473_().m_6182_("reloading");
              Entity entity = this.m_6095_().m_20615_(p_20118_);

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -339,7 +339,7 @@
     }
  
     public boolean m_7306_(Entity p_20356_) {
-@@ -2279,14 +_,20 @@
+@@ -2279,14 +_,21 @@
  
     @Nullable
     public Entity m_5489_(ServerLevel p_20118_) {
@@ -349,17 +349,15 @@
 +   public Entity changeDimension(ServerLevel p_20118_, net.minecraftforge.common.util.ITeleporter teleporter) {
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_20118_.m_46472_())) return null;
        if (this.f_19853_ instanceof ServerLevel && !this.m_213877_()) {
--         this.f_19853_.m_46473_().m_6180_("changeDimension");
--         this.m_19877_();
--         this.f_19853_.m_46473_().m_6180_("reposition");
++         if (!teleporter.canTeleport(this, p_20118_.m_46472_())) return null;
+          this.f_19853_.m_46473_().m_6180_("changeDimension");
+          this.m_19877_();
+          this.f_19853_.m_46473_().m_6180_("reposition");
 -         PortalInfo portalinfo = this.m_7937_(p_20118_);
 +         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_20118_, this::m_7937_);
           if (portalinfo == null) {
              return null;
           } else {
-+            this.f_19853_.m_46473_().m_6180_("changeDimension");
-+            this.m_19877_();
-+            this.f_19853_.m_46473_().m_6180_("reposition");
 +            Entity transportedEntity = teleporter.placeEntity(this, (ServerLevel) this.f_19853_, p_20118_, this.f_19857_, spawnPortal -> { //Forge: Start vanilla logic
              this.f_19853_.m_46473_().m_6182_("reloading");
              Entity entity = this.m_6095_().m_20615_(p_20118_);

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -7,14 +7,16 @@ package net.minecraftforge.common.util;
 
 import java.util.function.Function;
 
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.portal.PortalInfo;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.portal.PortalForcer;
 import net.minecraft.server.level.ServerLevel;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Interface for handling the placement of entities during dimension change.
@@ -27,6 +29,23 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface ITeleporter
 {
+    /**
+     * Called when the entity wants to teleport. Return false to cancel
+     * teleportation.
+     * <p>
+     * Note that this method should not attempt to load chunks in the
+     * destination level.
+     *
+     * @param entity the entity to be teleported
+     * @param dimension the dimension the entity is teleporting to
+     *
+     * @return false to cancel teleportation
+     */
+    default boolean canTeleport(Entity entity, ResourceKey<Level> dimension)
+    {
+        return true;
+    }
+
     /**
      * Called to handle placing the entity in the new world.
      * <p>
@@ -55,7 +74,8 @@ public interface ITeleporter
      * vanilla code and should not be used for your purposes.
      * Override this method to handle your own logic.
      * <p>
-     * Return {@code null} to prevent teleporting.
+     * This method should not return {@code null}. To prevent teleportation,
+     * return false from {@link #canTeleport(Entity, ResourceKey)}.
      *
      * @param entity The entity teleporting before the teleport
      * @param destWorld The world the entity is teleporting to
@@ -63,7 +83,7 @@ public interface ITeleporter
      *
      * @return The location, rotation, and motion of the entity in the destWorld after the teleport
      */
-    @Nullable
+    @NotNull
     default PortalInfo getPortalInfo(Entity entity, ServerLevel destWorld, Function<ServerLevel, PortalInfo> defaultPortalInfo)
     {
         return this.isVanilla() ? defaultPortalInfo.apply(destWorld) : new PortalInfo(entity.position(), Vec3.ZERO, entity.getYRot(), entity.getXRot());


### PR DESCRIPTION
Fixes #8459 for Minecraft 1.19.3.

Hello once again my friends! I've written this PR involving ITeleporter within Entity and ServerPlayer, but the patch surface is uncomfortably high, but I think it's worth it considering how this can affect implementations of ITeleporter.

In `ITeleporter`, the method override `getPortalInfo()` states that if the return value is null, the game will prevent the entity from teleporting. However within `ServerPlayer.changeDimension()`, *a lot* happens before the call to get the portal info is ever invoked. The `isChangingDimensions` field is set to true, packets are being set, and the server removes the player from the player list. The result of this is if the portal info is null, the game softlocks because the player is not arriving at the destination dimension even though the client has been informed of a change in dimension.

My proposal is this: I've moved the call to `teleporter.getPortalInfo()` to the top of the method, just under the ForgeHooks. That way, if the portal info is indeed null, the method will exit and there will be no adverse side effects. I've done a similar patch to `Entity.changeDimension()`, although the adverse side effect of being dismounted is far less troublesome than the ServerPlayer softlock.

If all goes well, I will happy write backports for 1.19.2 and 1.18.2. Please let me know what you think!