### PR TITLE
[1.20] Add `AFTER_LEVEL` render level stage

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -99,7 +99,7 @@
              } catch (Throwable throwable1) {
                 CrashReport crashreport1 = CrashReport.m_127521_(throwable1, "Rendering screen");
                 CrashReportCategory crashreportcategory1 = crashreport1.m_127514_("Screen render details");
-@@ -1099,12 +_,18 @@
+@@ -1099,12 +_,19 @@
        Matrix4f matrix4f = posestack.m_85850_().m_252922_();
        this.m_252879_(matrix4f);
        camera.m_90575_(this.f_109059_.f_91073_, (Entity)(this.f_109059_.m_91288_() == null ? this.f_109059_.f_91074_ : this.f_109059_.m_91288_()), !this.f_109059_.f_91066_.m_92176_().m_90612_(), this.f_109059_.f_91066_.m_92176_().m_90613_(), p_109090_);
@@ -115,6 +115,7 @@
        this.f_109059_.f_91060_.m_253210_(p_109092_, camera.m_90583_(), this.m_253088_(Math.max(d0, (double)this.f_109059_.f_91066_.m_231837_().m_231551_().intValue())));
        this.f_109059_.f_91060_.m_109599_(p_109092_, p_109090_, p_109091_, flag, camera, this, this.f_109074_, matrix4f);
 +      this.f_109059_.m_91307_().m_6182_("forge_render_last");
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderStage(net.minecraftforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.f_109059_.f_91060_, posestack, matrix4f, this.f_109059_.f_91060_.getTicks(), camera, this.f_109059_.f_91060_.getFrustum());
        this.f_109059_.m_91307_().m_6182_("hand");
        if (this.f_109070_) {
           RenderSystem.clear(256, Minecraft.f_91002_);

--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -172,7 +172,7 @@
        shaderinstance.m_173362_();
        VertexBuffer.m_85931_();
        this.f_109461_.m_91307_().m_7238_();
-+      net.minecraftforge.client.ForgeHooksClient.dispatchRenderStage(p_172994_, this, p_172995_, p_254039_, this.f_109477_, this.f_109461_.f_91063_.m_109153_(), this.f_109442_ != null ? this.f_109442_ : this.f_172938_);
++      net.minecraftforge.client.ForgeHooksClient.dispatchRenderStage(p_172994_, this, p_172995_, p_254039_, this.f_109477_, this.f_109461_.f_91063_.m_109153_(), this.getFrustum());
        p_172994_.m_110188_();
     }
  
@@ -203,11 +203,22 @@
              } else if (this.f_109461_.f_91066_.m_232080_().m_231551_() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
                 flag = chunkrenderdispatcher$renderchunk.m_112842_();
              }
-@@ -2396,7 +_,12 @@
+@@ -2396,7 +_,23 @@
        this.f_109469_.m_110859_(p_109502_, p_109503_, p_109504_, p_109505_);
     }
  
-+   @Deprecated // Forge: use item aware function below
++   public Frustum getFrustum() {
++      return this.f_109442_ != null ? this.f_109442_ : this.f_172938_;
++   }
++
++   public int getTicks() {
++      return this.f_109477_;
++   }
++
++   /**
++    * @deprecated Forge: Use item aware function below
++    */
++   @Deprecated
     public void m_109514_(@Nullable SoundEvent p_109515_, BlockPos p_109516_) {
 +      this.playStreamingMusic(p_109515_, p_109516_, p_109515_ == null? null : RecordItem.m_43040_(p_109515_));
 +   }

--- a/src/main/java/net/minecraftforge/client/event/RenderLevelStageEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLevelStageEvent.java
@@ -13,13 +13,19 @@ import javax.annotation.Nullable;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.Camera;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.ForgeRenderTypes;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.joml.Matrix4f;
 
 /**
@@ -201,6 +207,11 @@ public class RenderLevelStageEvent extends Event
          * Called within a fabulous graphics target.
          */
         public static final Stage AFTER_WEATHER = register("after_weather", null);
+        /**
+         * Use this to render after everything in the level has been rendered.
+         * Called after {@link LevelRenderer#renderLevel(PoseStack, float, long, boolean, Camera, GameRenderer, LightTexture, Matrix4f)} finishes.
+         */
+        public static final Stage AFTER_LEVEL = register("after_level", null);
 
         private final String name;
 


### PR DESCRIPTION
This restores behavior lost from the removal of `RenderLevelLastEvent`, as there was no direct replacement for its functionality.
Modders should still prefer the most specific stage for their use case.
I can't remember the specifics at this moment, but I believe this stage/`RenderLevelLastEvent` is outside of certain posestack transformations that apply to all the other stages in level rendering which makes them not a perfect match for certain rendering things. Need to investigate this more.