### PR TITLE
[1.20.x] Optimise `ForgeRegistry#validateContent`

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -103,7 +103,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         try {
             tmp = MethodHandles.lookup().findVirtual(BitSet.class, "trimToSize", MethodType.methodType(void.class));
         } catch (Exception ignored) {
-            tmp = null;
+            tmp = null; // We don't care... just a micro-optimization
         }
         BITSET_TRIM_TO_SIZE = tmp;
     }
@@ -591,7 +591,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
             try {
                 BITSET_TRIM_TO_SIZE.invokeExact(this.availabilityMap);
             } catch (Throwable ignored) {
-                // We don't care... just a micro-optimization
+                // BitSet.trimToSize() doesn't throw, so this should never happen.
             }
         }
 

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -58,10 +58,6 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     public static Marker REGISTRIES = MarkerManager.getMarker("REGISTRIES");
     private static final Marker REGISTRYDUMP = MarkerManager.getMarker("REGISTRYDUMP");
     private static final Logger LOGGER = LogManager.getLogger();
-
-    @Nullable
-    private static final MethodHandle BITSET_TRIM_TO_SIZE;
-
     private final RegistryManager stage;
     private final BiMap<Integer, V> ids = HashBiMap.create();
     private final BiMap<ResourceLocation, V> names = HashBiMap.create();
@@ -97,16 +93,6 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     private final RegistryBuilder<V> builder;
 
     private final Codec<V> codec = new RegistryCodec();
-
-    static {
-        MethodHandle tmp;
-        try {
-            tmp = MethodHandles.lookup().findVirtual(BitSet.class, "trimToSize", MethodType.methodType(void.class));
-        } catch (Exception ignored) {
-            tmp = null;
-        }
-        BITSET_TRIM_TO_SIZE = tmp;
-    }
 
     @SuppressWarnings("unchecked")
     ForgeRegistry(RegistryManager stage, ResourceLocation name, RegistryBuilder<V> builder)
@@ -587,14 +573,6 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
 
     void validateContent(ResourceLocation registryName)
     {
-        if (BITSET_TRIM_TO_SIZE != null) {
-            try {
-                BITSET_TRIM_TO_SIZE.invokeExact(this.availabilityMap);
-            } catch (Throwable ignored) {
-                // We don't care... just a micro-optimization
-            }
-        }
-
         for (V obj : this)
         {
             int id = getID(obj);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -5,9 +5,6 @@
 
 package net.minecraftforge.registries;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.IntFunction;

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -103,7 +103,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         try {
             tmp = MethodHandles.lookup().findVirtual(BitSet.class, "trimToSize", MethodType.methodType(void.class));
         } catch (Exception ignored) {
-            tmp = null; // We don't care... just a micro-optimization
+            tmp = null;
         }
         BITSET_TRIM_TO_SIZE = tmp;
     }
@@ -591,7 +591,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
             try {
                 BITSET_TRIM_TO_SIZE.invokeExact(this.availabilityMap);
             } catch (Throwable ignored) {
-                // BitSet.trimToSize() doesn't throw, so this should never happen.
+                // We don't care... just a micro-optimization
             }
         }
 


### PR DESCRIPTION
I remember someone pointing out that the same method is looked up with `ObfuscationReflectionHelper` and called reflectively on every call to `validateContent()`.

This PR fixes that by ~~instead using a `MethodHandle` constant and invoking that if available~~ removing it as it's been broken since 1.17.