### PR TITLE
feat(entity/api): add EntityEvent.IsPushable and implementation

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -247,6 +247,15 @@
     }
  
     public void m_19920_(float p_19921_, Vec3 p_19922_) {
+@@ -1525,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return false;
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, false);
+    }
+ 
+    public void m_5993_(Entity p_19953_, int p_19954_, DamageSource p_19955_) {
 @@ -1620,6 +_,8 @@
              p_20241_.m_128379_("HasVisualFire", this.f_146813_);
           }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -533,6 +533,15 @@
           if (itemstack.m_150930_(Items.f_42741_) && ElytraItem.m_41140_(itemstack)) {
              flag = true;
              int i = this.f_20937_ + 1;
+@@ -2764,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return this.m_6084_() && !this.m_5833_() && !this.m_6147_();
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, this.m_6084_() && !this.m_5833_() && !this.m_6147_());
+    }
+ 
+    public float m_6080_() {
 @@ -2821,8 +_,11 @@
  
     private void m_21329_() {

--- a/patches/minecraft/net/minecraft/world/entity/animal/Parrot.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Parrot.java.patch
@@ -9,3 +9,12 @@
                 this.m_21828_(p_29414_);
                 this.m_9236_().m_7605_(this, (byte)7);
              } else {
+@@ -352,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return true;
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, true);
+    }
+ 
+    protected void m_7324_(Entity p_29367_) {

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/horse/AbstractHorse.java
 +++ b/net/minecraft/world/entity/animal/horse/AbstractHorse.java
+@@ -267,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return !this.m_20160_();
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, !this.m_20160_());
+    }
+ 
+    private void m_30610_() {
 @@ -327,6 +_,7 @@
  
        this.f_30520_.m_19164_(this);

--- a/patches/minecraft/net/minecraft/world/entity/decoration/ArmorStand.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/decoration/ArmorStand.java.patch
@@ -9,3 +9,12 @@
     };
     private final NonNullList<ItemStack> f_31538_ = NonNullList.m_122780_(2, ItemStack.f_41583_);
     private final NonNullList<ItemStack> f_31539_ = NonNullList.m_122780_(4, ItemStack.f_41583_);
+@@ -271,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return false;
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, false);
+    }
+ 
+    protected void m_7324_(Entity p_31564_) {

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -45,7 +45,7 @@
  
     public boolean m_6094_() {
 -      return true;
-+      return canBePushed;
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, canBePushed);
     }
  
     protected Vec3 m_7643_(Direction.Axis p_38132_, BlockUtil.FoundRectangle p_38133_) {

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -9,6 +9,15 @@
     private static final EntityDataAccessor<Integer> f_38282_ = SynchedEntityData.m_135353_(Boat.class, EntityDataSerializers.f_135028_);
     private static final EntityDataAccessor<Integer> f_38283_ = SynchedEntityData.m_135353_(Boat.class, EntityDataSerializers.f_135028_);
     private static final EntityDataAccessor<Float> f_38284_ = SynchedEntityData.m_135353_(Boat.class, EntityDataSerializers.f_135029_);
+@@ -133,7 +_,7 @@
+    }
+ 
+    public boolean m_6094_() {
+-      return true;
++      return net.minecraftforge.common.ForgeHooks.onPushCheck(this, true);
+    }
+ 
+    protected Vec3 m_7643_(Direction.Axis p_38335_, BlockUtil.FoundRectangle p_38336_) {
 @@ -455,7 +_,7 @@
              for(int i2 = i1; i2 < j1; ++i2) {
                 blockpos$mutableblockpos.m_122178_(l1, k1, i2);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -376,6 +376,13 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new LivingJumpEvent(entity));
     }
 
+    public static boolean onPushCheck(Entity entity, boolean pushable)
+    {
+        var event = new EntityEvent.IsPushable(entity, pushable);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isPushable();
+    }
+
     @Nullable
     public static ItemEntity onPlayerTossEvent(@NotNull Player player, @NotNull ItemStack item, boolean includeName)
     {

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -8,7 +8,9 @@ package net.minecraftforge.event.entity;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Pose;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -225,5 +227,42 @@ public class EntityEvent extends Event
         public float getOriginalEyeHeight() { return originalEyeHeight; }
         public float getNewEyeHeight() { return newEyeHeight; }
         public void setNewEyeHeight(float newEyeHeight) { this.newEyeHeight = newEyeHeight; }
+    }
+
+
+    /**
+     * IsPushable is fired when an Entity is about to be pushed.<br>
+     * This event is fired whenever a push check is called from
+     * {@code LivingEntity#isPushable()} and other implementations
+     * <br>
+     * This event is fired via the {@link ForgeHooks#onPushCheck(Entity, boolean)}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class IsPushable extends EntityEvent
+    {
+
+        private boolean pushable;
+
+        public IsPushable(Entity entity, boolean pushable)
+        {
+            super(entity);
+
+            this.pushable = pushable;
+        }
+
+        public boolean isPushable()
+        {
+            return this.pushable;
+        }
+
+        public void setPushable(boolean pushable)
+        {
+            this.pushable = pushable;
+        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/entity/IsPushableTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/IsPushableTest.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.debug.entity;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(IsPushableTest.MODID)
+public class IsPushableTest {
+
+    public static final boolean ENABLE = false;
+    public static final String MODID = "is_pushable_test";
+
+    public IsPushableTest()
+    {
+        if (ENABLE)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void pushAttempt(EntityEvent.IsPushable event)
+    {
+        if (event.getEntity() instanceof Player player)
+        {
+            event.setPushable(false);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/IsPushableTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/IsPushableTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.entity;
 
 import net.minecraft.world.entity.player.Player;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -305,5 +305,7 @@ modId="custom_fluid_container_test"
 modId="alter_ground_event_test"
 [[mods]]
 modId="keymapping_test"
+[[mods]]
+modId="is_pushable_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
## Description
This PR adds the EntityEvent.IsPushable class so that you can prevent entities from being pushed in any given situation, with the main intention being to prevent this interaction with vanilla entities. 

## Reason
The main use-case I have for making this is for preventing players from being pushed. In lower versions there was a variable in the Entity class mapped to "pushthrough" which was used in Mojang's code for determining how much an Entity would be pushed by. However, in modern versions Mojang removed this and replaced this with the "isPushable" method. Unfortuantely this means that you cannot prevent players from being pushed anymore, and in my specific instance it means that when a player is in a GUI and gets pushed into a nether portal the nether portal GUI effect begins to cause graphical errors. They could also be pushed into other damage sources whilst in this GUI which is something I'd like to prevent without putting them in spectator mode.

## Details
I added the event to each of the overrides of the isPushable method such that it would fire consistently for all entities, with the exception of those entities that have a super call. I did this as I assumed it would be much more useful to others if it covered more than just the Player entity. 

I did not include the event call in classes such as the Warden where they have a super call, as I figured that if they wanted to prevent the warden from being pushed they could set it to return false and the logical and would end up returning false and as such the event won't fire twice. However, now I am considering that perhaps it is returning false and they want it to return true? Is this something that should be changed?

Code from Warden.java:
```java
   public boolean isPushable() {
      return !this.isDiggingOrEmerging() && super.isPushable();
   }
```
