### PR TITLE
[1.19.3] Fix continuing to use items after dropping or when a shield breaks (MC-231097, MC-168573)

### DIFF
--- a/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
@@ -8,6 +8,14 @@
        return false;
     }
  
+@@ -276,6 +_,7 @@
+ 
+    public boolean m_108700_(boolean p_108701_) {
+       ServerboundPlayerActionPacket.Action serverboundplayeractionpacket$action = p_108701_ ? ServerboundPlayerActionPacket.Action.DROP_ALL_ITEMS : ServerboundPlayerActionPacket.Action.DROP_ITEM;
++      if (m_6117_() && m_7655_() == InteractionHand.MAIN_HAND && (p_108701_ || m_21211_().m_41613_() == 1)) m_5810_(); // Forge: fix MC-231097 on the clientside
+       ItemStack itemstack = this.m_150109_().m_182403_(p_108701_);
+       this.f_108617_.m_104955_(new ServerboundPlayerActionPacket(serverboundplayeractionpacket$action, BlockPos.f_121853_, Direction.DOWN));
+       return !itemstack.m_41619_();
 @@ -462,7 +_,14 @@
     }
  

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -289,12 +289,13 @@
     public TextFilter m_8967_() {
        return this.f_8939_;
     }
-@@ -1550,11 +_,13 @@
+@@ -1550,11 +_,14 @@
  
     public boolean m_182294_(boolean p_182295_) {
        Inventory inventory = this.m_150109_();
 +      ItemStack selected = inventory.m_36056_();
 +      if (selected.m_41619_() || !selected.onDroppedByPlayer(this)) return false;
++      if (m_6117_() && m_7655_() == InteractionHand.MAIN_HAND && (p_182295_ || selected.m_41613_() == 1)) m_5810_(); // Forge: fix MC-231097 on the serverside
        ItemStack itemstack = inventory.m_182403_(p_182295_);
        this.f_36096_.m_182417_(inventory, inventory.f_35977_).ifPresent((p_182293_) -> {
           this.f_36096_.m_150404_(p_182293_, inventory.m_36056_());

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,11 +135,12 @@
           if (!this.f_19853_.f_46443_) {
              this.m_36246_(Stats.f_12982_.m_12902_(this.f_20935_.m_41720_()));
           }
-@@ -874,6 +_,7 @@
+@@ -874,6 +_,8 @@
              InteractionHand interactionhand = this.m_7655_();
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
++               m_5810_(); // Forge: fix MC-168573
              });
              if (this.f_20935_.m_41619_()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {


### PR DESCRIPTION
[MC-231097](https://bugs.mojang.com/browse/MC-231097) causes you to remain in the use item state if you drop an item while using it. While it does not let you perform any effects of the item (such as blocking with a shield), it makes it more difficult for both #9343 and workarounds for that missing hook to handle every case where you may stop using an item.

[MC-168573](https://bugs.mojang.com/browse/MC-168573) causes a desync as the shield breaking manages to alert the client side that it should stop using items, but the serverside continues to be using the now empty shield stack. Since slowdown when using items is controlled by the client side, you do not notice the impact unless you happen to have items in both hands and continue to hold right click after the shield breaks.

This fix is implemented in such a way that while independent of #9343, if both are merged this fix will automatically call that hook (hence calling `stopUsingItem` before modifying the inventory so the proper stack is present for the hooks, also helpful for the vanilla game event). Even without merging #9343, this fix is useful as it makes both the vanilla game event and the forge equipment change event more reliable for detecting when you no longer are using an item.

To test MC-231097, simply find any usable item (shield is easiest) then drop it while using it. Observe in vanilla you keep moving slowly, but with this fix you now return to regular speed. Edge cases to test:

* Dropping a single item when using a stack of size 1
* Dropping a single item when using a stack of size greater than 1
* Dropping a stack of items when using a stack of size greater than 1
* Dropping an item when using the offhand item

To test MC-168573, get a shield at 1 durability, then hold it in your main hand and another usable item (shield is easiest) in the offhand. Get a mob to attack you while blocking (but do not release the interaction key). You should see the offhand item visually appears to be used, but the effect does not happen (e.g. if its a shield, you look like you are blocking without actually blocking any damage)