### PR TITLE
[1.20.1] Re-add in-game mod menu

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/PauseScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/PauseScreen.java.patch
@@ -4,7 +4,7 @@
        } else {
           gridlayout$rowhelper.m_264139_(this.m_262456_(f_262254_, SocialInteractionsScreen::new));
        }
-+      gridlayout$rowhelper.m_264139_(this.m_262456_(Component.m_237115_("fml.menu.mods"), () -> new net.minecraftforge.client.gui.ModListScreen(this)));
++      gridlayout$rowhelper.m_264108_(Button.m_253074_(Component.m_237115_("fml.menu.mods"), button -> this.f_96541_.m_91152_(new net.minecraftforge.client.gui.ModListScreen(this))).m_252780_(f_262268_).m_253136_(), 2);
  
        Component component = this.f_96541_.m_91090_() ? f_262217_ : f_262246_;
        this.f_252482_ = gridlayout$rowhelper.m_264108_(Button.m_253074_(component, (p_280815_) -> {

--- a/patches/minecraft/net/minecraft/client/gui/screens/PauseScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/PauseScreen.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/gui/screens/PauseScreen.java
++++ b/net/minecraft/client/gui/screens/PauseScreen.java
+@@ -82,6 +_,7 @@
+       } else {
+          gridlayout$rowhelper.m_264139_(this.m_262456_(f_262254_, SocialInteractionsScreen::new));
+       }
++      gridlayout$rowhelper.m_264139_(this.m_262456_(Component.m_237115_("fml.menu.mods"), () -> new net.minecraftforge.client.gui.ModListScreen(this)));
+ 
+       Component component = this.f_96541_.m_91090_() ? f_262217_ : f_262246_;
+       this.f_252482_ = gridlayout$rowhelper.m_264108_(Button.m_253074_(component, (p_280815_) -> {


### PR DESCRIPTION
Successor to #9173.

To any future readers: If you need to change button to take up left column at half width, change the patch statement to this (mojmaps):
```java
  gridlayout$rowhelper.addChild(this.openScreenButton(Component.translatable("fml.menu.mods"), () -> new net.minecraftforge.client.gui.ModListScreen(this)));
```