### PR TITLE
[1.20.1] Fix parameters and add additional ones to adjustLightmapColors

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
@@ -4,7 +4,7 @@
                       }
                    }
  
-+                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, f, f7, f8, j, i, vector3f1);
++                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, j, i, f9, f10, f11, f7, m_234316_(clientlevel.m_6042_(), i), f8, f, vector3f1);
 +
                    if (f5 > 0.0F) {
                       float f13 = Math.max(vector3f1.x(), Math.max(vector3f1.y(), vector3f1.z()));

--- a/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LightTexture.java.patch
@@ -4,7 +4,7 @@
                       }
                    }
  
-+                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, j, i, f9, f10, f11, f7, m_234316_(clientlevel.m_6042_(), i), f8, f, vector3f1);
++                  clientlevel.m_104583_().adjustLightmapColors(clientlevel, p_109882_, f, f7, f8, j, i, vector3f1);
 +
                    if (f5 > 0.0F) {
                       float f13 = Math.max(vector3f1.x(), Math.max(vector3f1.y(), vector3f1.z()));

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -67,40 +67,15 @@ public interface IForgeDimensionSpecialEffects
      * Allows for manipulating the coloring of the lightmap texture.
      * Will be called for each 16*16 combination of sky/block light values.
      *
-     * @param level             The current level (client-side).
-     * @param partialTicks      Progress between ticks.
-     * @param skyDarken         Current darkness of the sky.
-     * @param blockLightFlicker Block light flicker factor.
-     * @param modifiedSkyLight  Sky light brightness factor (accounting for sky darkness).
-     * @param pixelX            X-coordinate of the lightmap texture (block).
-     * @param pixelY            Y-coordinate of the lightmap texture (sky).
-     * @param colors            The color values that will be used: [r, g, b].
-     * @see LightTexture#updateLightTexture(float)
-     * @deprecated Use {@link #adjustLightmapColors(ClientLevel, float, int, int, float, float, float, float, float, float, float, Vector3f)}.
-     */
-    @Deprecated(forRemoval = true, since = "1.20.1")
-    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float blockLightFlicker, float modifiedSkyLight, int pixelX, int pixelY, Vector3f colors) {}
-
-    /**
-     * Allows for manipulating the coloring of the lightmap texture.
-     * Will be called for each 16*16 combination of sky/block light values.
-     *
-     * @param level              The current level (client-side).
-     * @param partialTicks       Progress between ticks.
-     * @param pixelX             X-coordinate of the lightmap texture (block).
-     * @param pixelY             Y-coordinate of the lightmap texture (sky).
-     * @param blockLightRed      Block light brightness factor (red color).
-     * @param blockLightGreen    Block light brightness factor (green color).
-     * @param blockLightBlue     Block light brightness factor (blue color).
-     * @param blockLightFlicker  Block light brightness flicker factor.
-     * @param unmodifiedSkyLight Sky light brightness factor (without additional sky darkness calculation).
-     * @param modifiedSkyLight   Sky light brightness factor (accounting for sky darkness).
-     * @param skyDarken          Current darkness of the sky.
-     * @param colors             The color values that will be used: [r, g, b].
+     * @param level                The current level (client-side).
+     * @param partialTicks         Progress between ticks.
+     * @param skyDarken            Current darkness of the sky (can be used to calculate sky light).
+     * @param blockLightRedFlicker Block light flicker factor (red color) (can be used to calculate block light).
+     * @param skyLight             Sky light brightness (accounting for sky darkness).
+     * @param pixelX               X-coordinate of the lightmap texture (block).
+     * @param pixelY               Y-coordinate of the lightmap texture (sky).
+     * @param colors               The color values that will be used: [r, g, b].
      * @see LightTexture#updateLightTexture(float)
      */
-    default void adjustLightmapColors(ClientLevel level, float partialTicks, int pixelX, int pixelY, float blockLightRed, float blockLightGreen, float blockLightBlue, float blockLightFlicker, float unmodifiedSkyLight, float modifiedSkyLight, float skyDarken, Vector3f colors)
-    {
-        this.adjustLightmapColors(level, partialTicks, skyDarken, blockLightFlicker, modifiedSkyLight, pixelX, pixelY, colors);
-    }
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float blockLightRedFlicker, float skyLight, int pixelX, int pixelY, Vector3f colors) {}
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeDimensionSpecialEffects.java
@@ -67,15 +67,40 @@ public interface IForgeDimensionSpecialEffects
      * Allows for manipulating the coloring of the lightmap texture.
      * Will be called for each 16*16 combination of sky/block light values.
      *
