### PR TITLE
[1.19.3] Fix missing patch to apply TagBuilder#replace when generating tags

### DIFF
--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -63,8 +63,9 @@
              if (!list1.isEmpty()) {
                 throw new IllegalArgumentException(String.format(Locale.ROOT, "Couldn't define tag %s as it is missing following references: %s", resourcelocation, list1.stream().map(Objects::toString).collect(Collectors.joining(","))));
              } else {
-                JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, false)).getOrThrow(false, f_126541_::error);
+-               JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, false)).getOrThrow(false, f_126541_::error);
 -               Path path = this.f_236439_.m_245731_(resourcelocation);
++               JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, tagbuilder.isReplace())).getOrThrow(false, f_126541_::error);
 +               Path path = this.getPath(resourcelocation);
 +               if (path == null) return CompletableFuture.completedFuture(null); // Forge: Allow running this data provider without writing it. Recipe provider needs valid tags.
                 return DataProvider.m_253162_(p_253684_, jsonelement, path);

--- a/patches/minecraft/net/minecraft/tags/TagBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagBuilder.java.patch
@@ -19,7 +19,7 @@
     private final List<TagEntry> f_215897_ = new ArrayList<>();
  
     public static TagBuilder m_215899_() {
-@@ -34,5 +_,16 @@
+@@ -34,5 +_,21 @@
  
     public TagBuilder m_215909_(ResourceLocation p_215910_) {
        return this.m_215902_(TagEntry.m_215953_(p_215910_));
@@ -34,5 +34,10 @@
 +   // FORGE: Shorthand version of replace(true)
 +   public TagBuilder replace() {
 +      return replace(true);
++   }
++
++   // FORGE: Is this tag set to replace or not?
++   public boolean isReplace() {
++      return this.replace;
     }
  }


### PR DESCRIPTION
### The Issue

In 1.19, Forge added a `replace` field to `TagBuilder`, which was supposed to allow modders to generate replacement tags via datagen. However, it appears to have never been used, likely due to a missed patch.

### The fix

This PR adds a patch to apply the value of `TagBuilder#replace` when generating tags. It is now read by `TagsProvider#run` and passed into the `TagFile` before being serialized to JSON. The codec for `TagFile` already supports `replace` by default, so there are no changes required to serialization.

Tested and confirmed to work.

<details>
<summary>Show image</summary>

![Tag Replacement Test](https://user-images.githubusercontent.com/51261569/220978515-9ddf3058-a438-4c23-aefa-d332a0cfc662.png)

</details>

