### PR TITLE
separate the cancel render functionality into a new event

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/renderer/entity/LivingEntityRenderer.java
 +++ b/net/minecraft/client/renderer/entity/LivingEntityRenderer.java
-@@ -49,14 +_,17 @@
+@@ -49,14 +_,18 @@
     }
  
     public void m_7392_(T p_115308_, float p_115309_, float p_115310_, PoseStack p_115311_, MultiBufferSource p_115312_, int p_115313_) {
-+      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.Pre<T, M>(p_115308_, this, p_115310_, p_115311_, p_115312_, p_115313_))) return;
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.AboutToRender<T, M>(p_115308_, this, p_115310_, p_115311_, p_115312_, p_115313_))) return;
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.Pre<T, M>(p_115308_, this, p_115310_, p_115311_, p_115312_, p_115313_));
        p_115311_.m_85836_();
        this.f_115290_.f_102608_ = this.m_115342_(p_115308_, p_115310_);
 -      this.f_115290_.f_102609_ = p_115308_.m_20159_();

--- a/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/player/PlayerRenderer.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/renderer/entity/player/PlayerRenderer.java
 +++ b/net/minecraft/client/renderer/entity/player/PlayerRenderer.java
-@@ -59,7 +_,9 @@
+@@ -59,7 +_,10 @@
  
     public void m_7392_(AbstractClientPlayer p_117788_, float p_117789_, float p_117790_, PoseStack p_117791_, MultiBufferSource p_117792_, int p_117793_) {
        this.m_117818_(p_117788_);
-+      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Pre(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_))) return;
++      if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.AboutToRender(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_))) return;
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Pre(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_));
        super.m_7392_(p_117788_, p_117789_, p_117790_, p_117791_, p_117792_, p_117793_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Post(p_117788_, this, p_117790_, p_117791_, p_117792_, p_117793_));
     }

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * Fired when a player is being rendered.
  * See the two subclasses for listening for before and after rendering.
  *
+ * @see RenderPlayerEvent.AboutToRender
  * @see RenderPlayerEvent.Pre
  * @see RenderPlayerEvent.Post
  * @see PlayerRenderer
@@ -87,16 +88,31 @@ public abstract class RenderPlayerEvent extends PlayerEvent
 
     /**
      * Fired <b>before</b> the player is rendered.
-     * This can be used for rendering additional effects or suppressing rendering.
+     * This should be used for suppressing rendering.
      *
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
-     * If this event is cancelled, then the player will not be rendered and the corresponding
-     * {@link RenderPlayerEvent.Post} will not be fired.</p>
+     * If this event is cancelled, then the player will not be rendered.
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
+    public static class AboutToRender extends RenderPlayerEvent
+    {
+        @ApiStatus.Internal
+        public AboutToRender(Player player, PlayerRenderer renderer, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
+            super(player, renderer, partialTick, poseStack, multiBufferSource, packedLight);
+        }
+    }
+
+    /**
+     * Fired <b>before</b> the player is rendered. This can be used for rendering additional effects.
+     *
+     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+     *
+     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     */
     public static class Pre extends RenderPlayerEvent
     {
         @ApiStatus.Internal
@@ -104,10 +120,21 @@ public abstract class RenderPlayerEvent extends PlayerEvent
         {
             super(player, renderer, partialTick, poseStack, multiBufferSource, packedLight);
         }
+
+        /**
+         * The functionality to cancel the player render has been moved to {@link AboutToRender}
+         * @param cancel The new canceled value
+         */
+        @Deprecated(since = "1.20.1", forRemoval = true)
+        @Override
+        public void setCanceled(boolean cancel) {
+            super.setCanceled(cancel);
+        }
     }
 
     /**
-     * Fired <b>after</b> the player is rendered, if the corresponding {@link RenderPlayerEvent.Pre} is not cancelled.
+     * Fired <b>after</b> the player is rendered. This event can be used to render additional effects. If you have
+     * pushed to the pose stack in your pre event don't forget to pop here if you have not done so already.
      *
      * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *


### PR DESCRIPTION
This addresses #9118 

The issue here is a logical one. By convention rendering Pre and Post stages are often used to perform push and pop operations on the PoseStack. However, at the moment since Pre is cancellable if you have mods A and B, with A having a higher precedence in event ordering you can end up with something like this

Mod A : Push pose
Mod B : Cancel Render

Mod A : Never gets to call the corresponding pop, will crash down the line when the pose stack isnt empty at the end.

Manipulating the pose stack like this is a sensible thing to do in Pre and Post rendering events. My proposal is to separate the render cancellation functionality from Pre event. That way we know that if Render.Pre is called there will always be a corresponding call to Render.Post.