-     * @param level        The current level (client-side).
-     * @param partialTicks Progress between ticks.
-     * @param skyDarken    Current darkness of the sky.
-     * @param skyLight     Sky light brightness factor.
-     * @param blockLight   Block light brightness factor.
-     * @param pixelX       X-coordinate of the lightmap texture.
-     * @param pixelY       Y-coordinate of the lightmap texture.
-     * @param colors       The color values that will be used: [r, g, b].
+     * @param level             The current level (client-side).
+     * @param partialTicks      Progress between ticks.
+     * @param skyDarken         Current darkness of the sky.
+     * @param blockLightFlicker Block light flicker factor.
+     * @param modifiedSkyLight  Sky light brightness factor (accounting for sky darkness).
+     * @param pixelX            X-coordinate of the lightmap texture (block).
+     * @param pixelY            Y-coordinate of the lightmap texture (sky).
+     * @param colors            The color values that will be used: [r, g, b].
+     * @see LightTexture#updateLightTexture(float)
+     * @deprecated Use {@link #adjustLightmapColors(ClientLevel, float, int, int, float, float, float, float, float, float, float, Vector3f)}.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float blockLightFlicker, float modifiedSkyLight, int pixelX, int pixelY, Vector3f colors) {}
+
+    /**
+     * Allows for manipulating the coloring of the lightmap texture.
+     * Will be called for each 16*16 combination of sky/block light values.
+     *
+     * @param level              The current level (client-side).
+     * @param partialTicks       Progress between ticks.
+     * @param pixelX             X-coordinate of the lightmap texture (block).
+     * @param pixelY             Y-coordinate of the lightmap texture (sky).
+     * @param blockLightRed      Block light brightness factor (red color).
+     * @param blockLightGreen    Block light brightness factor (green color).
+     * @param blockLightBlue     Block light brightness factor (blue color).
+     * @param blockLightFlicker  Block light brightness flicker factor.
+     * @param unmodifiedSkyLight Sky light brightness factor (without additional sky darkness calculation).
+     * @param modifiedSkyLight   Sky light brightness factor (accounting for sky darkness).
+     * @param skyDarken          Current darkness of the sky.
+     * @param colors             The color values that will be used: [r, g, b].
      * @see LightTexture#updateLightTexture(float)
      */
-    default void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float skyLight, float blockLight, int pixelX, int pixelY, Vector3f colors) {}
+    default void adjustLightmapColors(ClientLevel level, float partialTicks, int pixelX, int pixelY, float blockLightRed, float blockLightGreen, float blockLightBlue, float blockLightFlicker, float unmodifiedSkyLight, float modifiedSkyLight, float skyDarken, Vector3f colors)
+    {
+        this.adjustLightmapColors(level, partialTicks, skyDarken, blockLightFlicker, modifiedSkyLight, pixelX, pixelY, colors);
+    }
 }


### PR DESCRIPTION
Fixes #9626 for Minecraft 1.20.1.

While maintaining binary compatibility, I have fixed the parameter names for `adjustLightmapColors` method in `IForgeDimensionSpecialEffects` class. Additionally, I have added a new method with the same name that contains more context variables that might be useful for dimension lightmap modification (see lines 84 - 101 in IForgeDimensionSpecialEffects). I worked with @FlashFyreMods to ensure that the parameter names and variables used are correct and make sense in context.