### PR TITLE
[1.20.1] AlterGroundEvent for modifying block placement performed by AlterGroundDecorator

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/feature/treedecorators/AlterGroundDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/feature/treedecorators/AlterGroundDecorator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/levelgen/feature/treedecorators/AlterGroundDecorator.java
++++ b/net/minecraft/world/level/levelgen/feature/treedecorators/AlterGroundDecorator.java
+@@ -72,7 +_,7 @@
+       for(int i = 2; i >= -3; --i) {
+          BlockPos blockpos = p_225975_.m_6630_(i);
+          if (Feature.m_65788_(p_225974_.m_226058_(), blockpos)) {
+-            p_225974_.m_226061_(blockpos, this.f_69303_.m_213972_(p_225974_.m_226067_(), p_225975_));
++            p_225974_.m_226061_(blockpos, net.minecraftforge.event.ForgeEventFactory.alterGround(p_225974_.m_226058_(), p_225974_.m_226067_(), blockpos, this.f_69303_.m_213972_(p_225974_.m_226067_(), p_225975_)));
+             break;
+          }
+ 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -30,6 +30,7 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
+import net.minecraft.world.level.LevelSimulatedReader;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
@@ -128,6 +129,7 @@ import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
+import net.minecraftforge.event.level.AlterGroundEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.BlockEvent.BlockToolModificationEvent;
 import net.minecraftforge.event.level.BlockEvent.CreateFluidSourceEvent;
@@ -724,6 +726,13 @@ public class ForgeEventFactory
         SaplingGrowTreeEvent event = new SaplingGrowTreeEvent(level, randomSource, pos, holder);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
+    }
+
+    public static BlockState alterGround(LevelSimulatedReader level, RandomSource random, BlockPos pos, BlockState altered)
+    {
+        AlterGroundEvent event = new AlterGroundEvent(level, random, pos, altered);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getNewAlteredState();
     }
 
     public static void fireChunkTicketLevelUpdated(ServerLevel level, long chunkPos, int oldTicketLevel, int newTicketLevel, @Nullable ChunkHolder chunkHolder)

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.level;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.LevelSimulatedReader;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecorator;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * This event is fired when {@link net.minecraft.world.level.levelgen.feature.treedecorators.AlterGroundDecorator#placeBlockAt(TreeDecorator.Context, BlockPos)}
+ * attempts to alter a ground block when generating a feature. An example of this would be large spruce trees converting grass blocks into podzol.
+ * <p>
+ * This event is not {@linkplain Cancelable cancellable}.
+ * <p>
+ * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
+ * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
+ */
+public class AlterGroundEvent extends Event {
+    private final LevelSimulatedReader level;
+    private final RandomSource random;
+    private final BlockPos pos;
+    private final BlockState originalAltered;
+    private BlockState newAltered;
+
+    @ApiStatus.Internal
+    public AlterGroundEvent(LevelSimulatedReader level, RandomSource random, BlockPos pos, BlockState altered) {
+        super();
+        this.level = level;
+        this.random = random;
+        this.pos = pos;
+        this.originalAltered = altered;
+        this.newAltered = altered;
+    }
+
+    public LevelSimulatedReader getLevel() {
+        return this.level;
+    }
+
+    public RandomSource getRandom() {
+        return this.random;
+    }
+
+    /**
+     * {@return the position of the block that will be altered}
+     */
+    public BlockPos getPos() {
+        return this.pos;
+    }
+
+    /**
+     * {@return the original block state that would be placed by the ground decorator}
+     */
+    public BlockState getOriginalAlteredState() {
+        return this.originalAltered;
+    }
+
+    /**
+     * {@return the new block state to be placed by the ground decorator}
+     */
+    public BlockState getNewAlteredState() {
+        return this.newAltered;
+    }
+
+    /**
+     * @param newAltered the new block state to be placed by the ground decorator
+     */
+    public void setNewAlteredState(BlockState newAltered) {
+        this.newAltered = newAltered;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/AlterGroundEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AlterGroundEventTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug;
+
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.event.level.AlterGroundEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("alter_ground_event_test")
+@Mod.EventBusSubscriber
+public class AlterGroundEventTest {
+    public static final boolean ENABLE = true;
+
+    @SubscribeEvent
+    public static void onAlterGround(AlterGroundEvent event)
+    {
+        if (ENABLE) {
+            if (event.getOriginalAlteredState().is(Blocks.PODZOL)) {
+                event.setNewAlteredState(Blocks.REDSTONE_BLOCK.defaultBlockState());
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -295,5 +295,7 @@ modId="trade_with_villager_event_test"
 modId="chunk_event_load_new_chunk_test"
 [[mods]]
 modId="custom_fluid_container_test"
+[[mods]]
+modId="alter_ground_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This PR adds a new event `AlterGroundEvent` to do as the name of this PR implies. 

The `AlterGroundDecorator` code by default checks for any blocks within the `#minecraft:dirt` tag for whether it can alter a ground block, which can be an issue for other mods' dirt blocks if they want them to be in the tag for other behavior but not be affected by things like large spruce trees grown from saplings creating podzol blocks. So, this adds an event that should allow for conditionally determining whether a block can be converted or not, or allow for changing what the created block is under certain conditions.

I debated solving this with a tag, but felt that solution would be too limiting.

1.19.2 - #9635
1.19.4 - #9636