### PR TITLE
[1.19.x] Support IPv6 address compression for logged IPs

### DIFF
--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -18,7 +18,7 @@
 +               final String ip;
 +
 +               // compress to short form if enabled in config
-+               if (net.minecraftforge.common.ForgeConfig.COMMON.compressIPv6Addresses.get())
++               if (net.minecraftforge.common.ForgeConfig.COMMON.compressIPv6Addresses.get() || net.minecraftforge.common.ForgeConfig.CLIENT.compressLanIPv6Addresses.get())
 +                  ip = com.google.common.net.InetAddresses.toAddrString(p_120098_);
 +               else
 +                  ip = p_120098_.getHostAddress();

--- a/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
+++ b/patches/minecraft/net/minecraft/client/server/LanServerDetection.java.patch
@@ -18,7 +18,7 @@
 +               final String ip;
 +
 +               // compress to short form if enabled in config
-+               if (net.minecraftforge.common.ForgeConfig.CLIENT.compressLanIPv6Addresses.get())
++               if (net.minecraftforge.common.ForgeConfig.COMMON.compressIPv6Addresses.get())
 +                  ip = com.google.common.net.InetAddresses.toAddrString(p_120098_);
 +               else
 +                  ip = p_120098_.getHostAddress();

--- a/patches/minecraft/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
@@ -15,6 +15,16 @@
           this.m_10055_();
        } else if (this.f_10019_ == ServerLoginPacketListenerImpl.State.DELAY_ACCEPT) {
           ServerPlayer serverplayer = this.f_10018_.m_6846_().m_11259_(this.f_10021_.getId());
+@@ -138,7 +_,8 @@
+    }
+ 
+    public String m_10056_() {
+-      return this.f_10021_ != null ? this.f_10021_ + " (" + this.f_10013_.m_129523_() + ")" : String.valueOf((Object)this.f_10013_.m_129523_());
++      final String addressString = net.minecraftforge.network.DualStackUtils.getAddressString(this.f_10013_.m_129523_());
++      return this.f_10021_ != null ? this.f_10021_ + " (" + addressString + ")" : addressString;
+    }
+ 
+    public void m_5990_(ServerboundHelloPacket p_10047_) {
 @@ -147,14 +_,14 @@
        GameProfile gameprofile = this.f_10018_.m_236731_();
        if (gameprofile != null && p_10047_.f_238040_().equalsIgnoreCase(gameprofile.getName())) {

--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -8,7 +8,15 @@
  
     public PlayerList(MinecraftServer p_203842_, LayeredRegistryAccess<RegistryLayer> p_251844_, PlayerDataStorage p_203844_, int p_203845_) {
        this.f_11195_ = p_203842_;
-@@ -168,6 +_,7 @@
+@@ -161,13 +_,14 @@
+       p_11263_.m_143425_(serverlevel1);
+       String s1 = "local";
+       if (p_11262_.m_129523_() != null) {
+-         s1 = p_11262_.m_129523_().toString();
++         s1 = net.minecraftforge.network.DualStackUtils.getAddressString(p_11262_.m_129523_());
+       }
+ 
+       f_11188_.info("{}[{}] logged in with entity id {} at ({}, {}, {})", p_11263_.m_7755_().getString(), s1, p_11263_.m_19879_(), p_11263_.m_20185_(), p_11263_.m_20186_(), p_11263_.m_20189_());
        LevelData leveldata = serverlevel1.m_6106_();
        p_11263_.m_143427_(compoundtag);
        ServerGamePacketListenerImpl servergamepacketlistenerimpl = new ServerGamePacketListenerImpl(this.f_11195_, p_11262_, p_11263_);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -160,7 +160,7 @@ public class ForgeConfig {
                     .define("useCombinedDepthStencilAttachment", false);
 
             compressLanIPv6Addresses = builder
-                    .comment("[DEPRECATED / NO EFFECT] [NOW IN COMMON CONFIG] When enabled, Forge will convert discovered 'Open to LAN' IPv6 addresses to their more compact, compressed representation")
+                    .comment("[DEPRECATED] [NOW IN COMMON CONFIG] When enabled, Forge will convert discovered 'Open to LAN' IPv6 addresses to their more compact, compressed representation")
                     .translation("forge.configgui.compressLanIPv6Addresses")
                     .define("compressLanIPv6Addresses", true);
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -84,6 +84,8 @@ public class ForgeConfig {
         @Deprecated(since = "1.19.2", forRemoval = true)
         public final BooleanValue indexModPackCachesOnThread;
 
+        public final BooleanValue compressIPv6Addresses;
+
         Common(ForgeConfigSpec.Builder builder) {
             builder.comment("[DEPRECATED / NO EFFECT]: General configuration settings")
                     .push("general");
@@ -106,6 +108,11 @@ public class ForgeConfig {
                     .worldRestart()
                     .define("indexModPackCachesOnThread", false);
 
+            compressIPv6Addresses = builder
+                    .comment("When enabled, Forge will convert IPv6 addresses to their more compact, compressed representation")
+                    .translation("forge.configgui.compressIPv6Addresses")
+                    .define("compressIPv6Addresses", true);
+
 
             builder.pop();
         }
@@ -123,6 +130,7 @@ public class ForgeConfig {
 
         public final BooleanValue useCombinedDepthStencilAttachment;
 
+        @Deprecated(since = "1.19.4", forRemoval = true)
         public final BooleanValue compressLanIPv6Addresses;
 
         Client(ForgeConfigSpec.Builder builder) {
@@ -152,7 +160,7 @@ public class ForgeConfig {
                     .define("useCombinedDepthStencilAttachment", false);
 
             compressLanIPv6Addresses = builder
-                    .comment("When enabled, Forge will convert discovered 'Open to LAN' IPv6 addresses to their more compact, compressed representation")
+                    .comment("[DEPRECATED / NO EFFECT] [NOW IN COMMON CONFIG] When enabled, Forge will convert discovered 'Open to LAN' IPv6 addresses to their more compact, compressed representation")
                     .translation("forge.configgui.compressLanIPv6Addresses")
                     .define("compressLanIPv6Addresses", true);
 

--- a/src/main/java/net/minecraftforge/network/DualStackUtils.java
+++ b/src/main/java/net/minecraftforge/network/DualStackUtils.java
@@ -5,12 +5,15 @@
 
 package net.minecraftforge.network;
 
+import com.google.common.net.InetAddresses;
 import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.client.multiplayer.resolver.ServerNameResolver;
 import net.minecraft.util.HttpUtil;
+import net.minecraftforge.common.ForgeConfig;
 
 import javax.annotation.Nullable;
+import java.net.SocketAddress;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -84,5 +87,29 @@ public class DualStackUtils
     public static String getMulticastGroup() {
         if (checkIPv6(getLocalAddress())) return "FF75:230::60";
         else return "224.0.2.60";
+    }
+
+    /**
+     * {@link SocketAddress#toString()} but with IPv6 address compression support
+     */
+    public static String getAddressString(final SocketAddress address) {
+        if (address instanceof final InetSocketAddress inetAddress) {
+            String formatted;
+            if (inetAddress.isUnresolved()) {
+                formatted = inetAddress.getHostName() + "/<unresolved>";
+            } else if (ForgeConfig.COMMON.compressIPv6Addresses.get()) {
+                formatted = InetAddresses.toAddrString(inetAddress.getAddress());
+                if (inetAddress.getAddress() instanceof Inet6Address)
+                    formatted = '[' + formatted + ']';
+
+                formatted = '/' + formatted;
+            } else {
+                return address.toString();
+            }
+
+            return formatted + ':' + inetAddress.getPort();
+        }
+
+        return address.toString();
     }
 }


### PR DESCRIPTION
Results in smaller log files and easier to read IPs.

Before: `Paint_Ninja[/[0:0:0:0:0:0:0:1]:13684] logged in with entity id 212 at (39.5, 67.0, 46.5)`
After: `Paint_Ninja[/[::1]:13684] logged in with entity id 212 at (39.5, 67.0, 46.5)`

The `compressLanIPv6Addresses` client config option has been deprecated in favour of the new unified `compressIPv6Addresses` common config option.