### PR TITLE
Invalidate Ingredients on tags update, make getItems() check ingredient invalidation

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -27,6 +27,15 @@
  
     protected Ingredient(Stream<? extends Ingredient.Value> p_43907_) {
        this.values = p_43907_.toArray((p_43933_) -> {
+@@ -50,7 +_,7 @@
+    }
+ 
+    public ItemStack[] getItems() {
+-      if (this.itemStacks == null) {
++      if (this.itemStacks == null || checkInvalidation()) {
+          this.itemStacks = Arrays.stream(this.values).flatMap((p_43916_) -> {
+             return p_43916_.getItems().stream();
+          }).distinct().toArray((p_43910_) -> {
 @@ -78,7 +_,8 @@
     }
  

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -58,6 +58,7 @@ import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveSpawnsBiomeModi
 import net.minecraftforge.common.world.NoneBiomeModifier;
 import net.minecraftforge.common.world.NoneStructureModifier;
 import net.minecraftforge.common.world.StructureModifier;
+import net.minecraftforge.event.TagsUpdatedEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
@@ -430,6 +431,7 @@ public class ForgeMod {
         MinecraftForge.EVENT_BUS.addListener(VillagerTradingManager::loadTrades);
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         MinecraftForge.EVENT_BUS.addListener(this::mappingChanged);
+        MinecraftForge.EVENT_BUS.addListener(this::tagsUpdated);
         MinecraftForge.EVENT_BUS.addListener(this::registerPermissionNodes);
         MinecraftForge.EVENT_BUS.register(new ForgeNetworkConfigurationHandler());
 
@@ -453,6 +455,10 @@ public class ForgeMod {
     }
 
     public void mappingChanged(IdMappingEvent evt) {
+        Ingredient.invalidateAll();
+    }
+
+    public void tagsUpdated(TagsUpdatedEvent evt) {
         Ingredient.invalidateAll();
     }
 


### PR DESCRIPTION
Since it doesn't make much sense that `invalidate()` erasing cached itemstacks, but method which build itemstack cache doesn't check for invalidation.

And since tag ingredients depend on tags, they should be rechecked when tags get updated.

**This fixes issue with recipes bricking IF they network Ingredients themselves rather than final ItemStacks of these ingredients.**