### PR TITLE
[1.20.x] Fix DelegatingPackResources searching resource path twice

### DIFF
--- a/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
+++ b/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
@@ -103,7 +103,7 @@ public class DelegatingPackResources extends AbstractPackResources
         {
             IoSupplier<InputStream> ioSupplier = pack.getResource(type, location);
             if (ioSupplier != null)
-                return pack.getResource(type, location);
+                return ioSupplier;
         }
 
         return null;


### PR DESCRIPTION
A very trivial fix that prevents calling `pack.getResource()` twice unnecessarily.

Reported downstream: https://github.com/neoforged/NeoForge/issues/120
Fixing upstream so that it can be fixed for a wider audience, including 1.19.4 players.