### PR TITLE
[1.20.x] Trivial `BackgroundScanHandler` optimisations

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
@@ -32,9 +32,9 @@ public class BackgroundScanHandler
 
     private static final Logger LOGGER = LogUtils.getLogger();
     private final ExecutorService modContentScanner;
-    private final List<ModFile> pendingFiles;
-    private final List<ModFile> scannedFiles;
-    private final List<ModFile> allFiles;
+    //private final List<ModFile> pendingFiles;
+    //private final List<ModFile> scannedFiles;
+    //private final List<ModFile> allFiles;
     private final List<ModFile> modFiles;
     private ScanStatus status;
     private LoadingModList loadingModList;
@@ -44,11 +44,12 @@ public class BackgroundScanHandler
         modContentScanner = Executors.newSingleThreadExecutor(r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);
             thread.setDaemon(true);
+            thread.setName("Background Scan Handler");
             return thread;
         });
-        scannedFiles = new ArrayList<>();
-        pendingFiles = new ArrayList<>();
-        allFiles = new ArrayList<>();
+        //scannedFiles = new ArrayList<>();
+        //pendingFiles = new ArrayList<>();
+        //allFiles = new ArrayList<>();
         status = ScanStatus.NOT_STARTED;
     }
 
@@ -63,8 +64,8 @@ public class BackgroundScanHandler
         }
         status = ScanStatus.RUNNING;
         ImmediateWindowHandler.updateProgress("Scanning mod candidates");
-        allFiles.add(file);
-        pendingFiles.add(file);
+        //allFiles.add(file);
+        //pendingFiles.add(file);
         final CompletableFuture<ModFileScanData> future = CompletableFuture.supplyAsync(file::compileContent, modContentScanner)
                 .whenComplete(file::setScanResult)
                 .whenComplete((r,t)-> this.addCompletedFile(file,r,t));
@@ -76,8 +77,8 @@ public class BackgroundScanHandler
             status = ScanStatus.ERRORED;
             LOGGER.error(LogMarkers.SCAN,"An error occurred scanning file {}", file, throwable);
         }
-        pendingFiles.remove(file);
-        scannedFiles.add(file);
+        //pendingFiles.remove(file);
+        //scannedFiles.add(file);
     }
 
     public void setLoadingModList(LoadingModList loadingModList)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
@@ -36,7 +36,7 @@ public class ModClassVisitor extends ClassVisitor
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces)
     {
         this.asmType = Type.getObjectType(name);
-        this.asmSuperType = superName != null && superName.length() > 0 ? Type.getObjectType(superName) : null;
+        this.asmSuperType = superName != null && !superName.isEmpty() ? Type.getObjectType(superName) : null;
         this.interfaces = Stream.of(interfaces).map(Type::getObjectType).collect(Collectors.toSet());
     }
 
@@ -65,7 +65,7 @@ public class ModClassVisitor extends ClassVisitor
         classes.add(new ModFileScanData.ClassData(this.asmType, this.asmSuperType, this.interfaces));
         final List<ModFileScanData.AnnotationData> collect = this.annotations.stream().
                 filter(ma->ModFileScanData.interestingAnnotations().test(ma.getASMType())).
-                map(a -> ModAnnotation.fromModAnnotation(this.asmType, a)).collect(Collectors.toList());
+                map(a -> ModAnnotation.fromModAnnotation(this.asmType, a)).toList();
         annotations.addAll(collect);
     }
 


### PR DESCRIPTION
- Comment out three private lists that are updated but never queried, with no getters. Presumably some left over debug code?
- Use `.toList()` instead of `.collect(Collectors.toList())` and `!str.isEmpty()` instead of `str.length() > 0` where appropriate