### PR TITLE
[1.19.2] Fix the rest of the spawn event calls

### DIFF
--- a/patches/minecraft/net/minecraft/server/commands/SummonCommand.java.patch
+++ b/patches/minecraft/net/minecraft/server/commands/SummonCommand.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/commands/SummonCommand.java
++++ b/net/minecraft/server/commands/SummonCommand.java
+@@ -55,6 +_,7 @@
+             throw f_138810_.create();
+          } else {
+             if (p_138825_ && entity instanceof Mob) {
++               if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn((Mob)entity, p_138821_.m_81372_(), (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), null, MobSpawnType.COMMAND))
+                ((Mob)entity).m_6518_(p_138821_.m_81372_(), p_138821_.m_81372_().m_6436_(entity.m_20183_()), MobSpawnType.COMMAND, (SpawnGroupData)null, (CompoundTag)null);
+             }
+ 

--- a/patches/minecraft/net/minecraft/util/SpawnUtil.java.patch
+++ b/patches/minecraft/net/minecraft/util/SpawnUtil.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/util/SpawnUtil.java
++++ b/net/minecraft/util/SpawnUtil.java
+@@ -24,7 +_,8 @@
+          if (p_216406_.m_6857_().m_61937_(blockpos$mutableblockpos) && m_216398_(p_216406_, p_216410_, blockpos$mutableblockpos, p_216411_)) {
+             T t = p_216404_.m_20655_(p_216406_, (CompoundTag)null, (Component)null, (Player)null, blockpos$mutableblockpos, p_216405_, false, false);
+             if (t != null) {
+-               if (t.m_5545_(p_216406_, p_216405_) && t.m_6914_(p_216406_)) {
++               int res = net.minecraftforge.common.ForgeHooks.canEntitySpawn(t, p_216406_, t.m_20185_(), t.m_20186_(), t.m_20189_(), null, p_216405_);
++               if (res == 1 || (res == 0 && t.m_5545_(p_216406_, p_216405_) && t.m_6914_(p_216406_))) {
+                   p_216406_.m_47205_(t);
+                   return Optional.of(t);
+                }

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -36,7 +36,7 @@
        }
  
        this.m_21557_(p_21450_.m_128471_("NoAI"));
-+      
++
 +      if (p_21450_.m_128441_("forge:spawn_type")) {
 +         try {
 +            this.spawnType = MobSpawnType.valueOf(p_21450_.m_128461_("forge:spawn_type"));
@@ -126,7 +126,7 @@
 +   }
 +
 +   /**
-+   * Returns the type of spawn that created this mob, if applicable.
++   * Returns the type of spawn that created this mob, if applicable.<br>
 +   * If it could not be determined, this will return null.
 +   * <p>
 +   * This is set via {@link Mob#finalizeSpawn}, so you should not call this from within that method, and instead use the parameter.

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
+@@ -116,6 +_,8 @@
+    private CompoundTag f_21359_;
+    private BlockPos f_21360_ = BlockPos.f_121853_;
+    private float f_21341_ = -1.0F;
++   @Nullable
++   private MobSpawnType spawnType;
+ 
+    protected Mob(EntityType<? extends Mob> p_21368_, Level p_21369_) {
+       super(p_21368_, p_21369_);
 @@ -210,7 +_,11 @@
     }
  
@@ -13,6 +22,31 @@
     }
  
     public boolean m_6549_(EntityType<?> p_21399_) {
+@@ -408,6 +_,9 @@
+          p_21484_.m_128379_("NoAI", this.m_21525_());
+       }
+ 
++      if (this.spawnType != null) {
++         p_21484_.m_128359_("forge:spawn_type", this.spawnType.name());
++      }
+    }
+ 
+    public void m_7378_(CompoundTag p_21450_) {
+@@ -460,6 +_,14 @@
+       }
+ 
+       this.m_21557_(p_21450_.m_128471_("NoAI"));
++      
++      if (p_21450_.m_128441_("forge:spawn_type")) {
++         try {
++            this.spawnType = MobSpawnType.valueOf(p_21450_.m_128461_("forge:spawn_type"));
++         } catch (Exception ex) {
++            p_21450_.m_128473_("forge:spawn_type");
++         }
++      }
+    }
+ 
+    protected void m_7625_(DamageSource p_21389_, boolean p_21390_) {
 @@ -499,9 +_,9 @@
     public void m_8107_() {
        super.m_8107_();
@@ -39,7 +73,26 @@
           if (entity != null) {
              double d0 = entity.m_20280_(this);
              int i = this.m_6095_().m_20674_().m_21611_();
-@@ -1374,13 +_,23 @@
+@@ -990,6 +_,10 @@
+ 
+    }
+ 
++   /**
++    * Calls to this method should be accompanied by firing the SpecialSpawn event via ForgeEventFactory.doSpecialSpawn.<br>
++    * Additionally, if you override this method, you should ensure you either call super, or manually set {@link #spawnType} from your override.
++    */
+    @Nullable
+    public SpawnGroupData m_6518_(ServerLevelAccessor p_21434_, DifficultyInstance p_21435_, MobSpawnType p_21436_, @Nullable SpawnGroupData p_21437_, @Nullable CompoundTag p_21438_) {
+       RandomSource randomsource = p_21434_.m_213780_();
+@@ -1000,6 +_,7 @@
+          this.m_21559_(false);
+       }
+ 
++      this.spawnType = p_21436_;
+       return p_21437_;
+    }
+ 
+@@ -1374,15 +_,25 @@
        return false;
     }
  
@@ -56,11 +109,30 @@
           this.m_20256_(this.m_20184_().m_82520_(0.0D, 0.3D, 0.0D));
        }
  
