### PR TITLE
Add `EmptyEnergyStorage`

### DIFF
--- a/src/main/java/net/minecraftforge/energy/EmptyEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EmptyEnergyStorage.java
@@ -1,0 +1,53 @@
+package net.minecraftforge.energy;
+
+/**
+ * Implementation of {@link IEnergyStorage} that cannot store, receive, or provide energy.
+ * Use the {@link #INSTANCE}, don't instantiate. Example:
+ * <pre>{@code
+ * ItemStack stack = ...;
+ * IEnergyStorage storage = stack.getCapability(ForgeCapabilities.ENERGY).orElse(EmptyEnergyStorage.INSTANCE);
+ * // Use storage without checking whether it's present.
+ * }</pre>
+ */
+public class EmptyEnergyStorage implements IEnergyStorage
+{
+    public static final EmptyEnergyStorage INSTANCE = new EmptyEnergyStorage();
+
+    protected EmptyEnergyStorage() {}
+
+    @Override
+    public int receiveEnergy(int maxReceive, boolean simulate)
+    {
+        return 0;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate)
+    {
+        return 0;
+    }
+
+    @Override
+    public int getEnergyStored()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getMaxEnergyStored()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean canExtract()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canReceive()
+    {
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/energy/EmptyEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EmptyEnergyStorage.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.energy;
 
 /**


### PR DESCRIPTION
Simple noop implementation to match `EmptyHandler` (items) and `EmptyFluidHandler`. I'd use it in AE2 and Powah.

#### Why the class is not final
It can be useful to write subclasses, here are some examples I found when searching `"extends EmptyFluidHandler`" on GitHub:
- https://github.com/ForestryMC/ForestryMC/blob/30149ccac155aa5b88f7323b39f039a8785a5cba/src/main/java/forestry/core/fluids/FakeTankManager.java#L23
- https://github.com/Kotori316/FluidTank/blob/f1f846f86b41b5e495ecf6cb743b758b278fb518/src/main/scala/com/kotori316/fluidtank/fluids/DebugFluidHandler.scala#L11