### PR TITLE
Make item name rendering and status bar rendering respect left and right height

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
@@ -17,8 +17,14 @@
                 TextureAtlasSprite textureatlassprite = mobeffecttexturemanager.m_118732_(mobeffect);
                 int i1 = j;
                 float f1 = f;
-@@ -574,12 +_,13 @@
+@@ -572,16 +_,21 @@
+    }
+ 
     public void m_280295_(GuiGraphics p_283501_) {
++      renderSelectedItemName(p_283501_, 0);
++   }
++
++   public void renderSelectedItemName(GuiGraphics p_283501_, int yShift) {
        this.f_92986_.m_91307_().m_6180_("selectedItemName");
        if (this.f_92993_ > 0 && !this.f_92994_.m_41619_()) {
 -         MutableComponent mutablecomponent = Component.m_237119_().m_7220_(this.f_92994_.m_41786_()).m_130940_(this.f_92994_.m_41791_().f_43022_);
@@ -31,8 +37,11 @@
 +         Component highlightTip = this.f_92994_.getHighlightTip(mutablecomponent);
 +         int i = this.m_93082_().m_92852_(highlightTip);
           int j = (this.f_92977_ - i) / 2;
-          int k = this.f_92978_ - 59;
+-         int k = this.f_92978_ - 59;
++         int k = this.f_92978_ - Math.max(yShift, 59);
           if (!this.f_92986_.f_91072_.m_105205_()) {
+             k += 14;
+          }
 @@ -593,7 +_,13 @@
  
           if (l > 0) {

--- a/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
@@ -485,8 +485,12 @@ public class ForgeGui extends Gui
 
             if (opacity > 8)
             {
+                //Include a shift based on the bar height plus the difference between the height that renderSelectedItemName
+                // renders at (59) and the height that the overlay/status bar renders at (68) by default
+                int yShift = Math.max(leftHeight, rightHeight) + (68 - 59);
                 guiGraphics.pose().pushPose();
-                guiGraphics.pose().translate(width / 2D, height - 68, 0.0D);
+                //If y shift is smaller less than the default y level, just render it at the base y level
+                guiGraphics.pose().translate(width / 2D, height - Math.max(yShift, 68), 0.0D);
                 RenderSystem.enableBlend();
                 RenderSystem.defaultBlendFunc();
                 int color = (animateOverlayMessageColor ? Mth.hsvToRgb(hue / 50.0F, 0.7F, 0.6F) & WHITE : WHITE);

--- a/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -144,7 +144,7 @@ public enum VanillaGuiOverlay
             gui.setupOverlayRenderState(true, false);
             if (gui.getMinecraft().gameMode.getPlayerMode() != GameType.SPECTATOR)
             {
-                gui.renderSelectedItemName(guiGraphics);
+                gui.renderSelectedItemName(guiGraphics, Math.max(gui.leftHeight, gui.rightHeight));
             }
             else if (gui.getMinecraft().player.isSpectator())
             {

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -1,6 +1,7 @@
 com/mojang/blaze3d/vertex/VertexConsumer.putBulkData(Lcom/mojang/blaze3d/vertex/PoseStack$Pose;Lnet/minecraft/client/renderer/block/model/BakedQuad;[FFFFF[IIZ)V=|p_85996_,p_85997_,p_85998_,p_85999_,p_86000_,p_86001_,alpha,p_86002_,p_86003_,p_86004_
 net/minecraft/advancements/Advancement$Builder.fromJson(Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;Lnet/minecraftforge/common/crafting/conditions/ICondition$IContext;)Lnet/minecraft/advancements/Advancement$Builder;=|p_138381_,p_138382_,context
 net/minecraft/client/Options.processOptionsForge(Lnet/minecraft/client/Options$FieldAccess;)V=|p_168428_
+net/minecraft/client/gui/Gui.renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;I)V=|p_283501_,yShift
 net/minecraft/client/gui/GuiGraphics.blitRepeating(Lnet/minecraft/resources/ResourceLocation;IIIIIIIIII)V=|p_283059_,p_283575_,p_283192_,p_281790_,p_283642_,p_282691_,p_281912_,p_281728_,p_282324_,textureWidth,textureHeight
 net/minecraft/client/gui/screens/MenuScreens.getScreenFactory(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/Minecraft;ILnet/minecraft/network/chat/Component;)Ljava/util/Optional;=|p_96202_,p_96203_,p_96204_,p_96205_
 net/minecraft/client/gui/screens/inventory/InventoryScreen.renderEntityInInventoryFollowsAngle(Lnet/minecraft/client/gui/GuiGraphics;IIIFFLnet/minecraft/world/entity/LivingEntity;)V=|p_282802_,p_275688_,p_275245_,p_275535_,angleXComponent,angleYComponent,p_275689_


### PR DESCRIPTION
Adjusts both the position rendering for `Gui#renderSelectedItemName` and `ForgeGui#renderRecordOverlay` to make the rendering take `ForgeGui.leftHeight` and `ForgeGui.rightHeight` into account when calculating where action bar/item name rendering should happen. This fixes cases where modders may add extra overlays above the armor bar or hunger bar that then would overlap with the rendered text like so: 
![image](https://github.com/MinecraftForge/MinecraftForge/assets/1203288/a79ee5e7-8ccc-461e-9fc9-e36ab760d3f9)


With these changes it instead renders like so: 
![image](https://github.com/MinecraftForge/MinecraftForge/assets/1203288/bb5ab69b-df33-43e7-aa05-c0fb7d229835)

The reasoning for changing both `Gui#renderSelectedItemName` and `ForgeGui#renderRecordOverlay` is to prevent cases where the slight shift could cause the selected item name rendering to intersect with the status bar rendering. I also included some max checks to ensure that if the shift from forge would end up being less of an adjustment than vanilla it will still move it to the vanilla position so that there is only functional/visual changes when mods have added extra overlays that would intersect.
