### PR TITLE
[1.19.x] Add default bucket sounds for milk

### DIFF
--- a/src/generated/resources/assets/minecraft/sounds.json
+++ b/src/generated/resources/assets/minecraft/sounds.json
@@ -1,0 +1,22 @@
+{
+  "item.bucket.empty_milk": {
+    "sounds": [
+      "item/bucket/empty1",
+      {
+        "name": "item/bucket/empty1",
+        "pitch": 0.9
+      },
+      "item/bucket/empty2",
+      "item/bucket/empty3"
+    ],
+    "subtitle": "subtitles.item.bucket.empty"
+  },
+  "item.bucket.fill_milk": {
+    "sounds": [
+      "item/bucket/fill1",
+      "item/bucket/fill2",
+      "item/bucket/fill3"
+    ],
+    "subtitle": "subtitles.item.bucket.fill"
+  }
+}

--- a/src/main/java/net/minecraftforge/common/data/VanillaSoundDefinitionsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/VanillaSoundDefinitionsProvider.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.common.data;
+
+
+import net.minecraft.data.PackOutput;
+import net.minecraftforge.common.ForgeMod;
+
+public class VanillaSoundDefinitionsProvider extends SoundDefinitionsProvider {
+
+    public VanillaSoundDefinitionsProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, "minecraft", helper);
+    }
+
+    @Override
+    public void registerSounds() {
+        this.add(ForgeMod.BUCKET_EMPTY_MILK.getId(), definition().subtitle("subtitles.item.bucket.empty")
+                .with(sound("item/bucket/empty1"), sound("item/bucket/empty1").pitch(0.9),
+                        sound("item/bucket/empty2"), sound("item/bucket/empty3")));
+        this.add(ForgeMod.BUCKET_FILL_MILK.getId(), definition().subtitle("subtitles.item.bucket.fill")
+                .with(sound("item/bucket/fill1"), sound("item/bucket/fill2"), sound("item/bucket/fill3")));
+    }
+}

--- a/src/main/java/net/minecraftforge/common/data/VanillaSoundDefinitionsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/VanillaSoundDefinitionsProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.data;
 
 


### PR DESCRIPTION
Closes #9316.

Adds the default bucket sounds for milk by datagenning the sound provider to be the same as those for water fill and empty.