### PR TITLE
Add `ChunkEvent.Load#isNewChunk`

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientChunkCache.java.patch
@@ -12,7 +12,7 @@
           }
  
           this.f_104411_.m_171649_(chunkpos);
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk));
++         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, false));
           return levelchunk;
        }
     }

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -24,7 +24,7 @@
 +               p_140384_.currentlyLoading = levelchunk; // Forge - bypass the future chain when getChunk is called, this prevents deadlocks.
                 levelchunk.m_156369_();
                 levelchunk.m_187958_(this.f_140133_);
-+               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk));
++               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, !(protochunk instanceof ImposterProtoChunk)));
 +               } finally {
 +                   p_140384_.currentlyLoading = null; // Forge - Stop bypassing the future chain.
 +               }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -58,9 +58,30 @@ public class ChunkEvent extends LevelEvent
      **/
     public static class Load extends ChunkEvent
     {
+        private final boolean newChunk;
+
+        @Deprecated
         public Load(ChunkAccess chunk)
         {
+            this(chunk, false);
+        }
+
+        public Load(ChunkAccess chunk, boolean newChunk)
+        {
             super(chunk);
+            this.newChunk = newChunk;
+        }
+
+        /**
+         * Check whether the Chunk is newly generated, and being loaded for the first time.
+         * <br>
+         * Will only ever return {@code true} on the {@link net.minecraftforge.fml.LogicalSide#SERVER logical server}.
+         *
+         * @return whether the Chunk is newly generated
+         */
+        public boolean isNewChunk()
+        {
+            return newChunk;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * ChunkEvent is fired when an event involving a chunk occurs.<br>
@@ -60,12 +61,14 @@ public class ChunkEvent extends LevelEvent
     {
         private final boolean newChunk;
 
-        @Deprecated
+        @ApiStatus.Internal
+        @Deprecated(forRemoval = true, since = "1.19.3")
         public Load(ChunkAccess chunk)
         {
             this(chunk, false);
         }
 
+        @ApiStatus.Internal
         public Load(ChunkAccess chunk, boolean newChunk)
         {
             super(chunk);
@@ -74,8 +77,8 @@ public class ChunkEvent extends LevelEvent
 
         /**
          * Check whether the Chunk is newly generated, and being loaded for the first time.
-         * <br>
-         * Will only ever return {@code true} on the {@link net.minecraftforge.fml.LogicalSide#SERVER logical server}.
+         *
+         * <p>Will only ever return {@code true} on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.</p>
          *
          * @return whether the Chunk is newly generated
          */

--- a/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
@@ -5,12 +5,12 @@
 
 package net.minecraftforge.debug.world;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 
 /**
  * Simple test for {@link ChunkEvent.Load#isNewChunk()}. Will log a message to console each time
@@ -32,10 +32,11 @@ import org.apache.logging.log4j.Logger;
  */
 @Mod(ChunkEventLoadNewChunkTest.MODID)
 @Mod.EventBusSubscriber
-public class ChunkEventLoadNewChunkTest {
+public class ChunkEventLoadNewChunkTest
+{
     static final String MODID = "chunk_event_load_new_chunk_test";
     private static final boolean ENABLED = true;
-    private static final Logger LOGGER = LogManager.getLogger(MODID);
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     @SubscribeEvent
     public static void onChunkLoad(final ChunkEvent.Load event)

--- a/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
@@ -1,0 +1,50 @@
+package net.minecraftforge.debug.world;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.event.level.ChunkEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Simple test for {@link ChunkEvent.Load#isNewChunk()}. Will log a message to console each time
+ * the event is fired for a newly generated chunk.
+ *
+ * <p>A simple way to check that it's behaving as expected is as follows:</p>
+ * <ul>
+ * <li>Generate a new world (and log in if using dedicated server). You should see many log messages about
+ * the spawn chunks being generated.</li>
+ * <li>Don't move around in game, to make sure we only generate the spawn chunks, and any chunks loaded
+ * by the player chunk loader for the players initial login position. (to make this test as
+ * reproducible as possible without lots of complexity)</li>
+ * <li>Once a couple seconds pass without any new chunk log messages, close out of the world/stop the server.</li>
+ * <li>Load the world/start the server (and log in if using dedicated server) again. For the same reasons as before,
+ * don't move around.</li>
+ * <li>You shouldn't see any log messages for new chunks this time.
+ * (until you start moving around to generate more chunks)</li>
+ * </ul>
+ */
+@Mod(ChunkEventLoadNewChunkTest.MODID)
+@Mod.EventBusSubscriber
+public class ChunkEventLoadNewChunkTest {
+    static final String MODID = "chunk_event_load_new_chunk_test";
+    private static final boolean ENABLED = true;
+    private static final Logger LOGGER = LogManager.getLogger(MODID);
+
+    @SubscribeEvent
+    public static void onChunkLoad(final ChunkEvent.Load event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        if (!event.isNewChunk())
+        {
+            return;
+        }
+
+        LOGGER.info("Loaded freshly generated chunk at {}{}", ((ServerLevel) event.getLevel()).dimension().location(), event.getChunk().getPos());
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkEventLoadNewChunkTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.world;
 
 import net.minecraft.server.level.ServerLevel;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -280,6 +280,8 @@ modId="creative_mode_tab_test"
 modId="render_level_stages_test"
 [[mods]]
 modId="trade_with_villager_event_test"
+[[mods]]
+modId="chunk_event_load_new_chunk_test"
 
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR adds a new boolean `isNewChunk()` to `ChunkEvent.Load`.

The purpose of this PR is to allow simple and reliable tracking of when a new chunk is generated. The current API-based workarounds involve having to manually keep track of every chunk that has ever been loaded, in order to check if it has been loaded before and infer that it is *probably* a newly generated chunk. Either using a capability on the chunk or external tracking.

My use case for this is to track newly generated chunks to queue render jobs for my web map mod, squaremap. Users are able to configure what kind of events trigger map updates, i.e. chunk loading, generation, explosions, player block breaks, etc. Of chunk loading and generation, only the generation trigger is on by default, as it's generally desirable to render chunks as they generate but not every time they load (rendering on load is only desirable in specific use cases, `fullrender` and `radiusrender` are meant for rendering existing chunks). 

For client-side map mods, this information is less relevant, as they only deal with updating the area immediately around a player, not the entire map of every world on a server. 

The main reason the aforementioned workarounds are not adequate for reliable tracking of if a chunk is new is that it's impossible to tell if a chunk is actually freshly generated, or generated before our mod was installed. I should also be able to uninstall the mod and reinstall it at a later date without unexpected behavior. This type of user behavior (adding or removing mods after starting a world/server) is more common for mods that don't touch anything that affects client sync or save data, like map mods or something like AppleSkin. Besides being a behavioral issue, this would also have performance implications. Not only directly but also by effectively giving the user less control over render triggers.

Other existing Forge web map mods currently rely on workarounds like the ones I've mentioned, and could also benefit from this addition.