### PR TITLE
fix invalid index being given to Item#inventoryTick by Inventory#tick…

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -27,18 +27,13 @@
           if (p_36049_.m_41782_()) {
              itemstack.m_41751_(p_36049_.m_41783_().m_6426_());
           }
-@@ -222,14 +_,16 @@
-    }
- 
-    public void m_36068_() {
-+      int index = 0;
+@@ -225,11 +_,11 @@
        for(NonNullList<ItemStack> nonnulllist : this.f_35979_) {
           for(int i = 0; i < nonnulllist.size(); ++i) {
              if (!nonnulllist.get(i).m_41619_()) {
 -               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, i, this.f_35977_ == i);
-+               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, index, this.f_35977_ == index);
++               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, i, nonnulllist == this.f_35974_ && this.f_35977_ == i);
              }
-+            ++index;
           }
        }
 -

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -27,7 +27,17 @@
           if (p_36049_.m_41782_()) {
              itemstack.m_41751_(p_36049_.m_41783_().m_6426_());
           }
-@@ -229,7 +_,7 @@
+@@ -222,14 +_,16 @@
+    }
+ 
+    public void m_36068_() {
++      int index = 0;
+       for(NonNullList<ItemStack> nonnulllist : this.f_35979_) {
+          for(int i = 0; i < nonnulllist.size(); ++i) {
+             if (!nonnulllist.get(i).m_41619_()) {
+-               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, i, this.f_35977_ == i);
++               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, index, this.f_35977_ == index);
++               ++index;
              }
           }
        }

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -37,8 +37,8 @@
              if (!nonnulllist.get(i).m_41619_()) {
 -               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, i, this.f_35977_ == i);
 +               nonnulllist.get(i).m_41666_(this.f_35978_.f_19853_, this.f_35978_, index, this.f_35977_ == index);
-+               ++index;
              }
++            ++index;
           }
        }
 -


### PR DESCRIPTION
… resulting in invalid selection check and potentially dangerous usage of Inventory#setItem.

Since Inventory.compartmens (aka f_35979_) are in the order items - armor - offhand, the indexes 36, 37, 38 and 39 will be given instead of 0, 1, 2, 3 to armor, and index 40 will be given to offhand instead of 0, making it more in line with Inventory#setItem method, also fixing the selection check being true for armor items/offhand when the selected belt slot is 0,1, 2 or 3.