### PR TITLE
Make the scheduled thread factory setDaemon on it's threads.

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -255,7 +255,11 @@ public class DisplayWindow implements ImmediateWindowProvider {
      */
     public Runnable start(@Nullable String mcVersion, final String forgeVersion) {
         initWindow(mcVersion);
-        renderScheduler = Executors.newSingleThreadScheduledExecutor();
+        renderScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final var thread = Executors.defaultThreadFactory().newThread(r);
+            thread.setDaemon(true);
+            return thread;
+        });
         renderScheduler.schedule(() -> initRender(mcVersion, forgeVersion), 1, TimeUnit.MILLISECONDS);
         return this::periodicTick;
     }


### PR DESCRIPTION
This should fix that the window might hang around after someone forgets to genRuns when switching from 1.19 to 1.20 and everything DEEP crashes during early setup of FML.