### PR TITLE
[1.19.4] Fix DelegatingPackResources searching resource path twice

### DIFF
--- a/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
+++ b/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
@@ -103,7 +103,7 @@ public class DelegatingPackResources extends AbstractPackResources
         {
             IoSupplier<InputStream> ioSupplier = pack.getResource(type, location);
             if (ioSupplier != null)
-                return pack.getResource(type, location);
+                return ioSupplier;
         }
 
         return null;


### PR DESCRIPTION
Legacy 1.19.4 backport of #9697 