### PR TITLE
Fix fluids without sound event causing exception in tryFillContainer and tryEmptyContainer

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -138,7 +138,11 @@ public class FluidUtil
                             if (player != null)
                             {
                                 SoundEvent soundevent = simulatedTransfer.getFluid().getFluidType().getSound(simulatedTransfer, SoundActions.BUCKET_FILL);
-                                player.level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+
+                                if (soundevent != null)
+                                {
+                                    player.level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+                                }
                             }
                         }
                         else
@@ -186,7 +190,11 @@ public class FluidUtil
                     if (doDrain && player != null)
                     {
                         SoundEvent soundevent = transfer.getFluid().getFluidType().getSound(transfer, SoundActions.BUCKET_EMPTY);
-                        player.level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+
+                        if (soundevent != null)
+                        {
+                            player.level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+                        }
                     }
 
                     ItemStack resultContainer = containerFluidHandler.getContainer();
@@ -596,7 +604,12 @@ public class FluidUtil
             if (!result.isEmpty())
             {
                 SoundEvent soundevent = resource.getFluid().getFluidType().getSound(resource, SoundActions.BUCKET_EMPTY);
-                level.playSound(player, pos, soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+
+                if (soundevent != null)
+                {
+                    level.playSound(player, pos, soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
+                }
+
                 return true;
             }
         }


### PR DESCRIPTION
Without this fix, if fluid has no sound for corresponding event, tryFillContainer/tryEmptyContainer will attempt to play `null` sound.

Example of bug in effect: When player right clicks on fluid container block with fluid container item in hand, fluid will be drained from block, but no fluid will be filled into player's item.

```
[01:15:35] [Server thread/ERROR] [minecraft/PacketUtils]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundUseItemOnPacket@5b0fe517, suppressing error
java.lang.NullPointerException: Cannot invoke "net.minecraft.sounds.SoundEvent.getRange(float)" because the return value of "net.minecraft.core.Holder.value()" is null
	at net.minecraft.server.level.ServerLevel.playSeededSound(ServerLevel.java:911) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.playSeededSound(Level.java:429) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.playSound(Level.java:435) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
	at net.minecraftforge.fluids.FluidUtil.lambda$tryFillContainer$2(FluidUtil.java:141) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.common.util.LazyOptional.map(LazyOptional.java:195) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:mixin,re:classloading}
	at net.minecraftforge.fluids.FluidUtil.tryFillContainer(FluidUtil.java:131) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.fluids.FluidUtil.tryFillContainerAndStow(FluidUtil.java:248) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.fluids.FluidUtil.lambda$interactWithFluidHandler$1(FluidUtil.java:96) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.common.util.LazyOptional.map(LazyOptional.java:195) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:mixin,re:classloading}
	at net.minecraftforge.fluids.FluidUtil.interactWithFluidHandler(FluidUtil.java:94) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.fluids.FluidUtil.lambda$interactWithFluidHandler$0(FluidUtil.java:70) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at net.minecraftforge.common.util.LazyOptional.map(LazyOptional.java:195) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:mixin,re:classloading}
	at net.minecraftforge.fluids.FluidUtil.interactWithFluidHandler(FluidUtil.java:70) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23203%23210!/:?] {re:classloading}
	at ru.dbotthepony.mc.otm.block.decorative.FluidTankBlock.use(FluidTankBlock.kt:32) ~[%23209!/:?] {re:classloading}
	at net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.use(BlockBehaviour.java:826) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,re:mixin}
	at net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java:349) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1084) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:38) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:8) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading}
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:40) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading}
	at net.minecraft.server.TickTask.run(TickTask.java:20) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading}
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:146) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:22) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:computing_frames,re:classloading}
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:794) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:164) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:116) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:777) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:771) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:129) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:757) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:686) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:251) ~[forge-1.19.3-44.1.5_mapped_parchment_2022.12.18-1.19.3-recomp.jar%23204!/:?] {re:classloading,pl:accesstransformer:B}
```