### PR TITLE
[1.19.x] Fix `NamespacedWrapper#wrapAsHolder`

### DIFF
--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -220,6 +220,13 @@ class NamespacedWrapper<T> extends MappedRegistry<T> implements ILockableRegistr
         return Optional.ofNullable(this.holdersByName.get(key.location()));
     }
 
+    @Override
+    public @NotNull Holder<T> wrapAsHolder(@NotNull T value)
+    {
+        final Holder<T> holder = this.holders.get(value);
+        return holder == null ? Holder.direct(value) : holder;
+    }
+
     Optional<Holder<T>> getHolder(ResourceLocation location)
     {
         return Optional.ofNullable(this.holdersByName.get(location));


### PR DESCRIPTION
Currently, `NamespacedWrapper` does not override `wrapAsHolder`, meaning that all calls to it will result in a direct holder as `MappedRegistry#byValue` is empty. 
This PR fixes that by overriding it and making it return the holder from `NamespacedWrapper#holders`.