### PR TITLE
[1.19.x] Error on deprecated members that should be removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1200,18 +1200,25 @@ project(':forge') {
             */
         }
     }
-    
+
     task findFinalizeSpawnTargets(type: BytecodePredicateFinder, dependsOn: ['createJoinedSRG']) {
         jar = createJoinedSRG.output
         output = rootProject.file('src/main/resources/coremods/finalize_spawn_targets.json')
         predicate = {
-            parent, node, insn -> 
+            parent, node, insn ->
                 'net/minecraft/world/level/BaseSpawner' != parent.name // Ignore this class as we special case it.
-                && insn.getOpcode() == Opcodes.INVOKEVIRTUAL 
-                && insn.name.equals('m_6518_') 
+                && insn.getOpcode() == Opcodes.INVOKEVIRTUAL
+                && insn.name.equals('m_6518_')
                 && insn.desc.equals('(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/entity/SpawnGroupData;')
         }
     }
+
+    tasks.register('validateDeprecations', ValidateDeprecations) {
+        input = tasks.jar.archiveFile
+        mcVersion = MC_VERSION
+    }
+
+    tasks.jar.finalizedBy 'validateDeprecations'
 
     tasks.register('checkAll') {
         dependsOn 'checkLicenses'

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJar.groovy
@@ -6,7 +6,7 @@ import org.gradle.api.provider.SetProperty
 
 abstract class InstallerJar extends Zip {
     @Input @Optional abstract SetProperty<String> getPackedDependencies()
-    
+
     InstallerJar() {
         archiveClassifier.set('installer')
         archiveExtension.set('jar') // Needs to be Zip task to not override Manifest, so set extension
@@ -15,7 +15,7 @@ abstract class InstallerJar extends Zip {
         def installerJson = project.tasks.installerJson
         def launcherJson = project.tasks.launcherJson
         def downloadInstaller = project.tasks.downloadInstaller
-        
+
         dependsOn(installerJson, launcherJson, downloadInstaller)
         from(installerJson, launcherJson)
 
@@ -24,13 +24,13 @@ abstract class InstallerJar extends Zip {
             from(project.zipTree(downloadInstaller.output)) {
                 duplicatesStrategy = 'exclude'
             }
-            
-            if (!System.env.MAVEN_USER) {
+
+            if (!System.env.TEAMCITY_VERSION) {
                 dependsOn(project.universalJar)
                 from(project.universalJar) {
                     into '/maven/' + project.group.replace('.', '/') + '/' + project.universalJar.archiveBaseName.get() + '/' + project.version + '/'
                 }
-    
+
                 packedDependencies.get().forEach {
                     def jarTask = project.rootProject.getTasks().findByPath(it)
                     dependsOn(jarTask)

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
@@ -2,13 +2,20 @@ package net.minecraftforge.forge.tasks
 
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
 
 import java.io.File
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
 
 public class Util {
+    static final ASM_LEVEL = Opcodes.ASM9
+
 	static void init() {
 		File.metaClass.sha1 = { ->
 			MessageDigest md = MessageDigest.getInstance('SHA-1')
@@ -146,5 +153,20 @@ public class Util {
     public static String getLatestForgeVersion(mcVersion) {
         def json = new JsonSlurper().parseText(new URL("https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json").getText("UTF-8"))
         return json.promos["$mcVersion-latest"]
+    }
+
+    static void processClassNodes(File file, Closure process) {
+        file.withInputStream { i ->
+            new ZipInputStream(i).withCloseable { zin ->
+                ZipEntry zein
+                while ((zein = zin.nextEntry) != null) {
+                    if (zein.name.endsWith('.class')) {
+                        def node = new ClassNode(ASM_LEVEL)
+                        new ClassReader(zin).accept(node, 0)
+                        process(node)
+                    }
+                }
+            }
+        }
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.forge.tasks
+
+import net.minecraftforge.srgutils.MinecraftVersion
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.ClassNode
+
+abstract class ValidateDeprecations extends DefaultTask {
+    @InputFile
+    abstract RegularFileProperty getInput()
+
+    @Input
+    abstract Property<String> getMcVersion()
+
+    ValidateDeprecations() {
+        this.onlyIf { !System.env.MAVEN_USER }
+    }
+
+    @TaskAction
+    protected void exec() {
+        def mcVer = MinecraftVersion.from(mcVersion.get())
+        def errors = []
+
+        Util.processClassNodes(input.get().asFile) {
+            processNode(mcVer, errors, it)
+        }
+
+        if (!errors.isEmpty()) {
+            errors.forEach {
+                this.logger.error("Deprecated ${it[0]} is marked for removal in ${it[1]} but is not yet removed")
+            }
+            throw new IllegalStateException("Found deprecated members marked for removal but not yet removed in ${mcVer}; see log for details")
+        }
+    }
+
+    protected processNode(MinecraftVersion mcVer, List<String> errors, ClassNode node) {
+        node.visibleAnnotations?.each { annotation ->
+            ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
+                "class ${node.name}"
+            }
+        }
+        if (node.fields != null) {
+            node.fields.each { field ->
+                field.visibleAnnotations?.each { annotation ->
+                    ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
+                        "field ${node.name}#${field.name}"
+                    }
+                }
+            }
+        }
+        if (node.methods != null) {
+            node.methods.each { method ->
+                method.visibleAnnotations?.each { annotation ->
+                    ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
+                        "method ${node.name}#${method.name}${method.desc}"
+                    }
+                }
+            }
+        }
+    }
+
+    private static void processAnnotations(AnnotationNode annotation, MinecraftVersion mcVer, List<String> errors, Closure context) {
+        def values = annotation.values
+        if (values == null)
+            return
+        int forRemoval = values.indexOf("forRemoval")
+        int since = values.indexOf("since")
+        if (annotation.desc == "Ljava/lang/Deprecated;" && forRemoval != -1 && since != -1 && values.size() >= 4 && values[forRemoval + 1] == true) {
+            def oldVersion = MinecraftVersion.from(values[since + 1])
+            def split = ValidateDeprecations.splitDots(oldVersion.toString())
+            if (split.length < 2)
+                return
+            def removeVersion = MinecraftVersion.from("${split[0]}.${split[1] + 1}")
+            if (removeVersion <= mcVer)
+                errors.add([context(), removeVersion])
+        }
+    }
+
+    private static int[] splitDots(String version) {
+        String[] pts = version.split("\\.");
+        int[] values = new int[pts.length];
+        for (int x = 0; x < pts.length; x++)
+            values[x] = Integer.parseInt(pts[x]);
+        return values;
+    }
+}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
@@ -23,7 +23,7 @@ abstract class ValidateDeprecations extends DefaultTask {
     abstract Property<String> getMcVersion()
 
     ValidateDeprecations() {
-        this.onlyIf { !System.env.MAVEN_USER }
+        this.onlyIf { !System.env.TEAMCITY_VERSION }
     }
 
     @TaskAction

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
@@ -49,21 +49,17 @@ abstract class ValidateDeprecations extends DefaultTask {
                 "class ${node.name}"
             }
         }
-        if (node.fields != null) {
-            node.fields.each { field ->
-                field.visibleAnnotations?.each { annotation ->
-                    ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
-                        "field ${node.name}#${field.name}"
-                    }
+        node.fields?.each { field ->
+            field.visibleAnnotations?.each { annotation ->
+                ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
+                    "field ${node.name}#${field.name}"
                 }
             }
         }
-        if (node.methods != null) {
-            node.methods.each { method ->
-                method.visibleAnnotations?.each { annotation ->
-                    ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
-                        "method ${node.name}#${method.name}${method.desc}"
-                    }
+        node.methods?.each { method ->
+            method.visibleAnnotations?.each { annotation ->
+                ValidateDeprecations.processAnnotations(annotation, mcVer, errors) {
+                    "method ${node.name}#${method.name}${method.desc}"
                 }
             }
         }
@@ -71,11 +67,11 @@ abstract class ValidateDeprecations extends DefaultTask {
 
     private static void processAnnotations(AnnotationNode annotation, MinecraftVersion mcVer, List<String> errors, Closure context) {
         def values = annotation.values
-        if (values == null)
+        if (values === null)
             return
-        int forRemoval = values.indexOf("forRemoval")
-        int since = values.indexOf("since")
-        if (annotation.desc == "Ljava/lang/Deprecated;" && forRemoval != -1 && since != -1 && values.size() >= 4 && values[forRemoval + 1] == true) {
+        int forRemoval = values.indexOf('forRemoval')
+        int since = values.indexOf('since')
+        if (annotation.desc == 'Ljava/lang/Deprecated;' && forRemoval !== -1 && since !== -1 && values.size() >= 4 && values[forRemoval + 1] === true) {
             def oldVersion = MinecraftVersion.from(values[since + 1])
             def split = ValidateDeprecations.splitDots(oldVersion.toString())
             if (split.length < 2)
@@ -87,10 +83,10 @@ abstract class ValidateDeprecations extends DefaultTask {
     }
 
     private static int[] splitDots(String version) {
-        String[] pts = version.split("\\.");
-        int[] values = new int[pts.length];
+        String[] pts = version.split('\\.')
+        int[] values = new int[pts.length]
         for (int x = 0; x < pts.length; x++)
-            values[x] = Integer.parseInt(pts[x]);
-        return values;
+            values[x] = Integer.parseInt(pts[x])
+        return values
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
@@ -1,5 +1,6 @@
 package net.minecraftforge.forge.tasks.checks
 
+import net.minecraftforge.forge.tasks.Util
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
@@ -7,7 +8,6 @@ import org.gradle.api.tasks.InputFiles
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 
 import java.util.zip.ZipEntry
@@ -67,7 +67,7 @@ abstract class CheckExcs extends CheckTask {
     private void collectKnown(Collection<String> known) {
         binary.get().asFile.withInputStream { i ->
             new ZipInputStream(i).withCloseable { zin ->
-                final visitor = new ClassVisitor(Opcodes.ASM9) {
+                final visitor = new ClassVisitor(Util.ASM_LEVEL) {
                     private String cls
                     @Override
                     void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {


### PR DESCRIPTION
* Adds a `validateDeprecations` task that runs every time `jar` runs to error out if any for-removal Deprecated annotations are left behind that should be removed in the current MC version
* Does not run in TeamCity (for speed & should be caught in dev testing anyways)