### PR TITLE
[1.19.x] Update Fluid a second time only when fall damage matters

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -16,7 +16,7 @@
     public static final int f_147166_ = 2;
     public static final int f_147167_ = 4;
     public static final int f_147168_ = 98;
-@@ -270,7 +_,7 @@
+@@ -270,11 +_,11 @@
     }
  
     public static AttributeSupplier.Builder m_21183_() {
@@ -25,6 +25,11 @@
     }
  
     protected void m_7840_(double p_20990_, boolean p_20991_, BlockState p_20992_, BlockPos p_20993_) {
+-      if (!this.m_20069_()) {
++      if (!this.isInFluidType(((fluidType, aDouble) -> fluidType.getFallDistanceModifier(this) == 0))) {
+          this.m_20074_();
+       }
+ 
 @@ -288,13 +_,15 @@
           if (!p_20992_.m_60795_()) {
              double d0 = Math.min((double)(0.2F + f / 15.0F), 2.5D);


### PR DESCRIPTION
Closes #8897 

Changes the check within `LivingEntity#checkFallDamage` when updating fluid heights to only when the player is not in any fluid that negates fall damage. This is an assumption made on vanilla's implementation since it makes no sense to update fluid logic towards fall damage if the player doesn't take any in the first place. Fluids that still allow the user to take some semblance of fall damage will still have their delta movement doubled.

I don't believe this needs to be migrated to a separate class in the fluid, but if it should, let me know and I'll do so.