### PR TITLE
[1.19.x] Add player join/leave message events

### DIFF
--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -52,6 +52,17 @@
                       InteractionResult interactionresult = this.f_9743_.f_8941_.m_7179_(this.f_9743_, serverlevel, itemstack, interactionhand, blockhitresult);
                       if (direction == Direction.UP && !interactionresult.m_19077_() && blockpos.m_123342_() >= i - 1 && m_9790_(this.f_9743_, itemstack)) {
                          Component component = Component.m_237110_("build.tooHigh", i - 1).m_130940_(ChatFormatting.RED);
+@@ -1116,7 +_,9 @@
+       this.f_241681_.close();
+       f_9744_.info("{} lost connection: {}", this.f_9743_.m_7755_().getString(), p_9825_.getString());
+       this.f_9745_.m_129929_();
+-      this.f_9745_.m_6846_().m_240416_(Component.m_237110_("multiplayer.player.left", this.f_9743_.m_5446_()).m_130940_(ChatFormatting.YELLOW), false);
++      Component leaveMessage = net.minecraftforge.event.ForgeEventFactory.firePlayerLogoutMessage(this.f_9743_, Component.m_237110_("multiplayer.player.left", this.f_9743_.m_5446_()).m_130940_(ChatFormatting.YELLOW));
++      if (leaveMessage != null && !leaveMessage.getString().isEmpty())
++         this.f_9745_.m_6846_().m_240416_(leaveMessage, false);
+       this.f_9743_.m_9231_();
+       this.f_9745_.m_6846_().m_11286_(this.f_9743_);
+       this.f_9743_.m_8967_().m_7670_();
 @@ -1182,10 +_,13 @@
                 }
  

--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -24,6 +24,26 @@
        servergamepacketlistenerimpl.m_9829_(new ClientboundUpdateRecipesPacket(this.f_11195_.m_129894_().m_44051_()));
        servergamepacketlistenerimpl.m_9829_(new ClientboundUpdateTagsPacket(TagNetworkSerialization.m_245799_(this.f_243858_)));
        this.m_11289_(p_11263_);
+@@ -184,14 +_,15 @@
+       p_11263_.m_8952_().m_12789_(p_11263_);
+       this.m_11273_(serverlevel1.m_6188_(), p_11263_);
+       this.f_11195_.m_129929_();
+-      MutableComponent mutablecomponent;
++      Component component;
+       if (p_11263_.m_36316_().getName().equalsIgnoreCase(s)) {
+-         mutablecomponent = Component.m_237110_("multiplayer.player.joined", p_11263_.m_5446_());
++         component = net.minecraftforge.event.ForgeEventFactory.firePlayerLoginMessage(p_11263_, Component.m_237110_("multiplayer.player.joined", p_11263_.m_5446_()).m_130940_(ChatFormatting.YELLOW), null);
+       } else {
+-         mutablecomponent = Component.m_237110_("multiplayer.player.joined.renamed", p_11263_.m_5446_(), s);
++         component = net.minecraftforge.event.ForgeEventFactory.firePlayerLoginMessage(p_11263_, Component.m_237110_("multiplayer.player.joined.renamed", p_11263_.m_5446_(), s).m_130940_(ChatFormatting.YELLOW), s);
+       }
+ 
+-      this.m_240416_(mutablecomponent.m_130940_(ChatFormatting.YELLOW), false);
++      if (component != null && !component.getString().isEmpty())
++         this.m_240416_(component, false);
+       servergamepacketlistenerimpl.m_9774_(p_11263_.m_20185_(), p_11263_.m_20186_(), p_11263_.m_20189_(), p_11263_.m_146908_(), p_11263_.m_146909_());
+       ServerStatus serverstatus = this.f_11195_.m_129928_();
+       if (serverstatus != null) {
 @@ -249,6 +_,7 @@
        }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -106,24 +106,10 @@ import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.MobSpawnEvent;
 import net.minecraftforge.event.entity.living.MobSpawnEvent.AllowDespawn;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
