### PR TITLE
[1.19.4] Replace blitOffset parameter with PoseStack in IItemDecorator

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch
@@ -64,7 +64,7 @@
           }
  
           p_275269_.m_85849_();
-+         net.minecraftforge.client.ItemDecoratorHandler.of(p_275590_).render(p_275652_, p_275590_, p_275202_, p_275508_, 0);
++         net.minecraftforge.client.ItemDecoratorHandler.of(p_275590_).render(p_275269_, p_275652_, p_275590_, p_275202_, p_275508_);
        }
     }
  

--- a/src/main/java/net/minecraftforge/client/IItemDecorator.java
+++ b/src/main/java/net/minecraftforge/client/IItemDecorator.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.client;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.world.item.ItemStack;
@@ -19,11 +21,11 @@ public interface IItemDecorator
 {
 
     /**
-     * Is called after {@linkplain ItemRenderer#renderGuiItemDecorations(Font, ItemStack, int, int, String)} is done rendering.
+     * Is called after {@linkplain ItemRenderer#renderGuiItemDecorations(PoseStack, Font, ItemStack, int, int, String)} is done rendering.
      * The StackCount is rendered at blitOffset+200 so use the blitOffset with caution.
      * <p>
      * The RenderState during this call will be: enableTexture, enableDepthTest, enableBlend and defaultBlendFunc
      * @return true if you have modified the RenderState and it has to be reset for other ItemDecorators
      */
-    boolean render(Font font, ItemStack stack, int xOffset, int yOffset, float blitOffset);
+    boolean render(PoseStack poseStack, Font font, ItemStack stack, int xOffset, int yOffset);
 }

