### PR TITLE
Implementing ShaderEffectLoadEvent Event

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -9,6 +9,18 @@
        }
  
     }
+@@ -320,6 +_,11 @@
+    }
+ 
+    public void m_109128_(ResourceLocation p_109129_) {
++      p_109129_ = net.minecraftforge.client.ForgeHooksClient.onEntityShaderLoad(this.f_109050_, p_109129_);
++      if (p_109129_ == null) {
++         return;
++      }
++
+       if (this.f_109050_ != null) {
+          this.f_109050_.close();
+       }
 @@ -586,6 +_,7 @@
           list1.add(Pair.of(new ShaderInstance(p_250719_, "rendertype_crumbling", DefaultVertexFormat.f_85811_), (p_234230_) -> {
              f_172607_ = p_234230_;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -49,6 +49,7 @@ import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.PostChain;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
@@ -131,6 +132,7 @@ import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
+import net.minecraftforge.client.event.ShaderEffectLoadEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.ToastAddEvent;
 import net.minecraftforge.client.event.ViewportEvent;
@@ -568,6 +570,14 @@ public class ForgeHooksClient
                 entityRenderer.loadEffect(shader);
             }
         }
+    }
+
+    @Nullable
+    public static ResourceLocation onEntityShaderLoad(@Nullable PostChain currentEffect, ResourceLocation newShaderEffect)
+    {
+        ShaderEffectLoadEvent event = new ShaderEffectLoadEvent(currentEffect == null ? null : new ResourceLocation(currentEffect.getName()), newShaderEffect);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getNewShaderEffect();
     }
 
     private static int slotMainHand = 0;

--- a/src/main/java/net/minecraftforge/client/event/ShaderEffectLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ShaderEffectLoadEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nullable;
+
+/**
+ * ShaderEffectEvent is triggered when a new shader effect is trying to load
+ * at {@link net.minecraft.client.renderer.GameRenderer#loadEffect(ResourceLocation)}
+ *
+ * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}, and
+ * does not have a {@link net.minecraftforge.eventbus.api.Event.Result}
+ */
+public class ShaderEffectLoadEvent extends Event
+{
+    @Nullable
+    private final ResourceLocation currentEffect;
+    private ResourceLocation newShaderEffect;
+
+    public ShaderEffectLoadEvent(@Nullable ResourceLocation currentEffect, ResourceLocation newShaderEffect)
+    {
+        this.currentEffect = currentEffect;
+        this.newShaderEffect = newShaderEffect;
+    }
+
+    /**
+     * Gets the name of the current active effect,
+     * e.g. ResourceLocation("minecraft:shaders/post/spider.json")
+     *
+     * The current effect may be null if there's no
+     * effect active
+     *
+     * @return Current active effect, or null if none
+     */
+    @Nullable
+    public ResourceLocation getCurrentEffect()
+    {
+        return currentEffect;
+    }
+
+    /**
+     * Gets the new effect that is trying to be loaded
+     * e.g. ResourceLocation("minecraft:shaders/post/spider.json")
+     *
+     * @return The new loading effect
+     */
+    public ResourceLocation getNewShaderEffect()
+    {
+        return newShaderEffect;
+    }
+
+    /**
+     * Sets the new effect that is going to be loaded
+     *
+     * If set to null, instead of unloading existing effect, no changes
+     * will be made, i.e. old effect preserved & new effect not applied
+     *
+     * To unload the current effect without a new effect,
+     * use {@link net.minecraft.client.renderer.GameRenderer#shutdownEffect} directly
+     *
+     * @param newShaderEffect The new effect to be loaded, null to cancel the load
+     */
+    public void setNewShaderEffect(@Nullable ResourceLocation newShaderEffect)
+    {
+        this.newShaderEffect = newShaderEffect;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/ShaderEffectLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/ShaderEffectLoadEventTest.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ShaderEffectLoadEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+
+@Mod("shader_effect_load_event_test")
+public class ShaderEffectLoadEventTest
+{
+    public ShaderEffectLoadEventTest()
+    {
+        if (FMLEnvironment.dist == Dist.CLIENT)
+            MinecraftForge.EVENT_BUS.addListener(Client::onShaderEffectLoad);
+    }
+
+    static class Client
+    {
+        private static final ResourceLocation SHADER_SPIDER = new ResourceLocation("minecraft:shaders/post/spider.json");
+        private static final ResourceLocation SHADER_GREEN = new ResourceLocation("minecraft:shaders/post/green.json");
+        private static final ResourceLocation SHADER_INVERT = new ResourceLocation("minecraft:shaders/post/invert.json");
+        public static void onShaderEffectLoad(ShaderEffectLoadEvent event)
+        {
+            ResourceLocation newEffect = event.getNewShaderEffect();
+
+            // Replaces the "spider" effect with "green"
+            if (SHADER_SPIDER.equals(newEffect))
+                event.setNewShaderEffect(SHADER_GREEN);
+
+            // Cancels the load of "enderman" effect
+            else if (SHADER_INVERT.equals(newEffect))
+                event.setNewShaderEffect(null);
+
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -21,6 +21,8 @@ license="LGPL v2.1"
     modId="advancement_event_test"
 [[mods]]
     modId="shader_resources_test"
+[[mods]]
+    modId="shader_effect_load_event_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
This event simply listens to GameRenderer#loadEffect.
The event allows users to interrupt with the change of effect shader. However, the unload/shutdown is not included.

A "currentEffect" (existing effect) and a "newEffect" (new effect ready for load) are provided in the event.

The users can change the final effect shader applied through
`ShaderEffectLoadEvent#setNewShaderEffect(@Nullable ResourceLocation newShaderEffect)`
setting it to null will prevent the shader effects from loading and unloading, i.e. old effect preserved & new effect not applied

Test mod `ShaderEffectLoadEventTest.java`
has successfully replaced "spider" with "green".
And prevents "invert (enderman)" from unloading the existing shader effect.