### PR TITLE
Expose holder lookup registry provider as a helper in RegistriesDatapackGenerator

### DIFF
--- a/patches/minecraft/net/minecraft/data/registries/RegistriesDatapackGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/data/registries/RegistriesDatapackGenerator.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/registries/RegistriesDatapackGenerator.java
 +++ b/net/minecraft/data/registries/RegistriesDatapackGenerator.java
-@@ -18,12 +_,23 @@
+@@ -18,20 +_,36 @@
  import net.minecraft.resources.ResourceKey;
  import org.slf4j.Logger;
  
@@ -24,7 +24,12 @@
        this.f_254747_ = p_255780_;
        this.f_254743_ = p_256643_;
     }
-@@ -31,7 +_,7 @@
+ 
++   /** Forge: Call this to get the registry holder lookup provider that includes elements added via {@link net.minecraftforge.common.data.DatapackBuiltinEntriesProvider} */
++   public CompletableFuture<HolderLookup.Provider> getRegistryProvider() {
++      return f_254747_;
++   }
++
     public CompletableFuture<?> m_213708_(CachedOutput p_255785_) {
        return this.f_254747_.thenCompose((p_256533_) -> {
           DynamicOps<JsonElement> dynamicops = RegistryOps.m_255058_(JsonOps.INSTANCE, p_256533_);


### PR DESCRIPTION
One pain point people have been running into is with creating tags for data pack registry elements they have added. This PR is one solution to that problem as Forge already merges the custom `RegistrySetBuilder` into the passed in registry lookup as part of the `DatapackBuiltinEntriesProvider` constructor. This PR exposes a getter for the underlying `CompletableFuture` so that it is possible to retrieve the merged registry lookup.

Example usage:
```java
public static void gatherData(GatherDataEvent event) {
    DataGenerator generator = event.getGenerator();
    PackOutput packOutput = generator.getPackOutput();
    DatapackBuiltinEntriesProvider datapackProvider = new DatapackBuiltinEntriesProvider(packOutput, event.getLookupProvider(), <builder>, Set.of(modid));
    CompletableFuture<HolderLookup.Provider> lookupProvider = datapackProvider.getRegistryProvider();
    generator.addProvider(event.includeServer(), datapackProvider);
    generator.addProvider(event.includeServer(), new TagsProvider<>(packOutput, registry, lookupProvider, modid, event.getExistingFileHelper()));
}
```