### PR TITLE
Fix StemBlock Patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/StemBlock.java
 +++ b/net/minecraft/world/level/block/StemBlock.java
-@@ -44,9 +_,10 @@
+@@ -44,22 +_,23 @@
     }
  
     public void m_213898_(BlockState p_222538_, ServerLevel p_222539_, BlockPos p_222540_, RandomSource p_222541_) {
@@ -11,8 +11,10 @@
 +         if (net.minecraftforge.common.ForgeHooks.onCropsGrowPre(p_222539_, p_222540_, p_222538_, p_222541_.m_188503_((int)(25.0F / f) + 1) == 0)) {
              int i = p_222538_.m_61143_(f_57013_);
              if (i < 7) {
-                p_222538_ = p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1));
-@@ -55,11 +_,12 @@
+-               p_222538_ = p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1));
+-               p_222539_.m_7731_(p_222540_, p_222538_, 2);
++               p_222539_.m_7731_(p_222540_, p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1)), 2);
+             } else {
                 Direction direction = Direction.Plane.HORIZONTAL.m_235690_(p_222541_);
                 BlockPos blockpos = p_222540_.m_121945_(direction);
                 BlockState blockstate = p_222539_.m_8055_(blockpos.m_7495_());

--- a/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/StemBlock.java
 +++ b/net/minecraft/world/level/block/StemBlock.java
-@@ -44,22 +_,24 @@
+@@ -44,9 +_,10 @@
     }
  
     public void m_213898_(BlockState p_222538_, ServerLevel p_222539_, BlockPos p_222540_, RandomSource p_222541_) {
@@ -11,16 +11,13 @@
 +         if (net.minecraftforge.common.ForgeHooks.onCropsGrowPre(p_222539_, p_222540_, p_222538_, p_222541_.m_188503_((int)(25.0F / f) + 1) == 0)) {
              int i = p_222538_.m_61143_(f_57013_);
              if (i < 7) {
--               p_222538_ = p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1));
--               p_222539_.m_7731_(p_222540_, p_222538_, 2);
-+               p_222539_.m_7731_(p_222540_, p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1)), 2);
-             } else {
+                p_222538_ = p_222538_.m_61124_(f_57013_, Integer.valueOf(i + 1));
+@@ -55,11 +_,12 @@
                 Direction direction = Direction.Plane.HORIZONTAL.m_235690_(p_222541_);
                 BlockPos blockpos = p_222540_.m_121945_(direction);
                 BlockState blockstate = p_222539_.m_8055_(blockpos.m_7495_());
 -               if (p_222539_.m_8055_(blockpos).m_60795_() && (blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
-+               Block block = blockstate.m_60734_();
-+               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this.f_57015_) || block == Blocks.f_50093_ || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
++               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this.f_57015_) || blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
                    p_222539_.m_46597_(blockpos, this.f_57015_.m_49966_());
                    p_222539_.m_46597_(p_222540_, this.f_57015_.m_7810_().m_49966_().m_61124_(HorizontalDirectionalBlock.f_54117_, direction));
                 }


### PR DESCRIPTION
Seems a change to the method was not noticed. In the past it checked all dirt-like blocks, while now it uses the tag.