### PR TITLE
[1.19.x] Collect and log exceptions occurring in DeferredWorkQueue tasks

### DIFF
--- a/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.debug;
+
+import com.mojang.logging.LogUtils;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import org.slf4j.Logger;
+
+/**
+ * Tests that the {@link net.minecraftforge.fml.DeferredWorkQueue} properly executes enqueued tasks and
+ * forwards any exceptions thrown by those tasks
+ */
+@Mod(DeferredWorkQueueTest.MOD_ID)
+@Mod.EventBusSubscriber(modid = DeferredWorkQueueTest.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class DeferredWorkQueueTest
+{
+    public static final String MOD_ID = "deferred_work_queue_test";
+    private static final boolean ENABLE = false;
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public DeferredWorkQueueTest() { }
+
+    @SubscribeEvent
+    public static void onCommonSetup(final FMLCommonSetupEvent event)
+    {
+        if (!ENABLE)
+        {
+            return;
+        }
+
+        event.enqueueWork(() -> LOGGER.info("Enqueued runnable ran"));
+        event.enqueueWork(() -> "Enqueued supplier ran").thenApply(s ->
+        {
+            LOGGER.info(s);
+            return null;
+        });
+
+        event.enqueueWork(DeferredWorkQueueTest::executeThrowingRunnable);
+        event.enqueueWork(DeferredWorkQueueTest::executeThrowingSupplier).thenApply(s ->
+        {
+            LOGGER.error("This must not be printed");
+            return null;
+        });
+    }
+
+    private static void executeThrowingRunnable()
+    {
+        LOGGER.info("Enqueued throwing runnable ran");
+        throw new IllegalStateException("Throwing runnable ran");
+    }
+
+    private static String executeThrowingSupplier()
+    {
+        LOGGER.info("Enqueued throwing supplier ran");
+        throw new IllegalStateException("Throwing supplier ran");
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug;
 
 import com.mojang.logging.LogUtils;

--- a/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredWorkQueueTest.java
@@ -34,18 +34,12 @@ public class DeferredWorkQueueTest
         }
 
         event.enqueueWork(() -> LOGGER.info("Enqueued runnable ran"));
-        event.enqueueWork(() -> "Enqueued supplier ran").thenApply(s ->
-        {
-            LOGGER.info(s);
-            return null;
-        });
+        event.enqueueWork(() -> "Enqueued supplier ran").thenAccept(LOGGER::info);
 
         event.enqueueWork(DeferredWorkQueueTest::executeThrowingRunnable);
-        event.enqueueWork(DeferredWorkQueueTest::executeThrowingSupplier).thenApply(s ->
-        {
-            LOGGER.error("This must not be printed");
-            return null;
-        });
+        event.enqueueWork(DeferredWorkQueueTest::executeThrowingSupplier).thenAccept(s ->
+                LOGGER.error("This must not be printed")
+        );
     }
 
     private static void executeThrowingRunnable()

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -26,6 +26,8 @@ modId="mdk_datagen"
     modId="shader_resources_test"
 [[mods]]
     modId="crash_callable_test"
+[[mods]]
+    modId="deferred_work_queue_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
This PR reworks `DeferredWorkQueue` to allow it to capture the `CompletableFuture`s backing the enqueued tasks such that exceptions happening in these tasks can be logged and in a future version rethrown to properly prevent mod loading from continuing.

I added a test mod to test that the DWQ properly executes the tasks and also properly forwards any exceptions happening in these tasks.

Fixes #8255