### PR TITLE
[1.20] Fix gametest collection potentially causing secondary crash in loading error state

### DIFF
--- a/src/main/java/net/minecraftforge/gametest/ForgeGameTestHooks.java
+++ b/src/main/java/net/minecraftforge/gametest/ForgeGameTestHooks.java
@@ -44,7 +44,7 @@ public class ForgeGameTestHooks
     @SuppressWarnings("deprecation")
     public static void registerGametests()
     {
-        if (!registeredGametests && isGametestEnabled())
+        if (!registeredGametests && isGametestEnabled() && ModLoader.isLoadingStateValid())
         {
             Set<String> enabledNamespaces = getEnabledNamespaces();
             LOGGER.info("Enabled Gametest Namespaces: {}", enabledNamespaces);


### PR DESCRIPTION
This PR adds a guard to the collection of gametests to prevent secondary crashes from `GameTestGenerator`s (which are immediately invoked through `GameTestRegistry#register()` by the code being guarded) trying to access data like `RegistryObjects` which may be uninitialized due to a prior error.