### PR TITLE
Fix EyeHeight event being fired twice

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -436,7 +436,7 @@
     }
  
 +   /**
-+    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntitySize)} instead.
++    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntityDimensions)} instead.
 +    */
 +   @Deprecated
     protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -643,15 +643,7 @@
     }
  
     public boolean m_5830_() {
-@@ -3187,11 +_,14 @@
-    }
- 
-    protected float m_6431_(Pose p_21131_, EntityDimensions p_21132_) {
--      return super.m_6380_(p_21131_, p_21132_);
-+       float eyeHeight = super.m_6380_(p_21131_, p_21132_);
-+       var evt = new net.minecraftforge.event.entity.EntityEvent.EyeHeight(self(), p_21131_, p_21132_, eyeHeight);
-+       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
-+       return evt.getNewEyeHeight();
+@@ -3191,7 +_,7 @@
     }
  
     public ItemStack m_6298_(ItemStack p_21272_) {


### PR DESCRIPTION
Through the comments of #9535 I noticed that the PR introduced an infinite loop. I thought I tested the changes of the original PR. Maybe I tested an older MC version but I don't really remember because that was a long time ago.
Anyway I see that the infinite loop was already fixed by 8df5a80.

But now I noticed another issue with the original PR and also with the fix.
Calling `getEyeHeightForge` will call `getEyeHeight` which will then call `getStandingEyeHeight`. The problem here is that both `getEyeHeightForge` and `getStandingEyeHeight` will fire the EyeHeight event.
Another problem is that `getStandingEyeHeight` gets overridden by several classes without calling super. These classes wouldn't be affected by modifications to the original `getStandingEyeHeight` method.

This means that `getStandingEyeHeight` shouldn't be modified at all and thus I changed the method back to behave like in vanilla again.

This PR also fixes the javadoc of the `getEyeHeight` method.