### PR TITLE
feat(network): add client reset packet

### DIFF
--- a/src/main/java/net/minecraftforge/network/ClientResetPacketHandler.java
+++ b/src/main/java/net/minecraftforge/network/ClientResetPacketHandler.java
@@ -1,0 +1,105 @@
+package net.minecraftforge.network;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.GenericDirtMessageScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.network.Connection;
+import net.minecraft.network.ConnectionProtocol;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.registries.GameData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+@OnlyIn(Dist.CLIENT)
+public class ClientResetPacketHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    static void handleClientReset(HandshakeMessages.S2CReset msg, final Supplier<NetworkEvent.Context> contextSupplier)
+    {
+        NetworkEvent.Context context = contextSupplier.get();
+        Connection connection = context.getNetworkManager();
+
+        if (context.getDirection() != NetworkDirection.LOGIN_TO_CLIENT && context.getDirection() != NetworkDirection.PLAY_TO_CLIENT)
+        {
+            connection.disconnect(Component.literal("Illegal packet received, terminating connection"));
+            throw new IllegalStateException("Invalid packet received, aborting connection");
+        }
+
+        LOGGER.debug(HandshakeHandler.FMLHSMARKER, "Received reset from server");
+
+        ServerData serverData = Minecraft.getInstance().getCurrentServer();
+        Screen screen = Minecraft.getInstance().screen;
+
+        if (!handleClear(context))
+        {
+            return;
+        }
+
+        NetworkHooks.registerClientLoginChannel(connection);
+        connection.setProtocol(ConnectionProtocol.LOGIN);
+        connection.setListener(new ClientHandshakePacketListenerImpl(
+                connection, Minecraft.getInstance(), serverData, screen, true, null, statusMessage -> {}
+        ));
+
+        context.setPacketHandled(true);
+        NetworkConstants.handshakeChannel.reply(
+                new HandshakeMessages.C2SAcknowledge(),
+                new NetworkEvent.Context(connection, NetworkDirection.LOGIN_TO_CLIENT, 98)
+        );
+
+        LOGGER.debug(HandshakeHandler.FMLHSMARKER, "Reset complete");
+    }
+
+    static boolean handleClear(NetworkEvent.Context context)
+    {
+        CompletableFuture<Void> future = context.enqueueWork(() ->
+        {
+            LOGGER.debug(HandshakeHandler.FMLHSMARKER, "Clearing");
+
+            // Clear
+            if (Minecraft.getInstance().level == null) {
+                // Ensure the GameData is reverted in case the client is reset during the handshake.
+                GameData.revertToFrozen();
+            }
+
+            // Clear
+            Minecraft.getInstance().clearLevel(new GenericDirtMessageScreen(Component.translatable("connect.negotiating")));
+
+            // Clear channel handlers so there isn't an error when they're added back (https://github.com/Just-Chaldea/Forge-Client-Reset-Packet/pull/12)
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:forge_fixes");
+            } catch (NoSuchElementException ignored) {
+            }
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:vanilla_filter");
+            } catch (NoSuchElementException ignored) {
+            }
+
+            // Restore
+//            Minecraft.getInstance().setCurrentServer(serverData); - This is commented out because I could not find an equivalent method in 1.19.X (from 1.16 & 1.18)
+        });
+
+        LOGGER.debug(HandshakeHandler.FMLHSMARKER, "Waiting for clear to complete");
+
+        try
+        {
+            future.get();
+            LOGGER.debug("Clear complete, continuing reset");
+            return true;
+        } catch (Exception ex)
+        {
+            LOGGER.error(HandshakeHandler.FMLHSMARKER, "Failed to clear, closing connection", ex);
+            context.getNetworkManager().disconnect(Component.literal("Failed to clear, closing connection"));
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/network/HandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeHandler.java
@@ -42,7 +42,11 @@ import org.apache.logging.log4j.MarkerManager;
 import com.google.common.collect.Maps;
 
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;

--- a/src/main/java/net/minecraftforge/network/HandshakeMessages.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeMessages.java
@@ -348,4 +348,19 @@ public class HandshakeMessages
             return mismatchedChannelData;
         }
     }
