### PR TITLE
[1.20] Fix issues in the deserialization of empty ingredients

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -118,7 +118,13 @@ public class CraftingHelper
                 ingredients.add(Ingredient.merge(vanilla));
 
             if (ingredients.size() == 0)
+            {
+                if (allowEmpty)
+                {
+                    return Ingredient.EMPTY;
+                }
                 throw new JsonSyntaxException("Item array cannot be empty, at least one item must be defined");
+            }
 
             if (ingredients.size() == 1)
                 return ingredients.get(0);

--- a/src/main/java/net/minecraftforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/DifferenceIngredient.java
@@ -120,8 +120,8 @@ public class DifferenceIngredient extends AbstractIngredient
         @Override
         public DifferenceIngredient parse(JsonObject json)
         {
-            Ingredient base = Ingredient.fromJson(json.get("base"));
-            Ingredient without = Ingredient.fromJson(json.get("subtracted"));
+            Ingredient base = Ingredient.fromJson(json.get("base"), false);
+            Ingredient without = Ingredient.fromJson(json.get("subtracted"), false);
             return new DifferenceIngredient(base, without);
         }
 

--- a/src/main/java/net/minecraftforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IntersectionIngredient.java
@@ -152,7 +152,12 @@ public class IntersectionIngredient extends AbstractIngredient
             JsonArray children = GsonHelper.getAsJsonArray(json, "children");
             if (children.size() < 2)
                 throw new JsonSyntaxException("Must have at least two children for an intersection ingredient");
-            return new IntersectionIngredient(IntStream.range(0, children.size()).mapToObj(i -> Ingredient.fromJson(children.get(i))).toList());
+
+            return new IntersectionIngredient(
+                    IntStream.range(0, children.size())
+                            .mapToObj(i -> Ingredient.fromJson(children.get(i), false))
+                            .toList()
+            );
         }
 
         @Override


### PR DESCRIPTION
This PR fixes two issues with the deserialization of empty ingredients:

1. Return an empty ingredient when the given ingredient array is empty and `allowEmpty` is true
2. Deny usage of empty ingredients in `DifferenceIngredient` and `IntersectionIngredient`

Especially for the second point it's worth noting that allowing or disallowing empty ingredients is only related to ingredients specified as an empty array in the recipe JSON. If the array contains an ingredient that specifies an empty tag for example, then this ingredient is considered non-empty for the purposes of the `allowEmpty` parameter, even though it will dissolve to an empty item list later.