### PR TITLE
[1.19.3] Add onStopUsing hook to IForgeItem

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -600,6 +600,14 @@
           if (this.f_20935_.m_41781_()) {
              this.m_21329_();
           }
+@@ -2996,6 +_,7 @@
+    }
+ 
+    public void m_5810_() {
++      if (this.m_6117_() && !this.f_20935_.m_41619_()) this.f_20935_.onStopUsing(this, f_20936_);
+       if (!this.f_19853_.f_46443_) {
+          boolean flag = this.m_6117_();
+          this.m_21155_(1, false);
 @@ -3011,7 +_,7 @@
     public boolean m_21254_() {
        if (this.m_6117_() && !this.f_20935_.m_41619_()) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -205,6 +205,10 @@ public interface IForgeItem
      * Called when an entity stops using an item for any reason, notably when selecting another item without releasing or finishing.
      * This method is called in addition to any other hooks called when an item is finished using; when another hook is also called it will be called before this method.
      *
+     * Note that if you break an item while using it (that is, it becomes empty without swapping the stack instance), this hook may not be called on the serverside as you are
+     * technically still using the empty item (thus this hook is called on air instead). It is necessary to call {@link LivingEntity#stopUsingItem()} as part of your
+     * {@link ItemStack#hurtAndBreak(int, LivingEntity, Consumer)} callback to prevent this issue.
+     *
      * For most uses, you likely want one of the following:
      * <ul>
      *   <li>{@link Item#finishUsingItem(ItemStack, Level, LivingEntity)} for when the player releases and enough ticks have passed

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -203,6 +203,7 @@ public interface IForgeItem
 
     /**
      * Called when an entity stops using an item for any reason, notably when selecting another item without releasing or finishing.
+     * This method is called in addition to any other hooks called when an item is finished using; when another hook is also called it will be called before this method.
      *
      * For most uses, you likely want one of the following:
      * <ul>

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -202,6 +202,24 @@ public interface IForgeItem
     }
 
     /**
+     * Called when an entity stops using an item for any reason, notably when selecting another item without releasing or finishing.
+     * Note that dropping an item does not cause you to stop using it, see MC-231097. Consider using {@link net.minecraftforge.event.entity.item.ItemTossEvent} as a workaround.
+     *
+     * For most uses, you likely want one of the following:
+     * <ul>
+     *   <li>{@link Item#finishUsingItem(ItemStack, Level, LivingEntity)} for when the player releases and enough ticks have passed
+     *   <li>{@link Item#releaseUsing(ItemStack, Level, LivingEntity, int)} (ItemStack, Level, LivingEntity)} for when the player releases but the full timer has not passed
+     * </ul>
+     *
+     * @param stack  The Item being used
+     * @param entity The entity using the item, typically a player
+     * @param count  The amount of time in tick the item has been used for continuously
+     */
+    default void onStopUsing(ItemStack stack, LivingEntity entity, int count)
+    {
+    }
+
+    /**
      * Called when the player Left Clicks (attacks) an entity. Processed before
      * damage is done, if return value is true further processing is canceled and
      * the entity is not attacked.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -203,7 +203,6 @@ public interface IForgeItem
 
     /**
      * Called when an entity stops using an item for any reason, notably when selecting another item without releasing or finishing.
-     * Note that dropping an item does not cause you to stop using it, see MC-231097. Consider using {@link net.minecraftforge.event.entity.item.ItemTossEvent} as a workaround.
      *
      * For most uses, you likely want one of the following:
      * <ul>

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -256,6 +256,17 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
+     * Called when an entity stops using an item item for any reason.
+     *
+     * @param entity The entity using the item, typically a player
+     * @param count  The amount of time in tick the item has been used for continuously
+     */
+    default void onStopUsing(LivingEntity entity, int count)
+    {
+        self().getItem().onStopUsing(self(), entity, count);
+    }
+
+    /**
      * Retrieves the normal 'lifespan' of this item when it is dropped on the ground
      * as a EntityItem. This is in ticks, standard result is 6000, or 5 mins.
      *

--- a/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
@@ -1,0 +1,139 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ComputeFovModifierEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.CreativeModeTabEvent;
+import net.minecraftforge.event.VanillaGameEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod(StopUsingItemTest.MODID)
+public class StopUsingItemTest
+{
+	protected static final String MODID = "stop_using_item";
+	private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+
+	/** Current FOV change, consumed by the event.
+	 * Good enough for a test mod as we only need one copy for the client player, in a real mod you probably want to reset this on world exit. */
+	private static float fovChange = 1.0f;
+
+	public StopUsingItemTest()
+	{
+		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		ITEMS.register(modEventBus);
+		modEventBus.addListener(this::addCreative);
+		MinecraftForge.EVENT_BUS.addListener(this::onVanillaEvent);
+	}
+
+	/** Attempt at a "reverse scope" that also makes you fly without using the Forge method. Will not remove the speed if you scroll away or swap items */
+	public static RegistryObject<Item> BAD = ITEMS.register("bad_scope", () -> new InvertedTelescope(new Item.Properties())
+	{
+		@Override
+		public ItemStack finishUsingItem(ItemStack stack, Level level, LivingEntity living)
+		{
+			removeFov(living);
+			return stack;
+		}
+
+		@Override
+		public void releaseUsing(ItemStack stack, Level level, LivingEntity living, int count)
+		{
+			removeFov(living);
+		}
+	});
+
+	/** Successful "scope item" using the Forge method, all cases of stopping using the item will stop the FOV change */
+	public static RegistryObject<Item> GOOD = ITEMS.register("good_scope", () -> new InvertedTelescope(new Item.Properties())
+	{
+		@Override
+		public void onStopUsing(ItemStack stack, LivingEntity living, int count)
+		{
+			removeFov(living);
+		}
+	});
+
+	private void addCreative(CreativeModeTabEvent.BuildContents event)
+	{
+		if (event.getTab() == CreativeModeTabs.COMBAT)
+		{
+			event.accept(BAD);
+			event.accept(GOOD);
+		}
+	}
+
+	private void onVanillaEvent(VanillaGameEvent event)
+	{
+		if (event.getVanillaEvent() == GameEvent.ITEM_INTERACT_FINISH && event.getCause() instanceof LivingEntity living && living.isUsingItem() && living.getUseItem().is(BAD.get()))
+			InvertedTelescope.removeFov(living);
+	}
+
+	private static abstract class InvertedTelescope extends Item
+	{
+		public InvertedTelescope(Properties props)
+		{
+			super(props);
+		}
+
+		@Override
+		public int getUseDuration(ItemStack stack)
+		{
+			return 72000;
+		}
+
+		@Override
+		public UseAnim getUseAnimation(ItemStack stack)
+		{
+			return UseAnim.EAT;
+		}
+
+		@Override
+		public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand)
+		{
+			player.startUsingItem(hand);
+			player.getAbilities().mayfly = true;
+			if (player.level.isClientSide)
+				fovChange = 10f;
+			return InteractionResultHolder.consume(player.getItemInHand(hand));
+		}
+
+		public static void removeFov(LivingEntity living)
+		{
+			if (living.level.isClientSide)
+				fovChange = 1f;
+			if (living instanceof Player player)
+			{
+				player.getAbilities().mayfly = player.isCreative();
+				if (!player.isCreative())
+					player.getAbilities().flying = false;
+			}
+		}
+	}
+
+	@EventBusSubscriber(modid = MODID, value = Dist.CLIENT, bus = Bus.FORGE)
+	public static class ClientEvents
+	{
+		@SubscribeEvent
+		static void computeFovModifier(ComputeFovModifierEvent event)
+		{
+			event.setNewFovModifier(event.getFovModifier() * fovChange);
+		}
+	}
+}

--- a/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
@@ -30,6 +30,17 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+/**
+ * This test mod provides two items for testing the Forge onStopUsing hook. Both items attempt to create an item that increases FOV and allows creative flight when used
+ * <ul>
+ *   <li>{@code stop_using_item:bad_scope}: Implements the item without the onStopUsing to demonstrate the problem.
+ *       Should see that when selecting another hotbar slot or dropping the item, the FOV is not properly reverted and you remain flying.
+ *   </li>
+ *   <li>{@code stop_using_item:good_scope}: Implements the item with onStopUsing to test that the hook hook works.
+ *       Should see that when selecting another hotbar slot or dropping the item, the FOV is properly reverted and you stop flying.
+ *   </li>
+ * </ul>
+ */
 @Mod(StopUsingItemTest.MODID)
 public class StopUsingItemTest
 {

--- a/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/StopUsingItemTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.world.InteractionHand;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -117,6 +117,8 @@ modId="custom_elytra_test"
 [[mods]]
 modId="snow_boots_test"
 [[mods]]
+modId="stop_using_item"
+[[mods]]
 modId="finite_water_test"
 [[mods]]
 modId="scaffolding_test"


### PR DESCRIPTION
## New hook

This PR introduces `IForgeItem#onStopUsing`, which is called in `LivingEntity#stopUsingItem`. This hook runs on both client and serverside after you stop using an item, whether you let go of right click, scroll to a different item, swap items, or are using a shield that is "broken" from an axe


There currently only two known cases the hook does not trigger, both of which are vanilla bugs fixed by #9344:
* When you drop an item, due to [MC-231097](https://bugs.mojang.com/browse/MC-231097).
* On the serverside when a shield breaks in use, due to [MC-168573](https://bugs.mojang.com/browse/MC-168573)

## Justification

Existing hooks (`finishUsingItem` and `releaseUsing`) are only called when you release right click on the item. While this is useful for canceling firing bows, it can prevent you from disabling an effect of using an item that was enabled in `use`. One workaround is to use the vanilla `ITEM_INTERACT_FINISH` game event, but that only runs serverside making it insufficient for things such as FOV changes (via `ComputeFovModifierEvent`) or some player abilities. Another workaround is the `LivingEquipmentChangeEvent`, which is much less reliable for this usecase and again, serverside only.

## Test Mod

Included is a test mod that adds two items: `stop_using_item:bad_scope` and `stop_using_item:good_scope`. Both items when activated grant you creative flight and increase the FOV by a significant amount. With `bad_scope`, you can observe that using the scroll wheel does not reset the FOV. 

## Vanilla Bug

As mentioned earlier, a vanilla bug causes you to keep using an item after dropping it or when a shield breaks. I implemented those fixes in #9344. The two PRs can be merged separately, but it will make this hook much nicer to use if the other PR is merged.