+
+    public static class S2CReset extends LoginIndexedMessage {
+
+        public S2CReset() {
+            super();
+        }
+
+        public void encode(FriendlyByteBuf buffer) {
+
+        }
+
+        public static S2CReset decode(FriendlyByteBuf buffer) {
+            return new S2CReset();
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInitialization.java
@@ -22,6 +22,13 @@ class NetworkInitialization {
                 networkProtocolVersion(() -> NetworkConstants.NETVERSION).
                 simpleChannel();
 
+        handshakeChannel.messageBuilder(HandshakeMessages.S2CReset.class, 98, NetworkDirection.LOGIN_TO_SERVER).
+                loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
+                decoder(HandshakeMessages.S2CReset::decode).
+                encoder(HandshakeMessages.S2CReset::encode).
+                consumerNetworkThread(HandshakeHandler.indexFirst(HandshakeHandler::handleClientReset)). //TODO
+                add();
+
         handshakeChannel.messageBuilder(HandshakeMessages.C2SAcknowledge.class, 99, NetworkDirection.LOGIN_TO_SERVER).
                 loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
                 decoder(HandshakeMessages.C2SAcknowledge::decode).

--- a/src/main/java/net/minecraftforge/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInitialization.java
@@ -26,7 +26,7 @@ class NetworkInitialization {
                 loginIndex(HandshakeMessages.LoginIndexedMessage::getLoginIndex, HandshakeMessages.LoginIndexedMessage::setLoginIndex).
                 decoder(HandshakeMessages.S2CReset::decode).
                 encoder(HandshakeMessages.S2CReset::encode).
-                consumerNetworkThread(HandshakeHandler.indexFirst(HandshakeHandler::handleClientReset)). //TODO
+                consumerNetworkThread(HandshakeHandler.indexFirst(HandshakeHandler::handleClientReset)).
                 add();
 
         handshakeChannel.messageBuilder(HandshakeMessages.C2SAcknowledge.class, 99, NetworkDirection.LOGIN_TO_SERVER).


### PR DESCRIPTION
## What does this do?
This adds the client side implementation of the [Forge Client Reset Packet](https://github.com/Just-Chaldea/Forge-Client-Reset-Packet) mod and as such allows modded clients using Forge versions of 1.13+ to use proxies when combined with the Velocity PR linked below (TLDR; this adds modded support for proxies).

This is achieved by sending the "client reset packet" to the Forge client before they swap servers which resets the client's registries before allowing them to enter the server. This is important as in 1.13 Mojang's codebase changed and the registries were introduced for datapacks. This means that whilst for Vanilla clients you can assume the registry will match between the client and the server, you cannot do that for the modded client as the server and client may not have matching mods (or any number of other similar issues). Hence, the reset packet is required to reset (and sync) the registries with the server before allowing the client to join the server seemlessly.

It is also important to note that this does not break existing Vanilla compatibility either.

## Why is this needed?
This is needed as the current solution is the distribution of a fork of Velocity and adding the Forge Client Reset Packet mod to the mod's modpack. Whilst this works for the time being it has resulted in mass confusion, plenty of people not knowing where to go for support, as well as general misinformation spread (mostly accidentally by those unaware such a mod exists). Therefore, adding official support is the best route as it will allow the communities that need this to grow again and reduce the bar for entry.

## What's changed from last time?
[Last time](https://github.com/PaperMC/Velocity/pull/690) there was no active implementation and there was a lot of theories as to if the solution would even work. However, now this mod has been in use for almost a year and is used daily by thousands of players on huge networks in, and out, of the Pixelmon community. 

## Velocity PR
https://github.com/PaperMC/Velocity/pull/932

## Issue
https://github.com/PaperMC/Velocity/issues/248

## Links
https://www.curseforge.com/minecraft/mc-mods/forge-client-reset-packet
https://github.com/Just-Chaldea/Forge-Client-Reset-Packet

## Example servers
- `hub.mc-complex.com` (Vanilla servers & Pixelmon servers)
- `play.nebulamc.gg`
- `play.mc-blaze.com` (Vanilla servers & Pixelmon servers)
- `mc.pokesmash.co`
- `play.happycloudmc.com`
- `pixelmon.projectshiba.com`
- `hexagonmc.eu` (Vanilla servers & Pixelmon servers)
- `roanoke.network` (Vanilla servers & Pixelmon servers)
- `play.squirtlesquadmc.com`  (Vanilla servers & Pixelmon servers)