### PR TITLE
Fix size event not being fired and split into size and eye height event

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -36,14 +36,15 @@
        this.f_19847_ = p_19870_;
        this.f_19853_ = p_19871_;
        this.f_19815_ = p_19870_.m_20680_();
-@@ -254,7 +_,11 @@
+@@ -254,7 +_,12 @@
        this.f_19804_.m_135372_(f_146800_, 0);
        this.m_8097_();
        this.m_6034_(0.0D, 0.0D, 0.0D);
 -      this.f_19816_ = this.m_6380_(Pose.STANDING, this.f_19815_);
-+      var sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.f_19815_, this.m_6380_(Pose.STANDING, this.f_19815_));
++      var sizeEvent = new net.minecraftforge.event.entity.EntityEvent.Size(this, Pose.STANDING, this.f_19815_);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(sizeEvent);
 +      this.f_19815_ = sizeEvent.getNewSize();
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      this.f_19816_ = this.getEyeHeightForge(Pose.STANDING, this.f_19815_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
@@ -391,6 +392,15 @@
           }
        } else {
           return null;
+@@ -2489,7 +_,7 @@
+    }
+ 
+    protected Vec3 m_7643_(Direction.Axis p_20045_, BlockUtil.FoundRectangle p_20046_) {
+-      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.m_6972_(this.m_20089_()));
++      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.getDimensionsForge(this.m_20089_()));
+    }
+ 
+    protected Optional<BlockUtil.FoundRectangle> m_183318_(ServerLevel p_185935_, BlockPos p_185936_, boolean p_185937_, WorldBorder p_185938_) {
 @@ -2557,6 +_,7 @@
        return this.f_19821_;
     }
@@ -399,15 +409,25 @@
     public boolean m_6063_() {
        return true;
     }
-@@ -2679,8 +_,10 @@
+@@ -2670,17 +_,16 @@
+    @Deprecated
+    protected void m_252801_() {
+       Pose pose = this.m_20089_();
+-      EntityDimensions entitydimensions = this.m_6972_(pose);
++      EntityDimensions entitydimensions = this.getDimensionsForge(pose);
+       this.f_19815_ = entitydimensions;
+-      this.f_19816_ = this.m_6380_(pose, entitydimensions);
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions);
+    }
+ 
+    public void m_6210_() {
        EntityDimensions entitydimensions = this.f_19815_;
        Pose pose = this.m_20089_();
-       EntityDimensions entitydimensions1 = this.m_6972_(pose);
-+      var sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, entitydimensions, entitydimensions1, this.m_6380_(pose, entitydimensions1));
-+      entitydimensions1 = sizeEvent.getNewSize();
-       this.f_19815_ = entitydimensions1;
+-      EntityDimensions entitydimensions1 = this.m_6972_(pose);
+-      this.f_19815_ = entitydimensions1;
 -      this.f_19816_ = this.m_6380_(pose, entitydimensions1);
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      EntityDimensions entitydimensions1 = this.getDimensionsForge(pose);
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions1);
        this.m_20090_();
        boolean flag = (double)entitydimensions1.f_20377_ <= 4.0D && (double)entitydimensions1.f_20378_ <= 4.0D;
        if (!this.m_9236_().f_46443_ && !this.f_19803_ && !this.f_19794_ && flag && (entitydimensions1.f_20377_ > entitydimensions.f_20377_ || entitydimensions1.f_20378_ > entitydimensions.f_20378_) && !(this instanceof Player)) {
@@ -422,6 +442,33 @@
           });
        }
  
