### PR TITLE
[1.19.x] Added Sprint Events

### DIFF
--- a/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
@@ -32,34 +32,47 @@
        this.f_108619_.m_91301_().m_120586_(this.f_108618_);
        if (this.m_6117_() && !this.m_20159_()) {
           this.f_108618_.f_108566_ *= 0.2F;
-@@ -660,7 +_,7 @@
+@@ -660,29 +_,31 @@
        }
  
        boolean flag4 = this.m_255269_();
 -      if ((this.f_19861_ || this.m_5842_() || this.m_20159_() && this.m_20202_().m_20096_()) && !flag1 && !flag2 && this.m_108733_() && !this.m_20142_() && flag4 && !this.m_6117_() && !this.m_21023_(MobEffects.f_19610_)) {
++      int sprint = 0;
 +      if ((this.f_19861_ || this.m_5842_() || this.m_20159_() && this.m_20202_().m_20096_() || this.canStartSwimming()) && !flag1 && !flag2 && this.m_108733_() && !this.m_20142_() && flag4 && !this.m_6117_() && !this.m_21023_(MobEffects.f_19610_)) {
           if (this.f_108583_ <= 0 && !this.f_108619_.f_91066_.f_92091_.m_90857_()) {
              this.f_108583_ = 7;
           } else {
-@@ -668,15 +_,15 @@
+-            this.m_6858_(true);
++            sprint = 1;
           }
        }
  
 -      if (!this.m_20142_() && (!this.m_20069_() || this.m_5842_()) && this.m_108733_() && flag4 && !this.m_6117_() && !this.m_21023_(MobEffects.f_19610_) && this.f_108619_.f_91066_.f_92091_.m_90857_()) {
-+      if (!this.m_20142_() && (!(this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) || (this.m_5842_() || this.canStartSwimming())) && this.m_108733_() && flag4 && !this.m_6117_() && !this.m_21023_(MobEffects.f_19610_) && this.f_108619_.f_91066_.f_92091_.m_90857_()) {
-          this.m_6858_(true);
+-         this.m_6858_(true);
++      if (!(this.m_20142_() || sprint == 1) && (!(this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType))) || (this.m_5842_() || this.canStartSwimming())) && this.m_108733_() && flag4 && !this.m_6117_() && !this.m_21023_(MobEffects.f_19610_) && this.f_108619_.f_91066_.f_92091_.m_90857_()) {
++         sprint = 2;
        }
  
-       if (this.m_20142_()) {
+-      if (this.m_20142_()) {
++      if (sprint > 0 || this.m_20142_()) {
           boolean flag5 = !this.f_108618_.m_108577_() || !flag4;
 -         boolean flag6 = flag5 || this.f_19862_ && !this.f_185931_ || this.m_20069_() && !this.m_5842_();
 +         boolean flag6 = flag5 || this.f_19862_ && !this.f_185931_ || (this.m_20069_() && !this.m_5842_()) || (this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)) && !this.canStartSwimming());
           if (this.m_6069_()) {
 -            if (!this.f_19861_ && !this.f_108618_.f_108573_ && flag5 || !this.m_20069_()) {
+-               this.m_6858_(false);
 +            if (!this.f_19861_ && !this.f_108618_.f_108573_ && flag5 || !(this.m_20069_() || this.isInFluidType((fluidType, height) -> this.canSwimInFluidType(fluidType)))) {
-                this.m_6858_(false);
++               sprint = -1;
              }
           } else if (flag6) {
+-            this.m_6858_(false);
++            sprint = -2;
+          }
+       }
++      if (sprint != 0 && !net.minecraftforge.client.ForgeHooksClient.beforeSprint(this, sprint > 0)) m_6858_(sprint > 0);
+ 
+       boolean flag7 = false;
+       if (this.m_150110_().f_35936_) {
 @@ -706,14 +_,15 @@
  
        if (this.f_108618_.f_108572_ && !flag7 && !flag && !this.m_150110_().f_35935_ && !this.m_20159_() && !this.m_6147_()) {

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -312,6 +312,14 @@
     public boolean m_6146_() {
        return true;
     }
+@@ -2009,6 +_,7 @@
+    }
+ 
+    public void m_6858_(boolean p_20274_) {
++      if (m_20142_() != p_20274_) net.minecraftforge.event.ForgeEventFactory.onEntitySprint(this, p_20274_);
+       this.m_20115_(3, p_20274_);
+    }
+ 
 @@ -2021,7 +_,7 @@
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -145,6 +145,7 @@ import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
 import net.minecraftforge.event.CreativeModeTabEvent;
+import net.minecraftforge.client.event.ShouldSprint;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.IExtensionPoint;
@@ -1223,5 +1224,10 @@ public class ForgeHooksClient
 
         for (var entry : entries)
             output.accept(entry.getKey(), entry.getValue());
+    }
+
+    public static boolean beforeSprint(LocalPlayer player, boolean willSprint) {
+        var event = new ShouldSprint(player, willSprint);
+        return MinecraftForge.EVENT_BUS.post(event);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ShouldSprint.java
+++ b/src/main/java/net/minecraftforge/client/event/ShouldSprint.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+/**
+ * This event is fired on client side when player decides to change running state.
+ * Canceling this event will prevent player's running state from changing,
+ * which can also prevent player from transitioning from running to walking.
+ **/
+@Cancelable
+public class ShouldSprint extends PlayerEvent {
+    public final boolean willSprint;
+
+    public ShouldSprint(LocalPlayer player, boolean willSprint) {
+        super(player);
+        this.willSprint = willSprint;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -85,12 +85,7 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
-import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.event.entity.EntityMobGriefingEvent;
-import net.minecraftforge.event.entity.EntityMountEvent;
-import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
-import net.minecraftforge.event.entity.EntityTeleportEvent;
-import net.minecraftforge.event.entity.ProjectileImpactEvent;
+import net.minecraftforge.event.entity.*;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
 import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingConversionEvent;
@@ -861,5 +856,11 @@ public class ForgeEventFactory
     public static void onAdvancementProgressedEvent(Player player, Advancement progressed, AdvancementProgress advancementProgress, String criterion, ProgressType progressType)
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementProgressEvent(player, progressed, advancementProgress, criterion, progressType));
+    }
+
+    @ApiStatus.Internal
+    public static void onEntitySprint(Entity entity, boolean willSprint)
+    {
+        MinecraftForge.EVENT_BUS.post(new EntitySprintEvent(entity, willSprint));
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntitySprintEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntitySprintEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity;
+
+import net.minecraft.world.entity.Entity;
+
+/**
+ * EntitySprintEvent is fired when {@link Entity#setSprinting(boolean)} is invoked.<br>
+ * This event will not be fired when sprint state has not been actually changed, such as
+ * invoking {@code entity.setSprint(true)} when entity is already sprinting.
+ **/
+public class EntitySprintEvent extends EntityEvent {
+    public final boolean willSprint;
+
+    public EntitySprintEvent(Entity entity, boolean willSprint) {
+        super(entity);
+        this.willSprint = willSprint;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/SprintEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/SprintEventTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.animal.Ocelot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.event.entity.EntitySprintEvent;
+import net.minecraftforge.client.event.ShouldSprint;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(SprintEventTest.MODID)
+@Mod.EventBusSubscriber
+public class SprintEventTest {
+    public static final String MODID = "sprint_event_test";
+    @SubscribeEvent
+    public static void onPlayerSprint(ShouldSprint event) {
+        Item item = event.getEntity().getMainHandItem().getItem();
+        if (item == Items.OBSIDIAN) {
+            if (!event.willSprint) return;
+            event.setCanceled(true); // Disallow running
+        }
+        if (item == Items.FEATHER) {
+            if (event.willSprint) return;
+            event.setCanceled(true); // Forcefully keep running state
+        }
+    }
+
+    @SubscribeEvent
+    public static void onEntitySprint(EntitySprintEvent event) {
+        if (event.getEntity() instanceof Ocelot ocelot && !ocelot.level.isClientSide && ocelot.getActiveEffects().isEmpty()) {
+            ocelot.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 30 * 20, 4)); // Makes ocelots run incredibly fast
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -276,6 +276,8 @@ modId="data_pack_registries_test"
 modId="creative_mode_tab_test"
 [[mods]]
 modId="trade_with_villager_event_test"
+[[mods]]
+modId="sprint_event_test"
 
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR adds 2 types of sprint events: One for all entities, and one for client players.

### Added events
`EntitySprintEvent` will be fired whenever `Entity#setSprinting` is invoked, and sprint state of entity changes. This event is not cancellable because `ServerPlayer` will call them when client starts to sprint, but cancelling that might cause desync. If there's solution to this potential problem then it can also be cancellable.

`ShouldSprint` will be fired on client side when player determines whether or not start/stop sprinting, and this one is cancellable. Cancelling this event will prevent sprint state from changing, so it can also force players to keep running.

### Possible use cases
One might want to make "heavy" item that not only has slowness attribute but also prevents players from running.
Or, a sort of minigame that contestants must keep running.

### Changes in vanilla behavior
In vanilla, `LocalPlayer#setSprinting` can be called multiple times in a row when deciding new running state, this pr changes it so that it is only called once per check.

Fixes #9132