### PR TITLE
Make ForgeSlider use the new vanilla texture

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java
@@ -229,16 +229,13 @@ public class ForgeSlider extends AbstractSliderButton
     public void renderWidget(@NotNull PoseStack poseStack, int mouseX, int mouseY, float partialTick)
     {
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
-        RenderSystem.setShaderTexture(0, WIDGETS_LOCATION);
+        RenderSystem.setShaderTexture(0, SLIDER_LOCATION);
 
         final Minecraft mc = Minecraft.getInstance();
-        final int bgYImage = !this.active ? 0 : (this.isHoveredOrFocused() ? 2 : 1);
-        ScreenUtils.blitWithBorder(poseStack, this.getX(), this.getY(), 0, 46 + bgYImage * 20, this.width, this.height, 200, 20, 2, 3, 2, 2, 0);
+        ScreenUtils.blitWithBorder(poseStack, this.getX(), this.getY(), 0, getTextureY(), this.width, this.height, 200, 20, 2, 3, 2, 2, 0);
 
-        final int sliderYImage = (this.isHoveredOrFocused() ? 2 : 1) * 20;
-        ScreenUtils.blitWithBorder(poseStack, this.getX() + (int)(this.value * (double)(this.width - 8)), this.getY(), 0, 46 + sliderYImage, 8, this.height, 200, 20 , 2, 3, 2, 2, 0);
+        ScreenUtils.blitWithBorder(poseStack, this.getX() + (int)(this.value * (double)(this.width - 8)), this.getY(), 0, getHandleTextureY(), 8, this.height, 200, 20 , 2, 3, 2, 2, 0);
 
-        final FormattedText message = mc.font.ellipsize(getMessage(), this.width - 6);
-        drawCenteredString(poseStack, mc.font, Language.getInstance().getVisualOrder(message), this.getX() + this.width / 2, this.getY() + (this.height - 8) / 2, getFGColor());
+        renderScrollingString(poseStack, mc.font, 2, getFGColor() | Mth.ceil(this.alpha * 255.0F) << 24);
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -65,6 +65,9 @@ public net.minecraft.client.gui.Gui m_93080_(Lcom/mojang/blaze3d/vertex/PoseStac
 protected net.minecraft.client.gui.components.AbstractSelectionList$Entry f_93521_ # list
 protected net.minecraft.client.gui.components.DebugScreenOverlay f_94032_ # block
 protected net.minecraft.client.gui.components.DebugScreenOverlay f_94033_ # liquid
+protected net.minecraft.client.gui.components.AbstractSliderButton m_264355_()I # getTextureY
+protected net.minecraft.client.gui.components.AbstractSliderButton m_264270_()I # getHandleTextureY
+public net.minecraft.client.gui.components.AbstractSliderButton f_263683_ # SLIDER_LOCATION
 public net.minecraft.client.gui.screens.MenuScreens m_96206_(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/gui/screens/MenuScreens$ScreenConstructor;)V # register
 public net.minecraft.client.gui.screens.MenuScreens$ScreenConstructor
 public net.minecraft.client.gui.screens.Screen f_169369_ # renderables


### PR DESCRIPTION
This PR makes `ForgeSlider` use the new `slider.png` vanilla texture so that the texture aligns with to the one of the normal slider. The message is also moved from an ellipsis to scrolling text to further be in line with vanilla.
Closes #9405.