### PR TITLE
Update default configs to match standard expectations.

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -120,16 +120,19 @@ public class DisplayWindow implements ImmediateWindowProvider {
         FMLConfig.updateConfig(FMLConfig.ConfigValue.EARLY_WINDOW_WIDTH, winWidth);
         FMLConfig.updateConfig(FMLConfig.ConfigValue.EARLY_WINDOW_HEIGHT, winHeight);
         fbScale = FMLConfig.getIntConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_FBSCALE);
-        try {
-            var optionLines = Files.readAllLines(FMLPaths.GAMEDIR.get().resolve(Paths.get("options.txt")));
-            var options = optionLines.stream().map(l->l.split(":")).filter(a->a.length == 2).collect(Collectors.toMap(a->a[0], a->a[1]));
-            var colourScheme = Boolean.parseBoolean(options.getOrDefault("darkMojangStudiosBackground", "false"));
-            this.colourScheme = colourScheme ? ColourScheme.BLACK : ColourScheme.RED;
-        } catch (IOException ioe) {
-            // No options
-            this.colourScheme = ColourScheme.RED; // default to red colourscheme
+        if (System.getenv("FML_EARLY_WINDOW_DARK")!= null) {
+            this.colourScheme = ColourScheme.BLACK;
+        } else {
+            try {
+                var optionLines = Files.readAllLines(FMLPaths.GAMEDIR.get().resolve(Paths.get("options.txt")));
+                var options = optionLines.stream().map(l -> l.split(":")).filter(a -> a.length == 2).collect(Collectors.toMap(a -> a[0], a -> a[1]));
+                var colourScheme = Boolean.parseBoolean(options.getOrDefault("darkMojangStudiosBackground", "false"));
+                this.colourScheme = colourScheme ? ColourScheme.BLACK : ColourScheme.RED;
+            } catch (IOException ioe) {
+                // No options
+                this.colourScheme = ColourScheme.RED; // default to red colourscheme
+            }
         }
-
         this.maximized = parsed.has(maximizedopt) || FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_MAXIMIZED);
 
         var forgeVersion = parsed.valueOf(forgeversionopt);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -36,8 +36,8 @@ public class FMLConfig
         EARLY_WINDOW_PROVIDER("earlyWindowProvider", "fmlearlywindow", "Early window provider"),
         EARLY_WINDOW_WIDTH("earlyWindowWidth", 854, "Early window width"),
         EARLY_WINDOW_HEIGHT("earlyWindowHeight", 480, "Early window height"),
-        EARLY_WINDOW_FBSCALE("earlyWindowFBScale", 2, "Early window framebuffer scale"),
-        EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", true, "Early window starts maximized")
+        EARLY_WINDOW_FBSCALE("earlyWindowFBScale", 1, "Early window framebuffer scale"),
+        EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", Boolean.FALSE, "Early window starts maximized")
         ;
 
         private final String entry;


### PR DESCRIPTION
Also allow a global override env variable for darkmode always. "FML_EARLY_WINDOW_DARK"