### PR TITLE
Log a proper duplicate mod(s) error message

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -81,7 +81,7 @@ public class UniqueModListBuilder
                 )).toList();
 
         if (!dupedModErrors.isEmpty()) {
-            LOGGER.error(LOADING, "Found duplicate mods:\n{}", dupedModErrors);
+            LOGGER.error(LOADING, "Found duplicate mods:\n{}", dupedModErrors.stream().collect(joining("\n")));
             throw new EarlyLoadingException("Duplicate mods found", null, dupedModErrors.stream()
                     .map(s -> new EarlyLoadingException.ExceptionData(s))
                     .toList());
@@ -90,13 +90,14 @@ public class UniqueModListBuilder
 
         final List<String> dupedLibErrors = versionedLibIds.values().stream()
                 .filter(modFiles -> modFiles.size() > 1)
-                .map(mods -> String.format("\tDuped lib set: %s",
+                .map(mods -> String.format("\tLibrary: '%s' from files: %s",
+                        getModId(mods.get(0)),
                         mods.stream()
-                                .map(modFile -> modFile.getSecureJar().name()).collect(joining(", "))
+                                .map(modFile -> modFile.getFileName()).collect(joining(", "))
                 )).toList();
 
         if (!dupedLibErrors.isEmpty()) {
-            LOGGER.error(LOADING, "Found duplicate libs:\n{}", dupedLibErrors);
+            LOGGER.error(LOADING, "Found duplicate plugins or libraries:\n{}", dupedLibErrors.stream().collect(joining("\n")));
             throw new EarlyLoadingException("Duplicate plugins or libraries found", null, dupedLibErrors.stream()
                     .map(s -> new EarlyLoadingException.ExceptionData(s))
                     .toList());

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -81,7 +81,7 @@ public class UniqueModListBuilder
                                     mod.getModId(),
                                     modIds.get(mod.getModId()).stream()
                                             .map(modInfo -> modInfo.getOwningFile().getFile().getFileName()).collect(joining(", "))
-                            )).collect(joining(" \n")));
+                            )).collect(joining("\n")));
 
             throw new EarlyLoadingException("Duplicate mods found", null,  duplicateModErrors);
         }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.*;
+import static net.minecraftforge.fml.loading.LogMarkers.LOADING;
 
 public class UniqueModListBuilder
 {
@@ -75,6 +76,13 @@ public class UniqueModListBuilder
             final List<EarlyLoadingException.ExceptionData> duplicateModErrors = dupedMods.stream()
                                                                                    .map(dm -> new EarlyLoadingException.ExceptionData("fml.modloading.dupedmod", dm, Objects.toString(dm)))
                                                                                    .toList();
+            LOGGER.error(LOADING, "Found duplicate mods:\n{}", dupedMods.stream()
+                            .map(mod -> String.format("\tMod ID: '%s' from mod files: %s",
+                                    mod.getModId(),
+                                    modIds.get(mod.getModId()).stream()
+                                            .map(modInfo -> modInfo.getOwningFile().getFile().getFileName()).collect(joining(", "))
+                            )).collect(joining(" \n")));
+
             throw new EarlyLoadingException("Duplicate mods found", null,  duplicateModErrors);
         }
 


### PR DESCRIPTION
Includes the modid(s) and mod files involved.
Example:
```
[main/ERROR] [ne.mi.fm.lo.UniqueModListBuilder/LOADING]: Found duplicate mods:
	Mod ID: 'very_unique_modid' from mod files: mod-b.jar, mod-a.jar
```

The two jars used to test this, which have nothing but a mods.toml because they are using the lowcode loader (which is very helpful for this): [duped_mods.zip](https://github.com/MinecraftForge/MinecraftForge/files/11359241/duped_mods.zip)

~~I have not touched the existing thrown error message, just added a log statement directly before that. I also do not use the existing duplicateModErrors list, as it seemed to be very lacking in information (I could only ever find one mod file mentioned in it, and it didnt even provide the name for that in a nice way).~~ The existing message has been removed, and the error for duplicate libs also replaced.