-+   }
-+
+    }
+ 
 +   @Override
 +   public void jumpInFluid(net.minecraftforge.fluids.FluidType type) {
 +      this.jumpInLiquidInternal(() -> super.jumpInFluid(type));
-    }
- 
++   }
++
     public void m_147272_() {
+       this.f_21345_.m_148096_();
+       this.m_6274_().m_147343_();
+@@ -1404,5 +_,16 @@
+ 
+    public Iterable<BlockPos> m_238383_() {
+       return ImmutableSet.of(new BlockPos(this.m_20191_().f_82288_, (double)this.m_146904_(), this.m_20191_().f_82290_), new BlockPos(this.m_20191_().f_82288_, (double)this.m_146904_(), this.m_20191_().f_82293_), new BlockPos(this.m_20191_().f_82291_, (double)this.m_146904_(), this.m_20191_().f_82290_), new BlockPos(this.m_20191_().f_82291_, (double)this.m_146904_(), this.m_20191_().f_82293_));
++   }
++
++   /**
++   * Returns the type of spawn that created this mob, if applicable.
++   * If it could not be determined, this will return null.
++   * <p>
++   * This is set via {@link Mob#finalizeSpawn}, so you should not call this from within that method, and instead use the parameter.
++   */
++   @Nullable
++   public final MobSpawnType getSpawnType() {
++      return this.spawnType;
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -126,7 +126,7 @@
 +   }
 +
 +   /**
-+   * Returns the type of spawn that created this mob, if applicable.<br>
++   * {@return the type of spawn that created this mob, if applicable}
 +   * If it could not be determined, this will return null.
 +   * <p>
 +   * This is set via {@link Mob#finalizeSpawn}, so you should not call this from within that method, and instead use the parameter.

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -78,7 +78,7 @@
     }
  
 +   /**
-+    * Calls to this method should be accompanied by firing the SpecialSpawn event via ForgeEventFactory.doSpecialSpawn.<br>
++    * <p>Calls to this method should be accompanied by firing the {@link net.minecraftforge.event.entity.living.LivingSpawnEvent.SpecialSpawn SpecialSpawn} event via {@link net.minecraftforge.event.ForgeEventFactory#doSpecialSpawn}.</p>
 +    * Additionally, if you override this method, you should ensure you either call super, or manually set {@link #spawnType} from your override.
 +    */
     @Nullable

--- a/patches/minecraft/net/minecraft/world/entity/monster/Strider.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Strider.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/entity/monster/Strider.java
++++ b/net/minecraft/world/entity/monster/Strider.java
+@@ -418,6 +_,7 @@
+ 
+    private SpawnGroupData m_33881_(ServerLevelAccessor p_33882_, DifficultyInstance p_33883_, Mob p_33884_, @Nullable SpawnGroupData p_33885_) {
+       p_33884_.m_7678_(this.m_20185_(), this.m_20186_(), this.m_20189_(), this.m_146908_(), 0.0F);
++      if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(p_33884_, p_33882_.m_6018_(), (float)p_33884_.m_20185_(), (float)p_33884_.m_20186_(), (float)p_33884_.m_20189_(), null, MobSpawnType.JOCKEY))
+       p_33884_.m_6518_(p_33882_, p_33883_, MobSpawnType.JOCKEY, p_33885_, (CompoundTag)null);
+       p_33884_.m_7998_(this, true);
+       return new AgeableMob.AgeableMobGroupData(0.0F);

--- a/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
@@ -5,7 +5,7 @@
           return 0;
        } else {
 +         cat.m_20035_(p_35334_, 0.0F, 0.0F); // Fix MC-147659: Some witch huts spawn the incorrect cat
-+         // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++         // Note: This call to canEntitySpawn is erroneous, it is only provided for backwards compatibility.
 +         if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL) == -1) return 0;
 +         if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL))
           cat.m_6518_(p_35335_, p_35335_.m_6436_(p_35334_), MobSpawnType.NATURAL, (SpawnGroupData)null, (CompoundTag)null);

