### PR TITLE
Fix living breathe handling

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -53,11 +53,12 @@
     public boolean m_6040_() {
        return this.m_6336_() == MobType.f_21641_;
     }
-@@ -352,6 +_,8 @@
+@@ -352,6 +_,9 @@
              }
           }
  
-+         net.minecraftforge.common.ForgeHooks.onLivingBreathe(this, -m_7302_(0), m_7305_(0));
++         int airSupply = this.m_20146_();
++         net.minecraftforge.common.ForgeHooks.onLivingBreathe(this, airSupply - m_7302_(airSupply), m_7305_(airSupply) - airSupply);
 +         if (false) // Forge: Handled in ForgeHooks#onLivingBreathe(LivingEntity, int, int)
           if (this.m_204029_(FluidTags.f_13131_) && !this.m_9236_().m_8055_(BlockPos.m_274561_(this.m_20185_(), this.m_20188_(), this.m_20189_())).m_60713_(Blocks.f_50628_)) {
              boolean flag1 = !this.m_6040_() && !MobEffectUtil.m_19588_(this) && (!flag || !((Player)this).m_150110_().f_35934_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1569,12 +1569,15 @@ public class ForgeHooks
     public static void onLivingBreathe(LivingEntity entity, int consumeAirAmount, int refillAirAmount)
     {
         boolean isAir = entity.getEyeInFluidType().isAir() || entity.level().getBlockState(BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ())).is(Blocks.BUBBLE_COLUMN);
-        boolean canBreathe = isAir || !entity.canDrownInFluidType(entity.getEyeInFluidType()) || MobEffectUtil.hasWaterBreathing(entity) || (entity instanceof Player && ((Player) entity).getAbilities().invulnerable);
-        LivingBreatheEvent breatheEvent = new LivingBreatheEvent(entity, canBreathe, consumeAirAmount, refillAirAmount);
+        boolean canBreathe = !entity.canDrownInFluidType(entity.getEyeInFluidType()) || MobEffectUtil.hasWaterBreathing(entity) || (entity instanceof Player && ((Player) entity).getAbilities().invulnerable);
+        LivingBreatheEvent breatheEvent = new LivingBreatheEvent(entity, isAir || canBreathe, isAir, consumeAirAmount, refillAirAmount);
         MinecraftForge.EVENT_BUS.post(breatheEvent);
         if (breatheEvent.canBreathe())
         {
-            entity.setAirSupply(Math.min(entity.getAirSupply() + breatheEvent.getRefillAirAmount(), entity.getMaxAirSupply()));
+            if (breatheEvent.canRefillAir())
+            {
+                entity.setAirSupply(Math.min(entity.getAirSupply() + breatheEvent.getRefillAirAmount(), entity.getMaxAirSupply()));
+            }
         }
         else
         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1601,7 +1601,7 @@ public class ForgeHooks
             }
         }
 
-        if (isAir && !entity.level().isClientSide && entity.isPassenger() && entity.getVehicle() != null && !entity.getVehicle().canBeRiddenUnderFluidType(entity.getEyeInFluidType(), entity))
+        if (!isAir && !entity.level().isClientSide && entity.isPassenger() && entity.getVehicle() != null && !entity.getVehicle().canBeRiddenUnderFluidType(entity.getEyeInFluidType(), entity))
         {
             entity.stopRiding();
         }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1565,10 +1565,13 @@ public class ForgeHooks
      * @param entity           The living entity which is currently updated
      * @param consumeAirAmount The amount of air to consume when the entity is unable to breathe
      * @param refillAirAmount  The amount of air to refill when the entity is able to breathe
