### PR TITLE
[1.19.4] Rebuild ItemEntity patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -108,7 +108,7 @@
  
        if (p_32034_.m_128403_("Owner")) {
           this.f_265881_ = p_32034_.m_128342_("Owner");
-@@ -313,10 +_,16 @@
+@@ -313,10 +_,17 @@
  
     public void m_6123_(Player p_32040_) {
        if (!this.f_19853_.f_46443_) {
@@ -121,7 +121,8 @@
 +         if (hook < 0) return;
 +         ItemStack copy = itemstack.m_41777_();
 +         if (this.f_31986_ == 0 && (this.f_265881_ == null || this.f_265881_.equals(p_32040_.m_20148_())) && (hook == 1 || i <= 0 || p_32040_.m_150109_().m_36054_(itemstack))) {
-+            copy.m_41764_(copy.m_41613_() - itemstack.m_41613_());
++            i = copy.m_41613_() - itemstack.m_41613_();
++            copy.m_41764_(i);
 +            net.minecraftforge.event.ForgeEventFactory.firePlayerItemPickupEvent(p_32040_, this, copy);
              p_32040_.m_7938_(this, i);
              if (itemstack.m_41619_()) {

--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -7,7 +7,7 @@
 +   /**
 +    * The maximum age of this EntityItem.  The item is expired once this is reached.
 +    */
-+   public int lifespan = 6000;
++   public int lifespan = ItemEntity.f_149659_;
  
     public ItemEntity(EntityType<? extends ItemEntity> p_31991_, Level p_31992_) {
        super(p_31991_, p_31992_);
@@ -15,10 +15,18 @@
        this.m_6034_(p_149664_, p_149665_, p_149666_);
        this.m_20334_(p_149668_, p_149669_, p_149670_);
        this.m_32045_(p_149667_);
-+      this.lifespan = (p_149667_.m_41720_() == null ? 6000 : p_149667_.getEntityLifespan(p_149663_));
++      this.lifespan = (p_149667_.m_41720_() == null ? ItemEntity.f_149659_ : p_149667_.getEntityLifespan(p_149663_));
     }
  
     private ItemEntity(ItemEntity p_31994_) {
+@@ -66,6 +_,7 @@
+       this.m_20359_(p_31994_);
+       this.f_31985_ = p_31994_.f_31985_;
+       this.f_31983_ = p_31994_.f_31983_;
++      this.lifespan = p_31994_.lifespan;
+    }
+ 
+    public boolean m_213854_() {
 @@ -94,6 +_,7 @@
     }
  
@@ -46,7 +54,7 @@
              }
  
              this.m_20256_(this.m_20184_().m_82542_((double)f1, 0.98D, (double)f1));
-@@ -158,7 +_,14 @@
+@@ -158,7 +_,16 @@
              }
           }
  
@@ -54,11 +62,13 @@
 +         ItemStack item = this.m_32055_();
 +         if (!this.f_19853_.f_46443_ && this.f_31985_ >= lifespan) {
 +             int hook = net.minecraftforge.event.ForgeEventFactory.onItemExpire(this, item);
-+             if (hook < 0) this.m_146870_();
-+             else          this.lifespan += hook;
++             if (hook < 0) {
++                this.m_146870_();
++             } else {
++                this.lifespan += hook;
++             }
 +         }
-+
-+         if (item.m_41619_()) {
++         if (item.m_41619_() && !this.m_213877_()) {
              this.m_146870_();
           }
  
@@ -71,14 +81,6 @@
        } else {
           return !p_32028_.m_41782_() || p_32028_.m_41783_().equals(p_32027_.m_41783_());
        }
-@@ -249,6 +_,7 @@
-    }
- 
-    public boolean m_6469_(DamageSource p_32013_, float p_32014_) {
-+      if (this.f_19853_.f_46443_ || this.m_213877_()) return false; //Forge: Fixes MC-53850
-       if (this.m_6673_(p_32013_)) {
-          return false;
-       } else if (!this.m_32055_().m_41619_() && this.m_32055_().m_150930_(Items.f_42686_) && p_32013_.m_269533_(DamageTypeTags.f_268415_)) {
 @@ -262,7 +_,7 @@
           this.f_31987_ = (int)((float)this.f_31987_ - p_32014_);
           this.m_146852_(GameEvent.f_223706_, p_32013_.m_7639_());
@@ -92,19 +94,21 @@
        p_32050_.m_128376_("Health", (short)this.f_31987_);
        p_32050_.m_128376_("Age", (short)this.f_31985_);
        p_32050_.m_128376_("PickupDelay", (short)this.f_31986_);
-+      p_32050_.m_128405_("Lifespan", lifespan);
++      p_32050_.m_128405_("Lifespan", this.lifespan);
        if (this.f_31988_ != null) {
           p_32050_.m_128362_("Thrower", this.f_31988_);
        }
-@@ -294,6 +_,7 @@
+@@ -294,6 +_,9 @@
        if (p_32034_.m_128441_("PickupDelay")) {
           this.f_31986_ = p_32034_.m_128448_("PickupDelay");
        }
-+      if (p_32034_.m_128441_("Lifespan")) lifespan = p_32034_.m_128451_("Lifespan");
++      if (p_32034_.m_128441_("Lifespan")) {
++         this.lifespan = p_32034_.m_128451_("Lifespan");
++      }
  
        if (p_32034_.m_128403_("Owner")) {
           this.f_265881_ = p_32034_.m_128342_("Owner");
-@@ -313,10 +_,18 @@
+@@ -313,10 +_,16 @@
  
     public void m_6123_(Player p_32040_) {
        if (!this.f_19853_.f_46443_) {
@@ -113,13 +117,11 @@
           Item item = itemstack.m_41720_();
           int i = itemstack.m_41613_();
 -         if (this.f_31986_ == 0 && (this.f_265881_ == null || this.f_265881_.equals(p_32040_.m_20148_())) && p_32040_.m_150109_().m_36054_(itemstack)) {
-+
 +         int hook = net.minecraftforge.event.ForgeEventFactory.onItemPickup(this, p_32040_);
 +         if (hook < 0) return;
-+
 +         ItemStack copy = itemstack.m_41777_();
-+         if (this.f_31986_ == 0 && (this.m_19749_() == null || lifespan - this.f_31985_ <= 200 || this.m_19749_().m_20148_().equals(p_32040_.m_20148_())) && (hook == 1 || i <= 0 || p_32040_.m_150109_().m_36054_(itemstack))) {
-+            copy.m_41764_(copy.m_41613_() - m_32055_().m_41613_());
++         if (this.f_31986_ == 0 && (this.f_265881_ == null || this.f_265881_.equals(p_32040_.m_20148_())) && (hook == 1 || i <= 0 || p_32040_.m_150109_().m_36054_(itemstack))) {
++            copy.m_41764_(copy.m_41613_() - itemstack.m_41613_());
 +            net.minecraftforge.event.ForgeEventFactory.firePlayerItemPickupEvent(p_32040_, this, copy);
              p_32040_.m_7938_(this, i);
              if (itemstack.m_41619_()) {
@@ -140,7 +142,7 @@
     public void m_32065_() {
        this.m_32062_();
 -      this.f_31985_ = 5999;
-+      this.f_31985_ = m_32055_().getEntityLifespan(f_19853_) - 1;
++      this.f_31985_ = m_32055_().getEntityLifespan(this.f_19853_) - 1;
     }
  
     public float m_32008_(float p_32009_) {


### PR DESCRIPTION
This PR rebuilds the `ItemEntity` patch from scratch to fix a few issues, the main one being the inability of a player to pickup an item until 10 seconds before its despawn if the player is not the one who threw the item on the ground.

---

Summary of the significant changes:

- [Line 10](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R10), [Line 18](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R18):
  - We have access to the constant fields now, we should not be hard-coding these magic numbers anymore
- [Line 26](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R26):
  - The copy constructor copies the age but not the lifespan. While this is not an issue for vanilla's use of `ItemEntity#copy()`, any other use case where the copy's remaining time is checked may run into issues
- [Line 71](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R71):
  - If an `ItemExpireEvent` handler causes the stack stored in the entity to become empty and cancels the event, the entity gets discarded twice
- [Lines 74-81](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66L74-L81):
  - Issue [MC-53850](https://bugs.mojang.com/browse/MC-53850) has been fixed in vanilla since snapshot 22w07a for 1.18.2, confirmed in Forgedev with the reproduction case provided on the linked issue
- [Line 123](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R123):
  - In 1.19.4 the `TraceableEntity` interface was introduced for entities that keep track of their owner. Presumably to avoid confusion with `TraceableEntity#getOwner()`, the `ItemEntity#owner` field was renamed to `ItemEntity#target` because the `target` field does not refer to the actual owner (the thrower is the actual owner and is stored in `ItemEntity#thrower`) and instead refers to the player that was given the item through advancement rewards or the `/give` command[^1]. While updating this patch, the reference to the old `owner` field was incorrectly changed to use the new `TraceableEntity#getOwner()` method. Tested with a Forgedev server and Forgedev client running this fix plus a vanilla 1.19.4 client as the second player
  - Before 1.15, it was possible for any player to pick up "target locked" item entities in the last ten seconds before they despawn. This was removed from vanilla in 1.15 but the Forge patch keeps reintroducing this small time window by adding back the `lifespan - this.age <= 200` check

---

One thing I am uncertain about is the position of the `ItemPickupEvent` hook ([Line 120](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R120)):

- In its current position and with the way the stack is accessed after the hook in the patch currently used in production, modifying the stack stored in the entity within the event may cause weird behaviour because some things will use the modified or replaced stack while others won't:
  - Setting the stack size will be ignored by some things (i.e. the `Player#take()` call) but not others (i.e. setting the count on the copied stack)
  - Replacing the stack completely via `ItemEntity#setItem()` will be ignored by some things using the stack directly in `ItemEntity#playerTouch()` but not others (i.e. setting the count on the copied stack uses `ItemEntity#getItem()` instead of the local variable holding the stack)
  - Some methods called from `ItemEntity#playerTouch()` will use the replaced stack (i.e. `LivingEntity#onItemPickup()`) while others won't (i.e. `Inventory#add()`)
- In its current position and with the way the stack is accessed after the hook in the patch presented in this PR, modifying the stack stored in the entity within the event may cause weird behaviour because some things will use the modified stack while others won't:
  - Setting the stack size will be ignored by some things (i.e. the `Player#take()` call) but not others (i.e. setting the count on the copied stack)
  - Replacing the stack completely via `ItemEntity#setItem()` will be ignored by anything using the stack directly in `ItemEntity#playerTouch()`
  - Some methods called from `ItemEntity#playerTouch()` will use the replaced stack (i.e. `LivingEntity#onItemPickup()`) while others won't (i.e. `Inventory#add()`)
- Assuming a modification or full replacement of the stack within the event is a supported use case, it may make sense to move the event hook to [Line 116](https://github.com/MinecraftForge/MinecraftForge/pull/9404/files#diff-4727e0eec6cba5fd9daf6a204dd8ffa0136766c9de4db93fc0042d7ca810bd66R116) before the stack is retrieved for the first time to guarantee that the same stack is used in all code paths following the event hook:
  - Setting the stack size will be respected by everything in `ItemEntity#playerTouch()` and all methods called from it
  - Replacing the stack completely via `ItemEntity#setItem()` will be respected by everything in `ItemEntity#playerTouch()` and all methods called from it



[^1]: When an item is given through advancement rewards or the `/give` command and doesn't completely fit into the player's inventory, an `ItemEntity` with no pickup delay is spawned in front of the player and prevented from being picked up by any other player by setting the player as the entity's "target"