### PR TITLE
Fix custom geometry in parent models not being resolved

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
@@ -39,17 +39,17 @@
     public Collection<ResourceLocation> m_7970_() {
        Set<ResourceLocation> set = Sets.newHashSet();
  
-@@ -134,6 +_,10 @@
-    }
+@@ -160,6 +_,10 @@
+          blockmodel.f_111418_ = (BlockModel)unbakedmodel;
+       }
  
-    public void m_5500_(Function<ResourceLocation, UnbakedModel> p_249059_) {
 +      if (customData.hasCustomGeometry()) {
 +         customData.getCustomGeometry().resolveParents(p_249059_, customData);
 +      }
 +
-       Set<UnbakedModel> set = Sets.newLinkedHashSet();
- 
-       for(BlockModel blockmodel = this; blockmodel.f_111419_ != null && blockmodel.f_111418_ == null; blockmodel = blockmodel.f_111418_) {
+       this.f_111426_.forEach((p_247932_) -> {
+          UnbakedModel unbakedmodel1 = p_249059_.apply(p_247932_.m_111718_());
+          if (!Objects.equals(unbakedmodel1, this)) {
 @@ -168,11 +_,18 @@
        });
     }


### PR DESCRIPTION
It seems in 1.19.3 the handling for when a model has custom geometry got moved to before parents get resolved. This means that when the geometry is in a parent model (in my case I have some bouncer models for separate colored items that point back to the same parent item model) it never has the resolve propagate.