### PR TITLE
Fixed FluidUtil#tryFillContainer returning invalid result when simulating

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -143,8 +143,8 @@ public class FluidUtil
                         }
                         else
                         {
-                            //The result should be the same regardless of weather we are simulating or not.
-                            //So we must execute the transfer on the copied item stack so the resultContainer is correct.
+                            // We are acting on a COPY of the stack, so performing changes on the source is acceptable even if we are simulating.
+                            // We need to perform the change otherwise the call to getContainer() will be incorrect.
                             containerFluidHandler.fill(simulatedTransfer, IFluidHandler.FluidAction.EXECUTE);
                         }
 

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -143,7 +143,9 @@ public class FluidUtil
                         }
                         else
                         {
-                            containerFluidHandler.fill(simulatedTransfer, IFluidHandler.FluidAction.SIMULATE);
+                            //The result should be the same regardless of weather we are simulating or not.
+                            //So we must execute the transfer on the copied item stack so the resultContainer is correct.
+                            containerFluidHandler.fill(simulatedTransfer, IFluidHandler.FluidAction.EXECUTE);
                         }
 
                         ItemStack resultContainer = containerFluidHandler.getContainer();


### PR DESCRIPTION
The expected behaviour when simulating a transfer is for the result of the call to be the same as if the transfer was actually completed. 

It looks like this bug was introduced 4 years ago in the fluid handler re-write where FluidAction was introduced. 
This parameter was changed from `true` (Meaning execute the fill operation) to `SIMULATE`. 