### PR TITLE
[1.19.4] Add BlockSetType#register to accesstransformer.cfg to make public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -410,6 +410,7 @@ public net.minecraft.world.level.block.entity.BlockEntityType$BlockEntitySupplie
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59395_(I)V # setCooldown
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59409_()Z # isOnCustomCooldown
 public net.minecraft.world.level.block.state.properties.WoodType m_61844_(Lnet/minecraft/world/level/block/state/properties/WoodType;)Lnet/minecraft/world/level/block/state/properties/WoodType; # register
+public net.minecraft.world.level.block.state.properties.BlockSetType m_272115_(Lnet/minecraft/world/level/block/state/properties/BlockSetType;)Lnet/minecraft/world/level/block/state/properties/BlockSetType; # register
 public net.minecraft.world.level.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/level/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/level/chunk/ChunkStatus$ChunkType;Lnet/minecraft/world/level/chunk/ChunkStatus$GenerationTask;Lnet/minecraft/world/level/chunk/ChunkStatus$LoadingTask;)V # constructor
 protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157994_ # barrierNoise
 protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157996_ # lavaNoise


### PR DESCRIPTION
Allows modders to register BlockSetTypes as it is currently private