### PR TITLE
[1.20.x] Use Spinning Effect Intensity instead of Partial Tick for Portal Overlay

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -47,7 +47,7 @@ public enum VanillaGuiOverlay
         float f1 = Mth.lerp(partialTick, gui.getMinecraft().player.oSpinningEffectIntensity, gui.getMinecraft().player.spinningEffectIntensity);
         if (f1 > 0.0F && !gui.getMinecraft().player.hasEffect(MobEffects.CONFUSION)) {
             gui.setupOverlayRenderState(true, false);
-            gui.renderPortalOverlay(guiGraphics, partialTick);
+            gui.renderPortalOverlay(guiGraphics, f1);
         }
     }),
     HOTBAR("hotbar", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {


### PR DESCRIPTION
Closes #9529

Minecraft changed how to render the portal overlay, so now we pass in a spinning effect intensity instead of the partial tick.