### PR TITLE
[1.19.x] Fix forge grindstone hooks allowing stacks of non-stackable items

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -179,10 +179,11 @@
     private void m_169380_(long p_169381_, boolean p_169382_) {
        this.f_169377_ = Util.m_137550_() + p_169381_;
        if (p_169382_) {
-@@ -734,4 +_,12 @@
+@@ -733,5 +_,13 @@
+          this.f_169421_ = p_169425_;
           this.f_169422_ = p_169426_;
        }
-    }
++   }
 +
 +   private void addEventWidget(GuiEventListener b) {
 +      if (b instanceof Renderable r)
@@ -190,5 +191,5 @@
 +      if (b instanceof NarratableEntry ne)
 +         this.f_169368_.add(ne);
 +      f_96540_.add(b);
-+   }
+    }
  }

--- a/patches/minecraft/net/minecraft/network/CompressionEncoder.java.patch
+++ b/patches/minecraft/net/minecraft/network/CompressionEncoder.java.patch
@@ -13,7 +13,7 @@
           friendlybytebuf.m_130130_(0);
           friendlybytebuf.writeBytes(p_129453_);
        } else {
-+         if (!DISABLE_PACKET_DEBUG && i > net.minecraft.network.CompressionDecoder.MAXIMUM_UNCOMPRESSED_LENGTH) {
++         if (!DISABLE_PACKET_DEBUG && i > net.minecraft.network.CompressionDecoder.f_182672_) {
 +             p_129453_.markReaderIndex();
 +             LOGGER.error("Attempted to send packet over maximum protocol size: {} > 2097152\nData:\n{}", i,
 +                     net.minecraftforge.logging.PacketDump.getContentDump(p_129453_));

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -13,13 +13,13 @@
        this.m_38897_(new Slot(this.f_39560_, 0, 49, 19) {
           public boolean m_5857_(ItemStack p_39607_) {
 -            return p_39607_.m_41763_() || p_39607_.m_150930_(Items.f_42690_) || p_39607_.m_41793_();
-+            return true; //Allow all items in the slot, not just repairable
++            return p_39607_.m_41763_() || p_39607_.m_150930_(Items.f_42690_) || p_39607_.m_41793_() || p_39607_.canGrindstoneRepair();
           }
        });
        this.m_38897_(new Slot(this.f_39560_, 1, 49, 40) {
           public boolean m_5857_(ItemStack p_39616_) {
 -            return p_39616_.m_41763_() || p_39616_.m_150930_(Items.f_42690_) || p_39616_.m_41793_();
-+            return true; //Allow all items in the slot, not just repairable
++            return p_39616_.m_41763_() || p_39616_.m_150930_(Items.f_42690_) || p_39616_.m_41793_() || p_39616_.canGrindstoneRepair();
           }
        });
        this.m_38897_(new Slot(this.f_39559_, 2, 129, 34) {
@@ -67,6 +67,17 @@
                 if (!ItemStack.m_41728_(itemstack, itemstack1)) {
                    this.f_39559_.m_6836_(0, ItemStack.f_41583_);
                    this.m_38946_();
+@@ -163,6 +_,10 @@
+             itemstack2 = flag3 ? itemstack : itemstack1;
+          }
+ 
++         // Forge: Skip the repair if the result would give an item stack with a count not normally obtainable
++         if (j > itemstack2.m_41741_())
++            this.f_39559_.m_6836_(0, ItemStack.f_41583_);
++         else
+          this.f_39559_.m_6836_(0, this.m_39579_(itemstack2, i, j));
+       }
+ 
 @@ -175,7 +_,7 @@
  
        for(Map.Entry<Enchantment, Integer> entry : map.entrySet()) {

--- a/patches/minecraft/net/minecraft/world/item/BundleItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BundleItem.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/item/BundleItem.java
++++ b/net/minecraft/world/item/BundleItem.java
+@@ -40,7 +_,7 @@
+    }
+ 
+    public boolean m_142207_(ItemStack p_150733_, Slot p_150734_, ClickAction p_150735_, Player p_150736_) {
+-      if (p_150735_ != ClickAction.SECONDARY) {
++      if (p_150733_.m_41613_() != 1 || p_150735_ != ClickAction.SECONDARY) {
+          return false;
+       } else {
+          ItemStack itemstack = p_150734_.m_7993_();
+@@ -62,6 +_,7 @@
+    }
+ 
+    public boolean m_142305_(ItemStack p_150742_, ItemStack p_150743_, Slot p_150744_, ClickAction p_150745_, Player p_150746_, SlotAccess p_150747_) {
++      if (p_150742_.m_41613_() != 1) return false;
+       if (p_150745_ == ClickAction.SECONDARY && p_150744_.m_150651_(p_150746_)) {
+          if (p_150743_.m_41619_()) {
+             m_150780_(p_150742_).ifPresent((p_186347_) -> {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -857,4 +857,12 @@ public interface IForgeItem
         return stack.isEnchanted();
     }
 
+    /**
+     * {@return true if the given ItemStack can be put into a grindstone to be repaired and/or stripped of its enchantments}
+     */
+    default boolean canGrindstoneRepair(ItemStack stack)
+    {
+        // TODO 1.20: Change to return false; this changes the default behavior for all items from opt-out to opt-in.
+        return true;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -587,4 +587,11 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
         return self().getItem().isNotReplaceableByPickAction(self(), player, inventorySlot);
     }
 
+    /**
+     * {@return true if the given ItemStack can be put into a grindstone to be repaired and/or stripped of its enchantments}
+     */
+    default boolean canGrindstoneRepair()
+    {
+        return self().getItem().canGrindstoneRepair(self());
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GrindstoneEventTest.java
@@ -23,8 +23,10 @@ public class GrindstoneEventTest {
     }
 
     @SubscribeEvent
-    public void onGrindestonePlace(GrindstoneEvent.OnplaceItem event)
+    public void onGrindstonePlace(GrindstoneEvent.OnplaceItem event)
     {
+        // TODO 1.20: This will not work once IForgeItem#canGrindstoneRepair is changed to have items opt-in to being able to place
+        //  rather than the current opt-out (the hook will no longer fire after the change). Fix?
         // all of these "recipes" are slot sensitive, the top and bottom must match exactly for the behavior to change
         // switching the order will cause the "recipe" to fail
         ItemStack topItem = event.getTopItem();


### PR DESCRIPTION
* Fix the forge grindstone hooks allowing users to combine non-stackable items (e.g. shulker boxes)
* Prevent bundle item modification whatsoever when the stack count is not equal to 1
* Add `IForgeItem/IForgeItemStack#canGrindstoneRepair`