### PR TITLE
[1.19.2] Fix SaplingGrowTreeEvent#setFeature being ignored in FungusBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
@@ -4,8 +4,9 @@
     }
  
     public void m_214148_(ServerLevel p_221243_, RandomSource p_221244_, BlockPos p_221245_, BlockState p_221246_) {
+-      this.f_53597_.get().m_203334_().m_224953_(p_221243_, p_221243_.m_7726_().m_8481_(), p_221244_, p_221245_);
 +      net.minecraftforge.event.level.SaplingGrowTreeEvent event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_221243_, p_221244_, p_221245_, this.f_53597_.get());
 +      if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY)) return;
-       this.f_53597_.get().m_203334_().m_224953_(p_221243_, p_221243_.m_7726_().m_8481_(), p_221244_, p_221245_);
++      event.getFeature().m_203334_().m_224953_(p_221243_, p_221243_.m_7726_().m_8481_(), p_221244_, p_221245_);
     }
  }


### PR DESCRIPTION
https://github.com/MinecraftForge/MinecraftForge/pull/8981 missed a patch in FungusBlock to allow the feature being set.

The backport, https://github.com/MinecraftForge/MinecraftForge/pull/8998, did not have this issue, so we have a weird case of a pseudo-regression.

fix for 19.x incoming as well.