### PR TITLE
Add PlayerSpawnPhantomsEvent, utilized to block or forcefully allow PhantomSpawner to spawn phantoms

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
++++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
+@@ -42,19 +_,21 @@
+                for(ServerPlayer serverplayer : p_64576_.m_6907_()) {
+                   if (!serverplayer.m_5833_()) {
+                      BlockPos blockpos = serverplayer.m_20183_();
+-                     if (!p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {
+-                        DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
++                     DifficultyInstance difficultyinstance = p_64576_.m_6436_(blockpos);
++                     var event = new net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent(serverplayer, 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1));
++                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) continue;
++                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_64576_.m_6042_().f_223549_() || blockpos.m_123342_() >= p_64576_.m_5736_() && p_64576_.m_45527_(blockpos)) {
+                         if (difficultyinstance.m_19049_(randomsource.m_188501_() * 3.0F)) {
+                            ServerStatsCounter serverstatscounter = serverplayer.m_8951_();
+                            int j = Mth.m_14045_(serverstatscounter.m_13015_(Stats.f_12988_.m_12902_(Stats.f_12992_)), 1, Integer.MAX_VALUE);
+                            int k = 24000;
+-                           if (randomsource.m_188503_(j) >= 72000) {
++                           if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || randomsource.m_188503_(j) >= 72000) {
+                               BlockPos blockpos1 = blockpos.m_6630_(20 + randomsource.m_188503_(15)).m_122030_(-10 + randomsource.m_188503_(21)).m_122020_(-10 + randomsource.m_188503_(21));
+                               BlockState blockstate = p_64576_.m_8055_(blockpos1);
+                               FluidState fluidstate = p_64576_.m_6425_(blockpos1);
+                               if (NaturalSpawner.m_47056_(p_64576_, blockpos1, blockstate, fluidstate, EntityType.f_20509_)) {
+                                  SpawnGroupData spawngroupdata = null;
+-                                 int l = 1 + randomsource.m_188503_(difficultyinstance.m_19048_().m_19028_() + 1);
++                                 int l = event.getPhantomsToSpawn();
+ 
+                                  for(int i1 = 0; i1 < l; ++i1) {
+                                     Phantom phantom = EntityType.f_20509_.m_20615_(p_64576_);

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.world.level.levelgen.PhantomSpawner;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is fired from {@link PhantomSpawner#tick}, once per player, when phantoms would attempt to be spawned.<br>
+ * This event is not fired for spectating players.
+ * <p>
+ * This event is fired before any per-player checks (but <i>after<i/> {@link Player#isSpectator()}), but after all global checks.<br>
+ * The behavior of {@link PhantomSpawner} is determined by the result of this event.<br>
+ * See {@link #setResult} for documentation.<br>
+ * <p>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * @see PlayerSpawnPhantomsEvent#setResult for the effects of each result.
+ */
+@Event.HasResult
+public class PlayerSpawnPhantomsEvent extends PlayerEvent
+{
+    private int phantomsToSpawn;
+
+    public PlayerSpawnPhantomsEvent(Player player, int phantomsToSpawn)
+    {
+        super(player);
+        this.phantomsToSpawn = phantomsToSpawn;
+    }
+
+    /**
+     * @return How many phantoms will be spawned, if spawning is successful. The default value is randomly generated.
+     */
+    public int getPhantomsToSpawn()
+    {
+        return phantomsToSpawn;
+    }
+
+    /**
+     * Sets the number of phantoms to be spawned.
+     * @param phantomsToSpawn How many phantoms should spawn, given checks are passed.
+     */
+    public void setPhantomsToSpawn(int phantomsToSpawn)
+    {
+        this.phantomsToSpawn = phantomsToSpawn;
+    }
+
+    /**
+     * The result of this event controls if phantoms will be spawned.<br>
+     * <ul>
+     * <li>If the result is {@link Result#ALLOW}, phantoms will always be spawned;</li>
+     * <li>If the result is {@link Result#DENY}, phantoms will never be spawned;</li>
+     * <li>If the result is {@link Result#DEFAULT}, vanilla checks will be run to determine if the spawn may occur.</li>
+     * </ul>
+     */
+    @Override
+    public void setResult(@NotNull Result result)
+    {
+        super.setResult(result);
+    }
+}


### PR DESCRIPTION
This is essentially https://github.com/MinecraftForge/MinecraftForge/pull/9473, but without spawn cause on Phantoms, and this PR targets 1.20