### PR TITLE
Fixed ModMismatchDisconnectedScreen displaying missing mods wrongly

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ModMismatchDisconnectedScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/ModMismatchDisconnectedScreen.java
@@ -70,8 +70,8 @@ public class ModMismatchDisconnectedScreen extends Screen
         this.listHeight = modMismatchData.containsMismatches() ? 140 : 0;
         this.mismatchedDataFromServer = modMismatchData.mismatchedDataFromServer();
         this.presentModData = modMismatchData.presentModData();
-        this.missingModData = modMismatchData.mismatchedModData().entrySet().stream().filter(e -> e.getValue().equals(NetworkRegistry.ABSENT)).map(Entry::getKey).collect(Collectors.toList());
-        this.mismatchedModData = modMismatchData.mismatchedModData().entrySet().stream().filter(e -> !e.getValue().equals(NetworkRegistry.ABSENT)).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        this.missingModData = modMismatchData.mismatchedModData().entrySet().stream().filter(e -> e.getValue().equals(NetworkRegistry.ABSENT.version())).map(Entry::getKey).collect(Collectors.toList());
+        this.mismatchedModData = modMismatchData.mismatchedModData().entrySet().stream().filter(e -> !e.getValue().equals(NetworkRegistry.ABSENT.version())).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
         this.allModIds = presentModData.keySet().stream().map(ResourceLocation::getNamespace).distinct().collect(Collectors.toList());
         this.presentModUrls = ModList.get().getMods().stream().filter(info -> allModIds.contains(info.getModId())).map(info -> Pair.of(info.getModId(), (String)info.getConfig().getConfigElement("displayURL").orElse(""))).collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
     }


### PR DESCRIPTION
During the 1.19.4 port, the absent version marker `NetworkRegistry.ABSENT`, which used to be of type `String`, has been changed to now be a `ChannelData` instance. Consequentially, most occurrences of this marker were changed appropriately to use the `version` string stored in the `ChannelData` instance. However, in `ModMismatchDisconnectedScreen`, two of the instances where a version was compared to `NetworkRegistry.ABSENT` were not changed, likely due to an oversight. This leads to all mods that are missing on either side to not be displayed as missing, but as mismatched, resulting in an unintuitive display on the mod mismatch screen.
This PR fixes this issue by adding the `.version()` calls to the two affected checks, ensuring that the incoming version is compared to the actual "Absent" version string instead of the `ChannelData` object.
Below is a showcase of the mod mismatch screen, with the correct display (above) and the faulty display (below) that is currently present in 1.19.4.
![mismatch 0](https://user-images.githubusercontent.com/42962686/226206070-1f700445-4073-4f29-848a-0670e823408a.PNG)
![mismatch 1](https://user-images.githubusercontent.com/42962686/226206076-73ff0e3c-a96e-42a6-aecc-5f4bd6402aa7.PNG)
