### PR TITLE
Fix FinalizeSpawn not blocking spawns during worldgen

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/WorldGenRegion.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/WorldGenRegion.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/level/WorldGenRegion.java
++++ b/net/minecraft/server/level/WorldGenRegion.java
+@@ -297,6 +_,7 @@
+    }
+ 
+    public boolean m_7967_(Entity p_9580_) {
++      if (p_9580_ instanceof net.minecraft.world.entity.Mob mob && mob.isSpawnCancelled()) return false;
+       int i = SectionPos.m_123171_(p_9580_.m_146903_());
+       int j = SectionPos.m_123171_(p_9580_.m_146907_());
+       this.m_6325_(i, j).m_6286_(p_9580_);

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -16,6 +17,7 @@ import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraftforge.common.ForgeInternalHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
@@ -209,6 +211,7 @@ public abstract class MobSpawnEvent extends EntityEvent
         /**
          * Returns the current spawn cancellation status, which can be changed via {@link FinalizeSpawn#setSpawnCancelled(boolean)}.
          * @return If this mob's spawn is cancelled or not.
+         * @implNote This is enforced in {@link ForgeInternalHandler#builtinMobSpawnBlocker} and a patch in {@link WorldGenRegion#addEntity}
          */
         public boolean isSpawnCancelled() {
             return this.getEntity().isSpawnCancelled();


### PR DESCRIPTION
Currently, `FinalizeSpawn` has an issue in that `FinalizeSpawn#setSpawnCancelled` will not actually prevent mobs spawned during worldgen from being added to the Level.

This is because WorldGenRegion immediately stores the entity in NBT, and will then later deserialize and directly add to the level all entities collected during the worldgen process.

There are two potential solutions to this problem:
1. Patch `WorldGenRegion#addEntity` so that spawn-cancelled mobs are not added to the level
2. Loosen `EntityJoinLevelEvent` to `LevelAccessor` instead of `Level` and fire it from `WorldGenRegion#addEntity`.

This PR takes the first approach.  The second, while it may be more generally useful, has the potential to cause deadlock if people are accessing the "true" level during the event.