### PR TITLE
[1.20] make piston push reaction overridable in the block again

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -92,6 +92,14 @@
        public BlockState m_60717_(Rotation p_60718_) {
           return this.m_60734_().m_6843_(this.m_7160_(), p_60718_);
        }
+@@ -623,6 +_,7 @@
+       }
+ 
+       public PushReaction m_60811_() {
++         PushReaction reaction = m_60734_().getPistonPushReaction(m_7160_()); if (reaction != null) return reaction;
+          return this.f_278134_;
+       }
+ 
 @@ -972,8 +_,9 @@
        boolean f_243850_ = true;
        NoteBlockInstrument f_279538_ = NoteBlockInstrument.HARP;

--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -92,11 +92,12 @@
        public BlockState m_60717_(Rotation p_60718_) {
           return this.m_60734_().m_6843_(this.m_7160_(), p_60718_);
        }
-@@ -623,6 +_,7 @@
+@@ -623,6 +_,8 @@
        }
  
        public PushReaction m_60811_() {
-+         PushReaction reaction = m_60734_().getPistonPushReaction(m_7160_()); if (reaction != null) return reaction;
++         PushReaction reaction = m_60734_().getPistonPushReaction(m_7160_());
++         if (reaction != null) return reaction;
           return this.f_278134_;
        }
  

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
+import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.core.Direction;
@@ -950,5 +951,16 @@ public interface IForgeBlock
     default BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side, @Nullable BlockState queryState, @Nullable BlockPos queryPos)
     {
         return state;
+    }
+
+    /**
+     * @deprecated call the method on BlockState
+     * @param state The state of this block
+     * @return the PushReaction of this state or null if the one passed into the block properties should be used
+     */
+    @Deprecated
+    default @Nullable PushReaction getPistonPushReaction(BlockState state)
+    {
+        return null;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -954,12 +954,20 @@ public interface IForgeBlock
     }
 
     /**
-     * @deprecated call the method on BlockState
+     * Returns how the Block reacts to being pushed/pulled by a piston.<br/>
+     * NORMAL: is pushable and pullable by sticky pistons<br/>
+     * DESTROY: is being destroyed on pushing and pulling<br/>
+     * BLOCK: is not being able to be moved<br/>
+     * IGNORE: only usable by entities<br/>
+     * PUSH_ONLY: can only be pushed, blocks on trying to be pulled<br/>
+     * null: use the PistonPushReaction from the BlockBehaviour.Properties passed into the Block Constructor<br/>
+     *
+     * @see BlockBehaviour.BlockStateBase#getPistonPushReaction()
      * @param state The state of this block
      * @return the PushReaction of this state or null if the one passed into the block properties should be used
      */
-    @Deprecated
-    default @Nullable PushReaction getPistonPushReaction(BlockState state)
+    @Nullable
+    default PushReaction getPistonPushReaction(BlockState state)
     {
         return null;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -954,17 +954,18 @@ public interface IForgeBlock
     }
 
     /**
-     * Returns how the Block reacts to being pushed/pulled by a piston.<br/>
-     * NORMAL: is pushable and pullable by sticky pistons<br/>
-     * DESTROY: is being destroyed on pushing and pulling<br/>
-     * BLOCK: is not being able to be moved<br/>
-     * IGNORE: only usable by entities<br/>
-     * PUSH_ONLY: can only be pushed, blocks on trying to be pulled<br/>
-     * null: use the PistonPushReaction from the BlockBehaviour.Properties passed into the Block Constructor<br/>
+     * Returns the reaction of the block when pushed or pulled by a piston. This method should be not called directly, instead via {@link BlockState#getPistonPushReaction()}.
+     * <ul>
+     *     <li>NORMAL: is pushable and pullable by sticky pistons</li>
+     *     <li>DESTROY: is being destroyed on pushing and pulling</li>
+     *     <li>BLOCK: is not being able to be moved</li>
+     *     <li>IGNORE: only usable by entities</li>
+     *     <li>PUSH_ONLY: can only be pushed, blocks on trying to be pulled</li>
+     *     <li>{@code null}: use the PistonPushReaction from the BlockBehaviour.Properties passed into the Block Constructor</li>
+     * </ul>
      *
-     * @see BlockBehaviour.BlockStateBase#getPistonPushReaction()
      * @param state The state of this block
-     * @return the PushReaction of this state or null if the one passed into the block properties should be used
+     * @return the PushReaction of this state or {@code null} if the one passed into the block properties should be used
      */
     @Nullable
     default PushReaction getPistonPushReaction(BlockState state)


### PR DESCRIPTION
mojang moved the pistonpushreaction to a Property during Block creation. This PR makes the PushReaction overridable again, so that mods can do state dependent push reactions