### PR TITLE
[mdk] Add a starter Github action workflow file

### DIFF
--- a/mdk/.github/workflows/ci.yml
+++ b/mdk/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Validate gradlew integrity
+      uses: gradle/wrapper-validation-action@v1    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', '**/gradle-wrapper.properties') }}
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Archive Forge Binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: Forge Jars
+        path: build/libs/*.jar


### PR DESCRIPTION
[mdk] Add a starter Github action workflow file

Just a small template that helps modders that choose to open-source their mods vet their
and others' changes.  All it does is validate that no one tampered with the gradle wrapper
(this is a possible attack vector that has been exploited before, iirc), and that the mod
compiles.

I think it'd be good to make gametests run by default too, but build.gradle says that
having no tests crashes the run config, so I didn't add one yet.
