### PR TITLE
Rename RegisterParticleProviderEvent's register methods to describe what kind of particle providers they register (deprecating old methods to avoid breaking) and minor docs tweaks

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -64,7 +64,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
      * @deprecated Renamed to {@link #registerSpecial}
      * @see #registerSpecial
      */
-    @Deprecated(forRemoval=true, since="1.19.4")
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider<T> provider)
     {
         registerSpecial(type, provider);
@@ -96,7 +96,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
      * @deprecated Renamed to {@link #registerSprite}
      * @see #registerSprite
      */
-    @Deprecated(forRemoval=true, since="1.19.4")
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider.Sprite<T> sprite)
     {
         registerSprite(type, sprite);
@@ -106,7 +106,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
      * Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
-     * @param type ParticleType to register a particle prov for.
+     * @param type ParticleType to register a particle provider for.
      * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
@@ -121,14 +121,14 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
      * Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
-     * @param type ParticleType to register a particle prov for.
+     * @param type ParticleType to register a particle provider for.
      * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
      * @deprecated Renamed to {@link #registerSpriteSet}
      * @see #registerSpriteSet
      */
-    @Deprecated(forRemoval=true, since="1.19.4")
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration)
     {
         registerSpriteSet(type, registration);

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -54,7 +54,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     public <T extends ParticleOptions> void registerSpecial(ParticleType<T> type, ParticleProvider<T> provider) {
         particleEngine.register(type, provider);
     }
-    
+
     /**
      * <p>Registers a ParticleProvider for a non-json-based ParticleType.
      * These particles do not receive a list of texture sprites to use for rendering themselves.</p>
@@ -90,7 +90,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     {
         particleEngine.register(type, sprite);
     }
-    
+
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType with a single texture;
      * the resulting {@link TextureSheetParticle}s will use that texture when created.</p>
@@ -126,7 +126,7 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     {
         particleEngine.register(type, registration);
     }
-    
+
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.</p>

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -40,12 +40,14 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
 
     /**
-     * Registers a ParticleProvider for a non-json-based ParticleType.
-     * These particles do not receive a list of texture sprites to use for rendering themselves.
+     * <p>Registers a ParticleProvider for a non-json-based ParticleType.
+     * These particles do not receive a list of texture sprites to use for rendering themselves.</p>
+     * 
+     * <p>There must be <strong>no</strong> particle json with an ID matching the ParticleType,
+     * or a redundant texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
      * @param type ParticleType to register a ParticleProvider for.
-     * There must be no particle json with an ID matching this ParticleType,
-     * or a redundant texture list error will occur when particle jsons load.
      * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
      */
     @SuppressWarnings("deprecation")
@@ -54,15 +56,17 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
     
     /**
-     * Registers a ParticleProvider for a non-json-based ParticleType.
-     * These particles do not receive a list of texture sprites to use for rendering themselves.
+     * <p>Registers a ParticleProvider for a non-json-based ParticleType.
+     * These particles do not receive a list of texture sprites to use for rendering themselves.</p>
+     * 
+     * There must be <strong>no</strong> particle json with an ID matching the ParticleType,
+     * or a redundant texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
      * @param type ParticleType to register a ParticleProvider for.
-     * There must be no particle json with an ID matching this ParticleType,
-     * or a redundant texture list error will occur when particle jsons load.
      * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
-     * @deprecated Renamed to {@link #registerSpecial}
      * @see #registerSpecial
+     * @deprecated Renamed to {@link #registerSpecial}
      */
     @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider<T> provider)
@@ -71,12 +75,14 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
 
     /**
-     * Registers a ParticleProvider for a json-based ParticleType with a single texture;
-     * the resulting {@link TextureSheetParticle}s will use that texture when created.
+     * <p>Registers a ParticleProvider for a json-based ParticleType with a single texture;
+     * the resulting {@link TextureSheetParticle}s will use that texture when created.</p>
+     * 
+     * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and Sprite function.
      * @param type ParticleType to register a ParticleProvider for.
-     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
-     * or a missing texture list error will occur when particle jsons load.
      * @param sprite Sprite function responsible for providing that ParticleType's particles.
      */
     @SuppressWarnings("deprecation")
@@ -86,15 +92,17 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
     
     /**
-     * Registers a ParticleProvider for a json-based ParticleType with a single texture;
-     * the resulting {@link TextureSheetParticle}s will use that texture when created.
+     * <p>Registers a ParticleProvider for a json-based ParticleType with a single texture;
+     * the resulting {@link TextureSheetParticle}s will use that texture when created.</p>
+     * 
+     * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and Sprite function.
      * @param type ParticleType to register a ParticleProvider for.
-     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
-     * or a missing texture list error will occur when particle jsons load.
      * @param sprite Sprite function responsible for providing that ParticleType's particles.
-     * @deprecated Renamed to {@link #registerSprite}
      * @see #registerSprite
+     * @deprecated Renamed to {@link #registerSprite}
      */
     @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider.Sprite<T> sprite)
@@ -103,12 +111,14 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
 
     /**
-     * Registers a ParticleProvider for a json-based ParticleType.
-     * Particle jsons define a list of texture sprites which the particle can use to render itself.
+     * <p>Registers a ParticleProvider for a json-based ParticleType.
+     * Particle jsons define a list of texture sprites which the particle can use to render itself.</p>
+     * 
+     * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
      * @param type ParticleType to register a particle provider for.
-     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
-     * or a missing texture list error will occur when particle jsons load.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
      */
     @SuppressWarnings("deprecation")
@@ -118,15 +128,17 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     }
     
     /**
-     * Registers a ParticleProvider for a json-based ParticleType.
-     * Particle jsons define a list of texture sprites which the particle can use to render itself.
+     * <p>Registers a ParticleProvider for a json-based ParticleType.
+     * Particle jsons define a list of texture sprites which the particle can use to render itself.</p>
+     * 
+     * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.</p>
+     * 
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
      * @param type ParticleType to register a particle provider for.
-     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
-     * or a missing texture list error will occur when particle jsons load.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
-     * @deprecated Renamed to {@link #registerSpriteSet}
      * @see #registerSpriteSet
+     * @deprecated Renamed to {@link #registerSpriteSet}
      */
     @Deprecated(forRemoval = true, since = "1.19.4")
     public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration)

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -42,10 +42,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a non-json-based ParticleType.
      * These particles do not receive a list of texture sprites to use for rendering themselves.</p>
