### PR TITLE
[1.19.3] Fix incorrect ListTag.getLongArray result (MC-260378)

### DIFF
--- a/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
@@ -5,7 +5,7 @@
        if (p_177992_ >= 0 && p_177992_ < this.f_128716_.size()) {
           Tag tag = this.f_128716_.get(p_177992_);
 -         if (tag.m_7060_() == 11) {
-+         if (tag.m_7060_() == 12) {
++         if (tag.m_7060_() == 12) { // FORGE: Fix MC-260378 by using correct constant for long array tag which is Tag.TAG_LONG_ARRAY
              return ((LongArrayTag)tag).m_128851_();
           }
        }

--- a/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/nbt/ListTag.java
++++ b/net/minecraft/nbt/ListTag.java
+@@ -224,7 +_,7 @@
+    public long[] m_177991_(int p_177992_) {
+       if (p_177992_ >= 0 && p_177992_ < this.f_128716_.size()) {
+          Tag tag = this.f_128716_.get(p_177992_);
+-         if (tag.m_7060_() == 11) {
++         if (tag.m_7060_() == 12) {
+             return ((LongArrayTag)tag).m_128851_();
+          }
+       }

--- a/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/ListTag.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/nbt/ListTag.java
 +++ b/net/minecraft/nbt/ListTag.java
-@@ -224,7 +_,7 @@
+@@ -224,7 +_,8 @@
     public long[] m_177991_(int p_177992_) {
        if (p_177992_ >= 0 && p_177992_ < this.f_128716_.size()) {
           Tag tag = this.f_128716_.get(p_177992_);
 -         if (tag.m_7060_() == 11) {
-+         if (tag.m_7060_() == 12) { // FORGE: Fix MC-260378 by using correct constant for long array tag which is Tag.TAG_LONG_ARRAY
++         // FORGE: Fix MC-260378 by using correct constant for long array tag which is Tag.TAG_LONG_ARRAY
++         if (tag.m_7060_() == 12) {
              return ((LongArrayTag)tag).m_128851_();
           }
        }


### PR DESCRIPTION
The method `ListTag.getLongArray(int id)` checks for the wrong tag id. It checks for `11`, but the id of a long array is `12`. I have reported this issue to Mojang [here](https://bugs.mojang.com/projects/MC/issues/MC-260378).