### PR TITLE
Add a config option to restore the calculate all normals behavior

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -146,6 +146,7 @@ import net.minecraftforge.client.gui.overlay.GuiOverlayManager;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.textures.ForgeTextureMetadata;
 import net.minecraftforge.client.textures.TextureAtlasSpriteLoaderManager;
+import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
@@ -508,7 +509,7 @@ public class ForgeHooksClient
     public static void fillNormal(int[] faceData, Direction facing, boolean calculateNormals)
     {
         Vector3f v2;
-        if (calculateNormals) {
+        if (calculateNormals || ForgeConfig.CLIENT.calculateAllNormals.get()) {
             Vector3f v1 = getVertexPos(faceData, 3);
             Vector3f t1 = getVertexPos(faceData, 1);
             v2 = getVertexPos(faceData, 2);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -106,6 +106,8 @@ public class ForgeConfig {
         @Deprecated(since = "1.20.1", forRemoval = true) // Config option ignored.
         public final BooleanValue compressLanIPv6Addresses;
 
+        public final BooleanValue calculateAllNormals;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -136,6 +138,15 @@ public class ForgeConfig {
                     .comment("[DEPRECATED] Does nothing anymore, IPv6 addresses will be compressed always")
                     .translation("forge.configgui.compressLanIPv6Addresses")
                     .define("compressLanIPv6Addresses", true);
+
+            calculateAllNormals = builder
+                    .comment("During block model baking, manually calculates the normal for all faces.",
+                            "This was the default behavior of forge between versions 31.0 and 47.1.",
+                            "May result in differences between vanilla rendering and forge rendering.",
+                            "Will only produce differences for blocks that contain non-axis aligned faces.",
+                            "You will need to reload your resources to see results.")
+                    .translation("forge.configgui.calculateAllNormals")
+                    .define("calculateAllNormals", false);
 
             builder.pop();
         }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -195,6 +195,8 @@
   "forge.configgui.indexVanillaPackCachesOnThread": "Index vanilla resource packs on thread",
   "forge.configgui.indexModPackCachesOnThread.tooltip": "Set this to true to index mod resource and data packs on thread",
   "forge.configgui.indexModPackCachesOnThread": "Index mod resource packs on thread",
+  "forge.configgui.calculateAllNormals": "Calculate All Normals",
+  "forge.configgui.calculateAllNormals.tooltip": "During block model baking, manually calculates the normal for all faces. You will need to reload your resources to see results.",
 
   "forge.controlsgui.shift": "SHIFT + %s",
   "forge.controlsgui.control": "CTRL + %s",


### PR DESCRIPTION
From version 31.0 to 47.1, forge was overriding the vanilla normals of all faces with the merging of #9664 we restored the original vanilla behavior by default, preserving the ability to calculate face normals as an opt-in model setting. However, perhaps some players or modders were relying on having all faces calculate their normals (the main use for this I can think of is maybe people who are doing a lot with shaders, or possibly mods with tons of non-axis aligned blocks that havent yet have time to update rendering weird). Anyway, this restores the 31.0 to 47.1 forge behavior as a toggleable config option. It is defaulted to false because it is my opinion that forge should render with full parity to vanilla by default.

The best way to test this is in concert with the changes in #9669 . With calculate all normals to true and stabilize nearest to false you should see the vanilla campfire display the same buggy flickering as the test campfire ("calculate_normals_test:fire_accurate_normals_test") block. Toggling on stabilize nearest you should then see the block break stabilize for both.

