### PR TITLE
[1.19.x] Update documentation on FinalizeSpawn

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -74,16 +74,17 @@
           if (entity != null) {
              double d0 = entity.m_20280_(this);
              int i = this.m_6095_().m_20674_().m_21611_();
-@@ -1020,6 +_,15 @@
+@@ -1020,6 +_,16 @@
  
     }
  
 +   /**
-+    * Forge: Deprecated, call via ForgeEventFactory.onFinalizeSpawn.<br>
-+    * Overrides are fine. Super calls within overrides are fine and should not be wrapped (as that will cause stack overflows).<br>
-+    * Vanilla calls are replaced with a transformer, and are not visible in source.
++    * Forge: Override-Only, call via ForgeEventFactory.onFinalizeSpawn.<br>
++    * Overrides are allowed. Do not wrap super calls within override (as that will cause stack overflows).<br>
++    * Vanilla calls are replaced with a transformer, and are not visible in source.<br>
 +    * <p>
 +    * Be certain to either call super.finalizeSpawn or set the {@link #spawnType} field from within your override.
++    * @see {@link net.minecraftforge.event.ForgeEventFactory#onFinalizeSpawn onFinalizeSpawn} for additional documentation.
 +    */
 +   @Deprecated
 +   @org.jetbrains.annotations.ApiStatus.OverrideOnly

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -193,12 +193,37 @@ public class ForgeEventFactory
      * Vanilla calls to {@link Mob#finalizeSpawn} are replaced with calls to this method via coremod.<br>
      * Mods should call this method in place of calling {@link Mob#finalizeSpawn}. Super calls (from within overrides) should not be wrapped.
      * <p>
-     * Returns the SpawnGroupData from this event, or null if it was canceled.
+     * When interfacing with this event, write all code as normal, and replace {@link Mob#finalizeSpawn} with {@link #onFinalizeSpawn}.<p>
+     * As an example, the following code block:
+     * 
+     * <blockquote><pre>
+     * var zombie = new Zombie(level);
+     * zombie.finalizeSpawn(level, difficulty, spawnType, spawnData, spawnTag);
+     * level.tryAddFreshEntityWithPassengers(zombie);
+     * if (zombie.isAddedToWorld()) {
+     *     // Do stuff with your new zombie
+     * }
+     * </blockquote></pre>
+     * 
+     * Would become:
+     * <blockquote><pre>
+     * var zombie = new Zombie(level);
+     * ForgeEventFactory.onFinalizeSpawn(zombie, level, difficulty, spawnType, spawnData, spawnTag);
+     * level.tryAddFreshEntityWithPassengers(zombie);
+     * if (zombie.isAddedToWorld()) {
+     *     // Do stuff with your new zombie
+     * }
+     * </blockquote></pre>
+     * <p>
+     * The only code that changes is the {@link Mob#finalizeSpawn} call.
+     * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned.
      * @see MobSpawnEvent.FinalizeSpawn
      * @see Mob#finalizeSpawn(ServerLevelAccessor, DifficultyInstance, MobSpawnType, SpawnGroupData, CompoundTag)
+     * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      * @implNote Changes to the signature of this method must be reflected in the method redirector coremod. 
      */
     @Nullable
+    @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
     public static SpawnGroupData onFinalizeSpawn(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag spawnTag)
     {
         var event = new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, spawnTag, null);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -195,23 +195,23 @@ public class ForgeEventFactory
      * <p>
      * When interfacing with this event, write all code as normal, and replace the call to {@link Mob#finalizeSpawn} with a call to this method.<p>
      * As an example, the following code block:
-     * <pre>
+     * <code><pre>
      * var zombie = new Zombie(level);
      * zombie.finalizeSpawn(level, difficulty, spawnType, spawnData, spawnTag);
      * level.tryAddFreshEntityWithPassengers(zombie);
      * if (zombie.isAddedToWorld()) {
      *     // Do stuff with your new zombie
      * }
-     * </pre>
+     * </pre></code>
      * Would become:
-     * <pre>
+     * <code><pre>
      * var zombie = new Zombie(level);
      * ForgeEventFactory.onFinalizeSpawn(zombie, level, difficulty, spawnType, spawnData, spawnTag);
      * level.tryAddFreshEntityWithPassengers(zombie);
      * if (zombie.isAddedToWorld()) {
      *     // Do stuff with your new zombie
      * }
-     * </pre>
+     * </pre></code>
      * The only code that changes is the {@link Mob#finalizeSpawn} call.
      * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned.
      * @see MobSpawnEvent.FinalizeSpawn

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -193,7 +193,7 @@ public class ForgeEventFactory
      * Vanilla calls to {@link Mob#finalizeSpawn} are replaced with calls to this method via coremod.<br>
      * Mods should call this method in place of calling {@link Mob#finalizeSpawn}. Super calls (from within overrides) should not be wrapped.
      * <p>
-     * When interfacing with this event, write all code as normal, and replace {@link Mob#finalizeSpawn} with {@link #onFinalizeSpawn}.<p>
+     * When interfacing with this event, write all code as normal, and replace the call to {@link Mob#finalizeSpawn} with a call to this method.<p>
      * As an example, the following code block:
      * 
      * <blockquote><pre>

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -195,26 +195,23 @@ public class ForgeEventFactory
      * <p>
      * When interfacing with this event, write all code as normal, and replace {@link Mob#finalizeSpawn} with {@link #onFinalizeSpawn}.<p>
      * As an example, the following code block:
-     * 
-     * <blockquote><pre>
+     * <pre>
      * var zombie = new Zombie(level);
      * zombie.finalizeSpawn(level, difficulty, spawnType, spawnData, spawnTag);
      * level.tryAddFreshEntityWithPassengers(zombie);
      * if (zombie.isAddedToWorld()) {
      *     // Do stuff with your new zombie
      * }
-     * </blockquote></pre>
-     * 
+     * </pre>
      * Would become:
-     * <blockquote><pre>
+     * <pre>
      * var zombie = new Zombie(level);
      * ForgeEventFactory.onFinalizeSpawn(zombie, level, difficulty, spawnType, spawnData, spawnTag);
      * level.tryAddFreshEntityWithPassengers(zombie);
      * if (zombie.isAddedToWorld()) {
      *     // Do stuff with your new zombie
      * }
-     * </blockquote></pre>
-     * <p>
+     * </pre>
      * The only code that changes is the {@link Mob#finalizeSpawn} call.
      * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned.
      * @see MobSpawnEvent.FinalizeSpawn

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -86,14 +86,16 @@ public abstract class MobSpawnEvent extends EntityEvent
     }
 
     /**
-     * This event is fired before {@link Mob#finalizeSpawn(ServerLevelAccessor, DifficultyInstance, MobSpawnType, SpawnGroupData, CompoundTag)} is called.<br>
+     * This event is fired before {@link Mob#finalizeSpawn} is called.<br>
      * This allows mods to control mob initialization.<br>
-     * In vanilla code, this event is injected by a transformer and not via patch, so calls cannot be traced via call hierarchy.
+     * In vanilla code, this event is injected by a transformer and not via patch, so calls cannot be traced via call hierarchy (it is not source-visible).
      * <p>
      * Canceling this event will result in {@link Mob#finalizeSpawn} not being called, and the returned value always being null, instead of propagating the SpawnGroupData.<br>
-     * The entity will still be spawned. If you want to prevent the spawn, use {@link FinalizeSpawn#cancelSpawn()}
+     * The entity will still be spawned. If you want to prevent the spawn, use {@link FinalizeSpawn#setSpawnCancelled}, which will cause Forge to prevent the spawn.
      * <p>
      * This event is fired on {@link MinecraftForge#EVENT_BUS}, and is only fired on the logical server.
+     * @see ForgeEventFactory#onFinalizeSpawn
+     * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
     @Cancelable
     public static class FinalizeSpawn extends MobSpawnEvent


### PR DESCRIPTION
This PR updates the documentation on the new `FinalizeSpawn` event and the various call sites to ensure that modders can understand the expected implementation without having to ask additional questions, as there is a bit of ambiguity in the current wording.