### PR TITLE
Fix experimental warning screen appearing everytime a world is created or opened

### DIFF
--- a/patches/minecraft/net/minecraft/core/registries/BuiltInRegistries.java.patch
+++ b/patches/minecraft/net/minecraft/core/registries/BuiltInRegistries.java.patch
@@ -265,7 +265,7 @@
     }
  
 +   private static <T> Registry<T> forge(ResourceKey<? extends Registry<T>> key, BuiltInRegistries.RegistryBootstrap<T> def) {
-+      return forge(key, Lifecycle.experimental(), def);
++      return forge(key, Lifecycle.stable(), def);
 +   }
 +
     private static <T> DefaultedRegistry<T> m_257988_(ResourceKey<? extends Registry<T>> p_259887_, String p_259325_, BuiltInRegistries.RegistryBootstrap<T> p_259759_) {
@@ -273,7 +273,7 @@
     }
  
 +   private static <T> DefaultedRegistry<T> forge(ResourceKey<? extends Registry<T>> key, String defKey, BuiltInRegistries.RegistryBootstrap<T> def) {
-+      return forge(key, defKey, Lifecycle.experimental(), def);
++      return forge(key, defKey, Lifecycle.stable(), def);
 +   }
 +
     private static <T> DefaultedRegistry<T> m_257834_(ResourceKey<? extends Registry<T>> p_259296_, String p_259101_, BuiltInRegistries.RegistryBootstrap<T> p_259485_) {

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -51,7 +51,7 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
     private final Multimap<TagKey<T>, Supplier<T>> optionalTags = Multimaps.newSetMultimap(new IdentityHashMap<>(), HashSet::new);
 
     boolean locked = false;
-    Lifecycle registryLifecycle = Lifecycle.experimental();
+    Lifecycle registryLifecycle = Lifecycle.stable();
     private boolean frozen = false; // Frozen is vanilla's variant of locked, but it can be unfrozen
     private List<Holder.Reference<T>> holdersSorted;
     private ObjectList<Holder.Reference<T>> holdersById = new ObjectArrayList<>(256);
@@ -62,7 +62,7 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
 
     NamespacedWrapper(ForgeRegistry<T> fowner, Function<T, Holder.Reference<T>> intrusiveHolderCallback, RegistryManager stage)
     {
-        super(fowner.getRegistryKey(), Lifecycle.experimental(), intrusiveHolderCallback != null);
+        super(fowner.getRegistryKey(), Lifecycle.stable(), intrusiveHolderCallback != null);
         this.delegate = fowner;
         this.intrusiveHolderCallback = intrusiveHolderCallback;
         this.stage = stage;


### PR DESCRIPTION
Fixes the experimental warning screen appearing everytime a world is created or opened due to a lot of the registries being incorrectly set to experimental.
Fixes #9272