-     * 
+     *
      * <p>There must be <strong>no</strong> particle json with an ID matching the ParticleType,
      * or a redundant texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
      * @param type ParticleType to register a ParticleProvider for.
      * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
@@ -58,10 +58,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a non-json-based ParticleType.
      * These particles do not receive a list of texture sprites to use for rendering themselves.</p>
-     * 
+     *
      * There must be <strong>no</strong> particle json with an ID matching the ParticleType,
      * or a redundant texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
      * @param type ParticleType to register a ParticleProvider for.
      * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
@@ -77,10 +77,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType with a single texture;
      * the resulting {@link TextureSheetParticle}s will use that texture when created.</p>
-     * 
+     *
      * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and Sprite function.
      * @param type ParticleType to register a ParticleProvider for.
      * @param sprite Sprite function responsible for providing that ParticleType's particles.
@@ -94,10 +94,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType with a single texture;
      * the resulting {@link TextureSheetParticle}s will use that texture when created.</p>
-     * 
+     *
      * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and Sprite function.
      * @param type ParticleType to register a ParticleProvider for.
      * @param sprite Sprite function responsible for providing that ParticleType's particles.
@@ -113,10 +113,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.</p>
-     * 
+     *
      * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
      * @param type ParticleType to register a particle provider for.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
@@ -130,10 +130,10 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     /**
      * <p>Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.</p>
-     * 
+     *
      * <p>A particle json with an ID matching the ParticleType <strong>must exist</strong> in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.</p>
-     * 
+     *
      * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
      * @param type ParticleType to register a particle provider for.
      * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -45,32 +46,91 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
      * @param type ParticleType to register a ParticleProvider for.
      * There must be no particle json with an ID matching this ParticleType,
      * or a redundant texture list error will occur when particle jsons load.
-     * @param provider ParticleProvider responsible for providing that ParticleType's particles.
+     * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
      */
     @SuppressWarnings("deprecation")
