### PR TITLE
Expose EntityRendererProvider.Context to AddLayers event

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
@@ -27,6 +27,6 @@
        EntityRendererProvider.Context entityrendererprovider$context = new EntityRendererProvider.Context(this, this.f_173995_, this.f_234576_, this.f_234577_, p_174004_, this.f_173996_, this.f_114365_);
        this.f_114362_ = EntityRenderers.m_174049_(entityrendererprovider$context);
        this.f_114363_ = EntityRenderers.m_174051_(entityrendererprovider$context);
-+      net.minecraftforge.fml.ModLoader.get().postEvent(new net.minecraftforge.client.event.EntityRenderersEvent.AddLayers(f_114362_, f_114363_));
++      net.minecraftforge.fml.ModLoader.get().postEvent(new net.minecraftforge.client.event.EntityRenderersEvent.AddLayers(f_114362_, f_114363_, entityrendererprovider$context));
     }
  }

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -6,7 +6,6 @@
 package net.minecraftforge.client.event;
 
 import com.google.common.collect.ImmutableMap;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.SkullModel;
 import net.minecraft.client.model.SkullModelBase;
@@ -143,13 +142,14 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
     {
         private final Map<EntityType<?>, EntityRenderer<?>> renderers;
         private final Map<String, EntityRenderer<? extends Player>> skinMap;
-        private final EntityModelSet entityModels = Minecraft.getInstance().getEntityModels();
+        private final EntityRendererProvider.Context context;
 
         @ApiStatus.Internal
-        public AddLayers(Map<EntityType<?>, EntityRenderer<?>> renderers, Map<String, EntityRenderer<? extends Player>> playerRenderers)
+        public AddLayers(Map<EntityType<?>, EntityRenderer<?>> renderers, Map<String, EntityRenderer<? extends Player>> playerRenderers, EntityRendererProvider.Context context)
         {
             this.renderers = renderers;
             this.skinMap = playerRenderers;
+            this.context = context;
         }
 
         /**
@@ -199,7 +199,15 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
          */
         public EntityModelSet getEntityModels()
         {
-            return entityModels;
+            return this.context.getModelSet();
+        }
+
+        /**
+         * {@return the context for the entity renderer provider}
+         */
+        public EntityRendererProvider.Context getContext()
+        {
+            return context;
         }
     }
 


### PR DESCRIPTION
Exposes `EntityRendererProvider.Context` to the `AddLayers` event. My use case is to get the ModelManager from the context in order to get an atlas from it. I also adjusted the implementation of `getEntityModels` to grab it from the context as opposed to the Minecraft instance.