+import net.minecraftforge.event.entity.player.*;
 import net.minecraftforge.event.entity.player.AdvancementEvent.AdvancementEarnEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent.AdvancementProgressEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent.AdvancementProgressEvent.ProgressType;
-import net.minecraftforge.event.entity.player.ArrowLooseEvent;
-import net.minecraftforge.event.entity.player.ArrowNockEvent;
-import net.minecraftforge.event.entity.player.BonemealEvent;
-import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
-import net.minecraftforge.event.entity.player.FillBucketEvent;
-import net.minecraftforge.event.entity.player.ItemTooltipEvent;
-import net.minecraftforge.event.entity.player.PermissionsChangedEvent;
-import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
-import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.event.entity.player.PlayerFlyableFallEvent;
-import net.minecraftforge.event.entity.player.PlayerSetSpawnEvent;
-import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
-import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
-import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
-import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.BlockEvent.BlockToolModificationEvent;
@@ -795,9 +781,21 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.PlayerLoggedInEvent(player));
     }
 
+    public static Component firePlayerLoginMessage(ServerPlayer player, Component message, String oldName)
+    {
+        PlayerJoinMessageEvent event = new PlayerJoinMessageEvent(player, message, oldName);
+        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+    }
+
     public static void firePlayerLoggedOut(Player player)
     {
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.PlayerLoggedOutEvent(player));
+    }
+
+    public static Component firePlayerLogoutMessage(ServerPlayer player, Component message)
+    {
+        PlayerLeaveMessageEvent event = new PlayerLeaveMessageEvent(player, message);
+        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
     }
 
     public static void firePlayerRespawnEvent(Player player, boolean endConquered)

