### PR TITLE
Revert EntityEvent.Size changes to before #9018 was pulled.

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -36,13 +36,14 @@
        this.f_19847_ = p_19870_;
        this.f_19853_ = p_19871_;
        this.f_19815_ = p_19870_.m_20680_();
-@@ -254,7 +_,10 @@
+@@ -254,7 +_,11 @@
        this.f_19804_.m_135372_(f_146800_, 0);
        this.m_8097_();
        this.m_6034_(0.0D, 0.0D, 0.0D);
 -      this.f_19816_ = this.m_6380_(Pose.STANDING, this.f_19815_);
-+      this.f_19815_ = this.getDimensionsForge(Pose.STANDING);
-+      this.f_19816_ = this.getEyeHeightForge(Pose.STANDING, this.f_19815_);
++      var sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.f_19815_, this.m_6380_(Pose.STANDING, this.f_19815_));
++      this.f_19815_ = sizeEvent.getNewSize();
++      this.f_19816_ = sizeEvent.getNewEyeHeight();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
@@ -390,15 +391,6 @@
           }
        } else {
           return null;
-@@ -2489,7 +_,7 @@
-    }
- 
-    protected Vec3 m_7643_(Direction.Axis p_20045_, BlockUtil.FoundRectangle p_20046_) {
--      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.m_6972_(this.m_20089_()));
-+      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.getDimensionsForge(this.m_20089_()));
-    }
- 
-    protected Optional<BlockUtil.FoundRectangle> m_183318_(ServerLevel p_185935_, BlockPos p_185936_, boolean p_185937_, WorldBorder p_185938_) {
 @@ -2557,6 +_,7 @@
        return this.f_19821_;
     }
@@ -407,25 +399,15 @@
     public boolean m_6063_() {
        return true;
     }
-@@ -2670,17 +_,17 @@
-    @Deprecated
-    protected void m_252801_() {
-       Pose pose = this.m_20089_();
--      EntityDimensions entitydimensions = this.m_6972_(pose);
-+      EntityDimensions entitydimensions = this.getDimensionsForge(pose);
-       this.f_19815_ = entitydimensions;
--      this.f_19816_ = this.m_6380_(pose, entitydimensions);
-+      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions);
-    }
- 
-    public void m_6210_() {
+@@ -2679,8 +_,10 @@
        EntityDimensions entitydimensions = this.f_19815_;
        Pose pose = this.m_20089_();
--      EntityDimensions entitydimensions1 = this.m_6972_(pose);
-+      EntityDimensions entitydimensions1 = this.getDimensionsForge(pose);
+       EntityDimensions entitydimensions1 = this.m_6972_(pose);
++      var sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, entitydimensions, entitydimensions1, this.m_6380_(pose, entitydimensions1));
++      entitydimensions1 = sizeEvent.getNewSize();
        this.f_19815_ = entitydimensions1;
 -      this.f_19816_ = this.m_6380_(pose, entitydimensions1);
-+      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions1);
++      this.f_19816_ = sizeEvent.getNewEyeHeight();
        this.m_20090_();
        boolean flag = (double)entitydimensions1.f_20377_ <= 4.0D && (double)entitydimensions1.f_20378_ <= 4.0D;
        if (!this.m_9236_().f_46443_ && !this.f_19803_ && !this.f_19794_ && flag && (entitydimensions1.f_20377_ > entitydimensions.f_20377_ || entitydimensions1.f_20378_ > entitydimensions.f_20378_) && !(this instanceof Player)) {
@@ -440,33 +422,6 @@
           });
        }
  
