### PR TITLE
[1.19.2] Fix forge grindstone hooks allowing stacks of non-stackable items

### DIFF
--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -67,6 +67,17 @@
                 if (!ItemStack.m_41728_(itemstack, itemstack1)) {
                    this.f_39559_.m_6836_(0, ItemStack.f_41583_);
                    this.m_38946_();
+@@ -163,6 +_,10 @@
+             itemstack2 = flag3 ? itemstack : itemstack1;
+          }
+ 
++         // Forge: Skip the repair if the result would give an item stack with a count not normally obtainable
++         if (j > itemstack2.m_41741_())
++            this.f_39559_.m_6836_(0, ItemStack.f_41583_);
++         else
+          this.f_39559_.m_6836_(0, this.m_39579_(itemstack2, i, j));
+       }
+ 
 @@ -175,7 +_,7 @@
  
        for(Map.Entry<Enchantment, Integer> entry : map.entrySet()) {

--- a/patches/minecraft/net/minecraft/world/item/BundleItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BundleItem.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/item/BundleItem.java
++++ b/net/minecraft/world/item/BundleItem.java
+@@ -40,7 +_,7 @@
+    }
+ 
+    public boolean m_142207_(ItemStack p_150733_, Slot p_150734_, ClickAction p_150735_, Player p_150736_) {
+-      if (p_150735_ != ClickAction.SECONDARY) {
++      if (p_150733_.m_41613_() != 1 || p_150735_ != ClickAction.SECONDARY) {
+          return false;
+       } else {
+          ItemStack itemstack = p_150734_.m_7993_();
+@@ -62,6 +_,7 @@
+    }
+ 
+    public boolean m_142305_(ItemStack p_150742_, ItemStack p_150743_, Slot p_150744_, ClickAction p_150745_, Player p_150746_, SlotAccess p_150747_) {
++      if (p_150742_.m_41613_() != 1) return false;
+       if (p_150745_ == ClickAction.SECONDARY && p_150744_.m_150651_(p_150746_)) {
+          if (p_150743_.m_41619_()) {
+             m_150780_(p_150742_).ifPresent((p_186347_) -> {


### PR DESCRIPTION
Backport of #9457 for 1.19.2.
(Almost) direct copy of #9458.

* Fix the forge grindstone hooks allowing users to combine non-stackable items (e.g. shulker boxes)
* Prevent bundle item modification whatsoever when the stack count is not equal to 1
* `IForgeItem/IForgeItemStack#canGrindstoneRepair` has *not* been included, as this branch is in bugfix mode and new API is generally unnecessary for this feature