### PR TITLE
feat(api/entity): add EntityEvent.Push when an entity is pushed

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -244,6 +244,16 @@
     }
  
     public void moveRelative(float p_19921_, Vec3 p_19922_) {
+@@ -1450,7 +_,8 @@
+    }
+ 
+    public void push(double p_20286_, double p_20287_, double p_20288_) {
+-      this.setDeltaMovement(this.getDeltaMovement().add(p_20286_, p_20287_, p_20288_));
++      var motion = net.minecraftforge.common.ForgeHooks.onPush(this, p_20286_, p_20287_, p_20288_);
++      this.setDeltaMovement(this.getDeltaMovement().add(motion.x(), motion.y(), motion.z()));
+       this.hasImpulse = true;
+    }
+ 
 @@ -1630,6 +_,8 @@
              p_20241_.putBoolean("HasVisualFire", this.hasVisualFire);
           }

--- a/patches/minecraft/net/minecraft/world/entity/decoration/HangingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/decoration/HangingEntity.java.patch
@@ -9,3 +9,14 @@
                 if (!blockstate.isSolid() && !DiodeBlock.isDiode(blockstate)) {
                    return false;
                 }
+@@ -170,6 +_,10 @@
+    }
+ 
+    public void push(double p_31744_, double p_31745_, double p_31746_) {
++      var motion = net.minecraftforge.common.ForgeHooks.onPush(this, p_31744_, p_31745_, p_31746_);
++      p_31744_ = motion.x();
++      p_31745_ = motion.y();
++      p_31746_ = motion.z();
+       if (!this.level().isClientSide && !this.isRemoved() && p_31744_ * p_31744_ + p_31745_ * p_31745_ + p_31746_ * p_31746_ > 0.0D) {
+          this.kill();
+          this.dropItem((Entity)null);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -129,6 +129,7 @@ import net.minecraftforge.event.RegisterStructureConversionsEvent;
 import net.minecraftforge.event.VanillaGameEvent;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.EnderManAngerEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -329,6 +330,13 @@ public class ForgeHooks {
 
     public static void onLivingJump(LivingEntity entity) {
         MinecraftForge.EVENT_BUS.post(new LivingJumpEvent(entity));
+    }
+
+    public static Vec3 onPush(Entity entity, double motionX, double motionY, double motionZ)
+    {
+        var event = new EntityEvent.Push(entity, motionX, motionY, motionZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getMotion();
     }
 
     @SuppressWarnings("resource")

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -106,6 +107,38 @@ public class EntityEvent extends Event {
          */
         public boolean didChunkChange() {
             return SectionPos.x(packedOldPos) != SectionPos.x(packedNewPos) || SectionPos.z(packedOldPos) != SectionPos.z(packedNewPos);
+        }
+    }
+
+    /**
+     * This event is fired whenever {@link Entity#push(double, double, double)} gets called.<br>
+     * You can use this to modify the push motion. <br>
+     * Setting the motion on all axies to 0 is equivalent to cancelling the push altogether
+     * <br>
+     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class Push extends EntityEvent
+    {
+        private Vec3 motion;
+
+        public Push(Entity entity, double motionX, double motionY, double motionZ)
+        {
+            super(entity);
+            this.motion = new Vec3(motionX, motionY, motionZ);
+        }
+
+        public Vec3 getMotion()
+        {
+            return this.motion;
+        }
+
+        public void setMotion(Vec3 motion)
+        {
+            this.motion = motion;
         }
     }
 }


### PR DESCRIPTION
This PR is a continuation of the conversation from https://github.com/MinecraftForge/MinecraftForge/pull/9675.

## Reason
The main reason I initially wanted to be able to modify the entity's push reaction was to prevent players from being pushed when in a specific GUI. In lower versions this was achievable by modifying the "pushthrough" variable on the Entity however, this was later removed by Mojang in favour of the "isPushable" method. In changing it to use this method they unfortunately removed the capability to prevent entities from being pushed outside of extending the entity and using your own class.

## Details
Originally I added an event called when the `isPushable` method was called. However, when discussing the useful-ness I realized that perhaps adding functionality for modifying the push reaction would be more widely useful. There is only one other instance that this event doesn't cover which is the ItemFrame's push implementation as it eventually calls super anyway

From ItemFrame.java:
```java

   public void push(double p_31817_, double p_31818_, double p_31819_) {
      if (!this.fixed) {
         super.push(p_31817_, p_31818_, p_31819_);
      }

   }
```

The only other consideration I had when making this PR was that potentially someone would want the "cause" of the push. There is a method `LivingEntity#doPush` however, it is a protected method and only defers to `Entity#push`. TL;DR: Currently I don't think it is pheasible to include the cause without creating a lot of changes in the Mojang code (which I assume is undesirable)