--- a/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
@@ -1,10 +1,12 @@
 --- a/net/minecraft/world/entity/npc/CatSpawner.java
 +++ b/net/minecraft/world/entity/npc/CatSpawner.java
-@@ -86,8 +_,9 @@
+@@ -86,8 +_,11 @@
        if (cat == null) {
           return 0;
        } else {
 +         cat.m_20035_(p_35334_, 0.0F, 0.0F); // Fix MC-147659: Some witch huts spawn the incorrect cat
++         // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++         if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL) == -1) return 0;
 +         if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL))
           cat.m_6518_(p_35335_, p_35335_.m_6436_(p_35334_), MobSpawnType.NATURAL, (SpawnGroupData)null, (CompoundTag)null);
 -         cat.m_20035_(p_35334_, 0.0F, 0.0F);

--- a/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/CatSpawner.java.patch
@@ -5,7 +5,7 @@
           return 0;
        } else {
 +         cat.m_20035_(p_35334_, 0.0F, 0.0F); // Fix MC-147659: Some witch huts spawn the incorrect cat
-+         if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL) == -1) return 0;
++         if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(cat, p_35335_, p_35334_.m_123341_(), p_35334_.m_123342_(), p_35334_.m_123343_(), null, MobSpawnType.NATURAL))
           cat.m_6518_(p_35335_, p_35335_.m_6436_(p_35334_), MobSpawnType.NATURAL, (SpawnGroupData)null, (CompoundTag)null);
 -         cat.m_20035_(p_35334_, 0.0F, 0.0F);
           p_35335_.m_47205_(cat);

--- a/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/BaseSpawner.java
 +++ b/net/minecraft/world/level/BaseSpawner.java
-@@ -127,11 +_,15 @@
+@@ -127,10 +_,15 @@
                    entity.m_7678_(entity.m_20185_(), entity.m_20186_(), entity.m_20189_(), randomsource.m_188501_() * 360.0F, 0.0F);
                    if (entity instanceof Mob) {
                       Mob mob = (Mob)entity;
@@ -11,11 +11,11 @@
                          continue;
                       }
  
++                     // Fire this early so mods can react to mobs that vanilla normally ignores.
++                     if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, (LevelAccessor)p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this, MobSpawnType.SPAWNER))
                       if (this.f_45444_.m_186567_().m_128440_() == 1 && this.f_45444_.m_186567_().m_128425_("id", 8)) {
-+                        if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, (LevelAccessor)p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this, MobSpawnType.SPAWNER))
                          ((Mob)entity).m_6518_(p_151312_, p_151312_.m_6436_(entity.m_20183_()), MobSpawnType.SPAWNER, (SpawnGroupData)null, (CompoundTag)null);
                       }
