### PR TITLE
[1.19.x] Fix Upwards Velocity when Jumping in a Fluid while Touching the Ground

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -489,12 +489,13 @@
              if (map == null) {
                 map = Maps.newEnumMap(EquipmentSlot.class);
              }
-@@ -2523,6 +_,8 @@
+@@ -2523,6 +_,9 @@
        this.f_19853_.m_46473_().m_6180_("jump");
        if (this.f_20899_ && this.m_6129_()) {
           double d7;
 +         net.minecraftforge.fluids.FluidType fluidType = this.getMaxHeightFluidType();
 +         if (!fluidType.isAir()) d7 = this.getFluidTypeHeight(fluidType);
++         else
           if (this.m_20077_()) {
              d7 = this.m_204036_(FluidTags.f_13132_);
           } else {


### PR DESCRIPTION
This is republish of #8741 as it was originally merged into a different PR which was closed.

## Issue

When jumping in a modded fluid while touching the ground, the y velocity of the player was the same as if the player was not jumping in a fluid. This can be seen in the [following video](https://streamable.com/plidw9). The issue stems from a missing patch within `LivingEntity` when performing a conditional check. After it sets the correct fluidtype height value, it then attempts to set the value to lava and then defaults to water. As this value is `0` since the player is in a different fluid, the jump is treated as if the player was not in a fluid.

https://github.com/MinecraftForge/MinecraftForge/blob/0eb9d94bf3fe2a4ce22b4d048e85bd846b46642d/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch#L493-L500

## Fix

The fix is just to prevent the conditional from activating once the value is set. This can be done by adding a trailing `else` to make the below conditions as part of the newly added one. This causes the jump to be treated appropriately for the fluid as shown in [this video](https://streamable.com/g5ovq3).
