### PR TITLE
Fix experimental lighting pipeline breaking vanilla's emissive rendering

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/lighting/FlatQuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/FlatQuadLighter.java
@@ -38,9 +38,10 @@ public class FlatQuadLighter extends QuadLighter
         isFullCube = Block.isShapeFullBlock(state.getCollisionShape(level, pos));
         for (Direction side : SIDES)
         {
-            packedLight[side.ordinal()] = LevelRenderer.getLightColor(level, pos.relative(side));
+            packedLight[side.ordinal()] = getLightColor(level, pos.relative(side), state);
         }
-        packedLight[6] = LevelRenderer.getLightColor(level, pos);
+        //Note: We can just use the LevelRenderer method as we know the state is the state at the given position
+        packedLight[6] = LevelRenderer.getLightColor(level, state, pos);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
@@ -8,9 +8,11 @@ package net.minecraftforge.client.model.lighting;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3f;
 
@@ -149,5 +151,21 @@ public abstract class QuadLighter
     {
         float yFactor = constantAmbientLight ? 0.9F : ((3.0F + normalY) / 4.0F);
         return Math.min(normalX * normalX * 0.6F + normalY * normalY * yFactor + normalZ * normalZ * 0.8F, 1.0F);
+    }
+
+    /**
+     * Note: This method is subtly different than {@link net.minecraft.client.renderer.LevelRenderer#getLightColor(BlockAndTintGetter, BlockState, BlockPos)}
+     * as it only uses the state for querying if the state has emissive rendering but instead looks up the state at the given position for checking the
+     * light emission.
+     */
+    protected static int getLightColor(BlockAndTintGetter level, BlockPos pos, BlockState state)
+    {
+        if (state.emissiveRendering(level, pos))
+        {
+            return LightTexture.FULL_BRIGHT;
+        }
+        int skyLight = level.getBrightness(LightLayer.SKY, pos);
+        int blockLight = Math.max(level.getBrightness(LightLayer.BLOCK, pos), level.getBlockState(pos).getLightEmission(level, pos));
+        return skyLight << 20 | blockLight << 4;
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/lighting/SmoothQuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/SmoothQuadLighter.java
@@ -50,7 +50,7 @@ public class SmoothQuadLighter extends QuadLighter
                     pos.setWithOffset(origin, x - 1, y - 1, z - 1);
                     BlockState neighborState = level.getBlockState(pos);
                     t[x][y][z] = neighborState.getLightBlock(level, pos) < 15;
-                    int brightness = LevelRenderer.getLightColor(level, pos);
+                    int brightness = getLightColor(level, pos, state);
                     s[x][y][z] = LightTexture.sky(brightness);
                     b[x][y][z] = LightTexture.block(brightness);
                     ao[x][y][z] = neighborState.getShadeBrightness(level, pos);


### PR DESCRIPTION
The difference that can be seen in #9552 for vanilla's pipeline and forge's comes from the fact that vanilla when calculating block light for rendering a model it passes the current state regardless of if it is the one actually at the given location. This way vanilla is able to replace the light level with full bright when the block returns true for `emissiveRendering` regardless of if the block is the correct on for a given location. This PR fixes the forge pipeline by instead of querying the world for the neighboring block and its light level first queries the state to see if it has `emissiveRendering` and then queries the world to get the light level of the neighboring block.

I have tested it and it appears to work, however I would definitely like a rendering person to tell me if my suspicions about forge's pipeline intentionally grabbing the light emission of the neighboring block instead of doing it like vanilla does and using the current block's light emission is correct as I could see it go either way:
- If it is intentional like this PR assumes: allows for lighting blocks based on their surroundings
- If it wrong and I should just call vanilla's `getLightColor` with state version: It then would take into account the block's own light level for purposes of potentially increasing the light level the model renders itself at