--- a/src/main/java/net/minecraftforge/client/IItemDecorator.java
+++ b/src/main/java/net/minecraftforge/client/IItemDecorator.java
@@ -23,7 +23,7 @@ public interface IItemDecorator
      * Use {@linkplain IItemDecorator#render(PoseStack, Font, ItemStack, int, int)} instead.
      */
     @Deprecated(forRemoval = true, since = "1.19.4")
-    default boolean render(Font font, ItemStack stack, int xOffset, int yOffset, int blitOffset) {
+    default boolean render(Font font, ItemStack stack, int xOffset, int yOffset, float blitOffset) {
         return false;
     }
 

--- a/src/main/java/net/minecraftforge/client/IItemDecorator.java
+++ b/src/main/java/net/minecraftforge/client/IItemDecorator.java
@@ -19,6 +19,13 @@ import net.minecraftforge.client.event.RegisterItemDecorationsEvent;
  */
 public interface IItemDecorator
 {
+    /**
+     * Use {@linkplain IItemDecorator#render(PoseStack, Font, ItemStack, int, int)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.19.4")
+    default boolean render(Font font, ItemStack stack, int xOffset, int yOffset, int blitOffset) {
+        return false;
+    }
 
     /**
      * Is called after {@linkplain ItemRenderer#renderGuiItemDecorations(PoseStack, Font, ItemStack, int, int, String)} is done rendering.
@@ -27,5 +34,7 @@ public interface IItemDecorator
      * The RenderState during this call will be: enableTexture, enableDepthTest, enableBlend and defaultBlendFunc
      * @return true if you have modified the RenderState and it has to be reset for other ItemDecorators
      */
-    boolean render(PoseStack poseStack, Font font, ItemStack stack, int xOffset, int yOffset);
+    default boolean render(PoseStack poseStack, Font font, ItemStack stack, int xOffset, int yOffset) {
+        return IItemDecorator.this.render(font, stack, xOffset, yOffset, 0);
+    }
 }

--- a/src/main/java/net/minecraftforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/minecraftforge/client/ItemDecoratorHandler.java
@@ -5,21 +5,23 @@
 
 package net.minecraftforge.client;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jetbrains.annotations.ApiStatus;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.systems.RenderSystem;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import com.mojang.blaze3d.vertex.PoseStack;
+
 import net.minecraft.client.gui.Font;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.RegisterItemDecorationsEvent;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModLoadingContext;
-import org.jetbrains.annotations.ApiStatus;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @ApiStatus.Internal
 public final class ItemDecoratorHandler
@@ -53,12 +55,12 @@ public final class ItemDecoratorHandler
         return DECORATOR_LOOKUP.getOrDefault(stack.getItem(), EMPTY);
     }
 
-    public void render(Font font, ItemStack stack, int xOffset, int yOffset, float blitOffset)
+    public void render(PoseStack poseStack, Font font, ItemStack stack, int xOffset, int yOffset)
     {
         resetRenderState();
         for (IItemDecorator itemDecorator : itemDecorators)
         {
-            if (itemDecorator.render(font, stack, xOffset, yOffset, blitOffset))
+            if (itemDecorator.render(poseStack, font, stack, xOffset, yOffset))
                 resetRenderState();
         }
     }

--- a/src/test/java/net/minecraftforge/debug/client/rendering/CustomItemDecorationsTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CustomItemDecorationsTest.java
@@ -6,25 +6,19 @@
 package net.minecraftforge.debug.client.rendering;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.BufferUploader;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.Tesselator;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.gui.GuiComponent;
+import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.util.Mth;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.IItemDecorator;
-import net.minecraftforge.client.ItemDecoratorHandler;
 import net.minecraftforge.client.event.RegisterItemDecorationsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.registries.ForgeRegistries;
 
 @Mod(CustomItemDecorationsTest.MOD_ID)
 public class CustomItemDecorationsTest
@@ -47,31 +41,22 @@ public class CustomItemDecorationsTest
 
     private static class StackSizeDurabilityBar implements IItemDecorator
     {
-
         @Override
-        public boolean render(Font font, ItemStack stack, int xOffset, int yOffset, float blitOffset)
+        public boolean render(PoseStack poseStack, Font font, ItemStack stack, int xOffset, int yOffset)
         {
             RenderSystem.disableBlend();
-            Tesselator tesselator = Tesselator.getInstance();
-            BufferBuilder bufferbuilder = tesselator.getBuilder();
-            float f = Math.max(0.0F, (stack.getMaxStackSize() - (float)stack.getCount()) / stack.getMaxStackSize());
-            int i = Math.round(13.0F - (float)stack.getCount() * 13.0F / stack.getMaxStackSize());
-            int j = Mth.hsvToRgb(f / 3.0F,1f,1f);
-            fillRect(bufferbuilder, xOffset + 2, yOffset, blitOffset + 189, 13, 2, 0, 0, 0);
-            fillRect(bufferbuilder, xOffset + 2, yOffset, blitOffset + 190, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255);
+            float f = Math.max(0.0F, (float)stack.getCount() / stack.getMaxStackSize());
+            int i = Math.round((float)stack.getCount() * 13.0F / stack.getMaxStackSize());
+            int j = Mth.hsvToRgb(f / 3.0F, 1f, 1f) | 0xFF000000;
+            int x = xOffset + 2;
+            int y = yOffset + 13;
+            poseStack.pushPose();
+            poseStack.translate(0.0F, 0.0F, ItemRenderer.ITEM_COUNT_BLIT_OFFSET + 1F);
+            GuiComponent.fill(poseStack, x, y, x + 13, y + 2, 0xFF000000);
+            GuiComponent.fill(poseStack, x, y, x + i, y + 1, j);
+            poseStack.popPose();
             RenderSystem.enableBlend();
             return true;
-        }
-
-        private static void fillRect(BufferBuilder pRenderer, int pX, int pY, float pZ, int pWidth, int pHeight, int pRed, int pGreen, int pBlue)
-        {
-            RenderSystem.setShader(GameRenderer::getPositionColorShader);
-            pRenderer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            pRenderer.vertex(pX, pY, pZ).color(pRed, pGreen, pBlue, 255).endVertex();
-            pRenderer.vertex(pX, pY + pHeight, pZ).color(pRed, pGreen, pBlue, 255).endVertex();
-            pRenderer.vertex(pX + pWidth, pY + pHeight, pZ).color(pRed, pGreen, pBlue, 255).endVertex();
-            pRenderer.vertex(pX + pWidth, pY, pZ).color(pRed, pGreen, pBlue, 255).endVertex();
-            BufferUploader.drawWithShader(pRenderer.end());
         }
     }
 }


### PR DESCRIPTION
In 1.19.4 `PoseStack` is required for most gui rendering methods (fill, blit, etc.). This MR adapts the `IItemDecorator` to the latest changes. It replaces the `blitOffset` parameter, which is no longer a thing (mostly), with the correct instance of `PoseStack`, when an item stack is being rendered in `ItemRenderer`. I also adjusted the test mod to actually function like a durability bar would. It now drains as the stack count goes down.