### PR TITLE
Fix mobs not always taking damage

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -371,7 +371,7 @@
           p_21241_ = this.m_21161_(p_21240_, p_21241_);
           p_21241_ = this.m_6515_(p_21240_, p_21241_);
           float f1 = Math.max(p_21241_ - this.m_6103_(), 0.0F);
-@@ -1560,14 +_,16 @@
+@@ -1560,10 +_,11 @@
              Entity entity = p_21240_.m_7639_();
              if (entity instanceof ServerPlayer) {
                 ServerPlayer serverplayer = (ServerPlayer)entity;
@@ -384,11 +384,6 @@
           if (f1 != 0.0F) {
              float f2 = this.m_21223_();
              this.m_21231_().m_19289_(p_21240_, f2, f1);
-             this.m_21153_(f2 - f1);
-+            this.m_21153_(f1 - f2); // Forge: moved to fix MC-121048
-             this.m_7911_(this.m_6103_() - f1);
-             this.m_146850_(GameEvent.f_223706_);
-          }
 @@ -1622,6 +_,8 @@
     }
  


### PR DESCRIPTION
Some locals were renamed in `actuallyHurt`, meaning the call to `setHealth` now heals the mob rather than damaging it. However, it appears that the bug has been fixed upstream (see the line above our call to `setHealth`/`m_21153_`), so we can remove just this patch.

Closes #9382