### PR TITLE
Living override scale test

### DIFF
--- a/src/test/java/net/minecraftforge/debug/entity/living/LivingOverrideScaleTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/LivingOverrideScaleTest.java
@@ -1,9 +1,13 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.entity.living;
 
 import net.minecraft.client.renderer.entity.PigRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.animal.Pig;

--- a/src/test/java/net/minecraftforge/debug/entity/living/LivingOverrideScaleTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/LivingOverrideScaleTest.java
@@ -1,0 +1,79 @@
+package net.minecraftforge.debug.entity.living;
+
+import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.animal.Pig;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod(LivingOverrideScaleTest.MODID)
+@Mod.EventBusSubscriber(modid=LivingOverrideScaleTest.MODID, bus= Mod.EventBusSubscriber.Bus.MOD)
+public class LivingOverrideScaleTest {
+    public static final String MODID = "living_override_scale_test";
+
+    public static final DeferredRegister<EntityType<?>> ENTITY_TYPES = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES,
+            MODID);
+
+
+    public static final RegistryObject<EntityType<TestPig>> TEST_PIG = ENTITY_TYPES.register(
+            "test_scale_pig", () ->
+                    EntityType.Builder.of(TestPig::new, MobCategory.CREATURE)
+                            .sized(EntityType.PIG.getWidth(), EntityType.PIG.getHeight())
+                            .build(new ResourceLocation(MODID, "test_scale_pig").toString())
+    );
+
+    public LivingOverrideScaleTest ()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ENTITY_TYPES.register(modEventBus);
+    }
+
+    @SubscribeEvent
+    public static void entityRegistry(EntityAttributeCreationEvent event)
+    {
+        event.put(TEST_PIG.get(), Pig.createAttributes().build());
+    }
+
+    @Mod.EventBusSubscriber(modid = MODID, value= Dist.CLIENT, bus= Mod.EventBusSubscriber.Bus.MOD)
+    private static class LivingOverrideScaleClient
+    {
+        @SubscribeEvent
+        public static void registerModels(EntityRenderersEvent.RegisterRenderers evt)
+        {
+            evt.registerEntityRenderer(TEST_PIG.get(), PigRenderer::new);
+        }
+    }
+
+    public static class TestPig extends Pig {
+
+        private final HumanoidArm someNullable;
+
+
+        public TestPig(EntityType<? extends Pig> p_29462_, Level p_29463_) {
+            super(p_29462_, p_29463_);
+            someNullable = HumanoidArm.LEFT;
+        }
+
+        @Override
+        public float getScale() {
+            if (someNullable.ordinal() > 0){
+                return 2.0f;
+            } else {
+                return 1.0f;
+            }
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -41,6 +41,9 @@ modId="mdk_datagen"
 [[mods]]
     modId="calculate_normals_test"
 
+[[mods]]
+    modId="living_override_scale_test"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
A simple test to catch one of the issues we've seen with the Living#getDimensions changes

Overrides getScale with a value that is null during construction. If you try to summon the test pig at the moment you'll see:

`java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.HumanoidArm.ordinal()" because "this.someNullable" is null
	at net.minecraftforge.debug.entity.living.LivingOverrideScaleTest$TestPig.getScale(LivingOverrideScaleTest.java:72) ~[%23196!/:?] {re:classloading}
	at net.minecraft.world.entity.LivingEntity.getDimensions(LivingEntity.java:3165) ~[%23191!/:?] {re:classloading}
	at net.minecraft.world.entity.Entity.getDimensionsForge(Entity.java:3496) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.entity.Entity.<init>(Entity.java:261) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.entity.LivingEntity.<init>(LivingEntity.java:233) ~[%23191!/:?] {re:classloading}
	at net.minecraft.world.entity.Mob.<init>(Mob.java:123) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.entity.PathfinderMob.<init>(PathfinderMob.java:14) ~[%23191!/:?] {re:classloading}
	at net.minecraft.world.entity.AgeableMob.<init>(AgeableMob.java:24) ~[%23191!/:?] {re:classloading}
	at net.minecraft.world.entity.animal.Animal.<init>(Animal.java:40) ~[%23191!/:?] {re:classloading}
	at net.minecraft.world.entity.animal.Pig.<init>(Pig.java:57) ~[%23191!/:?] {re:classloading}
	at net.minecraftforge.debug.entity.living.LivingOverrideScaleTest$TestPig.<init>(LivingOverrideScaleTest.java:66) ~[%23196!/:?] {re:classloading}
	at net.minecraft.world.entity.EntityType.create(EntityType.java:525) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.world.entity.EntityType.lambda$create$4(EntityType.java:530) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at java.util.Optional.map(Optional.java:260) ~[?:?] {}
	at net.minecraft.world.entity.EntityType.create(EntityType.java:529) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.world.entity.EntityType.loadStaticEntity(EntityType.java:607) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.world.entity.EntityType.loadEntityRecursive(EntityType.java:563) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.server.commands.SummonCommand.createEntity(SummonCommand.java:52) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.server.commands.SummonCommand.spawnEntity(SummonCommand.java:73) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at net.minecraft.server.commands.SummonCommand.lambda$register$1(SummonCommand.java:36) ~[%23191!/:?] {re:classloading,xf:fml:forge:forge_method_redirector}
	at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:264) ~[brigadier-1.1.8.jar%23161!/:?] {}
	at net.minecraft.commands.Commands.performCommand(Commands.java:257) ~[%23191!/:?] {re:classloading}
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performChatCommand(ServerGamePacketListenerImpl.java:1246) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$11(ServerGamePacketListenerImpl.java:1223) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:58) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?] {}
	at net.minecraft.server.TickTask.run(TickTask.java:17) ~[%23191!/:?] {re:classloading}
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:143) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:22) ~[%23191!/:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:770) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:161) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:116) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:753) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:747) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:126) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:733) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:665) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:251) ~[%23191!/:?] {re:classloading,pl:accesstransformer:B}
	at java.lang.Thread.run(Thread.java:833) ~[?:?] {}
[07:24:24] [Render thread/INFO] [minecraft/ChatComponent]: [System] [CHAT] Unable to summon entity`