### PR TITLE
Expose loaded RegistryAccess through AddReloadListenerEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -30,7 +30,7 @@
        ReloadableServerResources reloadableserverresources = new ReloadableServerResources(p_251163_, p_250212_, p_249301_, p_251126_);
 -      return SimpleReloadInstance.m_203834_(p_248588_, reloadableserverresources.m_206890_(), p_249136_, p_249601_, f_206846_, f_206845_.isDebugEnabled()).m_7237_().whenComplete((p_255534_, p_255535_) -> {
 +      List<PreparableReloadListener> listeners = new java.util.ArrayList<>(reloadableserverresources.m_206890_());
-+      listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources));
++      listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources, p_251163_));
 +      return SimpleReloadInstance.m_203834_(p_248588_, listeners, p_249136_, p_249601_, f_206846_, f_206845_.isDebugEnabled()).m_7237_().whenComplete((p_214309_, p_214310_) -> {
           reloadableserverresources.f_214300_.m_254905_(CommandBuildContext.MissingTagAccessPolicy.FAIL);
        }).thenApply((p_214306_) -> {

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
@@ -30,10 +31,12 @@ public class AddReloadListenerEvent extends Event
 {
     private final List<PreparableReloadListener> listeners = new ArrayList<>();
     private final ReloadableServerResources serverResources;
+    private final RegistryAccess registryAccess;
 
-    public AddReloadListenerEvent(ReloadableServerResources serverResources)
+    public AddReloadListenerEvent(ReloadableServerResources serverResources, RegistryAccess registryAccess)
     {
         this.serverResources = serverResources;
+        this.registryAccess = registryAccess;
     }
 
    /**
@@ -64,6 +67,16 @@ public class AddReloadListenerEvent extends Event
     public ICondition.IContext getConditionContext()
     {
         return serverResources.getConditionContext();
+    }
+
+    /**
+     * Provides access to the loaded registries associated with these server resources.
+     * All built-in and dynamic registries are loaded and frozen by this point.
+     * @return The RegistryAccess context for the currently active reload.
+     */
+    public RegistryAccess getRegistryAccess()
+    {
+        return registryAccess;
     }
 
     private static class WrappedStateAwareListener implements PreparableReloadListener {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -18,6 +18,7 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.level.ChunkHolder;
@@ -758,9 +759,9 @@ public class ForgeEventFactory
         return event.getNewTime();
     }
 
-    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources)
+    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, RegistryAccess registryAccess)
     {
-        AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources);
+        AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources, registryAccess);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getListeners();
     }


### PR DESCRIPTION
A tiny (hopefully reasonable! 🙂) tweak to `AddReloadListenerEvent` to provide access to the associated `RegistryAccess` for the current server data reload. 

This is mostly useful to be able to access and reference dynamic registry content from some custom `/reload`-able data. Vanilla has access to this in a very similar way through command registration and tag loading, but as far as I could tell, this is not exposed through Forge currently.