### PR TITLE
Add PlayerSpawnPhantomsEvent event, add (player) spawn cause to phantoms

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
-@@ -47,6 +_,31 @@
-    Vec3 f_33097_ = Vec3.f_82478_;
-    BlockPos f_33098_ = BlockPos.f_121853_;
-    Phantom.AttackPhase f_33096_ = Phantom.AttackPhase.CIRCLE;
+@@ -488,4 +_,37 @@
+          }
+       }
+    }
++
++   // Forge start
 +   @Nullable
-+   private net.minecraft.server.level.ServerPlayer spawnCause = null;
++   private java.util.UUID spawnCause = null;
 +
 +   /**
 +    * @return The player that caused this phantom spawn. null if not applicable.
@@ -13,7 +15,10 @@
 +   @Nullable
 +   public net.minecraft.server.level.ServerPlayer getSpawnCause()
 +   {
-+      return spawnCause;
++      if (spawnCause != null && f_19853_ instanceof net.minecraft.server.level.ServerLevel serverLevel)
++         return serverLevel.m_7654_().m_6846_().m_11259_(spawnCause);
++
++      return null;
 +   }
 +
 +   /**
@@ -27,8 +32,9 @@
 +    */
 +   public void setSpawnCause(@Nullable net.minecraft.server.level.ServerPlayer spawnCause)
 +   {
-+      this.spawnCause = spawnCause;
++      if (spawnCause == null)
++         this.spawnCause = null;
++      else
++         this.spawnCause = spawnCause.m_20148_();
 +   }
- 
-    public Phantom(EntityType<? extends Phantom> p_33101_, Level p_33102_) {
-       super(p_33101_, p_33102_);
+ }

--- a/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
@@ -23,14 +23,14 @@
 +   }
 +
 +   // Forge start
-+   @Nullable
++   @org.jetbrains.annotations.Nullable
 +   private java.util.UUID spawnCause = null;
 +
 +   /**
 +    * This value is only available on the logical server, and will always be null on the client.
 +    * @return The UUID of the entity that caused the Phantom to spawn, or null if unknown.
 +    */
-+   @Nullable
++   @org.jetbrains.annotations.Nullable
 +   public java.util.UUID getSpawnCause()
 +   {
 +      return this.spawnCause;

--- a/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
@@ -27,7 +27,8 @@
 +   private java.util.UUID spawnCause = null;
 +
 +   /**
-+    * @return UUID describing what caused phantom to spawn (generally a player's UUID). null if not applicable.
++    * This value is only available on the logical server, and will always be null on the client.
++    * @return The UUID of the entity that caused the Phantom to spawn, or null if unknown.
 +    */
 +   @Nullable
 +   public java.util.UUID getSpawnCause()
@@ -36,16 +37,15 @@
 +   }
 +
 +   /**
-+    * Allows to specify spawn cause for phantoms (for event listeners).<br>
-+    * <br>
-+    * This should be called by mods right away when they create phantoms, so
-+    * event listeners such as {@link net.minecraftforge.event.entity.EntityJoinLevelEvent} can figure out
-+    * what caused this phantom to spawn.<br>
-+    *
-+    * @param spawnCause UUID describing what caused phantom to spawn (generally a player's UUID).
++    * Sets the spawn cause of this phantom.
++    * <p>
++    * This should be called as soon as possible in the Phantom's lifecycle, to ensure it is present for event handlers.
++    * @param spawnCause The UUID of the entity that caused the Phantom to spawn.
++    * @throws UnsupportedOperationException if the spawn cause has already been set.
 +    */
-+   public void setSpawnCause(@Nullable java.util.UUID spawnCause)
++   public void setSpawnCause(@org.jetbrains.annotations.NotNull java.util.UUID spawnCause)
 +   {
-+      this.spawnCause = spawnCause;
++      if (this.spawnCause != null) throw new UnsupportedOperationException("Can not change spawn cause after it has been already set");
++      this.spawnCause = com.google.common.base.Preconditions.checkNotNull(spawnCause, "spawnCause is null");
     }
  }

