### PR TITLE
[1.19.x] Log error when Sheets is class-loaded before registration is completed

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModStateManager.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModStateManager.java
@@ -39,4 +39,13 @@ public class ModStateManager {
         nodes.forEach(n->graph.putEdge(lookup.getOrDefault(n.previous(), dummy), n));
         return TopologicalSort.topologicalSort(graph, Comparator.comparingInt(nodes::indexOf)).stream().filter(st->st!=dummy).toList();
     }
+
+    public IModLoadingState findState(final String stateName) {
+        return stateMap.values()
+                .stream()
+                .flatMap(Collection::stream)
+                .filter(mls -> mls.name().equals(stateName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown IModLoadingState: " + stateName));
+    }
 }

--- a/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
@@ -16,10 +16,11 @@
     }
  
     public static Material m_173381_(WoodType p_173382_) {
-@@ -209,5 +_,13 @@
+@@ -208,6 +_,23 @@
+          case SINGLE:
           default:
              return p_110773_;
-       }
++      }
 +   }
 +
 +   /**
@@ -28,5 +29,14 @@
 +   public static void addWoodType(WoodType woodType) {
 +      f_110743_.put(woodType, m_173385_(woodType));
 +      f_244291_.put(woodType, m_245275_(woodType));
++   }
++
++   static {
++      if (net.minecraftforge.fml.ModLoader.isLoadingStateValid() && !net.minecraftforge.registries.GameData.isRegistrationCompleted()) {
++         com.mojang.logging.LogUtils.getLogger().error(
++                 "net.minecraft.client.renderer.Sheets loaded too early, modded registry-based materials may not work correctly",
++                 new IllegalStateException("net.minecraft.client.renderer.Sheets loaded too early")
++         );
+       }
     }
  }

--- a/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
@@ -32,7 +32,7 @@
 +   }
 +
 +   static {
-+      if (net.minecraftforge.fml.ModLoader.isLoadingStateValid() && !net.minecraftforge.registries.GameData.isRegistrationCompleted()) {
++      if (net.minecraftforge.fml.ModLoader.isLoadingStateValid() && !net.minecraftforge.fml.ModLoader.get().hasCompletedState("LOAD_REGISTRIES")) {
 +         com.mojang.logging.LogUtils.getLogger().error(
 +                 "net.minecraft.client.renderer.Sheets loaded too early, modded registry-based materials may not work correctly",
 +                 new IllegalStateException("net.minecraft.client.renderer.Sheets loaded too early")

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -119,7 +119,6 @@ public class GameData
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
     private static final BiConsumer<ResourceLocation, ForgeRegistry<?>> LOCK_VANILLA = (name, reg) -> reg.slaves.values().stream().filter(o -> o instanceof ILockableRegistry).forEach(o -> ((ILockableRegistry)o).lock());
-    private static boolean registrationCompleted = false;
 
     static {
         init();
@@ -406,8 +405,6 @@ public class GameData
             SpawnPlacements.fireSpawnPlacementEvent();
             CreativeModeTabRegistry.fireCollectionEvent();
         }
-
-        registrationCompleted = true;
     }
 
     //Lets us clear the map so we can rebuild it.
@@ -901,10 +898,5 @@ public class GameData
             prefix = oldPrefix;
         }
         return new ResourceLocation(prefix, name);
-    }
-
-    public static boolean isRegistrationCompleted()
-    {
-        return registrationCompleted;
     }
 }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -119,6 +119,7 @@ public class GameData
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
     private static final BiConsumer<ResourceLocation, ForgeRegistry<?>> LOCK_VANILLA = (name, reg) -> reg.slaves.values().stream().filter(o -> o instanceof ILockableRegistry).forEach(o -> ((ILockableRegistry)o).lock());
+    private static boolean registrationCompleted = false;
 
     static {
         init();
@@ -405,6 +406,8 @@ public class GameData
             SpawnPlacements.fireSpawnPlacementEvent();
             CreativeModeTabRegistry.fireCollectionEvent();
         }
+
+        registrationCompleted = true;
     }
 
     //Lets us clear the map so we can rebuild it.
@@ -898,5 +901,10 @@ public class GameData
             prefix = oldPrefix;
         }
         return new ResourceLocation(prefix, name);
+    }
+
+    public static boolean isRegistrationCompleted()
+    {
+        return registrationCompleted;
     }
 }


### PR DESCRIPTION
This PR adds a check for the registration phase being completed to the static init of `Sheets` and logs an error if a mod class-loads it before registration is completed. This allows for easier identification of the issue mentioned in #8976.

A few noteworthy things about the specific implementation:

- Throwing an exception in static init is not an option as it would cause a `NoClassDefFoundError` on any subsequent access of the `Sheets` class (which is almost guaranteed to happen from vanilla code), which would cover up the actual exception in the crash report.
- Throwing a wrench into the mod loading process without throwing an exception is not possible as loading exceptions are only propagated by yet another exception that is only thrown in response to an exception being thrown in the loading process. Manually marking the loading state invalid by setting `ModLoader#loadingStateValid` to false and adding an exception to the loading exception list does not prevent the game from reaching the title screen.
- There appears to be no way to check which mod loading state the game is in and whether that state is before or after a specific one, so the only viable option I could find is to add a flag in `GameData` and setting it after all register events are fired.
- Moving the "mark registration completed" line to registry freezing is not an option as the `ModelManager` is loaded between the registry filling and registry freezing stages, which would then lead to erronous error messages due to the `ModelManager` accessing `Sheets`

This was tested by moving the `WoodType` texture registration of the `CustomSignTest` test mod to its mod constructor (https://github.com/MinecraftForge/MinecraftForge/blob/1.19.x/src/test/java/net/minecraftforge/debug/block/CustomSignsTest.java#L95)