-@@ -2720,7 +_,7 @@
-    }
- 
-    protected AABB m_20217_(Pose p_20218_) {
--      EntityDimensions entitydimensions = this.m_6972_(p_20218_);
-+      EntityDimensions entitydimensions = this.getDimensionsForge(p_20218_);
-       float f = entitydimensions.f_20377_ / 2.0F;
-       Vec3 vec3 = new Vec3(this.m_20185_() - (double)f, this.m_20186_(), this.m_20189_() - (double)f);
-       Vec3 vec31 = new Vec3(this.m_20185_() + (double)f, this.m_20186_() + (double)entitydimensions.f_20378_, this.m_20189_() + (double)f);
-@@ -2731,12 +_,16 @@
-       this.f_19828_ = p_20012_;
-    }
- 
-+   /**
-+    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntityDimensions)} instead.
-+    */
-+   @Deprecated
-    protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {
-       return p_19977_.f_20378_ * 0.85F;
-    }
- 
-    public float m_20236_(Pose p_20237_) {
--      return this.m_6380_(p_20237_, this.m_6972_(p_20237_));
-+      return this.getEyeHeightForge(p_20237_, this.getDimensionsForge(p_20237_));
-    }
- 
-    public final float m_20192_() {
 @@ -2980,9 +_,22 @@
        this.f_19859_ = this.m_146908_();
     }
@@ -577,17 +532,6 @@
        return this.f_19799_.getDouble(p_204037_);
     }
  
-@@ -3080,6 +_,10 @@
-       return new ClientboundAddEntityPacket(this);
-    }
- 
-+   /**
-+    * @deprecated Can be overridden. Use {@link #getDimensionsForge(Pose)} instead.
-+    */
-+   @Deprecated
-    public EntityDimensions m_6972_(Pose p_19975_) {
-       return this.f_19847_.m_20680_();
-    }
 @@ -3192,6 +_,7 @@
  
           this.f_146801_.m_142044_();
@@ -604,7 +548,7 @@
     public float m_274421_() {
        return this.f_19793_;
     }
-@@ -3319,6 +_,111 @@
+@@ -3319,6 +_,109 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -672,6 +616,7 @@
 +   /**
 +    * Accessor method for {@link #getEyeHeight(Pose, EntityDimensions)}
 +    */
++   @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
 +   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
 +   }
@@ -703,12 +648,9 @@
 +      return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
 +   }
 +
++   @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
 +   public EntityDimensions getDimensionsForge(Pose pose) {
-+       EntityDimensions size = m_6972_(pose);
-+       if (size == null) size = this.f_19815_; // this is called in the entity constructor so it is possible that subclasses are not initalized and dont return anything here. So use the default.
-+       var evt = new net.minecraftforge.event.entity.EntityEvent.Size(this, pose, size, this.m_6380_(pose, size));
-+       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
-+       return evt.getNewSize();
++       return m_6972_(pose);
 +   }
 +
 +   /* ================================== Forge End =====================================*/

--- a/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -9,12 +9,3 @@
     };
     private static final float f_256985_ = 4.0F;
     private static final double f_256802_ = 1.0D;