-                   }
 @@ -275,4 +_,12 @@
     public double m_45474_() {
        return this.f_45446_;

--- a/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
@@ -23,7 +23,7 @@
                          mob.m_7678_(d0, (double)i, d1, p_47040_.f_46441_.m_188501_() * 360.0F, 0.0F);
 -                        if (m_46991_(p_47040_, mob, d2)) {
 +                        int canSpawn = net.minecraftforge.common.ForgeHooks.canEntitySpawn(mob, p_47040_, d0, i, d1, null, MobSpawnType.NATURAL);
-+                        if (canSpawn != -1 && (canSpawn == 1 || m_46991_(p_47040_, mob, d2))) {
++                        if (canSpawn == 1 || (canSpawn == 0 && m_46991_(p_47040_, mob, d2))) {
 +                           if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, (LevelAccessor) p_47040_, (float)d0, (float)i, (float)d1, null, MobSpawnType.NATURAL))
                             spawngroupdata = mob.m_6518_(p_47040_, p_47040_.m_6436_(mob.m_20183_()), MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
                             ++j;
@@ -75,11 +75,14 @@
        }
     }
  
-@@ -370,6 +_,7 @@
+@@ -370,7 +_,9 @@
                          entity.m_7678_(d0, (double)blockpos.m_123342_(), d1, p_220454_.m_188501_() * 360.0F, 0.0F);
                          if (entity instanceof Mob) {
                             Mob mob = (Mob)entity;
-+                           if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(mob, p_220451_, d0, blockpos.m_123342_(), d1, null, MobSpawnType.CHUNK_GENERATION) == -1) continue;
-                            if (mob.m_5545_(p_220451_, MobSpawnType.CHUNK_GENERATION) && mob.m_6914_(p_220451_)) {
+-                           if (mob.m_5545_(p_220451_, MobSpawnType.CHUNK_GENERATION) && mob.m_6914_(p_220451_)) {
++                           int res = net.minecraftforge.common.ForgeHooks.canEntitySpawn(mob, p_220451_, d0, blockpos.m_123342_(), d1, null, MobSpawnType.CHUNK_GENERATION);
++                           if (res == 1 || (res == 0 && mob.m_5545_(p_220451_, MobSpawnType.CHUNK_GENERATION) && mob.m_6914_(p_220451_))) {
++                              if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, p_220451_, (float) d0, blockpos.m_123342_(), (float) d1, null, MobSpawnType.CHUNK_GENERATION))
                                spawngroupdata = mob.m_6518_(p_220451_, p_220451_.m_6436_(mob.m_20183_()), MobSpawnType.CHUNK_GENERATION, spawngroupdata, (CompoundTag)null);
                                p_220451_.m_47205_(mob);
+                               flag = true;

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
@@ -1,9 +1,11 @@
 --- a/net/minecraft/world/level/levelgen/PatrolSpawner.java
 +++ b/net/minecraft/world/level/levelgen/PatrolSpawner.java
-@@ -104,6 +_,7 @@
+@@ -104,6 +_,9 @@
              }
  
              patrollingmonster.m_6034_((double)p_224534_.m_123341_(), (double)p_224534_.m_123342_(), (double)p_224534_.m_123343_());
++            // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++            if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL) == -1) return false;
 +            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL))
              patrollingmonster.m_6518_(p_224533_, p_224533_.m_6436_(p_224534_), MobSpawnType.PATROL, (SpawnGroupData)null, (CompoundTag)null);
              p_224533_.m_47205_(patrollingmonster);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
@@ -4,7 +4,7 @@
              }
  
              patrollingmonster.m_6034_((double)p_224534_.m_123341_(), (double)p_224534_.m_123342_(), (double)p_224534_.m_123343_());
-+            // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++            // Note: This call to canEntitySpawn is erroneous, it is only provided for backwards compatibility.
 +            if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL) == -1) return false;
 +            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL))
              patrollingmonster.m_6518_(p_224533_, p_224533_.m_6436_(p_224534_), MobSpawnType.PATROL, (SpawnGroupData)null, (CompoundTag)null);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PatrolSpawner.java.patch
@@ -4,7 +4,7 @@
              }
  
              patrollingmonster.m_6034_((double)p_224534_.m_123341_(), (double)p_224534_.m_123342_(), (double)p_224534_.m_123343_());
-+            if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL) == -1) return false;
++            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(patrollingmonster, p_224533_, p_224534_.m_123341_(), p_224534_.m_123342_(), p_224534_.m_123343_(), null, MobSpawnType.PATROL))
              patrollingmonster.m_6518_(p_224533_, p_224533_.m_6436_(p_224534_), MobSpawnType.PATROL, (SpawnGroupData)null, (CompoundTag)null);
              p_224533_.m_47205_(patrollingmonster);
              return true;

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,9 +1,11 @@
 --- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
 +++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
