### PR TITLE
Update pack versions

### DIFF
--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,8 +1,8 @@
 {
     "pack": {
         "description": "examplemod resources",
-        "pack_format": 12,
-        "forge:resource_pack_format": 12,
-        "forge:data_pack_format": 10
+        "pack_format": 13,
+        "forge:client_resources_pack_format": 13,
+        "forge:server_data_pack_format": 12
     }
 }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,10 +1,10 @@
 {
    "pack": {
-      "pack_format": 12,
+      "pack_format": 13,
       "description": {
          "translate": "pack.forge.description"
       },
-      "forge:resource_pack_format": 12,
-      "forge:data_pack_format": 10
+      "forge:client_resources_pack_format": 13,
+      "forge:server_data_pack_format": 12
    }
 }

--- a/src/test/resources/pack.mcmeta
+++ b/src/test/resources/pack.mcmeta
@@ -1,8 +1,8 @@
 {
    "pack": {
-      "pack_format": 12,
+      "pack_format": 13,
       "description": "Forge tests resource pack",
-      "forge:resource_pack_format": 12,
-      "forge:data_pack_format": 10
+      "forge:client_resources_pack_format": 13,
+      "forge:server_data_pack_format": 12
    }
 }


### PR DESCRIPTION
The change in [ForgeHooks](https://github.com/MinecraftForge/MinecraftForge/blob/44c689f1712fcfb7ccb13262d1c02f0a880055be/src/main/java/net/minecraftforge/common/ForgeHooks.java#L1550-L1553) in the 1.19.4 update changed the keys for the typed pack versions. However, the forge `pack.mcmeta` has not yet been updated. Also minecraft bumped resource and datapack versions.