-@@ -207,7 +_,7 @@
-       Direction.Axis direction$axis = blockstate.m_61145_(BlockStateProperties.f_61364_).orElse(Direction.Axis.X);
-       double d0 = (double)p_259931_.f_124349_;
-       double d1 = (double)p_259931_.f_124350_;
--      EntityDimensions entitydimensions = p_259166_.m_6972_(p_259166_.m_20089_());
-+      EntityDimensions entitydimensions = p_259166_.getDimensionsForge(p_259166_.m_20089_());
-       int i = p_259901_ == direction$axis ? 0 : 90;
-       Vec3 vec3 = p_259901_ == direction$axis ? p_260043_ : new Vec3(p_260043_.f_82481_, p_260043_.f_82480_, -p_260043_.f_82479_);
-       double d2 = (double)entitydimensions.f_20377_ / 2.0D + (d0 - (double)entitydimensions.f_20377_) * p_259630_.m_7096_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -430,12 +430,10 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
         return false;
     }
 
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
     default float getEyeHeightForge(Pose pose, EntityDimensions size)
     {
-        float eyeHeight = self().getEyeHeightAccess(pose, size);
-        EntityEvent.EyeHeight evt = new EntityEvent.EyeHeight(self(), pose, size, eyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt.getNewEyeHeight();
+        return self().getEyeHeightAccess(pose, size);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -40,11 +40,13 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -89,6 +91,7 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityMobGriefingEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
@@ -268,7 +271,7 @@ public class ForgeEventFactory
      * @see MobSpawnEvent.FinalizeSpawn
      * @see Mob#finalizeSpawn(ServerLevelAccessor, DifficultyInstance, MobSpawnType, SpawnGroupData, CompoundTag)
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
-     * @implNote Changes to the signature of this method must be reflected in the method redirector coremod. 
+     * @implNote Changes to the signature of this method must be reflected in the method redirector coremod.
      */
     @Nullable
     @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
@@ -787,6 +790,22 @@ public class ForgeEventFactory
     {
         RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment, context);
         MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
+    {
+        var evt = new EntityEvent.Size(entity, pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float newEyeHeight)
+    {
+        var evt = new EntityEvent.Size(entity, pose, oldSize, newSize, entity.getEyeHeight(), newEyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
     public static boolean canLivingConvert(LivingEntity entity, EntityType<? extends LivingEntity> outcome, Consumer<Integer> timer)

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -128,7 +128,6 @@ public class EntityEvent extends Event
     }
 
     /**
-     * This event is fired whenever {@link Entity#getDimensionsForge(Pose)} gets called.<br>
      * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
      * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
@@ -138,28 +137,23 @@ public class EntityEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Size extends EntityEvent
-    {
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    public static class Size extends EntityEvent {
         private final Pose pose;
         private final EntityDimensions originalSize;
         private EntityDimensions newSize;
         private final float oldEyeHeight;
         private float newEyeHeight;
 
-        public Size(Entity entity, Pose pose, EntityDimensions size)
-        {
+        public Size(Entity entity, Pose pose, EntityDimensions size) {
             this(entity, pose, size, 1.0f); // Eye height doesn't matter this is just for binary compatibility.
         }
 
-        @Deprecated(forRemoval = true, since = "1.20.1")
-        public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight)
-        {
+        public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight) {
             this(entity, pose, size, size, defaultEyeHeight, defaultEyeHeight);
         }
 
-        @Deprecated(forRemoval = true, since = "1.20.1")
-        public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight)
-        {
+        public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight) {
             super(entity);
             this.pose = pose;
             this.originalSize = oldSize;
@@ -169,50 +163,33 @@ public class EntityEvent extends Event
         }
 
         public Pose getPose() { return pose; }
-        /** @deprecated Use {@link #getOriginalSize()} */
-        @Deprecated(forRemoval = true, since = "1.20.1")
         public EntityDimensions getOldSize() { return this.getOriginalSize(); }
         public EntityDimensions getOriginalSize() { return originalSize; }
         public EntityDimensions getNewSize() { return newSize; }
         public void setNewSize(EntityDimensions size) { this.newSize = size; }
 
-        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. Updating the eye height will not actually so anything anymore. */
-        @Deprecated(forRemoval = true)
-        public void setNewSize(EntityDimensions size, boolean updateEyeHeight)
-        {
+        public void setNewSize(EntityDimensions size, boolean updateEyeHeight) {
             this.setNewSize(size);
-            if (updateEyeHeight)
-            {
+            if (updateEyeHeight) {
                 this.newEyeHeight = this.getEntity().getEyeHeightAccess(this.getPose(), this.newSize);
             }
         }
-        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. */
-        @Deprecated(forRemoval = true, since = "1.20.1")
         public float getOldEyeHeight() { return oldEyeHeight; }
-        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. */
-        @Deprecated(forRemoval = true, since = "1.20.1")
+        public float getNewEyeHeight() { return newEyeHeight; }
         public void setNewEyeHeight(float eyeHeight) { this.newEyeHeight = eyeHeight; }
     }
 
     /**
-     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose, EntityDimensions)} gets called.<br>
-     * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
-     * <br>
-     * This event is not {@link Cancelable}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult}
-     * <br>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     *Remove Entity Eye/Size hooks, as they need to be redesigned, this is no longer fired in any forge/vanilla code.
      **/
-    public static class EyeHeight extends EntityEvent
-    {
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public static class EyeHeight extends EntityEvent {
         private final Pose pose;
         private final EntityDimensions size;
         private final float originalEyeHeight;
         private float newEyeHeight;
 
-        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
-        {
+        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight) {
             super(entity);
             this.pose = pose;
             this.size = size;


### PR DESCRIPTION
Kept newly added methods for binary compatibility but deprecated them all for removal. The entire pose/eye/size system needs to be reevaluated and address some of Mojang's changes. However this should fix any bugs that pulling that PR may of caused.

Ya I fucked up on this one, I'm sorry. 