### PR TITLE
Fix forge registries not being accessible in GatherDataEvent's HolderLookup

### DIFF
--- a/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/data/loading/DatagenModLoader.java
@@ -40,10 +40,10 @@ public class DatagenModLoader {
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;
         Bootstrap.bootStrap();
+        ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
         CompletableFuture<HolderLookup.Provider> lookupProvider = CompletableFuture.supplyAsync(VanillaRegistries::createLookup, Util.backgroundExecutor());
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, lookupProvider, serverGenerators,
                 clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);
-        ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ()->{});
         if (!mods.contains("forge")) {
             // If we aren't generating data for forge, automatically add forge as an existing so mods can access forge's data
             existingMods.add("forge");


### PR DESCRIPTION
Straightforward change to ensure mods are initialized, and thus forge registries with wrappers (aka ones with support for tags) have been injected into the BuildtinRegistries when the HolderLookup gets created. This fixes the TagsProvider not working properly for custom forge registries that support tags due to it validating if the registry is in the HolderLookup