### PR TITLE
[1.20] Add missing calls to level-sensitive block SoundType getter

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -127,7 +127,7 @@
              Vec3 vec33 = m_198894_(this, new Vec3(p_20273_.f_82479_, 0.0D, p_20273_.f_82481_), aabb.m_82383_(vec32), this.m_9236_(), list).m_82549_(vec32);
              if (vec33.m_165925_() > vec31.m_165925_()) {
                 vec31 = vec33;
-@@ -1033,14 +_,15 @@
+@@ -1033,19 +_,20 @@
        return !blockstate.m_204336_(BlockTags.f_144271_) && !blockstate.m_204336_(BlockTags.f_276549_) ? p_278049_ : blockpos;
     }
  
@@ -146,6 +146,12 @@
 +   protected void playMuffledStepSound(BlockState p_283110_, BlockPos pos) {
 +      SoundType soundtype = p_283110_.getSoundType(this.f_19853_, pos, this);
        this.m_5496_(soundtype.m_56776_(), soundtype.m_56773_() * 0.05F, soundtype.m_56774_() * 0.8F);
+    }
+ 
+    protected void m_7355_(BlockPos p_20135_, BlockState p_20136_) {
+-      SoundType soundtype = p_20136_.m_60827_();
++      SoundType soundtype = p_20136_.getSoundType(this.f_19853_, p_20135_, this);
+       this.m_5496_(soundtype.m_56776_(), soundtype.m_56773_() * 0.15F, soundtype.m_56774_());
     }
  
 @@ -1176,19 +_,22 @@

--- a/patches/minecraft/net/minecraft/world/entity/animal/camel/Camel.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/camel/Camel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/camel/Camel.java
++++ b/net/minecraft/world/entity/animal/camel/Camel.java
+@@ -307,7 +_,7 @@
+    }
+ 
+    protected void m_7355_(BlockPos p_252056_, BlockState p_251457_) {
+-      if (p_251457_.m_60827_() == SoundType.f_56746_) {
++      if (p_251457_.getSoundType(m_9236_(), p_252056_, this) == SoundType.f_56746_) {
+          this.m_5496_(SoundEvents.f_244016_, 1.0F, 1.0F);
+       } else {
+          this.m_5496_(SoundEvents.f_244506_, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/world/entity/animal/sniffer/Sniffer.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/sniffer/Sniffer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/sniffer/Sniffer.java
++++ b/net/minecraft/world/entity/animal/sniffer/Sniffer.java
+@@ -277,7 +_,7 @@
+             }
+ 
+             if (this.f_19797_ % 10 == 0) {
+-               this.m_9236_().m_7785_(this.m_20185_(), this.m_20186_(), this.m_20189_(), blockstate.m_60827_().m_56778_(), this.m_5720_(), 0.5F, 0.5F, false);
++               this.m_9236_().m_7785_(this.m_20185_(), this.m_20186_(), this.m_20189_(), blockstate.getSoundType(m_9236_(), blockpos.m_7495_(), this).m_56778_(), this.m_5720_(), 0.5F, 0.5F, false);
+             }
+          }
+       }


### PR DESCRIPTION
This PR adds three missing calls to the level-sensitive block `SoundType` getter (`IForgeBlockState#getSoundType()`), two of which were most likely missed due to the major changes to step sounds.