+     * @implNote This method needs to closely replicate the logic found right after the call site in {@link LivingEntity#baseTick()} as it overrides it.
      */
     public static void onLivingBreathe(LivingEntity entity, int consumeAirAmount, int refillAirAmount)
     {
+    	// Check things that vanilla considers to be air - these will cause the air supply to be increased.
         boolean isAir = entity.getEyeInFluidType().isAir() || entity.level().getBlockState(BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ())).is(Blocks.BUBBLE_COLUMN);
+        // The following effects cause the entity to not drown, but do not cause the air supply to be increased.
         boolean canBreathe = !entity.canDrownInFluidType(entity.getEyeInFluidType()) || MobEffectUtil.hasWaterBreathing(entity) || (entity instanceof Player && ((Player) entity).getAbilities().invulnerable);
         LivingBreatheEvent breatheEvent = new LivingBreatheEvent(entity, isAir || canBreathe, isAir, consumeAirAmount, refillAirAmount);
         MinecraftForge.EVENT_BUS.post(breatheEvent);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1583,13 +1583,13 @@ public class ForgeHooks
 
         if (entity.getAirSupply() <= 0)
         {
-            LivingDrownEvent drownEvent = new LivingDrownEvent(entity, entity.getAirSupply() <= -20);
+            LivingDrownEvent drownEvent = new LivingDrownEvent(entity);
             if (!MinecraftForge.EVENT_BUS.post(drownEvent) && drownEvent.isDrowning())
             {
                 entity.setAirSupply(0);
                 Vec3 vec3 = entity.getDeltaMovement();
 
-                for (int i = 0; i < 8; ++i)
+                for (int i = 0; i < drownEvent.getBubbleCount(); ++i)
                 {
                     double d2 = entity.getRandom().nextDouble() - entity.getRandom().nextDouble();
                     double d3 = entity.getRandom().nextDouble() - entity.getRandom().nextDouble();
@@ -1597,7 +1597,7 @@ public class ForgeHooks
                     entity.level().addParticle(ParticleTypes.BUBBLE, entity.getX() + d2, entity.getY() + d3, entity.getZ() + d4, vec3.x, vec3.y, vec3.z);
                 }
 
-                entity.hurt(entity.damageSources().drown(), 2.0F);
+                if (drownEvent.getDamageAmount() > 0) entity.hurt(entity.damageSources().drown(), drownEvent.getDamageAmount());
             }
         }
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -7,21 +7,20 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingBreatheEvent is fired whenever a living entity ticks.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingBreathe(LivingEntity, int, int)}.<br>
- * <br>
- * {@link #canBreathe()} contains if this entity can breathe.<br>
- * {@link #getConsumeAirAmount()} contains the amount of air that will be consumed if this entity can't breathe.<br>
- * {@link #getRefillAirAmount()} contains the amount of air that will be refilled if this entity can breathe.<br>
+ * This event is fired via {@link ForgeHooks#onLivingBreathe(LivingEntity, int, int)}.<br>
  * <br>
  * This event is not {@link Cancelable}.<br>
  * <br>
  * This event does not have a result. {@link HasResult}
- **/
+ * <br>
+ * This event is fired on {@link MinecraftForge#EVENT_BUS}
+ */
 public class LivingBreatheEvent extends LivingEvent
 {
     private boolean canBreathe;
@@ -38,41 +37,76 @@ public class LivingBreatheEvent extends LivingEvent
         this.refillAirAmount = Math.max(refillAirAmount, 0);
     }
 
+    /**
+     * If the entity can breathe and {@link #canRefillAir()} returns true, their air value will be increased by {@link #getRefillAirAmount()}.<br>
+     * If the entity can breathe and {@link #canRefillAir()} returns false, their air value will stay the same.<br>
+     * If the entity cannot breathe, their air value will be reduced by {@link #getConsumeAirAmount()}.
+     * @return True if the entity can breathe
+     */
     public boolean canBreathe()
     {
         return canBreathe;
     }
 
+    /**
+     * Sets if the entity can breathe or not.
+     * @param canBreathe The new value.
+     */
     public void setCanBreathe(boolean canBreathe)
     {
         this.canBreathe = canBreathe;
     }
 
+    /**
+     * If the entity can breathe, {@link #canRefillAir()} will be checked to see if their air value should be refilled.
+     * @return True if the entity can refill its air value
+     */
     public boolean canRefillAir()
     {
         return canRefillAir;
     }
 
+    /**
+     * Sets if the entity can refill its air value or not.
+     * @param canRefillAir The new value.
+     */
     public void setCanRefillAir(boolean canRefillAir)
     {
         this.canRefillAir = canRefillAir;
     }
 
+    /**
+     * @return The amount the entity's {@linkplain LivingEntity#getAirSupply() air supply} will be reduced by if the entity {@linkplain #canBreathe() cannot breathe}.
+     */
     public int getConsumeAirAmount()
     {
         return consumeAirAmount;
     }
 
+    /**
+     * Sets the new consumed air amount.
+     * @param consumeAirAmount The new value.
+     * @see #getConsumeAirAmount()
+     */
     public void setConsumeAirAmount(int consumeAirAmount)
     {
         this.consumeAirAmount = Math.max(consumeAirAmount, 0);
     }
 
+    /**
+     * @return The amount the entity's {@linkplain LivingEntity#getAirSupply() air supply} will be increased by if the entity {@linkplain #canBreathe() can breathe}.
+     */
     public int getRefillAirAmount()
     {
         return refillAirAmount;
     }
 
+    /**
+     * Sets the new refilled air amount.
+     * 
+     * @param refillAirAmount The new value.
+     * @see #getRefillAirAmount()
+     */
     public void setRefillAirAmount(int refillAirAmount)
     {
         this.refillAirAmount = Math.max(refillAirAmount, 0);

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -5,7 +5,9 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.effect.MobEffectUtil;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -35,6 +37,11 @@ public class LivingBreatheEvent extends LivingEvent
         this.canRefillAir = canRefillAir;
         this.consumeAirAmount = Math.max(consumeAirAmount, 0);
         this.refillAirAmount = Math.max(refillAirAmount, 0);
+    }
+
+    public LivingBreatheEvent(LivingEntity entity, boolean canBreathe, int consumeAirAmount, int refillAirAmount)
+    {
+        this(entity, canBreathe, !entity.canDrownInFluidType(entity.getEyeInFluidType()) || MobEffectUtil.hasWaterBreathing(entity) || (entity instanceof Player && ((Player) entity).getAbilities().invulnerable), consumeAirAmount, refillAirAmount);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -25,13 +25,15 @@ import net.minecraftforge.eventbus.api.Cancelable;
 public class LivingBreatheEvent extends LivingEvent
 {
     private boolean canBreathe;
+    private boolean canRefillAir;
     private int consumeAirAmount;
     private int refillAirAmount;
 
-    public LivingBreatheEvent(LivingEntity entity, boolean canBreathe, int consumeAirAmount, int refillAirAmount)
+    public LivingBreatheEvent(LivingEntity entity, boolean canBreathe, boolean canRefillAir, int consumeAirAmount, int refillAirAmount)
     {
         super(entity);
         this.canBreathe = canBreathe;
+        this.canRefillAir = canRefillAir;
         this.consumeAirAmount = Math.max(consumeAirAmount, 0);
         this.refillAirAmount = Math.max(refillAirAmount, 0);
     }
@@ -44,6 +46,16 @@ public class LivingBreatheEvent extends LivingEvent
     public void setCanBreathe(boolean canBreathe)
     {
         this.canBreathe = canBreathe;
+    }
+
+    public boolean canRefillAir()
+    {
+        return canRefillAir;
+    }
+
+    public void setCanRefillAir(boolean canRefillAir)
+    {
+        this.canRefillAir = canRefillAir;
     }
 
     public int getConsumeAirAmount()

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -57,6 +57,16 @@ public class LivingDrownEvent extends LivingEvent
     }
 
     /**
+     * Constructor which auto-populates with some vanilla values.
+     * 
+     * @see #LivingDrownEvent(LivingEntity, boolean, float, boolean)
+     */
+    public LivingDrownEvent(LivingEntity entity, boolean isDrowning)
+    {
+        this(entity, isDrowning, 2.0F, 8);
+    }
+
+    /**
      * This method returns true if the entity is "actively" drowning.<br>
      * For most entities, this happens when their air supply reaches -20.<br>
      * When this is true, the entity will take damage, spawn particles, and reset their air supply to 0.

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -5,23 +5,23 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.world.damagesource.DamageSources;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * LivingDrownEvent is fired whenever a living entity can't breathe and its air aupply is less than or equal to
- * zero.<br>
- * <br>
- * This event is fired via the {@link ForgeHooks#onLivingBreathe(LivingEntity, int, int)}.<br>
- * <br>
- * {@link #isDrowning()} contains if this entity is drowning.<br>
- * <br>
- * This event is {@link Cancelable}.<br>
- * If this event is canceled, this entity won't take drowning damage, no particles will be spawned and the air supply
- * won't be reset to zero ignoring if {@link #isDrowning()} is true or not.<br>
- * <br>
- * This event does not have a result. {@link HasResult}
+ * LivingDrownEvent is fired whenever a living entity can't breathe and its air supply is less than or equal to zero.
+ * <p>
+ * This event is fired via {@link ForgeHooks#onLivingBreathe(LivingEntity, int, int)}.
+ * <p>
+ * This event is {@link Cancelable}. Effects of cancellation are noted in {@link #setCanceled(boolean)}.
+ * <p>
+ * This event does not {@linkplain HasResult have a result}.
+ * This event is fired on {@link MinecraftForge#EVENT_BUS}
  **/
 @Cancelable
 public class LivingDrownEvent extends LivingEvent
@@ -30,6 +30,14 @@ public class LivingDrownEvent extends LivingEvent
     private float damageAmount;
     private int bubbleCount;
 
+    /**
+     * Constructs a new LivingDrownEvent.
+     * 
+     * @param entity       The entity that is drowning.
+     * @param isDrowning   If the entity is "actively" drowning, and would take damage.
+     * @param damageAmount The amount of {@linkplain DamageSources#drown() drowning damage} the entity would take.
+     * @param bubbleCount  The number of {@linkplain ParticleTypes#BUBBLE} particles that will be spawned when actively drowning.
+     */
     public LivingDrownEvent(LivingEntity entity, boolean isDrowning, float damageAmount, int bubbleCount)
     {
         super(entity);
@@ -38,38 +46,95 @@ public class LivingDrownEvent extends LivingEvent
         this.bubbleCount = bubbleCount;
     }
 
+    /**
+     * Constructor which auto-populates with all vanilla values.
+     * 
+     * @see #LivingDrownEvent(LivingEntity, boolean, float, boolean)
+     */
     public LivingDrownEvent(LivingEntity entity)
     {
         this(entity, entity.getAirSupply() <= -20, 2.0F, 8);
     }
 
+    /**
+     * This method returns true if the entity is "actively" drowning.<br>
+     * For most entities, this happens when their air supply reaches -20.<br>
+     * When this is true, the entity will take damage, spawn particles, and reset their air supply to 0.
+     * 
+     * @return If the entity is actively drowning.
+     */
     public boolean isDrowning()
     {
         return isDrowning;
     }
 
+    /**
+     * Sets if the entity is actively drowning.
+     * 
+     * @param isDrowning The new value.
+     * @see #isDrowning()
+     */
     public void setDrowning(boolean isDrowning)
     {
         this.isDrowning = isDrowning;
     }
 
+    /**
+     * Gets the amount of {@linkplain DamageSources#drown() drowning damage} the entity would take.<br>
+     * Drowning damage is only inflicted if the entity is {@linkplain #isDrowning() actively drowning}.<br>
+     * For vanilla entities, the default amount of damage is 2 (1 heart).
+     * <p>
+     * If the damage amount is less than or equal to zero, {@link Entity#hurt} will not be called.
+     * 
+     * @return The amount of damage that will be dealt to the entity when actively drowning.
+     */
     public float getDamageAmount()
     {
         return damageAmount;
     }
 
+    /**
+     * Sets the amount of drowning damage that may be inflicted.
+     * 
+     * @param damageAmount The new value.
+     * @see #getDamageAmount()
+     */
     public void setDamageAmount(float damageAmount)
     {
         this.damageAmount = damageAmount;
     }
 
+    /**
+     * Gets the number of {@linkplain ParticleTypes#BUBBLE} particles that would be spawned.<br>
+     * Bubbles are only spawned if the entity is {@linkplain #isDrowning() actively drowning}.<br>
+     * For vanilla entities, the default value is 8 particles.
+     * 
+     * @return The number of bubble particles that will spawn when actively drowning.
+     */
     public int getBubbleCount()
     {
         return bubbleCount;
     }
 
+    /**
+     * Sets the amount of bubbles that may be spawned.
+     * 
+     * @param bubbleCount The new value.
+     * @see #getBubbleCount()
+     */
     public void setBubbleCount(int bubbleCount)
     {
         this.bubbleCount = bubbleCount;
+    }
+
+    /**
+     * Cancels the drowning event.<br>
+     * Cancellation is mostly equivalent to {@link #setDrowning(boolean)} with a value of false.<br>
+     * However, this also incurs the usual side effects of cancellation.
+     */
+    @Override
+    public void setCanceled(boolean cancel)
+    {
+        super.setCanceled(cancel);
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -27,11 +27,20 @@ import net.minecraftforge.eventbus.api.Cancelable;
 public class LivingDrownEvent extends LivingEvent
 {
     private boolean isDrowning;
+    private float damageAmount;
+    private int bubbleCount;
 
-    public LivingDrownEvent(LivingEntity entity, boolean isDrowning)
+    public LivingDrownEvent(LivingEntity entity, boolean isDrowning, float damageAmount, int bubbleCount)
     {
         super(entity);
         this.isDrowning = isDrowning;
+        this.damageAmount = damageAmount;
+        this.bubbleCount = bubbleCount;
+    }
+
+    public LivingDrownEvent(LivingEntity entity)
+    {
+        this(entity, entity.getAirSupply() <= -20, 2.0F, 8);
     }
 
     public boolean isDrowning()
@@ -42,5 +51,25 @@ public class LivingDrownEvent extends LivingEvent
     public void setDrowning(boolean isDrowning)
     {
         this.isDrowning = isDrowning;
+    }
+
+    public float getDamageAmount()
+    {
+        return damageAmount;
+    }
+
+    public void setDamageAmount(float damageAmount)
+    {
+        this.damageAmount = damageAmount;
+    }
+
+    public int getBubbleCount()
+    {
+        return bubbleCount;
+    }
+
+    public void setBubbleCount(int bubbleCount)
+    {
+        this.bubbleCount = bubbleCount;
     }
 }


### PR DESCRIPTION
#9525 introduced some issues:
- Players are not unmounted from entities like horses while underwater
- When underwater the air supply of entities is refilled when the entity is unable to drown (i.e. water breathing, creative mode, ...)
- Non-linear decreaseAirSupply/increaseAirSupply overrides are not supported

The LivingDrownEvent is extended by this PR allowing modders to control the bubble count and damage amount when an entity is drowning.

This PR also adds comments to all the methods of the LivingBreatheEvent and LivingDrownEvent class.

Most of these changes are based on https://github.com/neoforged/NeoForge/commit/bfeb5e03f7b1047ef6e5711f09fac0942dd85bfe with an agreement from Shadows-of-Fire that I'm allowed to create this PR.
The only difference is that this PR adds the `canRefillAir` parameter to the LivingBreatheEvent. This fixes the issue of water breathing refilling the air supply while underwater without loosing information by setting the refillAirAmount to 0.