### PR TITLE
Fix hardcoded precipitation in ClimateSettingsBuilder

### DIFF
--- a/src/main/java/net/minecraftforge/common/world/ClimateSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/ClimateSettingsBuilder.java
@@ -6,7 +6,6 @@
 package net.minecraftforge.common.world;
 
 import net.minecraft.world.level.biome.Biome.ClimateSettings;
-import net.minecraft.world.level.biome.Biome.Precipitation;
 import net.minecraft.world.level.biome.Biome.TemperatureModifier;
 
 /**
@@ -56,7 +55,7 @@ public class ClimateSettingsBuilder
      */
     public ClimateSettings build()
     {
-        return new ClimateSettings(true, this.temperature, this.temperatureModifier, this.downfall);
+        return new ClimateSettings(this.hasPrecipitation, this.temperature, this.temperatureModifier, this.downfall);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #9397 by removing the hardcoded `true` for the `hasPrecipitation` in the climate settings builder and using the stored property value. See my comment on the linked issue for details: https://github.com/MinecraftForge/MinecraftForge/issues/9397#issuecomment-1475607851.