--- a/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
@@ -1,24 +1,38 @@
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
-@@ -488,4 +_,37 @@
+@@ -152,6 +_,7 @@
+       }
+ 
+       this.m_33108_(p_33132_.m_128451_("Size"));
++      this.spawnCause = p_33132_.m_128441_("ForgeSpawnCause") ? p_33132_.m_128342_("ForgeSpawnCause") : null;
+    }
+ 
+    public void m_7380_(CompoundTag p_33141_) {
+@@ -160,6 +_,7 @@
+       p_33141_.m_128405_("AY", this.f_33098_.m_123342_());
+       p_33141_.m_128405_("AZ", this.f_33098_.m_123343_());
+       p_33141_.m_128405_("Size", this.m_33172_());
++      if (spawnCause != null) p_33141_.m_128362_("ForgeSpawnCause", this.spawnCause);
+    }
+ 
+    public boolean m_6783_(double p_33107_) {
+@@ -487,5 +_,32 @@
+ 
           }
        }
-    }
++   }
 +
 +   // Forge start
 +   @Nullable
 +   private java.util.UUID spawnCause = null;
 +
 +   /**
-+    * @return The player that caused this phantom spawn. null if not applicable.
++    * @return UUID describing what caused phantom to spawn (generally a player's UUID). null if not applicable.
 +    */
 +   @Nullable
-+   public net.minecraft.server.level.ServerPlayer getSpawnCause()
++   public java.util.UUID getSpawnCause()
 +   {
-+      if (spawnCause != null && f_19853_ instanceof net.minecraft.server.level.ServerLevel serverLevel)
-+         return serverLevel.m_7654_().m_6846_().m_11259_(spawnCause);
-+
-+      return null;
++      return this.spawnCause;
 +   }
 +
 +   /**
@@ -26,15 +40,12 @@
 +    * <br>
 +    * This should be called by mods right away when they create phantoms, so
 +    * event listeners such as {@link net.minecraftforge.event.entity.EntityJoinLevelEvent} can figure out
-+    * who caused this phantom to spawn.<br>
++    * what caused this phantom to spawn.<br>
 +    *
-+    * @param spawnCause The player that caused phantoms to spawn
++    * @param spawnCause UUID describing what caused phantom to spawn (generally a player's UUID).
 +    */
-+   public void setSpawnCause(@Nullable net.minecraft.server.level.ServerPlayer spawnCause)
++   public void setSpawnCause(@Nullable java.util.UUID spawnCause)
 +   {
-+      if (spawnCause == null)
-+         this.spawnCause = null;
-+      else
-+         this.spawnCause = spawnCause.m_20148_();
-+   }
++      this.spawnCause = spawnCause;
+    }
  }

