### PR TITLE
[1.20.x] Item Handler capability for Chiseled Bookshelf

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
@@ -1,0 +1,31 @@
+--- a/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java
+@@ -121,4 +_,28 @@
+    public int m_262444_() {
+       return this.f_262317_;
+    }
++
++   private net.minecraftforge.common.util.LazyOptional<?> itemHandler = net.minecraftforge.common.util.LazyOptional.of(this::createUnSidedHandler);
++   protected net.minecraftforge.items.IItemHandler createUnSidedHandler() {
++      return new net.minecraftforge.items.wrapper.InvWrapper(this);
++   }
++
++   @Override
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
++      if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++         return itemHandler.cast();
++      return super.getCapability(cap, side);
++   }
++
++   @Override
++   public void invalidateCaps() {
++      super.invalidateCaps();
++      itemHandler.invalidate();
++   }
++
++   @Override
++   public void reviveCaps() {
++      super.reviveCaps();
++      itemHandler = net.minecraftforge.common.util.LazyOptional.of(this::createUnSidedHandler);
++   }
+ }


### PR DESCRIPTION
This PR adds an unsided ItemHandler capability to the new Chiseled Bookshelf (BlockEntity) to make it more usable by mods.

My usecase is, that I have two mods, which add different hoppers to the game. They are interacting only with the ItemHandler capability of a BlockEntity and therefore they are not compatible with the new Chiseled Bookshelf.

The code is the same as the code of the common `BaseContainerBlockEntity`, so there shouldn't be an issue by using it also for Chiseled Bookshelves.