### PR TITLE
Fixes #9426 - The null assignment breaks the list if you remove an Item with some variants

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/MutableHashedLinkedMap.java
+++ b/src/main/java/net/minecraftforge/common/util/MutableHashedLinkedMap.java
@@ -249,7 +249,6 @@ public class MutableHashedLinkedMap<K, V> implements Iterable<Map.Entry<K, V>>
         else if (e.previous != null) // Should never be null, but just in case.
         {
             e.previous.next = e.next;
-            e.previous = null;
         }
 
         if (last == e)
@@ -257,7 +256,6 @@ public class MutableHashedLinkedMap<K, V> implements Iterable<Map.Entry<K, V>>
         else if (e.next != null) // Should never be null, but just in case.
         {
             e.next.previous = e.previous;
-            e.next = null;
         }
     }
 


### PR DESCRIPTION
Closes #9426 

This PR fixes an issue with the `remove` method inside the `MutableHashedLinkedMap` class. What has been noticed is that if you try to remove an ItemStack that has some variants (i.e. Paintings) the whole iterator of the map breaks due to some null assignments for both the `entry.previous` and `entry.next` properties. This results in the tab list being broken and cutoff, but also not removing the items that the code is supposed to.

More details on this bug can be found in the [related issue](https://github.com/MinecraftForge/MinecraftForge/issues/9426)
and in [this forum post](https://forums.minecraftforge.net/topic/122420-1194-how-to-remove-items-from-vanilla-creative-tabs/), where a preliminary analysis was made with [warjort](https://forums.minecraftforge.net/profile/201837-warjort/)