### PR TITLE
[1.18.x] Ensure all GUI event listeners receive `mouseClicked` event (MC-147605)

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/components/events/ContainerEventHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/events/ContainerEventHandler.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/client/gui/components/events/ContainerEventHandler.java
++++ b/net/minecraft/client/gui/components/events/ContainerEventHandler.java
+@@ -24,6 +_,8 @@
+    }
+ 
+    default boolean m_6375_(double p_94695_, double p_94696_, int p_94697_) {
++      boolean result = false; // Forge: Fix MC-147605
++
+       for(GuiEventListener guieventlistener : this.m_6702_()) {
+          if (guieventlistener.m_6375_(p_94695_, p_94696_, p_94697_)) {
+             this.m_7522_(guieventlistener);
+@@ -31,11 +_,11 @@
+                this.m_7897_(true);
+             }
+ 
+-            return true;
++            result = true;
+          }
+       }
+ 
+-      return false;
++      return result;
+    }
+ 
+    default boolean m_6348_(double p_94722_, double p_94723_, int p_94724_) {


### PR DESCRIPTION
## Introduction

This is a backport of [MC-147605](https://bugs.mojang.com/browse/MC-147605) fix, which is available since 22w46a.

## Background

19w14b introduced a bug which prevents some GUI event listeners from receiving `mouseClicked` event under certain circumstances. The issue lies inside of `ContainerEventHandler#mouseClicked` method. 

While looping through children, whenever child's `mouseClicked` returns true, specific logic is executed on that child only, inevitably breaking a loop afterwards. This means that other children will never receive a `mouseClicked` event.

## Reproduction

This is best visible with `EditBox` widget as it uses `mouseClicked` to update focus. Suppose we have 2 `EditBox`es. When we click on the second one, it becomes focused. Now click on the first one - both will be focused. Why? This happens because the first `EditBox`'s `mouseClicked` returned `true`, meaning it has broken the loop inside of `ContainerEventHandler#mouseClicked`, making the second `EditBox` unable to determine whether it is still focused or not.

## Solution

Mojang's solution is pretty straightforward: now `ContainerEventHandler#mouseClicked` loops through all children, stores the last child which returned `true` inside `mouseClicked`, and executes specific logic on it afterwards.

However, as Lex [mentioned](https://discord.com/channels/313125603924639766/852298000042164244/1067986895239389224), this can be drastically simplified down to a boolean flag, ending up with the exact same result.