### PR TITLE
[1.19.x] Guard player and living entity pre-render events against unbalanced PoseStack modification

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/vertex/PoseStack.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/vertex/PoseStack.java.patch
@@ -9,3 +9,14 @@
     private final Deque<PoseStack.Pose> f_85834_ = Util.m_137469_(Queues.newArrayDeque(), (p_85848_) -> {
        Matrix4f matrix4f = new Matrix4f();
        Matrix3f matrix3f = new Matrix3f();
+@@ -82,6 +_,10 @@
+ 
+    public void m_252931_(Matrix4f p_254128_) {
+       (this.f_85834_.getLast()).f_85852_.mul(p_254128_);
++   }
++
++   public int size() {
++      return this.f_85834_.size();
+    }
+ 
+    @OnlyIn(Dist.CLIENT)

--- a/patches/minecraft/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
@@ -4,7 +4,7 @@
     }
  
     public void m_7392_(T p_115308_, float p_115309_, float p_115310_, PoseStack p_115311_, MultiBufferSource p_115312_, int p_115313_) {
-+      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.Pre<T, M>(p_115308_, this, p_115310_, p_115311_, p_115312_, p_115313_))) return;
++      if (net.minecraftforge.client.ForgeHooksClient.onRenderLivingPre(p_115308_, this, p_115310_, p_115311_, p_115312_, p_115313_)) return;
        p_115311_.m_85836_();
        this.f_115290_.f_102608_ = this.m_115342_(p_115308_, p_115310_);
 -      this.f_115290_.f_102609_ = p_115308_.m_20159_();

--- a/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
@@ -4,7 +4,7 @@
  
     public void m_7392_(AbstractClientPlayer p_117788_, float p_117789_, float p_117790_, PoseStack p_117791_, MultiBufferSource p_117792_, int p_117793_) {
        this.m_117818_(p_117788_);
-+      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Pre(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_))) return;
++      if (net.minecraftforge.client.ForgeHooksClient.onRenderPlayerPre(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_)) return;
        super.m_7392_(p_117788_, p_117789_, p_117790_, p_117791_, p_117792_, p_117793_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Post(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_));
     }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1287,5 +1287,5 @@ public class ForgeHooksClient
             return true;
         }
         return false;
-	}
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderLivingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderLivingEventTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.client.rendering;
 
 import com.mojang.math.Axis;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderLivingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderLivingEventTest.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.debug.client.rendering;
+
+import com.mojang.math.Axis;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.Pig;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Test protection of pre-render events against unbalanced {@link com.mojang.blaze3d.vertex.PoseStack} modifications.<br>
+ *
+ * <p>
+ * The {@link com.mojang.blaze3d.vertex.PoseStack} is pushed and modified in {@link RenderLivingEvent.Pre} and popped in
+ * {@link RenderLivingEvent.Post}. A second, lower priority {@link RenderLivingEvent.Pre} handler cancels the event,
+ * causing an unbalanced modification of the {@link com.mojang.blaze3d.vertex.PoseStack} that would lead to a crash.
+ * </p>
+ *
+ * <p>
+ * The {@link com.mojang.blaze3d.vertex.PoseStack} modification is applied to pigs and crouching will cancel
+ * the rendering of pigs.
+ * </p>
+ */
+@Mod(RenderLivingEventTest.MOD_ID)
+public class RenderLivingEventTest
+{
+    public static final String MOD_ID = "render_living_event_test";
+    private static final boolean ENABLED = false;
+
+    @Mod.EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+    private static class ClientEvents
+    {
+        @SubscribeEvent
+        public static void onLivingRenderPreChangePose(RenderLivingEvent.Pre<LivingEntity, EntityModel<LivingEntity>> event)
+        {
+            if (!ENABLED) return;
+
+            if (event.getEntity() instanceof Pig)
+            {
+                event.getPoseStack().pushPose();
+                event.getPoseStack().translate(.5, .5, .5);
+                event.getPoseStack().mulPose(Axis.ZP.rotationDegrees(180));
+                event.getPoseStack().translate(-.5, -.5, -.5);
+            }
+        }
+
+        @SubscribeEvent
+        public static void onLivingRenderPostChangePose(RenderLivingEvent.Post<LivingEntity, EntityModel<LivingEntity>> event)
+        {
+            if (!ENABLED) return;
+
+            if (event.getEntity() instanceof Pig)
+            {
+                event.getPoseStack().popPose();
+            }
+        }
+
+        @SubscribeEvent(priority = EventPriority.LOW)
+        public static void onLivingRenderPreCancel(RenderLivingEvent.Pre<LivingEntity, EntityModel<LivingEntity>> event)
+        {
+            if (!ENABLED) return;
+
+            if (event.getEntity() instanceof Pig && Minecraft.getInstance().player.isShiftKeyDown())
+            {
+                event.setCanceled(true);
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -30,6 +30,8 @@ modId="mdk_datagen"
     modId="deferred_work_queue_test"
 [[mods]]
     modId="custom_game_rule_test"
+[[mods]]
+    modId="render_living_event_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
This PR implements a guard on `RenderPlayerEvent.Pre` and `RenderLivingEvent.Pre` to prevent the game from crashing when a higher priority event handler pushes the `PoseStack` given by the event and a lower priority event handler then cancels the event, preventing the owner of the higher priority handler from popping the stack again in the respective post event.

Fixes #9118