### PR TITLE
rendering examples to demonstrate current issues with pre/post events

### DIFF
--- a/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.client.rendering;
 
 import net.minecraftforge.api.distmarker.Dist;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(CancelTestPigMod.MODID)
+public class CancelTestPigMod {
+
+    public static final String MODID = "cancel_test_pig";
+
+    public static final boolean DO_CANCEL = true;
+
+
+    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    private static class CancelTestPigClient
+    {
+
+        @SubscribeEvent(priority = EventPriority.LOW)
+        public static void entityPre(RenderLivingEvent.Pre<?, ?> evt)
+        {
+            if (DO_CANCEL && evt.getRenderer() instanceof RenderingPrePostTest.SpecialPigRenderer)
+            {
+                evt.setCanceled(true);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/CancelTestPigMod.java
@@ -19,7 +19,7 @@ public class CancelTestPigMod {
     public static final boolean DO_CANCEL = true;
 
 
-    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    @Mod.EventBusSubscriber(modid = MODID, value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
     private static class CancelTestPigClient
     {
 

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.client.rendering;
 
 import net.minecraft.client.renderer.entity.EntityRendererProvider;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
@@ -59,7 +59,7 @@ public class RenderingPrePostTest
         }
     }
 
-    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.MOD)
+    @Mod.EventBusSubscriber(modid = MODID, value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.MOD)
     private static class RenderingPrePostTestClient
     {
         @SubscribeEvent
@@ -69,7 +69,7 @@ public class RenderingPrePostTest
         }
     }
 
-    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    @Mod.EventBusSubscriber(modid = MODID, value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
     private static class RaiseHeightClient
     {
 
@@ -94,7 +94,7 @@ public class RenderingPrePostTest
         }
     }
 
-    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    @Mod.EventBusSubscriber(modid = MODID, value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
     private static class DoublerClient
     {
         public static final boolean DO_DOUBLE = true;

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderingPrePostTest.java
@@ -1,0 +1,111 @@
+package net.minecraftforge.debug.client.rendering;
+
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.animal.Pig;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.*;
+
+
+@Mod(RenderingPrePostTest.MODID)
+@Mod.EventBusSubscriber(modid=RenderingPrePostTest.MODID, bus= Mod.EventBusSubscriber.Bus.MOD)
+public class RenderingPrePostTest
+{
+    public static final String MODID = "rendering_pre_post_test";
+
+    public static final DeferredRegister<EntityType<?>> ENTITY_TYPES = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES,
+            RenderingPrePostTest.MODID);
+
+
+    public static final RegistryObject<EntityType<Pig>> TEST_PIG = ENTITY_TYPES.register(
+            "test_pig", () ->
+                    EntityType.Builder.of(Pig::new, MobCategory.CREATURE)
+                            .sized(EntityType.PIG.getWidth(), EntityType.PIG.getHeight())
+                            .build(new ResourceLocation(RenderingPrePostTest.MODID, "test_pig").toString())
+    );
+
+    public RenderingPrePostTest()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ENTITY_TYPES.register(modEventBus);
+    }
+
+    @SubscribeEvent
+    public static void entityRegistry(EntityAttributeCreationEvent event)
+    {
+        event.put(TEST_PIG.get(), Pig.createAttributes().build());
+    }
+
+    public static class SpecialPigRenderer extends PigRenderer {
+
+        public final PigRenderer nestedRenderer;
+        public SpecialPigRenderer(EntityRendererProvider.Context p_174340_) {
+            super(p_174340_);
+            nestedRenderer = new PigRenderer(p_174340_);
+        }
+    }
+
+    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.MOD)
+    private static class RenderingPrePostTestClient
+    {
+        @SubscribeEvent
+        public static void registerModels(EntityRenderersEvent.RegisterRenderers evt)
+        {
+            evt.registerEntityRenderer(TEST_PIG.get(), SpecialPigRenderer::new);
+        }
+    }
+
+    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    private static class RaiseHeightClient
+    {
+
+        public static final boolean DO_RAISE = false;
+        @SubscribeEvent
+        public static void entityPre(RenderLivingEvent.Pre<?, ?> evt)
+        {
+            if (DO_RAISE && evt.getEntity().getType().equals(TEST_PIG.get()))
+            {
+                evt.getPoseStack().pushPose();
+                evt.getPoseStack().translate(0.0, 0.5, 0.0);
+            }
+        }
+
+        @SubscribeEvent
+        public static void entityPost(RenderLivingEvent.Post<?, ?> evt)
+        {
+            if (DO_RAISE && evt.getEntity().getType().equals(TEST_PIG.get()))
+            {
+                evt.getPoseStack().popPose();
+            }
+        }
+    }
+
+    @Mod.EventBusSubscriber(value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.FORGE)
+    private static class DoublerClient
+    {
+        public static final boolean DO_DOUBLE = true;
+        @SubscribeEvent
+        public static void entityPre(RenderLivingEvent.Pre<?, ?> evt)
+        {
+            if (!evt.isCanceled() && DO_DOUBLE && evt.getEntity().getType().equals(TEST_PIG.get()))
+            {
+                evt.getPoseStack().pushPose();
+                evt.getPoseStack().translate(0.0, 0.5, 0.0);
+                if (evt.getRenderer() instanceof SpecialPigRenderer pig) {
+                    pig.nestedRenderer.render((Pig)evt.getEntity(), 0.0f, evt.getPartialTick(), evt.getPoseStack(), evt.getMultiBufferSource(), evt.getPackedLight());
+                }
+                evt.getPoseStack().popPose();
+            }
+        }
+
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -41,6 +41,12 @@ modId="mdk_datagen"
 [[mods]]
     modId="calculate_normals_test"
 
+[[mods]]
+    modId="rendering_pre_post_test"
+
+[[mods]]
+    modId="cancel_test_pig"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
Ok these are a little contrived but I hope they illustrate the problem mentioned in #9118 

If you want to hard crash the client, set RaiseHeightClient#DO_RAISE to true

However, I've included a non-crashing version of the bug as well, this is the one that is defaulted to on. The DoublerClient pre event simply performs some additional rendering in the pre event (in this case I'm literally just rerendering the pig but imagine it as something less contrived). This event is properly attempting to handle cancellation but due to priority ordering it will still run. This will result in rendering only the doubled pig instead of 2 pigs as the original rendering will be cancelled. 

You can turn CancelTestPigMod#DO_CANCEL to false if you want to see what rendering looks like in the 'intended' way in either of these examples.