### PR TITLE
Remove amount from FluidStack hashCode to fix the equal/hashCode java contract

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -315,7 +315,6 @@ public class FluidStack
     {
         int code = 1;
         code = 31*code + getFluid().hashCode();
-        code = 31*code + amount;
         if (tag != null)
             code = 31*code + tag.hashCode();
         return code;

--- a/src/test/java/net/minecraftforge/debug/CodecsTest.java
+++ b/src/test/java/net/minecraftforge/debug/CodecsTest.java
@@ -61,9 +61,9 @@ public class CodecsTest
             LOGGER.error("Error decoding withTag: {}", error);
         }).getFirst();
 
-        if (!noTag.equals(noTag_decode))
+        if (!noTag.isFluidStackIdentical(noTag_decode))
             throw new IllegalStateException("Decoded noTag does not match");
-        if (!withTag.equals(withTag_decode))
+        if (!withTag.isFluidStackIdentical(withTag_decode))
             throw new IllegalStateException("Decoded withTag does not match");
     }
 }


### PR DESCRIPTION
This follows the precedent set by #5272 of not having the amount in hashCode. This PR also changes the CodecsTest for fluid stack's codec to actually take the amount into account when validating if the two stacks are the same.