### PR TITLE
Make IItemDecorator a functional interface again

### DIFF
--- a/src/main/java/net/minecraftforge/client/IItemDecorator.java
+++ b/src/main/java/net/minecraftforge/client/IItemDecorator.java
@@ -24,7 +24,5 @@ public interface IItemDecorator
      * The RenderState during this call will be: enableTexture, enableDepthTest, enableBlend and defaultBlendFunc
      * @return true if you have modified the RenderState and it has to be reset for other ItemDecorators
      */
-    default boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
-        return false;
-    }
+    boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset);
 }


### PR DESCRIPTION
When `IItemDecorator` stopped being a functional interface in #9409 to prevent being a breaking change it was intended that when the old method deprecated method was removed that `IItemDecorator` be made a functional interface again. This PR does so