### PR TITLE
[1.20] Fix incorrect depth test state in debug graph rendering

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
@@ -654,7 +654,12 @@ public class ForgeGui extends Gui
         }
 
         @Override
-        protected void drawGameInformation(GuiGraphics guiGraphics) {}
+        protected void drawGameInformation(GuiGraphics guiGraphics)
+        {
+            // Replicate the depth test state "leak" caused by the text that is rendered here in vanilla
+            // being flushed when the graphs start drawing
+            RenderSystem.disableDepthTest();
+        }
 
         @Override
         protected void drawSystemInformation(GuiGraphics guiGraphics) {}

--- a/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
@@ -657,7 +657,7 @@ public class ForgeGui extends Gui
         protected void drawGameInformation(GuiGraphics guiGraphics)
         {
             // Replicate the depth test state "leak" caused by the text that is rendered here in vanilla
-            // being flushed when the graphs start drawing
+            // being flushed when the graphs start drawing (PR #9539)
             RenderSystem.disableDepthTest();
         }
 


### PR DESCRIPTION
This PR fixes the depth test state in the debug graph rendering being incorrect due to Forge separating the debug text rendering from the debug graph rendering.

Fixes #9534

---

## Detailed explanation
  
Due to an interaction between the way "managed" sections are implemented in `GuiGraphics` and the way `MultiBufferSource` handles "non-fixed" render types, the depth test state is different between text being rendered before the graph (vanilla) and no text being rendered before the graph (Forge).

A few prerequisite points:

- `GuiGraphics#flush()` disables the depth test, flushes the buffer and re-enables the depth test. Due to the text and graph being drawn in a `GuiGraphics#drawManaged()` block, this is called right before the text and graph are drawn.
- A `RenderType` with a depth test that is not `RenderStateShard.NO_DEPTH_TEST` will enable the depth test and set the correct depth function in its "setup" and will disable the depth test and set the depth function to "less or equal" in its "teardown".
- A `RenderType` with `RenderStateShard.NO_DEPTH_TEST` ("always" depth test) will not touch the depth state and depth function and expects the depth test to already be disabled
- The `MultiBufferSource` used by `GuiGraphics` has a set of "fixed buffers" for certain `RenderType`s and uses a single shared `BufferBuilder` for all others. When a buffer for a `RenderType` is requested and the last used `RenderType` used the shared buffer, that buffer will be flushed to the GPU, invoking the last `RenderType`'s setup function before and its teardown function after flushing

In vanilla, the debug text is drawn to the buffer with a text `RenderType` ("less or equal" depth test, does write to the depth buffer) and then the graphs are rendered with a different `RenderType` ("always" depth test, doesn't write to the depth buffer). Due to the text render type not having a "fixed buffer" and therefore using the shared `BufferBuilder`, the buffer is flushed when the graph rendering gets a `VertexConsumer` for its `RenderType`, which leads to the depth test getting disabled. The graph is then also drawn to that shared buffer. When the text on top of the graph (the min, max, average and y axis markers) is drawn, this flush happens again, except that the depth test state is not changed due to a `RenderType` without depth test not touching the depth test state.

In Forge, no text is drawn within that "managed" block, which means there is no buffer flush before the graph is drawn that disables the depth test by virtue of a `RenderType` with a depth test. The graph then renders while the depth test is still enabled from the `GuiGraphics#flush()` call before entering the "managed" block and when the buffer is flushed due to the text on top of the graph starting to render, the depth test state is not changed due to the aforementioned behaviour of `RenderType`s with no depth test.