-    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider<T> provider)
-    {
+    public <T extends ParticleOptions> void registerSpecial(ParticleType<T> type, ParticleProvider<T> provider) {
         particleEngine.register(type, provider);
     }
+    
+    /**
+     * Registers a ParticleProvider for a non-json-based ParticleType.
+     * These particles do not receive a list of texture sprites to use for rendering themselves.
+     * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
+     * @param type ParticleType to register a ParticleProvider for.
+     * There must be no particle json with an ID matching this ParticleType,
+     * or a redundant texture list error will occur when particle jsons load.
+     * @param provider ParticleProvider function responsible for providing that ParticleType's particles.
+     * @deprecated Renamed to {@link #registerSpecial}
+     * @see #registerSpecial
+     */
+    @Deprecated(forRemoval=true, since="1.19.4")
+    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider<T> provider)
+    {
+        registerSpecial(type, provider);
+    }
 
+    /**
+     * Registers a ParticleProvider for a json-based ParticleType with a single texture;
+     * the resulting {@link TextureSheetParticle}s will use that texture when created.
+     * @param <T> ParticleOptions used by the ParticleType and Sprite function.
+     * @param type ParticleType to register a ParticleProvider for.
+     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.
+     * @param sprite Sprite function responsible for providing that ParticleType's particles.
+     */
     @SuppressWarnings("deprecation")
-    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider.Sprite<T> sprite)
+    public <T extends ParticleOptions> void registerSprite(ParticleType<T> type, ParticleProvider.Sprite<T> sprite)
     {
         particleEngine.register(type, sprite);
+    }
+    
+    /**
+     * Registers a ParticleProvider for a json-based ParticleType with a single texture;
+     * the resulting {@link TextureSheetParticle}s will use that texture when created.
+     * @param <T> ParticleOptions used by the ParticleType and Sprite function.
+     * @param type ParticleType to register a ParticleProvider for.
+     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.
+     * @param sprite Sprite function responsible for providing that ParticleType's particles.
+     * @deprecated Renamed to {@link #registerSprite}
+     * @see #registerSprite
+     */
+    @Deprecated(forRemoval=true, since="1.19.4")
+    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleProvider.Sprite<T> sprite)
+    {
+        registerSprite(type, sprite);
     }
 
     /**
      * Registers a ParticleProvider for a json-based ParticleType.
      * Particle jsons define a list of texture sprites which the particle can use to render itself.
-     * @param <T> ParticleOptions used by the ParticleType and ParticleProvider.
-     * @param type ParticleType to register a ParticleProvider for.
+     * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
+     * @param type ParticleType to register a particle prov for.
      * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
      * or a missing texture list error will occur when particle jsons load.
-     * @param registration SpriteParticleRegistration responsible for providing that ParticleType's particles.
+     * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
      */
     @SuppressWarnings("deprecation")
-    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration)
+    public <T extends ParticleOptions> void registerSpriteSet(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration)
     {
         particleEngine.register(type, registration);
+    }
+    
+    /**
+     * Registers a ParticleProvider for a json-based ParticleType.
+     * Particle jsons define a list of texture sprites which the particle can use to render itself.
+     * @param <T> ParticleOptions used by the ParticleType and SpriteParticleRegistration function.
+     * @param type ParticleType to register a particle prov for.
+     * There must be a particle json with an ID matching this ParticleType in the <code>particles</code> asset folder,
+     * or a missing texture list error will occur when particle jsons load.
+     * @param registration SpriteParticleRegistration function responsible for providing that ParticleType's particles.
+     * @deprecated Renamed to {@link #registerSpriteSet}
+     * @see #registerSpriteSet
+     */
+    @Deprecated(forRemoval=true, since="1.19.4")
+    public <T extends ParticleOptions> void register(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration)
+    {
+        registerSpriteSet(type, registration);
     }
 }


### PR DESCRIPTION
The intent of this PR is to make the event's API more readable and describable (e.g. "use the register method that registers a SpriteParticleRegistration" vs. "use registerSpriteSet").

Currently going with `registerSpecial` for non-json particles (because they manually do special rendering), `registerSprite` for the single-texture-json provider we have as of 1.19.4, and `registerSpriteSet` for the multi-texture jsons, names aren't set in stone and can be improved.