+@@ -2720,7 +_,7 @@
+    }
+ 
+    protected AABB m_20217_(Pose p_20218_) {
+-      EntityDimensions entitydimensions = this.m_6972_(p_20218_);
++      EntityDimensions entitydimensions = this.getDimensionsForge(p_20218_);
+       float f = entitydimensions.f_20377_ / 2.0F;
+       Vec3 vec3 = new Vec3(this.m_20185_() - (double)f, this.m_20186_(), this.m_20189_() - (double)f);
+       Vec3 vec31 = new Vec3(this.m_20185_() + (double)f, this.m_20186_() + (double)entitydimensions.f_20378_, this.m_20189_() + (double)f);
+@@ -2731,12 +_,16 @@
+       this.f_19828_ = p_20012_;
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntityDimensions)} instead.
++    */
++   @Deprecated
+    protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {
+       return p_19977_.f_20378_ * 0.85F;
+    }
+ 
+    public float m_20236_(Pose p_20237_) {
+-      return this.m_6380_(p_20237_, this.m_6972_(p_20237_));
++      return this.getEyeHeightForge(p_20237_, this.getDimensionsForge(p_20237_));
+    }
+ 
+    public final float m_20192_() {
 @@ -2980,9 +_,22 @@
        this.f_19859_ = this.m_146908_();
     }
@@ -532,6 +579,17 @@
        return this.f_19799_.getDouble(p_204037_);
     }
  
+@@ -3080,6 +_,10 @@
+       return new ClientboundAddEntityPacket(this);
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getDimensionsForge(Pose)} instead.
++    */
++   @Deprecated
+    public EntityDimensions m_6972_(Pose p_19975_) {
+       return this.f_19847_.m_20680_();
+    }
 @@ -3192,6 +_,7 @@
  
           this.f_146801_.m_142044_();
@@ -548,7 +606,7 @@
     public float m_274421_() {
        return this.f_19793_;
     }
-@@ -3319,6 +_,109 @@
+@@ -3319,6 +_,103 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -616,7 +674,6 @@
 +   /**
 +    * Accessor method for {@link #getEyeHeight(Pose, EntityDimensions)}
 +    */
-+   @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
 +   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
 +   }
@@ -646,11 +703,6 @@
 +   @Override
 +   public net.minecraftforge.fluids.FluidType getMaxHeightFluidType() {
 +      return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
-+   }
-+
-+   @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
-+   public EntityDimensions getDimensionsForge(Pose pose) {
-+       return m_6972_(pose);
 +   }
 +
 +   /* ================================== Forge End =====================================*/

--- a/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -9,3 +9,12 @@
     };
     private static final float f_256985_ = 4.0F;
     private static final double f_256802_ = 1.0D;
+@@ -207,7 +_,7 @@
+       Direction.Axis direction$axis = blockstate.m_61145_(BlockStateProperties.f_61364_).orElse(Direction.Axis.X);
+       double d0 = (double)p_259931_.f_124349_;
+       double d1 = (double)p_259931_.f_124350_;
+-      EntityDimensions entitydimensions = p_259166_.m_6972_(p_259166_.m_20089_());
++      EntityDimensions entitydimensions = p_259166_.getDimensionsForge(p_259166_.m_20089_());
+       int i = p_259901_ == direction$axis ? 0 : 90;
+       Vec3 vec3 = p_259901_ == direction$axis ? p_260043_ : new Vec3(p_260043_.f_82481_, p_260043_.f_82480_, -p_260043_.f_82479_);
+       double d2 = (double)entitydimensions.f_20377_ / 2.0D + (d0 - (double)entitydimensions.f_20377_) * p_259630_.m_7096_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -430,10 +430,21 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
         return false;
     }
 
