### PR TITLE
Timer to try and fix possible hangs on early window creation

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -34,7 +34,8 @@ public class FMLConfig
         EARLY_WINDOW_WIDTH("earlyWindowWidth", 854, "Early window width"),
         EARLY_WINDOW_HEIGHT("earlyWindowHeight", 480, "Early window height"),
         EARLY_WINDOW_FBSCALE("earlyWindowFBScale", 1, "Early window framebuffer scale"),
-        EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", Boolean.FALSE, "Early window starts maximized")
+        EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", Boolean.FALSE, "Early window starts maximized"),
+        EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers")
         ;
 
         private final String entry;


### PR DESCRIPTION
We start a timer thread that times out window creation after 10 seconds, and crashes with an error. This will hopefully fix the scenario where a bad driver (AMD?!) might hang when asking for the version context, rather than failing to create it.
Also added in a skip config, to allow skipping bad versions in specific cases such as this, to try and get things working again. This might fix #9590 