### PR TITLE
[mdk] Make default mdk produce reproducible builds

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -209,7 +209,6 @@ jar {
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : project.jar.archiveVersion,
                 "Implementation-Vendor"   : mod_authors,
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
 }
@@ -219,6 +218,11 @@ jar {
 jar.finalizedBy('reobfJar')
 // However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
 // publish.dependsOn('reobfJar')
+
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
 
 publishing {
     publications {


### PR DESCRIPTION
[mdk] Make default mdk produce reproducible builds

Reproducible builds are those where the same commit of source code generates bit-identical
jar output. They are useful as a tool to audit for tampering of mods (though of course,
they're not a silver bullet, merely a tool in the toolbox).

The default mdk project does not reproducibly build. Fix this by doing two things:

1. Delete the `Implementation-Date` entry in the manifest, which precludes reproducibility
by design, because it embeds the build-time timestamp into the jar every time a build is
run, even though nothing changed.
2. Set the Gradle options necessary for reproducible jars, namely by sorting the files and
stripping timestamps (see
https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)

With these two changes, the mdk now reproducibly-builds. Verified by using diffoscope(1)
on two consecutive builds and observing that it returns 0.
