### PR TITLE
[1.20.x] Make overloads consistent for defineListAllowEmpty in ForgeConfigSpec.Builder

### DIFF
--- a/mdk/src/main/java/com/example/examplemod/Config.java
+++ b/mdk/src/main/java/com/example/examplemod/Config.java
@@ -35,7 +35,7 @@ public class Config
     // a list of strings that are treated as resource locations for items
     private static final ForgeConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
             .comment("A list of items to log on common setup.")
-            .defineListAllowEmpty(Collections.singletonList("items"), () -> List.of("minecraft:iron_ingot"), Config::validateItemName);
+            .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
 
     static final ForgeConfigSpec SPEC = BUILDER.build();
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -380,7 +380,15 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 }
             }, defaultSupplier);
         }
-
+        public <T> ConfigValue<List<? extends T>> defineListAllowEmpty(String path, List<? extends T> defaultValue, Predicate<Object> elementValidator) {
+            return defineListAllowEmpty(split(path), defaultValue, elementValidator);
+        }
+        public <T> ConfigValue<List<? extends T>> defineListAllowEmpty(String path, Supplier<List<? extends T>> defaultSupplier, Predicate<Object> elementValidator) {
+            return defineListAllowEmpty(split(path), defaultSupplier, elementValidator);
+        }
+        public <T> ConfigValue<List<? extends T>> defineListAllowEmpty(List<String> path, List<? extends T> defaultValue, Predicate<Object> elementValidator) {
+            return defineListAllowEmpty(path, () -> defaultValue, elementValidator);
+        }
         public <T> ConfigValue<List<? extends T>> defineListAllowEmpty(List<String> path, Supplier<List<? extends T>> defaultSupplier, Predicate<Object> elementValidator) {
             context.setClazz(List.class);
             return define(path, new ValueSpec(defaultSupplier, x -> x instanceof List && ((List<?>) x).stream().allMatch( elementValidator ), context, path) {


### PR DESCRIPTION
This makes `defineListAllowEmpty`'s overloads consistent with those of `defineList` in `ForgeConfigSpec.Builder` (and subsequently makes `defineListAllowEmpty` easier to use). Additionally, this updates the MDK config example to use one such overload to simplify its code.

This change targets the 1.20.x branch, although it could also be applied to the 1.19.x, 1.19.2, and 1.18.x branches (sparing the MDK change).