### PR TITLE
Add method to GatherDataEvent to obtain collection of all input paths.

### DIFF
--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -44,7 +44,7 @@ public class GatherDataEvent extends Event implements IModBusEvent
         return this.modContainer;
     }
 
-    public Collection<Path> getInputPaths() { return this.config.getInputs(); }
+    public Collection<Path> getInputs() { return this.config.getInputs(); }
     public DataGenerator getGenerator() { return this.dataGenerator; }
     public ExistingFileHelper getExistingFileHelper() { return existingFileHelper; }
     public CompletableFuture<HolderLookup.Provider> getLookupProvider() { return this.config.lookupProvider; }

--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -44,6 +44,7 @@ public class GatherDataEvent extends Event implements IModBusEvent
         return this.modContainer;
     }
 
+    public Collection<Path> getInputPaths() { return this.config.getInputs(); }
     public DataGenerator getGenerator() { return this.dataGenerator; }
     public ExistingFileHelper getExistingFileHelper() { return existingFileHelper; }
     public CompletableFuture<HolderLookup.Provider> getLookupProvider() { return this.config.lookupProvider; }


### PR DESCRIPTION
This pr introduces a new method to the GatherDataEvent which allows modders to look up a collection of all input paths for data generation, provided by the `--input <path>` program argument.

I am using this collection in my mod which allows me to parse in BlockBench models as Forges ModelBuilder system, pre-process them, and write them out to Minecrafts model json format.

Currently, there is no way to look up this list of input paths, so I make use of [reflection to obtain the DataConfig field at runtime](https://github.com/ApexStudios-Dev/ApexCore/blob/782784acbddc8ed4186e9b5b06dae1431915e781/forge/src/main/java/xyz/apex/minecraft/apexcore/forge/data/providers/BlockBenchModelConverter.java#L170-L183) and then using the config to obtain the input paths.

Allowing me to give our BlockBench models Forge added model properties, mainly setting the models render type.

---

Correct me if I'm wrong but believe it may have originally been intended to allow modders to access this collection as there already is a public getter in the DataConfig, but there is no public way for a modder to access the DataConfig object to make use of this getter.

https://github.com/MinecraftForge/MinecraftForge/blob/c8f9e59fef4c52875601014c9fa18e41be619d0f/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java#L82-L88

This pr just adds a simple wrapper method from the GatherDataEvent to use this getter in the DataConfig.