### PR TITLE
Auto generate names for modded loot pools. Fixes #9589

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -869,9 +869,6 @@ public class ForgeHooks
 
         ctx.poolCount++;
 
-        if (!ctx.vanilla)
-            throw new JsonParseException("Loot Table \"" + ctx.name.toString() + "\" Missing `name` entry for pool #" + (ctx.poolCount - 1));
-
         return ctx.poolCount == 1 ? "main" : "pool" + (ctx.poolCount - 1);
     }
 


### PR DESCRIPTION
In the port from 1.19.4 to 1.20 what is considered a custom pack changed from just being vanilla to any builtin pack including mods so that mods loot tables could be fired in the loot table load event. This means when #9573 was reimplemented that it caused names for loot pools to become required for modded loot tables as they were no longer getting caught by the custom check. Rather than changing it back or adding a second parameter that checks if the thing is the default pack this PR just removes the exception for modded loot tables and allows auto generating the index based names forge generates for vanilla.