### PR TITLE
Loosen access for BucketItem's canBlockContainFluid

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -107,7 +107,7 @@
 +   private final java.util.function.Supplier<? extends Fluid> fluidSupplier;
 +   public Fluid getFluid() { return fluidSupplier.get(); }
 +
-+   private boolean canBlockContainFluid(Level worldIn, BlockPos posIn, BlockState blockstate)
++   protected boolean canBlockContainFluid(Level worldIn, BlockPos posIn, BlockState blockstate)
 +   {
 +      return blockstate.m_60734_() instanceof LiquidBlockContainer && ((LiquidBlockContainer)blockstate.m_60734_()).m_6044_(worldIn, posIn, blockstate, this.f_40687_);
     }


### PR DESCRIPTION
Backport of https://github.com/MinecraftForge/MinecraftForge/pull/9421 to 1.19.2