--- a/src/main/java/net/minecraftforge/event/MessageEvent.java
+++ b/src/main/java/net/minecraftforge/event/MessageEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Objects;
+
+public abstract class MessageEvent extends Event
+{
+
+    private final ServerPlayer player;
+    private Component message;
+
+    @ApiStatus.Internal
+    protected MessageEvent(ServerPlayer player, Component message)
+    {
+        this.player = player;
+        this.message = message;
+    }
+
+    /**
+     * {@return the player who initiated the chat action}
+     */
+    public ServerPlayer getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Set the message to be sent to the relevant clients.
+     */
+    public void setMessage(Component message)
+    {
+        this.message = Objects.requireNonNull(message);
+    }
+
+    /**
+     * {@return the message that will be sent to the relevant clients, if the event is not cancelled}
+     */
+    public Component getMessage()
+    {
+        return message;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -5,13 +5,11 @@
 
 package net.minecraftforge.event;
 
-import java.util.Objects;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundChatPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -26,28 +24,17 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 @Cancelable
-public class ServerChatEvent extends Event
+public class ServerChatEvent extends MessageEvent
 {
-    private final ServerPlayer player;
     private final String username;
     private final String rawText;
-    private Component message;
 
     @ApiStatus.Internal
     public ServerChatEvent(ServerPlayer player, String rawText, Component message)
     {
-        this.player = player;
+        super(player, message);
         this.username = player.getGameProfile().getName();
         this.rawText = rawText;
-        this.message = message;
-    }
-
-    /**
-     * {@return the player who initiated the chat action}
-     */
-    public ServerPlayer getPlayer()
-    {
-        return this.player;
     }
 
     /**
@@ -64,21 +51,5 @@ public class ServerChatEvent extends Event
     public String getRawText()
     {
         return this.rawText;
-    }
-
-    /**
-     * Set the message to be sent to the relevant clients.
-     */
-    public void setMessage(Component message)
-    {
-        this.message = Objects.requireNonNull(message);
-    }
-
-    /**
-     * {@return the message that will be sent to the relevant clients, if the event is not cancelled}
-     */
-    public Component getMessage()
-    {
-        return this.message;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerJoinMessageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerJoinMessageEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.MessageEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.fml.LogicalSide;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This event is fired whenever a player joins the server. This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+ * If the event is cancelled, the message will not be sent to clients.
+ * <p>
+ * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#SERVER logical server}.
+ * <p>
+ */
+@Cancelable
+public class PlayerJoinMessageEvent extends MessageEvent
+{
+
+    private final @Nullable String oldName;
+
+    public PlayerJoinMessageEvent(ServerPlayer player, Component message, @Nullable String oldName)
+    {
+        super(player, message);
+        this.oldName = oldName;
+    }
+
+    /**
+     * @return The old name of the player, if they have changed their name, or null if they have not.
+     * Use {@link Player#getDisplayName()} for the current name of the player.
+     */
+    public @Nullable String getOldName()
+    {
+        return oldName;
+    }
+
+    /**
+     * @return True if the player has changed their name, false otherwise.
+     */
+    public boolean hasPlayerChangedName()
+    {
+        return oldName != null;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerLeaveMessageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerLeaveMessageEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.MessageEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * This event is fired whenever a player leaves the server. This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+ * If the event is cancelled, the message will not be sent to clients.
+ * <p>
+ * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#SERVER logical server}.
+ * <p>
+ */
+@Cancelable
+public class PlayerLeaveMessageEvent extends MessageEvent
+{
+
+    public PlayerLeaveMessageEvent(ServerPlayer player, Component message)
+    {
+        super(player, message);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerJoinMessageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerJoinMessageEventTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.event.entity.player.PlayerJoinMessageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("player_join_message_event_test")
+@Mod.EventBusSubscriber()
+public class PlayerJoinMessageEventTest
+{
+    private static final boolean ENABLE = true;
+    private static final Logger LOGGER = LogManager.getLogger(PlayerJoinMessageEventTest.class);
+
+    @SubscribeEvent
+    public static void onPlayerJoinMessageEvent(PlayerJoinMessageEvent event)
+    {
+        if (!ENABLE) return;
+        LOGGER.info("PlayerJoinMessageEvent fired for player '{}'. Original message: {}", event.getPlayer().getName().getString(), event.getMessage().getString());
+
+        // change the message
+        event.setMessage(Component.literal("Welcome ")
+                .append(event.getPlayer().getDisplayName())
+                .append(" to the server!").withStyle(ChatFormatting.GREEN));
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerLeaveMessageEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerLeaveMessageEventTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.event.entity.player.PlayerLeaveMessageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("player_leave_message_event_test")
+@Mod.EventBusSubscriber()
+public class PlayerLeaveMessageEventTest
+{
+    private static final boolean ENABLE = true;
+    private static final Logger LOGGER = LogManager.getLogger(PlayerLeaveMessageEventTest.class);
+
+    @SubscribeEvent
+    public static void onPlayerLeaveMessageEvent(PlayerLeaveMessageEvent event)
+    {
+        if (!ENABLE) return;
+        LOGGER.info("PlayerLeaveMessageEvent fired for player '{}'. Original message: {}", event.getPlayer().getName().getString(), event.getMessage().getString());
+
+        // change the message
+        event.setMessage(Component.literal("Goodbye ")
+                .append(event.getPlayer().getDisplayName())
+                .append(", see you later!").withStyle(ChatFormatting.RED));
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -27,6 +27,11 @@ modId="mdk_datagen"
 [[mods]]
     modId="crash_callable_test"
 
+[[mods]]
+    modId="player_join_message_event_test"
+[[mods]]
+    modId="player_leave_message_event_test"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
This PR intoduces forge events for changing the player join / leave message. An example:
![test](https://user-images.githubusercontent.com/21986809/229355517-de25990d-bca7-427d-88b5-abcaf0ab2dea.png)
(This image is a screenshot I made while executing the including tests)

It would be nice to see this added as changing these messages would be nice for ex. some kind of ranking system where the player would get their rank prefixed in the join and leave messages, like Hypixel does.

This event is also cancelable, this means that you can also completely hide the join / leave messages. An example usage for this is people that have vanish enabled.