### PR TITLE
[1.19.3] Make IForgeIntrinsicHolderTagAppender methods properly chainable

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender.java
@@ -6,8 +6,9 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
-import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 
 public interface IForgeIntrinsicHolderTagAppender<T> extends IForgeTagAppender<T>
 {
@@ -23,7 +24,7 @@ public interface IForgeIntrinsicHolderTagAppender<T> extends IForgeTagAppender<T
      * @param entry The entry to remove
      * @return The builder for chaining
      */
-    default TagsProvider.TagAppender<T> remove(final T entry)
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final T entry)
     {
         return remove(this.getKey(entry));
     }
@@ -35,13 +36,79 @@ public interface IForgeIntrinsicHolderTagAppender<T> extends IForgeTagAppender<T
      * @return The builder for chaining
      */
     @SuppressWarnings("unchecked")
-    default TagsProvider.TagAppender<T> remove(final T first, final T...entries)
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final T first, final T...entries)
     {
         this.remove(first);
         for (T entry : entries)
         {
             this.remove(entry);
         }
+        return self();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> addTags(TagKey<T>... values)
+    {
+        IForgeTagAppender.super.addTags(values);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> replace()
+    {
+        IForgeTagAppender.super.replace();
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> replace(boolean value)
+    {
+        IForgeTagAppender.super.replace(value);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final ResourceLocation location)
+    {
+        IForgeTagAppender.super.remove(location);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final ResourceLocation first, final ResourceLocation... locations)
+    {
+        IForgeTagAppender.super.remove(first, locations);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final ResourceKey<T> resourceKey)
+    {
+        IForgeTagAppender.super.remove(resourceKey);
+        return self();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final ResourceKey<T> firstResourceKey, final ResourceKey<T>... resourceKeys)
+    {
+        IForgeTagAppender.super.remove(firstResourceKey, resourceKeys);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(TagKey<T> tag)
+    {
+        IForgeTagAppender.super.remove(tag);
+        return self();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(TagKey<T> first, TagKey<T>...tags)
+    {
+        IForgeTagAppender.super.remove(first, tags);
         return self();
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
@@ -79,6 +79,7 @@ public interface IForgeTagAppender<T>
      * @param resourceKeys The resource keys of the elements to remove
      * @return The appender for chaining
      */
+    @SuppressWarnings("unchecked")
     default TagsProvider.TagAppender<T> remove(final ResourceKey<T> firstResourceKey, final ResourceKey<T>... resourceKeys)
     {
         this.remove(firstResourceKey.location());

--- a/src/main/resources/META-INF/coremods.json
+++ b/src/main/resources/META-INF/coremods.json
@@ -1,5 +1,6 @@
 {
   "field_to_method": "coremods/field_to_method.js",
   "field_to_instanceof": "coremods/field_to_instanceof.js",
-  "add_bouncer_method": "coremods/add_bouncer_method.js"
+  "add_bouncer_method": "coremods/add_bouncer_method.js",
+  "intrinsic_tag_appender_binary_compat": "coremods/intrinsic_tag_appender_binary_compat.js"
 }

--- a/src/main/resources/coremods/intrinsic_tag_appender_binary_compat.js
+++ b/src/main/resources/coremods/intrinsic_tag_appender_binary_compat.js
@@ -1,0 +1,65 @@
+var Opcodes = Java.type('org.objectweb.asm.Opcodes')
+var MethodNode = Java.type('org.objectweb.asm.tree.MethodNode')
+var VarInsnNode = Java.type('org.objectweb.asm.tree.VarInsnNode')
+var MethodInsnNode = Java.type('org.objectweb.asm.tree.MethodInsnNode')
+var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode')
+
+// TODO 1.20: Delete this whole coremod. We won't need to maintain binary compatibility then.
+// This coremod exists purely because of Java limitations - 2 methods with the same parameters and name but different return types are not allowed.
+// However, this restriction does not exist in the JVM.
+// The two remove() methods had their return types narrowed to allow chaining calls.
+// This coremod was made to maintain compatibility with mods compiled on old forge in the least invasive way.
+// It adds runtime methods for the two methods in IForgeIntrinsicTagAppender that return TagsProvider.TagAppender.
+// The ASM methods just delegate to the original methods.
+
+function initializeCoreMod() {
+    return {
+        'intrinsic_tag_appender_binary_compat': {
+            'target': {
+                'type': 'CLASS',
+                'name': 'net.minecraftforge.common.extensions.IForgeIntrinsicHolderTagAppender'
+            },
+            'transformer': function (classNode) {
+                var removeSingleNode = new MethodNode(
+                    Opcodes.ACC_PUBLIC,
+                    'remove',
+                    '(Ljava/lang/Object;)Lnet/minecraft/data/tags/TagsProvider$TagAppender;',
+                    null,
+                    null
+                );
+                removeSingleNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                removeSingleNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                removeSingleNode.instructions.add(new MethodInsnNode(
+                    Opcodes.INVOKESPECIAL,
+                    'net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender',
+                    'remove',
+                    '(Ljava/lang/Object;)Lnet/minecraft/data/tags/IntrinsicHolderTagsProvider$IntrinsicTagAppender;'
+                ));
+                removeSingleNode.instructions.add(new InsnNode(Opcodes.ARETURN));
+
+                var removeMultiNode = new MethodNode(
+                    Opcodes.ACC_PUBLIC | Opcodes.ACC_VARARGS,
+                    'remove',
+                    '(Ljava/lang/Object;[Ljava/lang/Object;)Lnet/minecraft/data/tags/TagsProvider$TagAppender;',
+                    null,
+                    null
+                );
+                removeMultiNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                removeMultiNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                removeMultiNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 2));
+                removeMultiNode.instructions.add(new MethodInsnNode(
+                    Opcodes.INVOKESPECIAL,
+                    'net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender',
+                    'remove',
+                    '(Ljava/lang/Object;[Ljava/lang/Object;)Lnet/minecraft/data/tags/IntrinsicHolderTagsProvider$IntrinsicTagAppender;'
+                ));
+                removeMultiNode.instructions.add(new InsnNode(Opcodes.ARETURN));
+
+                classNode.methods.add(removeSingleNode);
+                classNode.methods.add(removeMultiNode);
+
+                return classNode;
+            }
+        }
+    }
+}

--- a/src/main/resources/coremods/intrinsic_tag_appender_binary_compat.js
+++ b/src/main/resources/coremods/intrinsic_tag_appender_binary_compat.js
@@ -30,7 +30,7 @@ function initializeCoreMod() {
                 removeSingleNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
                 removeSingleNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
                 removeSingleNode.instructions.add(new MethodInsnNode(
-                    Opcodes.INVOKESPECIAL,
+                    Opcodes.INVOKEINTERFACE,
                     'net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender',
                     'remove',
                     '(Ljava/lang/Object;)Lnet/minecraft/data/tags/IntrinsicHolderTagsProvider$IntrinsicTagAppender;'
@@ -48,7 +48,7 @@ function initializeCoreMod() {
                 removeMultiNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
                 removeMultiNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 2));
                 removeMultiNode.instructions.add(new MethodInsnNode(
-                    Opcodes.INVOKESPECIAL,
+                    Opcodes.INVOKEINTERFACE,
                     'net/minecraftforge/common/extensions/IForgeIntrinsicHolderTagAppender',
                     'remove',
                     '(Ljava/lang/Object;[Ljava/lang/Object;)Lnet/minecraft/data/tags/IntrinsicHolderTagsProvider$IntrinsicTagAppender;'


### PR DESCRIPTION
This PR makes the methods in `IForgeIntrinsicHolderTagAppender` properly chainable as all of them currently fall back to the `IForgeTagAppender` super type, making them unchainable.

I suspect that this is at least a binary break, which is why I asked in [#github-discussions](https://discord.com/channels/313125603924639766/852298000042164244/1071113597041778763) whether this is acceptable if it purely affects datagen classes.