### PR TITLE
[1.19.x] Fix root transform matrix format and allow using all four root transform formats

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ExtendedBlockModelDeserializer.java
+++ b/src/main/java/net/minecraftforge/client/model/ExtendedBlockModelDeserializer.java
@@ -63,7 +63,7 @@ public class ExtendedBlockModelDeserializer extends BlockModel.Deserializer
 
         if (jsonobject.has("transform"))
         {
-            JsonObject transform = GsonHelper.getAsJsonObject(jsonobject, "transform");
+            JsonElement transform = jsonobject.get("transform");
             model.customData.setRootTransform(deserializationContext.deserialize(transform, Transformation.class));
         }
 

--- a/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/TransformationHelper.java
@@ -250,7 +250,7 @@ public final class TransformationHelper
             if (!e.isJsonArray()) throw new JsonParseException("Matrix: expected an array, got: " + e);
             JsonArray m = e.getAsJsonArray();
             if (m.size() != 3) throw new JsonParseException("Matrix: expected an array of length 3, got: " + m.size());
-            Matrix4f matrix = new Matrix4f().zero();
+            Matrix4f matrix = new Matrix4f();
             for (int rowIdx = 0; rowIdx < 3; rowIdx++)
             {
                 if (!m.get(rowIdx).isJsonArray()) throw new JsonParseException("Matrix row: expected an array, got: " + m.get(rowIdx));
@@ -268,6 +268,8 @@ public final class TransformationHelper
                     }
                 }
             }
+            // JOML's unsafe matrix component setter does not recalculate these properties, so the matrix would stay marked as identity
+            matrix.determineProperties();
             return matrix;
         }
 

--- a/src/test/resources/assets/composite_model_test/models/block/composite_block.json
+++ b/src/test/resources/assets/composite_model_test/models/block/composite_block.json
@@ -81,6 +81,15 @@
         "scale": [0.3, 0.3, 0.3],
         "origin": "center"
       }
+    },
+    "matrix_test_emerald_hovering_above": {
+      "_comment": "Translated up 1 block, rotated 45 degrees around the y axis, scaled to 1/3, over center origin",
+      "parent": "minecraft:block/emerald_block",
+      "transform": [
+        [ 0.2121, 0, 0.2121, 0.2879 ],
+        [ 0, 0.3, 0, 1.35 ],
+        [ -0.2121, 0, 0.2121, 0.5 ]
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR fixes the `Transformation` deserializer (`TransformationHelper.Deserializer`) using a zero matrix instead of an identity matrix as the target for parsing the raw matrix format into, making it unusable for root transforms of JSON models, and changes the `ExtendedBlockModelDeserializer` such that all four formats supported by the `TransformationHelper.Deserializer` can be used for the root transform of a JSON model. The change to the test mod's model tests both of these changes.