### PR TITLE
Determine the Forge version the PR was built against when running PR compat checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1218,7 +1218,7 @@ project(':forge') {
     }
 
     def baseForgeVersionProperty = project.objects.property(String)
-    baseForgeVersionProperty.set(project.provider { getLatestForgeVersion(MC_VERSION) }.map { MC_VERSION + '-' + it })
+    baseForgeVersionProperty.set(project.provider { TeamcityRequests.attemptFindBase(rootDir) ?: (MC_VERSION + '-' + getLatestForgeVersion(MC_VERSION)) })
     baseForgeVersionProperty.finalizeValueOnRead()
     def jarCompatibilityTaskSetup = { task ->
         task.group = 'jar compatibility'

--- a/build.gradle
+++ b/build.gradle
@@ -1218,7 +1218,7 @@ project(':forge') {
     }
 
     def baseForgeVersionProperty = project.objects.property(String)
-    baseForgeVersionProperty.set(project.provider { TeamcityRequests.attemptFindBase(rootDir) ?: (MC_VERSION + '-' + getLatestForgeVersion(MC_VERSION)) })
+    baseForgeVersionProperty.set(project.provider { TeamcityRequests.attemptFindBase(rootDir) ?: getLatestForgeVersion(MC_VERSION) })
     baseForgeVersionProperty.finalizeValueOnRead()
     def jarCompatibilityTaskSetup = { task ->
         task.group = 'jar compatibility'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,4 +9,5 @@ dependencies {
     implementation 'net.minecraftforge:srgutils:0.4.+'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.google.code.gson:gson:2.10'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     implementation 'net.minecraftforge:srgutils:0.4.+'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.google.code.gson:gson:2.10'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r' // JGit 6+ requires Java 11
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     implementation 'net.minecraftforge:srgutils:0.4.+'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.google.code.gson:gson:2.10'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r' // JGit 6+ requires Java 11
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -1,0 +1,54 @@
+package net.minecraftforge.forge.tasks
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import groovy.transform.CompileStatic
+import org.eclipse.jgit.api.Git
+
+import javax.annotation.Nullable
+
+@CompileStatic
+class TeamcityRequests {
+    public static final Gson GSON = new Gson()
+
+    static <T> T jsonRequest(TypeToken<T> clazz, String url) throws Exception {
+        final URLConnection conn = URI.create(url).toURL().openConnection()
+        conn.setRequestProperty('Accept', 'application/json')
+        try (final InputStream is = conn.getInputStream()) {
+            GSON.fromJson(new InputStreamReader(is), clazz.getType())
+        }
+    }
+
+    @Nullable
+    static Build findMatching(String commitId) throws IOException {
+        final builds = jsonRequest(new TypeToken<Builds>() {},
+                "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build)")
+        builds.build.find()
+    }
+
+    @Nullable
+    static String attemptFindBase(File gitPath) {
+        try (final git = Git.open(gitPath)) {
+            for (final commit in git.log().setMaxCount(100).call()) {
+                // Find the first commit which was built on CI
+                final build = findMatching(commit.id.name)
+                if (build) {
+                    return build.number
+                }
+            }
+        } catch (Exception ignored) {}
+        return null
+    }
+
+    static final class Builds {
+        public int count
+        public String href
+        public List<Build> build
+    }
+
+    static final class Build {
+        public int id
+        public String number
+        public String buildTypeId
+    }
+}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -15,6 +15,8 @@ class TeamcityRequests {
     static <T> T jsonRequest(TypeToken<T> clazz, String url) throws Exception {
         final HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection()
         conn.setRequestProperty('Accept', 'application/json')
+        conn.setReadTimeout(5 * 1000)
+        conn.setConnectTimeout(5 * 1000)
         conn.connect()
 
         if (conn.responseCode !== 200) {
@@ -28,7 +30,7 @@ class TeamcityRequests {
 
     @Nullable
     static Build findMatching(String commitId) throws IOException {
-        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build)")?.build?.find()
+        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),status:SUCCESS")?.build?.find()
     }
 
     @Nullable

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -6,6 +6,7 @@ import groovy.transform.CompileStatic
 import org.eclipse.jgit.api.Git
 
 import javax.annotation.Nullable
+import java.util.stream.Collectors
 
 @CompileStatic
 class TeamcityRequests {
@@ -29,16 +30,22 @@ class TeamcityRequests {
     }
 
     @Nullable
-    static Build findMatching(String commitId) throws IOException {
-        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),status:SUCCESS")?.build?.find()
+    static Map<String, Build> buildsByCommit() throws IOException {
+        final Map<String, Build> builds = [:]
+        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?fields=build:(revisions,number)&locator=buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),count:300,status:SUCCESS")
+                ?.build?.forEach {
+            it.revisions.revision.each { rev -> builds[rev.version] = it }
+        }
+        return builds
     }
 
     @Nullable
     static String attemptFindBase(File gitPath) {
         try (final git = Git.open(gitPath)) {
+            final Map<String, Build> buildByCommit = buildsByCommit()
             for (final commit in git.log().setMaxCount(100).call()) {
                 // Find the first commit which was built on CI
-                final build = findMatching(commit.id.name)
+                final build = buildByCommit[commit.id.name]
                 if (build) {
                     return build.number
                 }
@@ -48,14 +55,20 @@ class TeamcityRequests {
     }
 
     static final class Builds {
-        public int count
-        public String href
         public List<Build> build
     }
 
     static final class Build {
-        public int id
         public String number
-        public String buildTypeId
+        public Revisions revisions
+    }
+
+    static final class Revisions {
+        public int count
+        public List<Revision> revision
+    }
+
+    static final class Revision {
+        public String version
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -11,9 +11,16 @@ import javax.annotation.Nullable
 class TeamcityRequests {
     public static final Gson GSON = new Gson()
 
+    @Nullable
     static <T> T jsonRequest(TypeToken<T> clazz, String url) throws Exception {
-        final URLConnection conn = URI.create(url).toURL().openConnection()
+        final HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection()
         conn.setRequestProperty('Accept', 'application/json')
+        conn.connect()
+
+        if (conn.responseCode !== 200) {
+            return null
+        }
+
         try (final InputStream is = conn.getInputStream()) {
             GSON.fromJson(new InputStreamReader(is), clazz.getType())
         }
@@ -21,9 +28,7 @@ class TeamcityRequests {
 
     @Nullable
     static Build findMatching(String commitId) throws IOException {
-        final builds = jsonRequest(new TypeToken<Builds>() {},
-                "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build)")
-        builds.build.find()
+        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?locator=revision:($commitId),buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build)")?.build?.find()
     }
 
     @Nullable

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
@@ -143,8 +143,9 @@ public class Util {
 		}
 	}
 
-    public static String getLatestForgeVersion(mcVersion) {
-        def json = new JsonSlurper().parseText(new URL("https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json").getText("UTF-8"))
-        return json.promos["$mcVersion-latest"]
+    static String getLatestForgeVersion(mcVersion) {
+        final json = new JsonSlurper().parseText(new URL('https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json').getText('UTF-8'))
+        final ver = json.promos["$mcVersion-latest"]
+        ver === null ? null : (mcVersion + '-' + ver)
     }
 }


### PR DESCRIPTION
This PR adds a way of detecting the Forge version the PR was built on in order to properly determine the Forge version to check compatibility against, and avoid PRs constantly having failed checks.
The system iterates over the commit history, using the [TeamCity REST API](https://www.jetbrains.com/help/teamcity/rest/get-build-details.html#Get+Specific+Builds) in order to find the newest commit which was built on CI.