### PR TITLE
[1.19.2] fix inconsistent vaporization in BucketItem & FluidType

### DIFF
--- a/patches/minecraft/net/minecraft/core/dispenser/DispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/core/dispenser/DispenseItemBehavior.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/net/minecraft/core/dispenser/DispenseItemBehavior.java
+@@ -343,7 +_,7 @@
+             DispensibleContainerItem dispensiblecontaineritem = (DispensibleContainerItem)p_123562_.m_41720_();
+             BlockPos blockpos = p_123561_.m_7961_().m_121945_(p_123561_.m_6414_().m_61143_(DispenserBlock.f_52659_));
+             Level level = p_123561_.m_7727_();
+-            if (dispensiblecontaineritem.m_142073_((Player)null, level, blockpos, (BlockHitResult)null)) {
++            if (dispensiblecontaineritem.emptyContents((Player)null, level, blockpos, (BlockHitResult)null, p_123562_)) {
+                dispensiblecontaineritem.m_142131_((Player)null, level, p_123562_, blockpos);
+                return new ItemStack(Items.f_42446_);
+             } else {
 @@ -402,9 +_,10 @@
                 level.m_46597_(blockpos, BaseFireBlock.m_49245_(level, blockpos));
                 level.m_142346_((Entity)null, GameEvent.f_157797_, blockpos);

--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -38,15 +38,44 @@
                          p_40704_.m_5496_(p_150709_, 1.0F, 1.0F);
                       });
                       p_40703_.m_142346_(p_40704_, GameEvent.f_157816_, blockpos);
