### PR TITLE
Loosen access for BucketItem's canBlockContainFluid

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -107,7 +107,7 @@
 +   private final java.util.function.Supplier<? extends Fluid> fluidSupplier;
 +   public Fluid getFluid() { return fluidSupplier.get(); }
 +
-+   private boolean canBlockContainFluid(Level worldIn, BlockPos posIn, BlockState blockstate)
++   protected boolean canBlockContainFluid(Level worldIn, BlockPos posIn, BlockState blockstate)
 +   {
 +      return blockstate.m_60734_() instanceof LiquidBlockContainer && ((LiquidBlockContainer)blockstate.m_60734_()).m_6044_(worldIn, posIn, blockstate, this.f_40687_);
     }


### PR DESCRIPTION
The short of it is it seems odd to have `canBlockContainFluid` be private when it can be made protected so mod's custom buckets can add fluids to more than one block that accepts different fluids.

My use case is I have a Sugar Water Bucket. It places Sugar Water fluid normally and I got some blocks that can take in water tagged fluids to be waterlogged with Sugar Water. However, I would like to use my Sugar Water Bucket on regular blocks like Oak Slab and have it be waterlogged with normal water. The switch from Sugar Water to Water is desired by me. 

I extended BucketItem and overrode `emptyContents` to do my logic of checking if a block can take Sugar Water or Water and fill them with the respective fluid they can take. However, `emptyContents` will not be reached when I use Sugar Water Bucket on Oak Slab because the `use` method was patched by Forge to check the private `canBlockContainFluid` with will only check if the block can accept Sugar Water and cannot be overridden by me. I can work around this by copy/pasting and overriding the large `use` method but I figured it might be worth a PR to see about making `canBlockContainFluid` protected so just that others can do they bucket behaviors a bit easier and just override `canBlockContainFluid` to make their bucket watterlog different blocks with the fluids they accept better.