--- a/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Phantom.java.patch
@@ -1,0 +1,34 @@
+--- a/net/minecraft/world/entity/monster/Phantom.java
++++ b/net/minecraft/world/entity/monster/Phantom.java
+@@ -47,6 +_,31 @@
+    Vec3 f_33097_ = Vec3.f_82478_;
+    BlockPos f_33098_ = BlockPos.f_121853_;
+    Phantom.AttackPhase f_33096_ = Phantom.AttackPhase.CIRCLE;
++   @Nullable
++   private net.minecraft.server.level.ServerPlayer spawnCause = null;
++
++   /**
++    * @return The player that caused this phantom spawn. null if not applicable.
++    */
++   @Nullable
++   public net.minecraft.server.level.ServerPlayer getSpawnCause()
++   {
++      return spawnCause;
++   }
++
++   /**
++    * Allows to specify spawn cause for phantoms (for event listeners).<br>
++    * <br>
++    * This should be called by mods right away when they create phantoms, so
++    * event listeners such as {@link net.minecraftforge.event.entity.EntityJoinLevelEvent} can figure out
++    * who caused this phantom to spawn.<br>
++    *
++    * @param spawnCause The player that caused phantoms to spawn
++    */
++   public void setSpawnCause(@Nullable net.minecraft.server.level.ServerPlayer spawnCause)
++   {
++      this.spawnCause = spawnCause;
++   }
+ 
+    public Phantom(EntityType<? extends Phantom> p_33101_, Level p_33102_) {
+       super(p_33101_, p_33102_);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
++++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
+@@ -43,19 +_,21 @@
+                for(Player player : p_64576_.m_6907_()) {
+                   if (!player.m_5833_()) {
+                      BlockPos blockpos = player.m_20183_();
+-                     if (!p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {
+-                        DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
+-                        if (difficultyinstance.m_19049_(randomsource.m_188501_() * 3.0F)) {
++                     DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
++                     net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent event = new net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent(player, 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1));
++                     net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) continue;
++                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {
++                        if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || difficultyinstance.m_19049_(randomsource.m_188501_() * 3.0F)) {
+                            ServerStatsCounter serverstatscounter = ((ServerPlayer)player).m_8951_();
+                            int j = Mth.m_14045_(serverstatscounter.m_13015_(Stats.f_12988_.m_12902_(Stats.f_12992_)), 1, Integer.MAX_VALUE);
+                            int k = 24000;
+-                           if (randomsource.m_188503_(j) >= 72000) {
++                           if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || randomsource.m_188503_(j) >= 72000) {
+                               BlockPos blockpos1 = blockpos.m_6630_(20 + randomsource.m_188503_(15)).m_122030_(-10 + randomsource.m_188503_(21)).m_122020_(-10 + randomsource.m_188503_(21));
+                               BlockState blockstate = p_64576_.m_8055_(blockpos1);
+                               FluidState fluidstate = p_64576_.m_6425_(blockpos1);
+                               if (NaturalSpawner.m_47056_(p_64576_, blockpos1, blockstate, fluidstate, EntityType.f_20509_)) {
+                                  SpawnGroupData spawngroupdata = null;
+-                                 int l = 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1);
++                                 int l = event.getPhantomsToSpawn();
+ 
+                                  for(int i1 = 0; i1 < l; ++i1) {
+                                     Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -29,7 +29,7 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
                                      if (phantom != null) {
-+                                       phantom.setSpawnCause((ServerPlayer) player);
++                                       phantom.setSpawnCause(player.m_20148_());
                                         phantom.m_20035_(blockpos1, 0.0F, 0.0F);
                                         spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
                                         p_64576_.m_47205_(phantom);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
 +++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
-@@ -43,19 +_,21 @@
+@@ -43,23 +_,27 @@
                 for(Player player : p_64576_.m_6907_()) {
                    if (!player.m_5833_()) {
                       BlockPos blockpos = player.m_20183_();
@@ -28,3 +28,8 @@
  
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
+                                     if (phantom != null) {
++                                       phantom.setSpawnCause((ServerPlayer) player);
+                                        phantom.m_20035_(blockpos1, 0.0F, 0.0F);
+                                        spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
+                                        p_64576_.m_47205_(phantom);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -5,10 +5,9 @@
                    if (!player.m_5833_()) {
                       BlockPos blockpos = player.m_20183_();
 -                     if (!p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {
--                        DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
+                         DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
 -                        if (difficultyinstance.m_19049_(randomsource.m_188501_() * 3.0F)) {
-+                     DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
-+                     net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent event = new net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent(player, 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1));
++                     var event = new net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent(player, 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1));
 +                     net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) continue;
 +                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -1,0 +1,66 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fired from {@link net.minecraft.world.level.levelgen.PhantomSpawner} per player when it attempts to spawn phantoms.<br>
+ * <br>
+ * This event fires before any checks (but <i>after</i> check if player is a spectator and
+ * <i>after</i> global checks, such as dimension being dark enough or doInsomnia is true)
+ * and generally allow you to change properties of <i>potential</i> phantom spawns through
+ * {@link PlayerSpawnPhantomsEvent#setPhantomsToSpawn}.<br>
+ * <br>
+ * Behavior of {@link net.minecraft.world.level.levelgen.PhantomSpawner} is determined by {@link PlayerSpawnPhantomsEvent#getResult()}.<br>
+ * See {@link PlayerSpawnPhantomsEvent#setResult} for documentation.<br>
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ */
+@Event.HasResult
+public class PlayerSpawnPhantomsEvent extends PlayerEvent
+{
+    private int phantomsToSpawn;
+
+    public PlayerSpawnPhantomsEvent(Player player, int phantomsToSpawn)
+    {
+        super(player);
+        this.phantomsToSpawn = phantomsToSpawn;
+    }
+
+    /**
+     * @return How many phantoms to spawn. This value varies from event to event because it represents random number game was about to spawn.
+     */
+    public int getPhantomsToSpawn()
+    {
+        return phantomsToSpawn;
+    }
+
+    /**
+     * @param phantomsToSpawn How many phantoms should spawn, given checks are passed.
+     */
+    public void setPhantomsToSpawn(int phantomsToSpawn)
+    {
+        this.phantomsToSpawn = phantomsToSpawn;
+    }
+
+    /**
+     * Behavior of {@link net.minecraft.world.level.levelgen.PhantomSpawner} is determined by result:<br>
+     * <ul>
+     *     <li>If result is {@link Result#DEFAULT}, phantoms will be spawned when passing vanilla checks</li>
+     *     <li>If result is {@link Result#ALLOW}, phantoms will be spawned ignoring vanilla checks (except check whenever can phantoms fit in space)</li>
+     *     <li>If result is {@link Result#DENY}, no phantoms will be spawned</li>
+     * </ul>
+     *
+     * @param result The new result
+     */
+    @Override
+    public void setResult(@NotNull Result result)
+    {
+        super.setResult(result);
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -5,26 +5,22 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraft.world.level.levelgen.PhantomSpawner;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Fired from {@link net.minecraft.world.level.levelgen.PhantomSpawner} per player when it attempts to spawn phantoms.<br>
- * <br>
- * This event fires before any checks (but <i>after</i> check if player is a spectator and
- * <i>after</i> global checks, such as dimension being dark enough or doInsomnia is true)
- * and generally allow you to change properties of <i>potential</i> phantom spawns through
- * {@link PlayerSpawnPhantomsEvent#setPhantomsToSpawn}.<br>
- * <br>
- * Behavior of {@link net.minecraft.world.level.levelgen.PhantomSpawner} is determined by {@link PlayerSpawnPhantomsEvent#getResult()}.<br>
- * See {@link PlayerSpawnPhantomsEvent#setResult} for documentation.<br>
- * <br>
- * This event is not {@link Cancelable}.<br>
- * <br>
+ * This event is fired from {@link PhantomSpawner#tick}, once per player, when phantoms would attempt to be spawned.<br>
+ * This event is not fired for spectating players.
+ * <p>
+ * This event is fired before any per-player checks (but <i>after<i/> {@link Player#isSpectator()}), but after all global checks.<br>
+ * The behavior of {@link PhantomSpawner} is determined by the result of this event.<br>
+ * See {@link #setResult} for documentation.<br>
+ * <p>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * @see PlayerSpawnPhantomsEvent#setResult for the effects of each result.
  */
 @Event.HasResult
 public class PlayerSpawnPhantomsEvent extends PlayerEvent
@@ -38,7 +34,7 @@ public class PlayerSpawnPhantomsEvent extends PlayerEvent
     }
 
     /**
-     * @return How many phantoms to spawn. This value varies from event to event because it represents random number game was about to spawn.
+     * @return How many phantoms will be spawned, if spawning is successful. The default value is randomly generated.
      */
     public int getPhantomsToSpawn()
     {
@@ -46,6 +42,7 @@ public class PlayerSpawnPhantomsEvent extends PlayerEvent
     }
 
     /**
+     * Sets the number of phantoms to be spawned.
      * @param phantomsToSpawn How many phantoms should spawn, given checks are passed.
      */
     public void setPhantomsToSpawn(int phantomsToSpawn)
@@ -54,14 +51,12 @@ public class PlayerSpawnPhantomsEvent extends PlayerEvent
     }
 
     /**
-     * Behavior of {@link net.minecraft.world.level.levelgen.PhantomSpawner} is determined by result:<br>
+     * The result of this event controls if phantoms will be spawned.<br>
      * <ul>
-     *     <li>If result is {@link Result#DEFAULT}, phantoms will be spawned when passing vanilla checks</li>
-     *     <li>If result is {@link Result#ALLOW}, phantoms will be spawned ignoring vanilla checks (except check whenever can phantoms fit in space)</li>
-     *     <li>If result is {@link Result#DENY}, no phantoms will be spawned</li>
+     * <li>If the result is {@link Result#ALLOW}, phantoms will always be spawned;</li>
+     * <li>If the result is {@link Result#DENY}, phantoms will never be spawned;</li>
+     * <li>If the result is {@link Result#DEFAULT}, vanilla checks will be run to determine if the spawn may occur.</li>
      * </ul>
-     *
-     * @param result The new result
      */
     @Override
     public void setResult(@NotNull Result result)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;


### PR DESCRIPTION
The event allows to control phantom spawning *per player*, so mods can disallow (or forcefully allow) phantom spawning per specific player, or adjust amount of phantoms spawned per that player.

Adds context to Phantoms themselves (`getSpawnCause`, `setSpawnCause`) which store `ServerPlayer` who is responsible for this phantom's spawn.

While both changes somewhat correlate at what they are allowing to do, (both allow to stop phantoms to spawn per-player), the event allows to ignore vanilla spawn conditions and adjust amount of phantoms spawned.

Exaple justification for player context: if you hold (eg in inventory) certain item, spawned phantoms should be empowered/weakened, which is practically impossible to achieve currently