### PR TITLE
[1.19.4] Fix dummy air blocks not being marked as air

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -70,6 +70,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     private final BakeCallback<V> bake;
     private final MissingFactory<V> missing;
     private final BitSet availabilityMap;
+    @Deprecated(forRemoval = true, since = "1.19.4")
     private final Set<ResourceLocation> dummies = Sets.newHashSet();
     private final Set<Integer> blocked = Sets.newHashSet();
     private final Multimap<ResourceLocation, V> overrides = ArrayListMultimap.create();
@@ -77,6 +78,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     private final Map<V, Holder.Reference<V>> delegatesByValue = Maps.newHashMap();
     private final BiMap<OverrideOwner<V>, V> owners = HashBiMap.create();
     private final ForgeRegistryTagManager<V> tagManager;
+    @Deprecated(forRemoval = true, since = "1.19.4")
     private final DummyFactory<V> dummyFactory;
     private final int min;
     private final int max;
@@ -505,6 +507,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         LOGGER.trace(REGISTRIES,"Registry {} alias: {} -> {}", this.name, src, dst);
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     void addDummy(ResourceLocation key)
     {
         if (this.isLocked())
@@ -581,6 +584,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         return this.defaultValue;
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     boolean isDummied(ResourceLocation key)
     {
         return this.dummies.contains(key);
@@ -818,7 +822,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         }
     }
 
-    private record DumpRow(String id, String key, String value, String dummied) {}
+    private record DumpRow(String id, String key, String value, @Deprecated(forRemoval = true, since = "1.19.4") String dummied) {}
 
     public void loadIds(Map<ResourceLocation, Integer> ids, Map<ResourceLocation, String> overrides, Map<ResourceLocation, Integer> missing, Map<ResourceLocation, IdMappingEvent.IdRemapping> remapped, ForgeRegistry<V> old, ResourceLocation name)
     {
@@ -920,6 +924,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         }
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     boolean markDummy(ResourceLocation key, int id)
     {
         if (this.dummyFactory == null)
@@ -946,6 +951,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         return true;
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     private void createAndAddDummy(ResourceLocation key, int id)
     {
         V dummy = this.dummyFactory.createDummy(key);
@@ -1051,6 +1057,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         public final Map<ResourceLocation, Integer> ids = Maps.newTreeMap(sorter);
         public final Map<ResourceLocation, ResourceLocation> aliases = Maps.newTreeMap(sorter);
         public final Set<Integer> blocked = Sets.newTreeSet();
+        @Deprecated(forRemoval = true, since = "1.19.4")
         public final Set<ResourceLocation> dummied = Sets.newTreeSet(sorter);
         public final Map<ResourceLocation, String> overrides = Maps.newTreeMap(sorter);
         private FriendlyByteBuf binary = null;

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -516,7 +516,7 @@ public class GameData
         }
 
         @Deprecated(forRemoval = true, since = "1.19.4")
-        private static class DummyAirBlock extends AirBlock //A named class so DummyBlockReplacementTest can detect if its a dummy
+        private static class DummyAirBlock extends AirBlock
         {
             private DummyAirBlock(Block.Properties properties)
             {

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -489,6 +489,7 @@ public class GameData
         }
 
         @Override
+        @Deprecated(forRemoval = true, since = "1.19.4")
         public Block createDummy(ResourceLocation key)
         {
             Block ret = new DummyAirBlock(Block.Properties.of(Material.AIR).noCollission().noLootTable().air());
@@ -514,9 +515,10 @@ public class GameData
             DebugLevelSource.initValidStates();
         }
 
-        private static class BlockDummyAir extends AirBlock //A named class so DummyBlockReplacementTest can detect if its a dummy
+        @Deprecated(forRemoval = true, since = "1.19.4")
+        private static class DummyAirBlock extends AirBlock //A named class so DummyBlockReplacementTest can detect if its a dummy
         {
-            private BlockDummyAir(Block.Properties properties)
+            private DummyAirBlock(Block.Properties properties)
             {
                 super(properties);
             }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -491,7 +491,7 @@ public class GameData
         @Override
         public Block createDummy(ResourceLocation key)
         {
-            Block ret = new BlockDummyAir(Block.Properties.of(Material.AIR));
+            Block ret = new DummyAirBlock(Block.Properties.of(Material.AIR).noCollission().noLootTable().air());
             return ret;
         }
 

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -145,6 +145,7 @@ public interface IForgeRegistry<V> extends Iterable<V>
      * Factory for creating dummy entries, allowing worlds to be loaded and keep the missing block references.
      */
     @FunctionalInterface
+    @Deprecated(forRemoval = true, since = "1.19.4")
     interface DummyFactory<V>
     {
         V createDummy(ResourceLocation key);

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -143,6 +143,7 @@ public interface IForgeRegistry<V> extends Iterable<V>
 
     /**
      * Factory for creating dummy entries, allowing worlds to be loaded and keep the missing block references.
+     * @deprecated Dummies are being removed due to lack of use and high maintenance cost. There will not be an equivalent replacement feature added.
      */
     @FunctionalInterface
     @Deprecated(forRemoval = true, since = "1.19.4")

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -145,12 +145,14 @@ public class RegistryBuilder<T>
         return this.add(bake);
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public RegistryBuilder<T> set(DummyFactory<T> factory)
     {
         this.dummyFactory = factory;
         return this;
     }
 
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public RegistryBuilder<T> dummy(DummyFactory<T> factory)
     {
         return this.set(factory);
@@ -350,6 +352,7 @@ public class RegistryBuilder<T>
     }
 
     @Nullable
+    @Deprecated(forRemoval = true, since = "1.19.4")
     public DummyFactory<T> getDummyFactory()
     {
         return dummyFactory;

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -39,6 +39,7 @@ public class RegistryBuilder<T>
     private boolean allowOverrides = true;
     private boolean allowModifications = false;
     private boolean hasWrapper = false;
+    @Deprecated(forRemoval = true, since = "1.19.4")
     private DummyFactory<T> dummyFactory;
     private MissingFactory<T> missingFactory;
     private Set<ResourceLocation> legacyNames = new HashSet<>();


### PR DESCRIPTION
Fixes #9282 

This PR fixes the fact that the dummy air block instance does not return true to isAir, which causes errors when the block is not treated as air.

It also deprecates and marks for removal all dummy-related registry code, as it is only used for the block registry and is not worth the maintenance burden for restoring removed blocks (it does not work for anything beyond simple blocks).