### PR TITLE
Change keymapping resolution to allow click count to be set on conflicting bindings

### DIFF
--- a/patches/minecraft/net/minecraft/client/KeyMapping.java.patch
+++ b/patches/minecraft/net/minecraft/client/KeyMapping.java.patch
@@ -12,6 +12,15 @@
     private static final Set<String> f_90811_ = Sets.newHashSet();
     public static final String f_167805_ = "key.categories.movement";
     public static final String f_167806_ = "key.categories.misc";
+@@ -41,7 +_,7 @@
+    private int f_90818_;
+ 
+    public static void m_90835_(InputConstants.Key p_90836_) {
+-      KeyMapping keymapping = f_90810_.get(p_90836_);
++      for (KeyMapping keymapping : f_90810_.getAll(p_90836_))
+       if (keymapping != null) {
+          ++keymapping.f_90818_;
+       }
 @@ -49,7 +_,7 @@
     }
  

--- a/src/main/java/net/minecraftforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyMappingLookup.java
@@ -27,6 +27,7 @@ public class KeyMappingLookup
         }
     }
 
+    @Deprecated(forRemoval = true)
     @Nullable
     public KeyMapping get(InputConstants.Key keyCode)
     {
@@ -59,6 +60,16 @@ public class KeyMappingLookup
         return null;
     }
 
+    /**
+     * Returns all active keys associated with the given key code and the active
+     * modifiers and conflict context.
+     *
+     * This could probably be renamed to something like getActiveMappings, but
+     * that would be a breaking change.
+     *
+     * @param keyCode the key being pressed
+     * @return the list of key mappings
+     */
     public List<KeyMapping> getAll(InputConstants.Key keyCode)
     {
         List<KeyMapping> matchingBindings = new ArrayList<KeyMapping>();
@@ -67,7 +78,11 @@ public class KeyMappingLookup
             Collection<KeyMapping> bindings = bindingsMap.get(keyCode);
             if (bindings != null)
             {
-                matchingBindings.addAll(bindings);
+                for (KeyMapping binding : bindings)
+                {
+                    if (binding.isConflictContextAndModifierActive())
+                        matchingBindings.add(binding);
+                }
             }
         }
         return matchingBindings;

--- a/src/test/java/net/minecraftforge/debug/KeyMappingTest.java
+++ b/src/test/java/net/minecraftforge/debug/KeyMappingTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
+
+@Mod("keymapping_test")
+public class KeyMappingTest
+{
+    @Mod.EventBusSubscriber(modid = "keymapping_test", value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+    public static class ClientStuff {
+        // these are two separate keys to stand in for keys added by different
+        // mods that each do something similar with a held item from the
+        // respective mod, so the user wants them on the same physical key.
+        static KeyMapping stickKey = new KeyMapping("stick_key", InputConstants.KEY_BACKSLASH, KeyMapping.CATEGORY_MISC);
+        static KeyMapping rockKey = new KeyMapping("rock_key", InputConstants.KEY_BACKSLASH, KeyMapping.CATEGORY_MISC);
+        @SubscribeEvent
+        public static void init(FMLConstructModEvent event) {
+            MinecraftForge.EVENT_BUS.addListener(ClientStuff::tick);
+        }
+        @SubscribeEvent
+        public static void initKeys(RegisterKeyMappingsEvent event) {
+            event.register(stickKey);
+            event.register(rockKey);
+        }
+        public static void tick(TickEvent.ClientTickEvent event) {
+            if(event.phase != TickEvent.Phase.START) return;
+            if(stickKey.consumeClick()) {
+                Player player = Minecraft.getInstance().player;
+                if(player != null && player.getMainHandItem().is(Items.STICK))
+                    player.sendSystemMessage(Component.literal("stick found!"));
+            }
+            if(rockKey.consumeClick()) {
+                Player player = Minecraft.getInstance().player;
+                if(player != null && player.getMainHandItem().is(Items.COBBLESTONE))
+                    player.sendSystemMessage(Component.literal("rock found!"));
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -21,6 +21,8 @@ license="LGPL v2.1"
     modId="advancement_event_test"
 [[mods]]
     modId="shader_resources_test"
+[[mods]]
+    modId="keymapping_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
Currently, if two key mappings are assigned to the same physical key, both will have their isDown status set, but only one will have clickCount incremented. This causes problems in large modpacks since keybinding handling that relies on clickCount will have the key randomly fail if there is a conflicting binding, even if that binding shouldn't "really" conflict [both depend on what item is held, for example]

The slight change in the semantics of getAll [to only return active bindings based on conflict context and modifier rather than all bindings with all modifiers] shouldn't affect its existing use for isDown since the isDown() method already filters by this.