### PR TITLE
Add missing null check for TagsProvider#existingFileHelper

### DIFF
--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -83,7 +83,7 @@
                 return DataProvider.m_253162_(p_253684_, jsonelement, path);
              }
           }).toArray((p_253442_) -> {
-@@ -91,13 +_,23 @@
+@@ -91,13 +_,25 @@
        });
     }
  
@@ -104,7 +104,9 @@
  
     protected TagBuilder m_236451_(TagKey<T> p_236452_) {
        return this.f_126543_.computeIfAbsent(p_236452_.f_203868_(), (p_236442_) -> {
-+         existingFileHelper.trackGenerated(p_236442_, resourceType);
++         if (existingFileHelper != null) {
++            existingFileHelper.trackGenerated(p_236442_, resourceType);
++         }
           return TagBuilder.m_215899_();
        });
     }


### PR DESCRIPTION
Currently, running vanilla tag providers will throw a NPE in `TagsProvider#getOrCreateRawBuilder`, which is missing a null safety check for `existingFileHelper` that is marked as a nullable field. This PR adds the missing null check, fixing the issue.