### PR TITLE
[1.20.2] Add compat for 1.20.1 mods that use the old `IGNORESERVERONLY` constant

### DIFF
--- a/src/main/java/net/minecraftforge/network/NetworkConstants.java
+++ b/src/main/java/net/minecraftforge/network/NetworkConstants.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.network;
+
+import net.minecraftforge.fml.IExtensionPoint;
+
+@Deprecated
+public final class NetworkConstants {
+    /**
+     * To enable binary compatibility with mods compiled against older versions of Forge. Will be removed in MC 1.21.
+     * @deprecated Use {@link IExtensionPoint.DisplayTest#IGNORESERVERONLY} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.21")
+    public static final String IGNORESERVERONLY = IExtensionPoint.DisplayTest.IGNORESERVERONLY;
+}


### PR DESCRIPTION
Obviously won't help for mods that do proper networking, but for simpler ones that only touch this one constant for registering the extension point, this'll help.