### PR TITLE
Shaped/ShapelessRecipeBuilder with default recipe category

### DIFF
--- a/patches/minecraft/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
@@ -4,12 +4,12 @@
        this.f_126107_ = p_248948_;
     }
  
-+   public static ShapedRecipeBuilder shaped(ItemLike p_249747_) {
-+      return shaped(p_249747_, 1);
++   public static ShapedRecipeBuilder shaped(ItemLike result) {
++      return shaped(result, 1);
 +   }
 +
-+   public static ShapedRecipeBuilder shaped(ItemLike p_249747_, int count) {
-+      return m_246608_(RecipeCategory.MISC, p_249747_, count);
++   public static ShapedRecipeBuilder shaped(ItemLike result, int count) {
++      return m_246608_(RecipeCategory.MISC, result, count);
 +   }
 +
     public static ShapedRecipeBuilder m_245327_(RecipeCategory p_250853_, ItemLike p_249747_) {

--- a/patches/minecraft/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/data/recipes/ShapedRecipeBuilder.java
++++ b/net/minecraft/data/recipes/ShapedRecipeBuilder.java
+@@ -41,6 +_,14 @@
+       this.f_126107_ = p_248948_;
+    }
+ 
++   public static ShapedRecipeBuilder shaped(ItemLike p_249747_) {
++      return shaped(p_249747_, 1);
++   }
++
++   public static ShapedRecipeBuilder shaped(ItemLike p_249747_, int count) {
++      return m_246608_(RecipeCategory.MISC, p_249747_, count);
++   }
++
+    public static ShapedRecipeBuilder m_245327_(RecipeCategory p_250853_, ItemLike p_249747_) {
+       return m_246608_(p_250853_, p_249747_, 1);
+    }

--- a/patches/minecraft/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
@@ -4,12 +4,12 @@
        this.f_126174_ = p_252227_;
     }
  
-+   public static ShapelessRecipeBuilder shapeless(ItemLike p_249659_) {
-+      return shapeless(p_249659_, 1);
++   public static ShapelessRecipeBuilder shapeless(ItemLike result) {
++      return shapeless(result, 1);
 +   }
 +
-+   public static ShapelessRecipeBuilder shapeless(ItemLike p_249659_, int count) {
-+      return m_246517_(RecipeCategory.MISC, p_249659_, count);
++   public static ShapelessRecipeBuilder shapeless(ItemLike result, int count) {
++      return m_246517_(RecipeCategory.MISC, result, count);
 +   }
 +
     public static ShapelessRecipeBuilder m_245498_(RecipeCategory p_250714_, ItemLike p_249659_) {

--- a/patches/minecraft/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/data/recipes/ShapelessRecipeBuilder.java
++++ b/net/minecraft/data/recipes/ShapelessRecipeBuilder.java
+@@ -35,6 +_,14 @@
+       this.f_126174_ = p_252227_;
+    }
+ 
++   public static ShapelessRecipeBuilder shapeless(ItemLike p_249659_) {
++      return shapeless(p_249659_, 1);
++   }
++
++   public static ShapelessRecipeBuilder shapeless(ItemLike p_249659_, int count) {
++      return m_246517_(RecipeCategory.MISC, p_249659_, count);
++   }
++
+    public static ShapelessRecipeBuilder m_245498_(RecipeCategory p_250714_, ItemLike p_249659_) {
+       return new ShapelessRecipeBuilder(p_250714_, p_249659_, 1);
+    }


### PR DESCRIPTION
I wanted to create constructors that set the RecipeCategory by default equal to MISC, since that's the one that's often used in mods.
This PR is focused on avoiding having to always add `RecipeCategory.MISC` as a parameter to the constructor.