### PR TITLE
preserve the ability to calculate normals for block models but default to behaving like vanilla

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
@@ -5,7 +5,7 @@
        }
  
 -      return new BakedQuad(aint, p_111603_.f_111355_, direction, p_111604_, p_111608_);
-+      net.minecraftforge.client.ForgeHooksClient.fillNormal(aint, direction);
++      net.minecraftforge.client.ForgeHooksClient.fillNormal(aint, direction, p_111603_.getFaceData().calculateNormals());
 +      var data = p_111603_.getFaceData();
 +      var quad = new BakedQuad(aint, p_111603_.f_111355_, direction, p_111604_, p_111608_, data.ambientOcclusion());
 +      if (!net.minecraftforge.client.model.ForgeFaceData.DEFAULT.equals(data)) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -500,17 +500,21 @@ public class ForgeHooksClient
      * internal, relies on fixed format of FaceBakery
      */
     // TODO Do we need this?
-    public static void fillNormal(int[] faceData, Direction facing)
+    public static void fillNormal(int[] faceData, Direction facing, boolean calculateNormals)
     {
-        Vector3f v1 = getVertexPos(faceData, 3);
-        Vector3f t1 = getVertexPos(faceData, 1);
-        Vector3f v2 = getVertexPos(faceData, 2);
-        Vector3f t2 = getVertexPos(faceData, 0);
-        v1.sub(t1);
-        v2.sub(t2);
-        v2.cross(v1);
-        v2.normalize();
-
+        Vector3f v2;
+        if (calculateNormals) {
+            Vector3f v1 = getVertexPos(faceData, 3);
+            Vector3f t1 = getVertexPos(faceData, 1);
+            v2 = getVertexPos(faceData, 2);
+            Vector3f t2 = getVertexPos(faceData, 0);
+            v1.sub(t1);
+            v2.sub(t2);
+            v2.cross(v1);
+            v2.normalize();
+        } else {
+            v2 = new Vector3f(facing.getNormal().getX(), facing.getNormal().getY(), facing.getNormal().getZ());
+        }
         int x = ((byte) Math.round(v2.x() * 127)) & 0xFF;
         int y = ((byte) Math.round(v2.y() * 127)) & 0xFF;
         int z = ((byte) Math.round(v2.z() * 127)) & 0xFF;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -496,6 +496,10 @@ public class ForgeHooksClient
         return new Material(TextureAtlas.LOCATION_BLOCKS, loc);
     }
 
+    public static void fillNormal(int[] faceData, Direction facing) {
+        fillNormal(faceData, facing, false);
+    }
+
     /**
      * internal, relies on fixed format of FaceBakery
      */

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -496,7 +496,8 @@ public class ForgeHooksClient
         return new Material(TextureAtlas.LOCATION_BLOCKS, loc);
     }
 
-    public static void fillNormal(int[] faceData, Direction facing) {
+    public static void fillNormal(int[] faceData, Direction facing)
+    {
         fillNormal(faceData, facing, false);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
@@ -32,6 +32,9 @@ import net.minecraft.util.ExtraCodecs;
  */
 public record ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion, boolean calculateNormals)
 {
+    public ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion) {
+        this(color, blockLight, skyLight, ambientOcclusion, false);
+    }
 
     public static final ForgeFaceData DEFAULT = new ForgeFaceData(0xFFFFFFFF, 0, 0, true, false);
 

--- a/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
@@ -32,7 +32,8 @@ import net.minecraft.util.ExtraCodecs;
  */
 public record ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion, boolean calculateNormals)
 {
-    public ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion) {
+    public ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion)
+    {
         this(color, blockLight, skyLight, ambientOcclusion, false);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeFaceData.java
@@ -28,11 +28,12 @@ import net.minecraft.util.ExtraCodecs;
  * @param blockLight Block Light for this face from 0-15 (inclusive)
  * @param skyLight Sky Light for this face from 0-15 (inclusive)
  * @param ambientOcclusion If this face has AO
+ * @param calculateNormals If we should manually calculate the normals for this block or inherit facing normals like vanilla
  */
-public record ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion)
+public record ForgeFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion, boolean calculateNormals)
 {
 
-    public static final ForgeFaceData DEFAULT = new ForgeFaceData(0xFFFFFFFF, 0, 0, true);
+    public static final ForgeFaceData DEFAULT = new ForgeFaceData(0xFFFFFFFF, 0, 0, true, false);
 
     public static final Codec<Integer> COLOR = new ExtraCodecs.EitherCodec<>(Codec.INT, Codec.STRING).xmap(
             either -> either.map(Function.identity(), str -> (int) Long.parseLong(str, 16)),
@@ -42,7 +43,8 @@ public record ForgeFaceData(int color, int blockLight, int skyLight, boolean amb
             COLOR.optionalFieldOf("color", 0xFFFFFFFF).forGetter(ForgeFaceData::color),
             Codec.intRange(0, 15).optionalFieldOf("block_light", 0).forGetter(ForgeFaceData::blockLight),
             Codec.intRange(0, 15).optionalFieldOf("sky_light", 0).forGetter(ForgeFaceData::skyLight),
-            Codec.BOOL.optionalFieldOf("ambient_occlusion", true).forGetter(ForgeFaceData::ambientOcclusion))
+            Codec.BOOL.optionalFieldOf("ambient_occlusion", true).forGetter(ForgeFaceData::ambientOcclusion),
+            Codec.BOOL.optionalFieldOf("calculate_normals", false).forGetter(ForgeFaceData::calculateNormals))
             .apply(builder, ForgeFaceData::new));
 
     /**

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -60,7 +60,7 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         {
             faceData.compute(i, (key, value) -> {
                 ForgeFaceData fallback = value == null ? ForgeFaceData.DEFAULT : value;
-                return new ForgeFaceData(fallback.color(), blockLight, skyLight, fallback.ambientOcclusion());
+                return new ForgeFaceData(fallback.color(), blockLight, skyLight, fallback.ambientOcclusion(), fallback.calculateNormals());
             });
         }
         return this;
@@ -85,7 +85,7 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         {
             faceData.compute(i, (key, value) -> {
                 ForgeFaceData fallback = value == null ? ForgeFaceData.DEFAULT : value;
-                return new ForgeFaceData(color, fallback.blockLight(), fallback.skyLight(), fallback.ambientOcclusion());
+                return new ForgeFaceData(color, fallback.blockLight(), fallback.skyLight(), fallback.ambientOcclusion(), fallback.calculateNormals());
             });
         }
         return this;


### PR DESCRIPTION
This addresses #9608. 

The inherent issue is that features like the overlay for block breaking use the model normals in order to determine the placement of the effect. Blocks like the campfire do not in vanilla calculate correct normals for some parts of the geometry. For instance the flames in the campfire in vanilla receive the same normal from the direction facing as all other faces on the model, making it so that the normals for the fire are not actually the correct normals for that face.

By calculating normals for all faces we've been accidentally introducing divergent from vanilla behavior on vanilla models. This PR preserves the ability to opt into actual normal calculation while defaulting to parity with vanilla.