-@@ -60,6 +_,7 @@
+@@ -60,6 +_,9 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
                                      phantom.m_20035_(blockpos1, 0.0F, 0.0F);
++                                    // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++                                    if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL) == -1) { i--; continue; }
 +                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL))
                                      spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
                                      p_64576_.m_47205_(phantom);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -4,7 +4,7 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
                                      phantom.m_20035_(blockpos1, 0.0F, 0.0F);
-+                                    if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL) == -1) { i--; continue; }
++                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL))
                                      spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
                                      p_64576_.m_47205_(phantom);
                                   }

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -4,7 +4,7 @@
                                   for(int i1 = 0; i1 < l; ++i1) {
                                      Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);
                                      phantom.m_20035_(blockpos1, 0.0F, 0.0F);
-+                                    // Note: This call to canEntitySpawn is erroneous, it is only provided for binary compatibility.
++                                    // Note: This call to canEntitySpawn is erroneous, it is only provided for backwards compatibility.
 +                                    if (net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL) == -1) { i--; continue; }
 +                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(phantom, p_64576_, blockpos1.m_123341_(), blockpos1.m_123342_(), blockpos1.m_123343_(), null, MobSpawnType.NATURAL))
                                      spawngroupdata = phantom.m_6518_(p_64576_, difficultyinstance, MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentPieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentPieces.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentPieces.java
++++ b/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentPieces.java
+@@ -1442,6 +_,7 @@
+             ElderGuardian elderguardian = EntityType.f_20563_.m_20615_(p_228844_.m_6018_());
+             elderguardian.m_5634_(elderguardian.m_21233_());
+             elderguardian.m_7678_((double)blockpos.m_123341_() + 0.5D, (double)blockpos.m_123342_(), (double)blockpos.m_123343_() + 0.5D, 0.0F, 0.0F);
++            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(elderguardian, p_228844_, (float)elderguardian.m_20185_(), (float)elderguardian.m_20186_(), (float)elderguardian.m_20189_(), null, MobSpawnType.STRUCTURE))
+             elderguardian.m_6518_(p_228844_, p_228844_.m_6436_(elderguardian.m_20183_()), MobSpawnType.STRUCTURE, (SpawnGroupData)null, (CompoundTag)null);
+             p_228844_.m_47205_(elderguardian);
+             return true;

--- a/patches/minecraft/net/minecraft/world/level/levelgen/structure/structures/WoodlandMansionPieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/structure/structures/WoodlandMansionPieces.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/level/levelgen/structure/structures/WoodlandMansionPieces.java
++++ b/net/minecraft/world/level/levelgen/structure/structures/WoodlandMansionPieces.java
+@@ -1052,6 +_,7 @@
+             for(Mob mob : list) {
+                mob.m_21530_();
+                mob.m_20035_(p_230214_, 0.0F, 0.0F);
++               if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, p_230215_, (float)mob.m_20185_(), (float)mob.m_20186_(), (float)mob.m_20189_(), null, MobSpawnType.STRUCTURE))
+                mob.m_6518_(p_230215_, p_230215_.m_6436_(mob.m_20183_()), MobSpawnType.STRUCTURE, (SpawnGroupData)null, (CompoundTag)null);
+                p_230215_.m_47205_(mob);
+                p_230215_.m_7731_(p_230214_, Blocks.f_50016_.m_49966_(), 2);

--- a/patches/minecraft/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
@@ -86,7 +86,7 @@
              ListTag listtag = new ListTag();
              listtag.add(DoubleTag.m_128500_(vec31.f_82479_));
              listtag.add(DoubleTag.m_128500_(vec31.f_82480_));
