### PR TITLE
[1.19.4] Fix misaligned text render type patch

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderType.java.patch
@@ -1,21 +1,30 @@
 --- a/net/minecraft/client/renderer/RenderType.java
 +++ b/net/minecraft/client/renderer/RenderType.java
+@@ -308,7 +_,7 @@
+    }
+ 
+    public static RenderType m_110497_(ResourceLocation p_110498_) {
+-      return f_173173_.apply(p_110498_);
++      return net.minecraftforge.client.ForgeRenderTypes.getText(p_110498_);
+    }
+ 
+    public static RenderType m_269058_() {
 @@ -316,19 +_,19 @@
     }
  
     public static RenderType m_173237_(ResourceLocation p_173238_) {
 -      return f_173174_.apply(p_173238_);
-+      return net.minecraftforge.client.ForgeRenderTypes.getText(p_173238_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensity(p_173238_);
     }
  
     public static RenderType m_181444_(ResourceLocation p_181445_) {
 -      return f_181442_.apply(p_181445_);
-+      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensity(p_181445_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextPolygonOffset(p_181445_);
     }
  
     public static RenderType m_181446_(ResourceLocation p_181447_) {
 -      return f_181443_.apply(p_181447_);
-+      return net.minecraftforge.client.ForgeRenderTypes.getTextPolygonOffset(p_181447_);
++      return net.minecraftforge.client.ForgeRenderTypes.getTextIntensityPolygonOffset(p_181447_);
     }
  
     public static RenderType m_110500_(ResourceLocation p_110501_) {


### PR DESCRIPTION
This PR fixes the text render type patch being misaligned due to two new render types used for the text display entity being added. The misaligned patch breaks text rendering on signs (two modded signs and a vanilla oak sign) with glow ink applied:
![2023-03-16_16 11 58](https://user-images.githubusercontent.com/11262040/225700366-9795b578-3944-4ced-93ca-9f86ab6ebf58.png)
