### PR TITLE
Remove DistExecutor calls in PistonEventTest

### DIFF
--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -50,6 +50,8 @@ import java.util.Objects;
 @Mod(value = PistonEventTest.MODID)
 public class PistonEventTest
 {
+    static final boolean ENABLE_PISTON_EVENT_LOGGING = false;
+
     public static final String MODID = "piston_event_test";
     public static String blockName = "shiftonmove";
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
@@ -134,6 +136,8 @@ public class PistonEventTest
 
     private static void sendMessage(LevelAccessor levelAccessor, String message)
     {
+        if (!ENABLE_PISTON_EVENT_LOGGING) return;
+
         if (!levelAccessor.isClientSide() && levelAccessor instanceof ServerLevel level)
         {
             level.getServer().sendSystemMessage(Component.literal(message));

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -80,7 +80,7 @@ public class PistonEventTest
         {
             Level world = (Level) event.getLevel();
             PistonStructureResolver pistonHelper = event.getStructureHelper();
-            Player player = DistExecutor.safeCallWhenOn(Dist.CLIENT, () -> () -> Minecraft.getInstance().player);
+            Player player = DistExecutor.unsafeCallWhenOn(Dist.CLIENT, () -> () -> Minecraft.getInstance().player);
             if (world.isClientSide && player != null)
             {
                 if (pistonHelper.resolve())
@@ -122,7 +122,7 @@ public class PistonEventTest
         {
             boolean isSticky = event.getLevel().getBlockState(event.getPos()).getBlock() == Blocks.STICKY_PISTON;
 
-            Player player = DistExecutor.safeCallWhenOn(Dist.CLIENT, () -> () -> Minecraft.getInstance().player);
+            Player player = DistExecutor.unsafeCallWhenOn(Dist.CLIENT, () -> () -> Minecraft.getInstance().player);
             if (event.getLevel().isClientSide() && player != null)
             {
                 if (isSticky)

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -38,6 +38,7 @@ import net.minecraftforge.registries.RegistryObject;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * This test mod blocks pistons from moving cobblestone at all except indirectly
@@ -51,11 +52,11 @@ public class PistonEventTest
 {
     public static final String MODID = "piston_event_test";
     public static String blockName = "shiftonmove";
-    private static DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
-    private static DeferredRegister<Item>  ITEMS  = DeferredRegister.create(ForgeRegistries.ITEMS,  MODID);
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
 
-    private static RegistryObject<Block> SHIFT_ON_MOVE = BLOCKS.register(blockName, () -> new Block(Block.Properties.of(Material.STONE)));
-    private static RegistryObject<Item> SHIFT_ON_MOVE_ITEM = ITEMS.register(blockName, () -> new BlockItem(SHIFT_ON_MOVE.get(), new Item.Properties()));
+    private static final RegistryObject<Block> SHIFT_ON_MOVE = BLOCKS.register(blockName, () -> new Block(Block.Properties.of(Material.STONE)));
+    private static final RegistryObject<Item> SHIFT_ON_MOVE_ITEM = ITEMS.register(blockName, () -> new BlockItem(SHIFT_ON_MOVE.get(), new Item.Properties()));
 
     public PistonEventTest()
     {
@@ -78,7 +79,7 @@ public class PistonEventTest
         if (event.getPistonMoveType() == PistonMoveType.EXTEND)
         {
             Level world = (Level) event.getLevel();
-            PistonStructureResolver pistonHelper = event.getStructureHelper();
+            PistonStructureResolver pistonHelper = Objects.requireNonNull(event.getStructureHelper());
 
             if (pistonHelper.resolve())
             {
@@ -146,7 +147,7 @@ public class PistonEventTest
         gen.addProvider(event.includeClient(), new BlockStates(gen.getPackOutput(), event.getExistingFileHelper()));
     }
 
-    private class BlockStates extends BlockStateProvider
+    private static class BlockStates extends BlockStateProvider
     {
         public BlockStates(PackOutput output, ExistingFileHelper exFileHelper)
         {
@@ -156,7 +157,7 @@ public class PistonEventTest
         @Override
         protected void registerStatesAndModels()
         {
-            simpleBlockWithItem(SHIFT_ON_MOVE.get(), models().cubeAll(SHIFT_ON_MOVE.getId().getPath(), mcLoc("block/furnace_top")));
+            simpleBlockWithItem(SHIFT_ON_MOVE.get(), models().cubeAll(Objects.requireNonNull(SHIFT_ON_MOVE.getId()).getPath(), mcLoc("block/furnace_top")));
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -5,42 +5,39 @@
 
 package net.minecraftforge.debug.block;
 
-import java.util.List;
-import java.util.Locale;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.piston.PistonStructureResolver;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
-import net.minecraft.client.Minecraft;
-import net.minecraft.data.DataGenerator;
-import net.minecraft.data.PackOutput;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.core.Direction;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.model.generators.BlockStateProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.level.PistonEvent;
 import net.minecraftforge.event.level.PistonEvent.PistonMoveType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.List;
+import java.util.Locale;
 
 /**
  * This test mod blocks pistons from moving cobblestone at all except indirectly


### PR DESCRIPTION
The use of `DistExecutor#safeCallWhenOn` in the `PistonEventTest` causes a crash when a piston extends or retracts in the test mod runs, because `safeCallWhenOn` is passed a double lambda which is not a safe referent. (A safe referent is a lambda that returns a method reference.)

~~This PR fixes those crashes by changing to the unsafe variant, `unsafeCallWhenOn`, which does not check if the passed in lambda is a safe referent. This removes a long-time annoyance from the test sourceset runs, because the crash often occurs when testing other PRs (with a mechanism that uses a piston).~~

This PR fixes those crashes by removing the references to `DistExecutor` and the client local player and replacing message sending calls to broadcast to all players on the server. In addition, a constant is added to control whether these messages are actually sent, to avoid spamming the chat in case a test world uses many pistons. By default, the messages are disabled.

This PR also cleans up the warnings and formatting of the test mod.