### PR TITLE
MDK changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1628,7 +1628,7 @@ project(':forge') {
                     exclude it
             }
             filter(ReplaceTokens, tokens: [
-                FORGE_VERSION: project.version,
+                FORGE_VERSION: FORGE_VERSION,
                 FORGE_GROUP: project.group,
                 FORGE_NAME: project.name,
                 MC_VERSION: MC_VERSION,

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -211,13 +211,15 @@ tasks.named('jar', Jar).configure {
                 'Implementation-Vendor'   : mod_authors
         ])
     }
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
     // Example configuration to allow publishing using the maven-publish plugin
     // This is the preferred method to reobfuscate your jar file
     finalizedBy('reobfJar')
 }
 
 // However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
-// publish.dependsOn('reobfJar')
+// tasks.named('publish').configure { dependsOn('reobfJar') }
 
 publishing {
     publications {

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -205,7 +205,7 @@ tasks.named('jar', Jar).configure {
         attributes([
                 'Specification-Title'     : mod_id,
                 'Specification-Vendor'    : mod_authors,
-                'Specification-Version'   : "1", // We are version 1 of ourselves
+                'Specification-Version'   : '1', // We are version 1 of ourselves
                 'Implementation-Title'    : project.name,
                 'Implementation-Version'  : project.jar.archiveVersion,
                 'Implementation-Vendor'   : mod_authors

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -211,8 +211,12 @@ tasks.named('jar', Jar).configure {
                 'Implementation-Vendor'   : mod_authors
         ])
     }
+    
+    // The settings below make sure that your build is reproducible
+    // More information at https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+    
     // Example configuration to allow publishing using the maven-publish plugin
     // This is the preferred method to reobfuscate your jar file
     finalizedBy('reobfJar')

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -200,23 +200,22 @@ processResources {
 }
 
 // Example for how to get properties into the manifest for reading at runtime.
-jar {
+tasks.named('jar', Jar).configure {
     manifest {
         attributes([
-                "Specification-Title"     : mod_id,
-                "Specification-Vendor"    : mod_authors,
-                "Specification-Version"   : "1", // We are version 1 of ourselves
-                "Implementation-Title"    : project.name,
-                "Implementation-Version"  : project.jar.archiveVersion,
-                "Implementation-Vendor"   : mod_authors,
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                'Specification-Title'     : mod_id,
+                'Specification-Vendor'    : mod_authors,
+                'Specification-Version'   : "1", // We are version 1 of ourselves
+                'Implementation-Title'    : project.name,
+                'Implementation-Version'  : project.jar.archiveVersion,
+                'Implementation-Vendor'   : mod_authors
         ])
     }
+    // Example configuration to allow publishing using the maven-publish plugin
+    // This is the preferred method to reobfuscate your jar file
+    finalizedBy('reobfJar')
 }
 
-// Example configuration to allow publishing using the maven-publish plugin
-// This is the preferred method to reobfuscate your jar file
-jar.finalizedBy('reobfJar')
 // However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
 // publish.dependsOn('reobfJar')
 


### PR DESCRIPTION
This changes a few things in the MDK:
- Use the `FORGE_VERSION` for the forge version, instead of the project version
- Remove the `Implementation-Timestamp` from the manifest, as it causes the build to not be reproducible
- Lazily configure the `jar` task