### PR TITLE
[1.19.2] Fix StemBlock patch, backport StemGrownBlock patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/StemBlock.java
 +++ b/net/minecraft/world/level/block/StemBlock.java
-@@ -43,22 +_,24 @@
+@@ -43,22 +_,23 @@
     }
  
     public void m_213898_(BlockState p_222538_, ServerLevel p_222539_, BlockPos p_222540_, RandomSource p_222541_) {
@@ -19,8 +19,7 @@
                 BlockPos blockpos = p_222540_.m_121945_(direction);
                 BlockState blockstate = p_222539_.m_8055_(blockpos.m_7495_());
 -               if (p_222539_.m_8055_(blockpos).m_60795_() && (blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
-+               Block block = blockstate.m_60734_();
-+               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this) || block == Blocks.f_50093_ || block == Blocks.f_50493_ || block == Blocks.f_50546_ || block == Blocks.f_50599_ || block == Blocks.f_50440_)) {
++               if (p_222539_.m_46859_(blockpos) && (blockstate.canSustainPlant(p_222539_, blockpos.m_7495_(), Direction.UP, this.f_57015_) || blockstate.m_60713_(Blocks.f_50093_) || blockstate.m_204336_(BlockTags.f_144274_))) {
                    p_222539_.m_46597_(blockpos, this.f_57015_.m_49966_());
                    p_222539_.m_46597_(p_222540_, this.f_57015_.m_7810_().m_49966_().m_61124_(HorizontalDirectionalBlock.f_54117_, direction));
                 }

--- a/patches/minecraft/net/minecraft/world/level/block/StemGrownBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/StemGrownBlock.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/world/level/block/StemGrownBlock.java
++++ b/net/minecraft/world/level/block/StemGrownBlock.java
+@@ -2,7 +_,7 @@
+ 
+ import net.minecraft.world.level.block.state.BlockBehaviour;
+ 
+-public abstract class StemGrownBlock extends Block {
++public abstract class StemGrownBlock extends Block implements net.minecraftforge.common.IPlantable {
+    public StemGrownBlock(BlockBehaviour.Properties p_57058_) {
+       super(p_57058_);
+    }
+@@ -10,4 +_,11 @@
+    public abstract StemBlock m_7161_();
+ 
+    public abstract AttachedStemBlock m_7810_();
++
++   @Override
++   public net.minecraft.world.level.block.state.BlockState getPlant(net.minecraft.world.level.BlockGetter world, net.minecraft.core.BlockPos pos) {
++      net.minecraft.world.level.block.state.BlockState state = world.m_8055_(pos);
++      if (state.m_60734_() != this) return m_49966_();
++      return state;
++   }
+ }


### PR DESCRIPTION
Fixes #9336 by using the dirt tags (backport of #9337 to actually fix it).

Backports #9270 to fix the Stemblock not checking if the fruit can live. 