### PR TITLE
Fix ignoring maxUpStep method overrides on entities

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -17,14 +17,7 @@
     private final EntityType<?> f_19847_;
     private int f_19848_ = f_19843_.incrementAndGet();
     public boolean f_19850_;
-@@ -181,14 +_,17 @@
-    public double f_19790_;
-    public double f_19791_;
-    public double f_19792_;
-+   @Deprecated // Forge - see IForgeEntity#getStepHeight
-    public float f_19793_;
-    public boolean f_19794_;
-    protected final RandomSource f_19796_ = RandomSource.m_216327_();
+@@ -187,8 +_,10 @@
     public int f_19797_;
     private int f_19831_ = -this.m_6101_();
     protected boolean f_19798_;
@@ -524,6 +517,14 @@
  
     }
  
+@@ -3264,6 +_,7 @@
+       return false;
+    }
+ 
++   @Deprecated /** Forge: Use {@link net.minecraftforge.common.extensions.IForgeEntity#getStepHeight()} */
+    public float m_274421_() {
+       return this.f_19793_;
+    }
 @@ -3319,6 +_,103 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;

--- a/patches/minecraft/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java.patch
@@ -9,6 +9,15 @@
        }
  
        double d0 = this.m_142213_(new BlockPos(p_77641_.f_77271_, p_77641_.f_77272_, p_77641_.f_77273_));
+@@ -306,7 +_,7 @@
+    }
+ 
+    private double m_255203_() {
+-      return Math.max(1.125D, (double)this.f_77313_.m_274421_());
++      return Math.max(1.125D, (double)this.f_77313_.getStepHeight());
+    }
+ 
+    private Node m_230619_(int p_230620_, int p_230621_, int p_230622_, BlockPathTypes p_230623_, float p_230624_) {
 @@ -453,6 +_,11 @@
                 if (l != 0 || j1 != 0) {
                    p_77609_.m_122178_(i + l, j + i1, k + j1);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -203,13 +203,13 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
 
     /**
      * @return Return the height in blocks the Entity can step up without needing to jump
-     * This is the sum of vanilla's {@link Entity#maxUpStep} field and the current value
+     * This is the sum of vanilla's {@link Entity#maxUpStep()} method and the current value
      * of the {@link net.minecraftforge.common.ForgeMod#STEP_HEIGHT_ADDITION} attribute
      * (if this Entity is a {@link LivingEntity} and has the attribute), clamped at 0.
      */
     default float getStepHeight()
     {
-        float vanillaStep = self().maxUpStep;
+        float vanillaStep = self().maxUpStep();
         if (self() instanceof LivingEntity living)
         {
             AttributeInstance stepHeightAttribute = living.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get());

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -219,7 +219,6 @@ public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable
 #group public net.minecraft.world.damagesource.DamageSource *() #All methods public, most are already
 public net.minecraft.world.damagesource.DamageSource <init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;)V # constructor
 #endgroup
-public net.minecraft.world.entity.Entity f_19793_ # maxUpStep
 protected net.minecraft.world.entity.Entity f_19843_ # ENTITY_COUNTER
 public net.minecraft.world.entity.Entity m_20078_()Ljava/lang/String; # getEncodeId
 public net.minecraft.world.entity.ExperienceOrb f_20770_ # value


### PR DESCRIPTION
This PR fixes #9557 which became an issue when vanilla changed how they handle step height and made step height private with getters and setters. This PR is technically a minor breaking change as it removes the AT that was re-exposing the step height field.

My reasoning for keeping the separate `IForgeEntity#getStepHeight` method rather than just changing the default implementation of vanilla's `stepUpHeight` method is that otherwise it would limit ridden entities to a step height of one rather than allowing mods to use the attribute to increase it past that point. Additionally it is important that these two be different due to comments in code on places that have not been patched to use `getStepHeight` due to #8922 and #9376.

This PR also adds in a missing patch to getStepHeight for calculating the mob's jump height in `WalkNodeEvaluator`