### PR TITLE
[1.20] Add missing tooltip stack captures

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -23,7 +23,7 @@
        ItemStack itemstack = this.f_97711_.m_41619_() ? this.f_97732_.m_142621_() : this.f_97711_;
        if (!itemstack.m_41619_()) {
           int l1 = 8;
-@@ -149,7 +_,10 @@
+@@ -149,13 +_,16 @@
     }
  
     public static void m_280359_(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_) {
@@ -35,6 +35,13 @@
     }
  
     protected void m_280072_(GuiGraphics p_283594_, int p_282171_, int p_281909_) {
+       if (this.f_97732_.m_142621_().m_41619_() && this.f_97734_ != null && this.f_97734_.m_6657_()) {
+          ItemStack itemstack = this.f_97734_.m_7993_();
+-         p_283594_.m_280677_(this.f_96547_, this.m_280553_(itemstack), itemstack.m_150921_(), p_282171_, p_281909_);
++         p_283594_.renderTooltip(this.f_96547_, this.m_280553_(itemstack), itemstack.m_150921_(), itemstack, p_282171_, p_281909_);
+       }
+ 
+    }
 @@ -168,7 +_,8 @@
        p_282567_.m_280168_().m_85836_();
        p_282567_.m_280168_().m_252880_(0.0F, 0.0F, 232.0F);

--- a/patches/minecraft/net/minecraft/client/gui/screens/recipebook/RecipeBookComponent.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/recipebook/RecipeBookComponent.java.patch
@@ -9,3 +9,12 @@
           this.f_100279_.add(new RecipeBookTabButton(recipebookcategories));
        }
  
+@@ -294,7 +_,7 @@
+       }
+ 
+       if (itemstack != null && this.f_100272_.f_91080_ != null) {
+-         p_282776_.m_280666_(this.f_100272_.f_91062_, Screen.m_280152_(this.f_100272_, itemstack), p_282948_, p_283050_);
++         p_282776_.renderComponentTooltip(this.f_100272_.f_91062_, Screen.m_280152_(this.f_100272_, itemstack), p_282948_, p_283050_, itemstack);
+       }
+ 
+    }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -74,6 +74,7 @@ import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.ChatTypeDecoration;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.PlayerChatMessage;
 import net.minecraft.network.chat.Style;
@@ -1078,7 +1079,7 @@ public class ForgeHooksClient
         {
             return event.getTooltipElements().stream()
                     .flatMap(either -> either.map(
-                            text -> font.split(text, tooltipTextWidthF).stream().map(ClientTooltipComponent::create),
+                            text -> splitLine(text, font, tooltipTextWidthF),
                             component -> Stream.of(ClientTooltipComponent.create(component))
                     ))
                     .toList();
@@ -1089,6 +1090,15 @@ public class ForgeHooksClient
                         ClientTooltipComponent::create
                 ))
                 .toList();
+    }
+
+    private static Stream<ClientTooltipComponent> splitLine(FormattedText text, Font font, int maxWidth)
+    {
+        if (text instanceof Component component && component.getContents() == ComponentContents.EMPTY && component.getSiblings().isEmpty())
+        {
+            return Stream.of(component.getVisualOrderText()).map(ClientTooltipComponent::create);
+        }
+        return font.split(text, maxWidth).stream().map(ClientTooltipComponent::create);
     }
 
     public static Comparator<ParticleRenderType> makeParticleRenderTypeComparator(List<ParticleRenderType> renderOrder)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1094,7 +1094,7 @@ public class ForgeHooksClient
 
     private static Stream<ClientTooltipComponent> splitLine(FormattedText text, Font font, int maxWidth)
     {
-        if (text instanceof Component component && component.getContents() == ComponentContents.EMPTY && component.getSiblings().isEmpty())
+        if (text instanceof Component component && component.getString().isEmpty())
         {
             return Stream.of(component.getVisualOrderText()).map(ClientTooltipComponent::create);
         }


### PR DESCRIPTION
This PR adds two missing captures of the `ItemStack` from which a tooltip originates.

There is technically a third case in `SmithingScreen#renderOnboardingTooltips()` but in that case the relevant stack is significantly harder to capture and the context provided by the stack is questionable due to the tooltips being for a different slot than the stack is in.