### PR TITLE
[1.20] Fix JAR compatibility checks

### DIFF
--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -32,7 +32,7 @@ class TeamcityRequests {
     @Nullable
     static Map<String, Build> buildsByCommit() throws IOException {
         final Map<String, Build> builds = [:]
-        jsonRequest(new TypeToken<Builds>() {}, "https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?fields=build:(revisions,number)&locator=buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),count:300,status:SUCCESS")
+        jsonRequest(new TypeToken<Builds>() {}, 'https://teamcity.minecraftforge.net/guestAuth/app/rest/builds?fields=build:(revisions,number)&locator=buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),defaultFilter:false,count:300,status:SUCCESS')
                 ?.build?.forEach {
             it.revisions.revision.each { rev -> builds[rev.version] = it }
         }


### PR DESCRIPTION
* Changes Teamcity URL to not filter out 1.20 builds as it is not currently set as the default
* May need to update the default git branch on the 1.19.x and 1.20.x branches to actually be the 1.20.x branch