### PR TITLE
[1.20.1] Improve mod loading error message for errors inside mod constructors

### DIFF
--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -70,6 +70,11 @@ public class FMLModContainer extends ModContainer
         }
         catch (Throwable e)
         {
+            // When a mod constructor throws an exception, it's wrapped in an InvocationTargetException which hides the
+            // actual exception from mod loading error screen.
+            if (e instanceof InvocationTargetException)
+                e = e.getCause(); // unwrap the exception
+
             LOGGER.error(LOADING,"Failed to create mod instance. ModID: {}, class {}", getModId(), modClass.getName(), e);
             throw new ModLoadingException(modInfo, ModLoadingStage.CONSTRUCT, "fml.modloading.failedtoloadmod", e, modClass);
         }

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
 public class FMLModContainer extends ModContainer
@@ -71,7 +72,7 @@ public class FMLModContainer extends ModContainer
         catch (Throwable e)
         {
             // When a mod constructor throws an exception, it's wrapped in an InvocationTargetException which hides the
-            // actual exception from mod loading error screen.
+            // actual exception from the mod loading error screen.
             if (e instanceof InvocationTargetException)
                 e = e.getCause(); // unwrap the exception
 

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 import java.util.Optional;
 
 public class FMLModContainer extends ModContainer
@@ -73,8 +74,8 @@ public class FMLModContainer extends ModContainer
         {
             // When a mod constructor throws an exception, it's wrapped in an InvocationTargetException which hides the
             // actual exception from the mod loading error screen.
-            if (e instanceof InvocationTargetException)
-                e = e.getCause(); // unwrap the exception
+            if (e instanceof InvocationTargetException wrapped)
+                e = Objects.requireNonNullElse(wrapped.getCause(), e); // unwrap the exception
 
             LOGGER.error(LOADING,"Failed to create mod instance. ModID: {}, class {}", getModId(), modClass.getName(), e);
             throw new ModLoadingException(modInfo, ModLoadingStage.CONSTRUCT, "fml.modloading.failedtoloadmod", e, modClass);

--- a/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Test that the mod loading error screen shows the cause of the crash when a mod constructor throws an exception.
+ * <p>Enable or disable this test in the mods.toml</p>
+ */
+@Mod("constructor_throw_test")
+public class ConstructorThrowTest {
+    public ConstructorThrowTest() {
+        throw new RuntimeException("Test");
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug;
 
 import net.minecraftforge.fml.common.Mod;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -41,6 +41,9 @@ modId="mdk_datagen"
 [[mods]]
     modId="calculate_normals_test"
 
+#[[mods]]
+#    modId="constructor_throw_test"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
Before
<img width="429" alt="Screenshot 2023-09-03 114324" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/64e22db4-a874-4513-908c-483c18ac3b0f">

After
<img width="429" alt="Screenshot 2023-09-03 114810" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/93f42c5c-e8cb-4ab8-ac75-c89b82e4f0ee">
