### PR TITLE
[1.19.4] Fix infinite BE render bounds failing frustum intersection test

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
@@ -1,21 +1,11 @@
 --- a/net/minecraft/client/renderer/culling/Frustum.java
 +++ b/net/minecraft/client/renderer/culling/Frustum.java
-@@ -11,6 +_,7 @@
- @OnlyIn(Dist.CLIENT)
- public class Frustum {
-    public static final int f_194437_ = 4;
-+   private static final AABB INFINITE_AABB = new AABB(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-    private final FrustumIntersection f_252531_ = new FrustumIntersection();
-    private final Matrix4f f_252406_ = new Matrix4f();
-    private Vector4f f_194438_;
-@@ -59,6 +_,10 @@
+@@ -59,6 +_,8 @@
     }
  
     public boolean m_113029_(AABB p_113030_) {
 +      //FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles
-+      if (p_113030_.equals(INFINITE_AABB)) {
-+         return true;
-+      }
++      if (p_113030_.equals(net.minecraftforge.common.extensions.IForgeBlockEntity.INFINITE_EXTENT_AABB)) return true;
        return this.m_113006_(p_113030_.f_82288_, p_113030_.f_82289_, p_113030_.f_82290_, p_113030_.f_82291_, p_113030_.f_82292_, p_113030_.f_82293_);
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/client/renderer/culling/Frustum.java
++++ b/net/minecraft/client/renderer/culling/Frustum.java
+@@ -11,6 +_,7 @@
+ @OnlyIn(Dist.CLIENT)
+ public class Frustum {
+    public static final int f_194437_ = 4;
++   private static final AABB INFINITE_AABB = new AABB(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+    private final FrustumIntersection f_252531_ = new FrustumIntersection();
+    private final Matrix4f f_252406_ = new Matrix4f();
+    private Vector4f f_194438_;
+@@ -59,6 +_,10 @@
+    }
+ 
+    public boolean m_113029_(AABB p_113030_) {
++      //FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles
++      if (p_113030_.equals(INFINITE_AABB)) {
++         return true;
++      }
+       return this.m_113006_(p_113030_.f_82288_, p_113030_.f_82289_, p_113030_.f_82290_, p_113030_.f_82291_, p_113030_.f_82292_, p_113030_.f_82293_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/culling/Frustum.java.patch
@@ -4,7 +4,7 @@
     }
  
     public boolean m_113029_(AABB p_113030_) {
-+      //FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles
++      // FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles (GH-9321)
 +      if (p_113030_.equals(net.minecraftforge.common.extensions.IForgeBlockEntity.INFINITE_EXTENT_AABB)) return true;
        return this.m_113006_(p_113030_.f_82288_, p_113030_.f_82289_, p_113030_.f_82290_, p_113030_.f_82291_, p_113030_.f_82292_, p_113030_.f_82293_);
     }


### PR DESCRIPTION
This PR fixes infinite block entity render bounds failing the frustum intersection test at certain angles, closes #9321.

As suspected by the OP of the linked issue, this is caused by the use of JOML's `FrustumIntersection` where a bunch of vector dot products were used previously. The reason is that for the affected camera angles, certain values in the `FrustumIntersection` become 0 and then get multiplied with positive or negative infinity from the AABB which results in NaN and therefore fails all comparisons. This means that the infinite AABB needs to be special-cased since even the use of `-Double.MAX_VALUE` and `Double.MAX_VALUE` as the bounds ultimately leads to positive and negative infinity when the camera coordinates are subtracted from the bounds in Frustum#isVisible().