### PR TITLE
[1.19.4] Restore ability to change message in ClientChatEvent

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -15,6 +15,9 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Fired when the client is about to send a chat message to the server.
  *
+ * <p>{@link #message} contains the message that will be sent to the server. This can be changed by mods.</p>
+ * <p>{@link #originalMessage} contains the original message that was going to be sent to the server. This cannot be changed by mods.</p>
+ *
  * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the chat message will not be sent to the server.</p>
  *
@@ -24,13 +27,13 @@ import org.jetbrains.annotations.ApiStatus;
 @Cancelable
 public class ClientChatEvent extends Event
 {
-    // private String message;
+    private String message;
     private final String originalMessage;
 
     @ApiStatus.Internal
     public ClientChatEvent(String message)
     {
-        // this.setMessage(message);
+        this.setMessage(message);
         this.originalMessage = Strings.nullToEmpty(message);
     }
 
@@ -39,18 +42,18 @@ public class ClientChatEvent extends Event
      */
     public String getMessage()
     {
-        return this.originalMessage;
+        return this.message;
     }
 
-    // /**
-    //  * Sets the new message to be sent to the server, if the event is not cancelled.
-    //  *
-    //  * @param message the new message to be sent
-    //  */
-    // public void setMessage(String message)
-    // {
-    //     this.message = Strings.nullToEmpty(message);
-    // }
+    /**
+     * Sets the new message to be sent to the server, if the event is not cancelled.
+     *
+     * @param message the new message to be sent
+     */
+    public void setMessage(String message)
+    {
+        this.message = Strings.nullToEmpty(message);
+    }
 
     /**
      * {@return the original message that was to be sent to the server}

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -15,9 +15,6 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Fired when the client is about to send a chat message to the server.
  *
- * <p>{@link #message} contains the message that will be sent to the server. This can be changed by mods.</p>
- * <p>{@link #originalMessage} contains the original message that was going to be sent to the server. This cannot be changed by mods.</p>
- *
  * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the chat message will not be sent to the server.</p>
  *
@@ -35,10 +32,11 @@ public class ClientChatEvent extends Event
     {
         this.setMessage(message);
         this.originalMessage = Strings.nullToEmpty(message);
+        this.message = this.originalMessage;
     }
 
     /**
-     * {@return the message that will be sent to the server, if the event is not cancelled}
+     * {@return the message that will be sent to the server, if the event is not cancelled. This can be changed by mods.}
      */
     public String getMessage()
     {
@@ -56,7 +54,7 @@ public class ClientChatEvent extends Event
     }
 
     /**
-     * {@return the original message that was to be sent to the server}
+     * {@return the original message that was to be sent to the server. This cannot be changed by mods}
      */
     public String getOriginalMessage()
     {

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -54,7 +54,7 @@ public class ClientChatEvent extends Event
     }
 
     /**
-     * {@return the original message that was to be sent to the server. This cannot be changed by mods}
+     * {@return the original message that was to be sent to the server. This cannot be changed by mods.}
      */
     public String getOriginalMessage()
     {

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -36,7 +36,7 @@ public class ClientChatEvent extends Event
     }
 
     /**
-     * {@return the message that will be sent to the server, if the event is not cancelled. This can be changed by mods.}
+     * {@return the message that will be sent to the server, if the event is not cancelled. This can be changed by mods}
      */
     public String getMessage()
     {
@@ -54,7 +54,7 @@ public class ClientChatEvent extends Event
     }
 
     /**
-     * {@return the original message that was to be sent to the server. This cannot be changed by mods.}
+     * {@return the original message that was to be sent to the server. This cannot be changed by mods}
      */
     public String getOriginalMessage()
     {

--- a/src/test/java/net/minecraftforge/debug/chat/ClientChatEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/ClientChatEventTest.java
@@ -18,7 +18,7 @@ public class ClientChatEventTest
     {
         if (event.getMessage().equals("Cancel"))
             event.setCanceled(true);
-        // else if (event.getMessage().equals("Replace this text"))
-        //     event.setMessage("Text replaced.");
+        else if (event.getMessage().equals("Replace this text"))
+            event.setMessage("Text replaced.");
     }
 }


### PR DESCRIPTION
This PR should be easy to quickly review as it's basically just uncommenting some existing code in an event.

My use-case is a mod that helps prevent users from accidentally leaking their base coordinates. Currently I'm having to block the entire message if it contains a similar coordinate to the ones in a configurable range, but it would be nice if I could redact the coordinates and still send the rest of the message like in 1.18.2.

When I asked why this functionality was commented out in 1.19.3 in the Discord server, XFact game me a plausible explanation that it was disabled in 1.19.2 and simply forgot to be re-enabled in 1.19.3. If this is the case, this PR should solve that.
![image](https://user-images.githubusercontent.com/3158390/224507595-936bdefb-6107-4005-a247-a9c83e2b976e.png)

As usual, I've tested and confirmed it works before submitting this PR.