### PR TITLE
Remove erroneous brace patch in Inventory

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -1,10 +1,6 @@
 --- a/net/minecraft/world/entity/player/Inventory.java
 +++ b/net/minecraft/world/entity/player/Inventory.java
-@@ -126,14 +_,14 @@
-          if (this.f_35974_.get(j).m_41619_()) {
-             return j;
-          }
--      }
+@@ -130,7 +_,7 @@
  
        for(int k = 0; k < 9; ++k) {
           int l = (this.f_35977_ + k) % 9;
@@ -13,10 +9,6 @@
              return l;
           }
        }
-+      }
- 
-       return this.f_35977_;
-    }
 @@ -178,7 +_,8 @@
        int i = p_36049_.m_41613_();
        ItemStack itemstack = this.m_8020_(p_36048_);


### PR DESCRIPTION
This PR fixes #9459 by removing an erroneous brace in `Inventory#getSuitableHotbarSlot()`. See my comment on the linked issue for details: https://github.com/MinecraftForge/MinecraftForge/issues/9459#issuecomment-1518898492.