### PR TITLE
[1.20.x] Fix double message encoding in `Channel#toVanillaPacket` #9721

### DIFF
--- a/src/main/java/net/minecraftforge/network/Channel.java
+++ b/src/main/java/net/minecraftforge/network/Channel.java
@@ -58,7 +58,7 @@ public abstract class Channel<MSG> {
             return NetworkDirection.LOGIN_TO_CLIENT.buildPacket(data, getName()).getThis();
         } else if (protocol == ConnectionProtocol.PLAY || protocol == ConnectionProtocol.CONFIGURATION) {
             var dir = serverbound ? NetworkDirection.PLAY_TO_SERVER : NetworkDirection.PLAY_TO_CLIENT;
-            return dir.buildPacket(toBuffer(message), getName()).getThis();
+            return dir.buildPacket(data, getName()).getThis();
         } else
             throw new IllegalStateException("Unsupported protocol " + protocol.name() + " in Forge Networking Channel");
     }

--- a/src/main/java/net/minecraftforge/network/packets/OpenContainer.java
+++ b/src/main/java/net/minecraftforge/network/packets/OpenContainer.java
@@ -44,6 +44,7 @@ public class OpenContainer {
         buf.writeVarInt(msg.id);
         buf.writeVarInt(msg.windowId);
         buf.writeComponent(msg.name);
+        msg.additionalData.markReaderIndex();
         buf.writeByteArray(msg.additionalData.readByteArray());
         msg.additionalData.resetReaderIndex();
     }

--- a/src/main/java/net/minecraftforge/network/packets/OpenContainer.java
+++ b/src/main/java/net/minecraftforge/network/packets/OpenContainer.java
@@ -45,6 +45,7 @@ public class OpenContainer {
         buf.writeVarInt(msg.windowId);
         buf.writeComponent(msg.name);
         buf.writeByteArray(msg.additionalData.readByteArray());
+        msg.additionalData.resetReaderIndex();
     }
 
     public static OpenContainer decode(FriendlyByteBuf buf) {


### PR DESCRIPTION
This PR fixes #9721 by replacing the second `Channel#toBuffer` call with the `data` variable.