-@@ -391,10 +_,10 @@
+@@ -391,10 +_,11 @@
              compoundtag.m_128365_("Pos", listtag);
              compoundtag.m_128473_("UUID");
              m_74543_(p_74524_, compoundtag).ifPresent((p_205061_) -> {
@@ -97,6 +97,7 @@
                 p_205061_.m_7678_(vec31.f_82479_, vec31.f_82480_, vec31.f_82481_, f, p_205061_.m_146909_());
 -               if (p_74530_ && p_205061_ instanceof Mob) {
 +               if (placementIn.m_74414_() && p_205061_ instanceof Mob) {
++                  if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn((Mob)p_205061_, p_74524_, (float)p_205061_.m_20185_(), (float)p_205061_.m_20186_(), (float)p_205061_.m_20189_(), null, MobSpawnType.STRUCTURE))
                    ((Mob)p_205061_).m_6518_(p_74524_, p_74524_.m_6436_(new BlockPos(vec31)), MobSpawnType.STRUCTURE, (SpawnGroupData)null, compoundtag);
                 }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -185,7 +185,7 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
     }
 
-    public static Result canEntitySpawn(Mob entity, LevelAccessor level, double x, double y, double z, BaseSpawner spawner, MobSpawnType spawnReason)
+    public static Result canEntitySpawn(Mob entity, LevelAccessor level, double x, double y, double z, @Nullable BaseSpawner spawner, MobSpawnType spawnReason)
     {
         if (entity == null)
             return Result.DEFAULT;
@@ -194,7 +194,7 @@ public class ForgeEventFactory
         return event.getResult();
     }
 
-    public static boolean doSpecialSpawn(Mob entity, LevelAccessor level, float x, float y, float z, BaseSpawner spawner, MobSpawnType spawnReason)
+    public static boolean doSpecialSpawn(Mob entity, LevelAccessor level, float x, float y, float z, @Nullable BaseSpawner spawner, MobSpawnType spawnReason)
     {
         return MinecraftForge.EVENT_BUS.post(new LivingSpawnEvent.SpecialSpawn(entity, level, x, y, z, spawner, spawnReason));
     }

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -26,6 +27,7 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * on both logical sides.
+ * @apiNote If the spawned entity is a mob, and {@linkplain Mob#finalizeSpawn the spawn was finalized}, the spawn type is available via {@link Mob#getSpawnType()}
  **/
 @Cancelable
 public class EntityJoinLevelEvent extends EntityEvent

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -5,23 +5,21 @@
 
 package net.minecraftforge.event.entity.living;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.Nullable;
 
 /**
- * This event is fired whenever a {@link Mob} should do something spawn-related.
- * <p>
- * This event is not {@linkplain Cancelable cancellable} and does not {@linkplain HasResult have a result}.
- * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * only on the {@linkplain LogicalSide#SERVER logical server}.
+ * Base class for mob spawn events.
+ * Will not be fired directly.
  */
 public class LivingSpawnEvent extends LivingEvent
 {
@@ -83,7 +81,7 @@ public class LivingSpawnEvent extends LivingEvent
     }
 
     /**
-     * This event is fired before a {@link Mob} spawns.
+     * This event is fired when {@link Mob#checkSpawnRules} would be called.
      * <p>
      * This event is not {@linkplain Cancelable cancellable}, but does {@linkplain HasResult have a result}.
      * {@linkplain Result#DEFAULT DEFAULT} indicates that default spawn rules should be used.
@@ -125,13 +123,14 @@ public class LivingSpawnEvent extends LivingEvent
     }
 
     /**
-     * This event is fired whenever a {@link Mob} is set to be spawned, to allow for mod-specific initializers.
+     * This event is fired whenever {@link Mob#finalizeSpawn} would be called.
      * <p>
      * This event is {@linkplain Cancelable cancellable} and does not {@linkplain HasResult have a result}.
-     * If the event is canceled, the mob will not spawn.
+     * If the event is canceled, then {@link Mob#finalizeSpawn} will not be called.<br>
+     * The mob will still be spawned. Preventing the spawn requires usage of {@link EntityJoinLevelEvent}.
      * <p>
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * and only on the {@linkplain LogicalSide#SERVER logical server}.
      */
     @Cancelable
     public static class SpecialSpawn extends LivingSpawnEvent

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -20,6 +20,9 @@ import net.minecraftforge.fml.LogicalSide;
 /**
  * Base class for mob spawn events.
  * Will not be fired directly.
+ * @see CheckSpawn 
+ * @see SpecialSpawn
+ * @see AllowDespawn
  */
 public class LivingSpawnEvent extends LivingEvent
 {


### PR DESCRIPTION
This PR is a best effort backport of the changes from #9133 to 1.19.2.

It adds calls to `SpecialSpawn` and `CheckSpawn` to all necessary locations, updates javadocs, adds `Mob#getSpawnType`, and fixes some erroneous call sites where `CheckSpawn` was being fired instead of `SpecialSpawn`.