### PR TITLE
[1.19.4] Fix ItemLayerModel erroneously adding particle texture to layer texture list

### DIFF
--- a/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
+++ b/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
@@ -12,6 +12,7 @@
   "render_types": {},
   "textures": {
     "layer0": "minecraft:item/coal",
-    "layer1": "minecraft:item/stick"
+    "layer1": "minecraft:item/stick",
+    "particle": "minecraft:block/red_stained_glass"
   }
 }

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -56,10 +56,9 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
     @Override
     public BakedModel bake(IGeometryBakingContext context, ModelBaker baker, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation)
     {
-        if (textures == null) {
+        if (textures == null)
+        {
             ImmutableList.Builder<Material> builder = ImmutableList.builder();
-            if (context.hasMaterial("particle"))
-                builder.add(context.getMaterial("particle"));
             for (int i = 0; context.hasMaterial("layer" + i); i++)
             {
                 builder.add(context.getMaterial("layer" + i));

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -201,6 +201,7 @@ public class NewModelLoaderTest
         protected void registerModels()
         {
             withExistingParent(NewModelLoaderTest.item_layers.getId().getPath(), "forge:item/default")
+                    .texture("particle", "minecraft:block/red_stained_glass")
                     .texture("layer0", "minecraft:item/coal")
                     .texture("layer1", "minecraft:item/stick")
                     .customLoader(ItemLayerModelBuilder::begin)


### PR DESCRIPTION
This PR fixes the `ItemLayerModel` incorrectly adding the (optional) particle texture to the list of textures to be used for the layers if an explicit particle texture is specified. This leads to the layer texture list desyncing from the layer data list and the particle texture being added as a to the resulting model.

Relevant parts of the test model:
```json
{
  "textures": {
    "layer0": "minecraft:item/coal",
    "layer1": "minecraft:item/stick",
    "particle": "minecraft:block/red_stained_glass"
  },
  "forge_data": {
    "layers": {
      "1": {
        "block_light": 15,
        "sky_light": 15
      }
    }
  }
}
```

Without the fix (glass pane visible, coal rendered at full brightness):
![2023-04-06_03 42 48](https://user-images.githubusercontent.com/11262040/230252418-a929bfc9-38fa-4139-92d6-6a9d28f19f0a.png)

With the fix (glass pane absent, stick rendered at full brightness):
![2023-04-06_03 44 04](https://user-images.githubusercontent.com/11262040/230252429-a25000cc-f56c-46dc-8e92-397f33e704a2.png)

(Screenshots were intentionally made in a dark environment)