### PR TITLE
[1.19.2] Fixed submitted chat event incompatible with jarInJar

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -33,6 +33,7 @@ import com.mojang.serialization.Lifecycle;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.ResourceLocationException;
+import net.minecraft.Util;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -474,7 +475,7 @@ public class ForgeHooks
                     return message; // Vanilla should never get here with the patches we use, but let's be safe with dumb mods
 
                 return onServerChatSubmittedEvent(sender, getRawText(message), message, true);
-            });
+            }, Util.ioPool());
         }
 
         @NotNull
@@ -488,7 +489,7 @@ public class ForgeHooks
                         return onServerChatSubmittedEvent(sender, message.signedContent().plain(), message.signedContent().decorated(), false) == null;
 
                     return false;
-                }).thenApply(canceled -> canceled == Boolean.TRUE ? null : message);
+                }, Util.ioPool()).thenApply(canceled -> canceled == Boolean.TRUE ? null : message);
             }
 
             return this.decorate(sender, message.serverContent()).thenApply(component -> component == null ? null : message.withUnsignedContent(component));


### PR DESCRIPTION
I have identified an error when using the ServerChatEvent.Submitted event with JarInJar dependencies. The essence of the error is that if we cancel this event and add code from the JarInJar dependency, we will get a ClassNotFoundException error. This error was detected when using Kotlin as a JarInJar dependency. Perhaps in the current PR it is worth replacing Util#ioPool from Minecraft with your own ExecutorService.

In addition, I would like to say that using CompletableFuture without your own ExecutorService is a bad practice.

**Testing version:** 1.19.2

**Using ForkJoinPool**
Configuration gradle:
```gradle
dependencies {
    jarJar("org.jetbrains:annotations:[24.0.1]")
    jarJar("org.jetbrains.kotlin:kotlin-stdlib:[1.9.0]")
    jarJar("org.jetbrains.kotlin:kotlin-stdlib-common:[1.9.0]")
    jarJar("org.jetbrains.kotlin:kotlin-stdlib-jdk7:[1.9.0]")
    jarJar("org.jetbrains.kotlin:kotlin-stdlib-jdk8:[1.9.0]")
    jarJar("org.jetbrains.kotlin:kotlin-reflect:[1.9.0]")
    jarJar("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:[1.7.2]")
    jarJar("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:[1.7.2]")
    jarJar("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:[1.7.2]")
    jarJar("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:[1.5.1]")
    jarJar("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:[1.5.1]")
}
```
Mod code:
```kotlin
@Mod("test")
class FjkTest {
    init {
        MinecraftForge.EVENT_BUS.addListener(::onServerStarting)
    }

    private fun onServerStarting(event: ServerStartingEvent) {
        CompletableFuture.runAsync {
            testException { text ->
            }
        }
    }

    private fun testException(block: String.() -> Unit) {
        println("I will printed with exception")
    }
}
```

Build mod, run outside the IDE and join to world. Look at logs and check stacktrace with ClassNotFoundException: kotlin.blablabla.Lambda

**Using normal ExecutorService**
Configuration gradle: **look at message above**

Mod code:
```kotlin
import net.minecraft.Util

@Mod("test")
class ExecServiceTest {
    init {
        MinecraftForge.EVENT_BUS.addListener(::onServerStarting)
    }

    private fun onServerStarting(event: ServerStartingEvent) {
        CompletableFuture.runAsync({
            testException { text ->
            }
        }, Util.ioPool())
    }

    private fun testException(block: String.() -> Unit) {
        println("I will printed without exception")
    }
}
```