### PR TITLE
[1.18.x] Fixed PlayerInteractEvent.EntityInteractSpecific being called too late

### DIFF
--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -52,7 +52,7 @@
              }, ChatType.CHAT, this.f_9743_.m_142081_());
           }
  
-@@ -1216,12 +_,13 @@
+@@ -1216,10 +_,10 @@
              return;
           }
  
@@ -64,11 +64,16 @@
 +                  if(!ServerGamePacketListenerImpl.this.f_9743_.canInteractWith(entity, 1.5D)) return; //Forge: If the entity cannot be reached, do nothing. Original check was dist < 6, range is 4.5, so vanilla used padding=1.5
                    ItemStack itemstack = ServerGamePacketListenerImpl.this.f_9743_.m_21120_(p_143679_).m_41777_();
                    InteractionResult interactionresult = p_143680_.m_143694_(ServerGamePacketListenerImpl.this.f_9743_, entity, p_143679_);
-+                  if (net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, entity.m_20182_(), p_143679_) != null) return;
                    if (interactionresult.m_19077_()) {
-                      CriteriaTriggers.f_10565_.m_61494_(ServerGamePacketListenerImpl.this.f_9743_, itemstack, entity);
-                      if (interactionresult.m_19080_()) {
-@@ -1243,7 +_,7 @@
+@@ -1237,13 +_,15 @@
+ 
+                public void m_142143_(InteractionHand p_143682_, Vec3 p_143683_) {
+                   this.m_143678_(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
++                     InteractionResult onInteractEntityAtResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(f_9743_, entity, p_143683_, p_143682_);
++                     if (onInteractEntityAtResult != null) return onInteractEntityAtResult;
+                      return p_143687_.m_7111_(p_143686_, p_143683_, p_143688_);
+                   });
+                }
  
                 public void m_141994_() {
                    if (!(entity instanceof ItemEntity) && !(entity instanceof ExperienceOrb) && !(entity instanceof AbstractArrow) && entity != ServerGamePacketListenerImpl.this.f_9743_) {

--- a/src/test/java/net/minecraftforge/debug/entity/player/EntityInteractSpecificEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/EntityInteractSpecificEventTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod("entity_interact_specific_event_test")
+@Mod.EventBusSubscriber
+public class EntityInteractSpecificEventTest
+{
+    private static final boolean ENABLE = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @SubscribeEvent
+    public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event)
+    {
+        if (!ENABLE) return;
+        if (event.getTarget() instanceof ArmorStand)
+        {
+            LOGGER.info("EntityInteractSpecific event has been canceled for armor stand");
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -242,5 +242,7 @@ license="LGPL v2.1"
     modId="block_grow_feature_test"
 [[mods]]
     modId="grindstone_event_test"
+[[mods]]
+    modId="entity_interact_specific_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
## Introduction
This is a backport of https://github.com/MinecraftForge/MinecraftForge/pull/9079, which also closes https://github.com/MinecraftForge/MinecraftForge/issues/8143.

## Testing
I've added a test mod so that the patch can be tested with ease. `ENABLED` flag is set to false by default.