-@@ -72,7 +_,7 @@
+@@ -72,8 +_,8 @@
                 return InteractionResultHolder.m_19100_(itemstack);
              } else {
                 BlockState blockstate = p_40703_.m_8055_(blockpos);
 -               BlockPos blockpos2 = blockstate.m_60734_() instanceof LiquidBlockContainer && this.f_40687_ == Fluids.f_76193_ ? blockpos : blockpos1;
+-               if (this.m_142073_(p_40704_, p_40703_, blockpos2, blockhitresult)) {
 +               BlockPos blockpos2 = canBlockContainFluid(p_40703_, blockpos, blockstate) ? blockpos : blockpos1;
-                if (this.m_142073_(p_40704_, p_40703_, blockpos2, blockhitresult)) {
++               if (this.emptyContents(p_40704_, p_40703_, blockpos2, blockhitresult, itemstack)) {
                    this.m_142131_(p_40704_, p_40703_, itemstack, blockpos2);
                    if (p_40704_ instanceof ServerPlayer) {
+                      CriteriaTriggers.f_10591_.m_59469_((ServerPlayer)p_40704_, blockpos2, itemstack);
+@@ -98,7 +_,12 @@
+    public void m_142131_(@Nullable Player p_150711_, Level p_150712_, ItemStack p_150713_, BlockPos p_150714_) {
+    }
+ 
++   @Deprecated //Forge: use the ItemStack sensitive version
+    public boolean m_142073_(@Nullable Player p_150716_, Level p_150717_, BlockPos p_150718_, @Nullable BlockHitResult p_150719_) {
++      return this.emptyContents(p_150716_, p_150717_, p_150718_, p_150719_, null);
++   }
++
++   public boolean emptyContents(@Nullable Player p_150716_, Level p_150717_, BlockPos p_150718_, @Nullable BlockHitResult p_150719_, @Nullable ItemStack container) {
+       if (!(this.f_40687_ instanceof FlowingFluid)) {
+          return false;
+       } else {
+@@ -107,8 +_,12 @@
+          Material material = blockstate.m_60767_();
+          boolean flag = blockstate.m_60722_(this.f_40687_);
+          boolean flag1 = blockstate.m_60795_() || flag || block instanceof LiquidBlockContainer && ((LiquidBlockContainer)block).m_6044_(p_150717_, p_150718_, blockstate, this.f_40687_);
++         java.util.Optional<net.minecraftforge.fluids.FluidStack> containedFluidStack = java.util.Optional.ofNullable(container).flatMap(net.minecraftforge.fluids.FluidUtil::getFluidContained);
+          if (!flag1) {
+-            return p_150719_ != null && this.m_142073_(p_150716_, p_150717_, p_150719_.m_82425_().m_121945_(p_150719_.m_82434_()), (BlockHitResult)null);
++            return p_150719_ != null && this.emptyContents(p_150716_, p_150717_, p_150719_.m_82425_().m_121945_(p_150719_.m_82434_()), (BlockHitResult)null, container);
++         } else if (containedFluidStack.isPresent() && this.f_40687_.getFluidType().isVaporizedOnPlacement(p_150717_, p_150718_, containedFluidStack.get())) {
++            this.f_40687_.getFluidType().onVaporize(p_150716_, p_150717_, p_150718_, containedFluidStack.get());
++            return true;
+          } else if (p_150717_.m_6042_().f_63857_() && this.f_40687_.m_205067_(FluidTags.f_13131_)) {
+             int i = p_150718_.m_123341_();
+             int j = p_150718_.m_123342_();
 @@ -120,7 +_,7 @@
              }
  

--- a/patches/minecraft/net/minecraft/world/item/DispensibleContainerItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/DispensibleContainerItem.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/item/DispensibleContainerItem.java
++++ b/net/minecraft/world/item/DispensibleContainerItem.java
+@@ -6,9 +_,10 @@
+ import net.minecraft.world.level.Level;
+ import net.minecraft.world.phys.BlockHitResult;
+ 
+-public interface DispensibleContainerItem {
++public interface DispensibleContainerItem extends net.minecraftforge.common.extensions.IForgeDispensibleContainerItem {
+    default void m_142131_(@Nullable Player p_150817_, Level p_150818_, ItemStack p_150819_, BlockPos p_150820_) {
+    }
+ 
++   @Deprecated //Forge: use the ItemStack sensitive version
+    boolean m_142073_(@Nullable Player p_150821_, Level p_150822_, BlockPos p_150823_, @Nullable BlockHitResult p_150824_);
+ }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeDispensibleContainerItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeDispensibleContainerItem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.DispensibleContainerItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
+
+public interface IForgeDispensibleContainerItem
+{
+    private DispensibleContainerItem self()
+    {
+        return (DispensibleContainerItem)this;
+    }
+
+    /**
+     * Empties the contents of the container and returns whether it was successful.
+     *
+     * @param player    Player who empties the container. May be null for blocks like dispensers.
+     * @param level     Level to place the content in
+     * @param pos       The position in the level to empty the content
+     * @param hitResult Hit result of the interaction. May be null for blocks like dispensers.
+     * @param container ItemStack of the container. May be null for backwards compatibility.
+     * @return true if emptying the contents of the container was successful, false otherwise
+     */
+    default boolean emptyContents(@Nullable Player player, Level level, BlockPos pos, @Nullable BlockHitResult hitResult, @Nullable ItemStack container)
+    {
+        return self().emptyContents(player, level, pos, hitResult);
+    }
+}

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -65,6 +65,7 @@ net/minecraft/world/entity/player/Player.getDigSpeed(Lnet/minecraft/world/level/
 net/minecraft/world/entity/projectile/ThrownEnderpearl.changeDimension(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/world/entity/Entity;=|p_37506_,teleporter
 net/minecraft/world/food/FoodData.eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/LivingEntity;)V=|p_38713_,p_38714_,entity
 net/minecraft/world/item/BoneMealItem.applyBonemeal(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;)Z=|p_40628_,p_40629_,p_40630_,player
+net/minecraft/world/item/BucketItem.emptyContents(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/BlockHitResult;Lnet/minecraft/world/item/ItemStack;)Z=|p_150716_,p_150717_,p_150718_,p_150719_,container
 net/minecraft/world/item/DyeableHorseArmorItem.<init>(ILnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/item/Item$Properties;)V=|p_41110_,p_41111_,p_41112_
 net/minecraft/world/item/HorseArmorItem.<init>(ILnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/item/Item$Properties;)V=|p_41364_,p_41365_,p_41366_
 net/minecraft/world/item/ItemStack.<init>(Lnet/minecraft/world/level/ItemLike;ILnet/minecraft/nbt/CompoundTag;)V=|p_41604_,p_41605_,p_41606_


### PR DESCRIPTION
This PR backports the changes of #9269 to fix #9261 for 1.19.2. 
It extends the `BucketItem::emptyContents` method by adding the ItemStack parameter and an additional check for the `FluidType::isVaporizedOnPlacement`.