### PR TITLE
[1.16] Fix NPE in update checker when no content-encoding header is set

### DIFF
--- a/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -157,7 +157,7 @@ public class VersionChecker
                             }
                         }
 
-                        final boolean isGzipEncoded = huc.getContentEncoding().equals("gzip");
+                        final boolean isGzipEncoded = "gzip".equals(huc.getContentEncoding());
 
                         final String bodyStr;
                         try (InputStream inStream = isGzipEncoded ? new GZIPInputStream(huc.getInputStream()) : huc.getInputStream())


### PR DESCRIPTION
This is a small fix which allows the update checker to work with files which aren't served with a content-encoding header (currently the case for files hosted on GitHub pages). Previously, getContentEncoding() would return null, causing a NullPointerException to be thrown. Swapping the order of the String comparisons fixes this.