-    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    default EntityDimensions getDimensionsForge(Pose pose)
+    {
+        EntityDimensions size = self().getDimensions(pose);
+        EntityEvent.Size evt = new EntityEvent.Size(self(), pose, size);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewSize();
+    }
+
     default float getEyeHeightForge(Pose pose, EntityDimensions size)
     {
-        return self().getEyeHeightAccess(pose, size);
+        float eyeHeight = self().getEyeHeightAccess(pose, size);
+        // TODO Use EntityEvent.EyeHeight instead of EntityEvent.Size in 1.21
+        EntityEvent.Size evt = new EntityEvent.Size(self(), pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewEyeHeight();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -88,6 +88,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
@@ -792,7 +793,7 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
     }
 
-    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove this, as it will be replaced by IForgeEntity#getDimensionsForge(Pose) and IForgeEntity#getEyeHeightForge(Pose, EntityDimensions)
     public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
     {
         var evt = new EntityEvent.Size(entity, pose, size, eyeHeight);
@@ -800,7 +801,7 @@ public class ForgeEventFactory
         return evt;
     }
 
-    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
+    @Deprecated(forRemoval = true, since = "1.20.1") // Remove this, as it will be replaced by IForgeEntity#getDimensionsForge(Pose) and IForgeEntity#getEyeHeightForge(Pose, EntityDimensions)
     public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float newEyeHeight)
     {
         var evt = new EntityEvent.Size(entity, pose, oldSize, newSize, entity.getEyeHeight(), newEyeHeight);

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -128,6 +128,7 @@ public class EntityEvent extends Event
     }
 
     /**
+     * This event is fired whenever {@link IForgeEntity#getDimensionsForge(Pose)} gets called.<br>
      * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
      * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
@@ -137,22 +138,26 @@ public class EntityEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    @Deprecated(forRemoval = true, since = "1.20.1") // Remove Entity Eye/Size hooks, as they need to be redesigned
-    public static class Size extends EntityEvent {
+    public static class Size extends EntityEvent
+    {
         private final Pose pose;
         private final EntityDimensions originalSize;
         private EntityDimensions newSize;
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         private final float oldEyeHeight;
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         private float newEyeHeight;
 
         public Size(Entity entity, Pose pose, EntityDimensions size) {
             this(entity, pose, size, 1.0f); // Eye height doesn't matter this is just for binary compatibility.
         }
 
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight) {
             this(entity, pose, size, size, defaultEyeHeight, defaultEyeHeight);
         }
 
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight) {
             super(entity);
             this.pose = pose;
@@ -163,33 +168,47 @@ public class EntityEvent extends Event
         }
 
         public Pose getPose() { return pose; }
+        @Deprecated(forRemoval = true, since = "1.20.1") // Remove this, as it will be replaced by EntityEvent.Size#getOriginalSize
         public EntityDimensions getOldSize() { return this.getOriginalSize(); }
         public EntityDimensions getOriginalSize() { return originalSize; }
         public EntityDimensions getNewSize() { return newSize; }
         public void setNewSize(EntityDimensions size) { this.newSize = size; }
 
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public void setNewSize(EntityDimensions size, boolean updateEyeHeight) {
             this.setNewSize(size);
             if (updateEyeHeight) {
                 this.newEyeHeight = this.getEntity().getEyeHeightAccess(this.getPose(), this.newSize);
             }
         }
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public float getOldEyeHeight() { return oldEyeHeight; }
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public float getNewEyeHeight() { return newEyeHeight; }
+        @Deprecated(forRemoval = true, since = "1.20.1") // Replace this, as it will be replaced by EntityEvent.EyeHeight
         public void setNewEyeHeight(float eyeHeight) { this.newEyeHeight = eyeHeight; }
     }
 
     /**
-     *Remove Entity Eye/Size hooks, as they need to be redesigned, this is no longer fired in any forge/vanilla code.
+     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose, EntityDimensions)} gets called.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    @Deprecated(forRemoval = true, since = "1.20.1")
-    public static class EyeHeight extends EntityEvent {
+    @Deprecated(forRemoval = false, since = "1.20.1") // Use EntityEvent.EyeHeight instead of EntityEvent.Size in IForgeEntity#getEyeHeightForge(Pose)
+    public static class EyeHeight extends EntityEvent
+    {
         private final Pose pose;
         private final EntityDimensions size;
         private final float originalEyeHeight;
         private float newEyeHeight;
 
-        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight) {
+        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
+        {
             super(entity);
             this.pose = pose;
             this.size = size;


### PR DESCRIPTION
This is a re-implementation of #9535 with several changes:
- The LivingEntity patch was removed to fix an infinite loop
(see 8df5a80 and #9647)
- IForgeEntity#getDimensionsForge(Pose) is not called in the entity constructor
(see 16863c8 and #9676)
- No methods are deleted to keep binary compatibility
(see 26adf4d and #9679)
- EntityEvent.EyeHeight is marked as deprecated and unused to not introduce a breaking change
- All classes/field/methods that should be removed in the future are marked as deprecated