### PR TITLE
Remove duplicate line in FoodData patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/food/FoodData.java.patch
+++ b/patches/minecraft/net/minecraft/world/food/FoodData.java.patch
@@ -1,10 +1,7 @@
 --- a/net/minecraft/world/food/FoodData.java
 +++ b/net/minecraft/world/food/FoodData.java
-@@ -21,11 +_,18 @@
-    public void m_38707_(int p_38708_, float p_38709_) {
-       this.f_38696_ = Math.min(p_38708_ + this.f_38696_, 20);
+@@ -23,9 +_,15 @@
        this.f_38697_ = Math.min(this.f_38697_ + (float)p_38708_ * p_38709_ * 2.0F, (float)this.f_38696_);
-+      this.f_38697_ = Math.min(this.f_38697_ + (float)p_38708_ * p_38709_ * 2.0F, (float)this.f_38696_);
     }
  
 +   // Use the LivingEntity sensitive version in favour of this.


### PR DESCRIPTION
This PR fixes #9422 by removing the duplicated line in `FoodData`, which resulted from the 1.19.4 update and patch process.