### PR TITLE
Fix the Emissive Rendering for Experimental Light Pipeline

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/lighting/FlatQuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/FlatQuadLighter.java
@@ -38,7 +38,7 @@ public class FlatQuadLighter extends QuadLighter
         isFullCube = Block.isShapeFullBlock(state.getCollisionShape(level, pos));
         for (Direction side : SIDES)
         {
-            packedLight[side.ordinal()] = getLightColor(level, pos.relative(side), state);
+            packedLight[side.ordinal()] = LevelRenderer.getLightColor(level, state, pos.relative(side));
         }
         //Note: We can just use the LevelRenderer method as we know the state is the state at the given position
         packedLight[6] = LevelRenderer.getLightColor(level, state, pos);

--- a/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
@@ -8,9 +8,11 @@ package net.minecraftforge.client.model.lighting;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3f;
 
@@ -149,5 +151,22 @@ public abstract class QuadLighter
     {
         float yFactor = constantAmbientLight ? 0.9F : ((3.0F + normalY) / 4.0F);
         return Math.min(normalX * normalX * 0.6F + normalY * normalY * yFactor + normalZ * normalZ * 0.8F, 1.0F);
+    }
+
+    /**
+     * Note: This method is subtly different than {@link net.minecraft.client.renderer.LevelRenderer#getLightColor(BlockAndTintGetter, BlockState, BlockPos)}
+     * as it only uses the state for querying if the state has emissive rendering but instead looks up the state at the given position for checking the
+     * light emission.
+     */
+    @Deprecated(since = "1.20.1")
+    protected static int getLightColor(BlockAndTintGetter level, BlockPos pos, BlockState state)
+    {
+        if (state.emissiveRendering(level, pos))
+        {
+            return LightTexture.FULL_BRIGHT;
+        }
+        int skyLight = level.getBrightness(LightLayer.SKY, pos);
+        int blockLight = Math.max(level.getBrightness(LightLayer.BLOCK, pos), level.getBlockState(pos).getLightEmission(level, pos));
+        return skyLight << 20 | blockLight << 4;
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
@@ -8,11 +8,9 @@ package net.minecraftforge.client.model.lighting;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
-import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3f;
 

--- a/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/QuadLighter.java
@@ -152,20 +152,4 @@ public abstract class QuadLighter
         float yFactor = constantAmbientLight ? 0.9F : ((3.0F + normalY) / 4.0F);
         return Math.min(normalX * normalX * 0.6F + normalY * normalY * yFactor + normalZ * normalZ * 0.8F, 1.0F);
     }
-
-    /**
-     * Note: This method is subtly different than {@link net.minecraft.client.renderer.LevelRenderer#getLightColor(BlockAndTintGetter, BlockState, BlockPos)}
-     * as it only uses the state for querying if the state has emissive rendering but instead looks up the state at the given position for checking the
-     * light emission.
-     */
-    protected static int getLightColor(BlockAndTintGetter level, BlockPos pos, BlockState state)
-    {
-        if (state.emissiveRendering(level, pos))
-        {
-            return LightTexture.FULL_BRIGHT;
-        }
-        int skyLight = level.getBrightness(LightLayer.SKY, pos);
-        int blockLight = Math.max(level.getBrightness(LightLayer.BLOCK, pos), level.getBlockState(pos).getLightEmission(level, pos));
-        return skyLight << 20 | blockLight << 4;
-    }
 }

--- a/src/main/java/net/minecraftforge/client/model/lighting/SmoothQuadLighter.java
+++ b/src/main/java/net/minecraftforge/client/model/lighting/SmoothQuadLighter.java
@@ -50,7 +50,7 @@ public class SmoothQuadLighter extends QuadLighter
                     pos.setWithOffset(origin, x - 1, y - 1, z - 1);
                     BlockState neighborState = level.getBlockState(pos);
                     t[x][y][z] = neighborState.getLightBlock(level, pos) < 15;
-                    int brightness = getLightColor(level, pos, state);
+                    int brightness = LevelRenderer.getLightColor(level, neighborState, pos);
                     s[x][y][z] = LightTexture.sky(brightness);
                     b[x][y][z] = LightTexture.block(brightness);
                     ao[x][y][z] = neighborState.getShadeBrightness(level, pos);


### PR DESCRIPTION
Addresses #9584 

PR #9582 attempted to address this issue but actually just flipped the problem around while introducing an unnecessary copy of LevelRenderer#getLightColor in QuadLight#getLightColor. We need to look up the light level of ourselves using our neighbors state the way vanilla does to properly handle emissive

![image](https://github.com/MinecraftForge/MinecraftForge/assets/1936976/b8e70b16-33bc-4db7-8430-ad874a687f24)
