### PR TITLE
[1.20.2] Add `IForgeBlock(State).isWaterlogged` and fix waterlogged blocks being flammable

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.SignalGetter;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
@@ -628,7 +629,7 @@ public interface IForgeBlock
      */
     default boolean isFlammable(BlockState state, BlockGetter level, BlockPos pos, Direction direction)
     {
-        return state.ignitedByLava() || state.getFlammability(level, pos, direction) > 0;
+        return state.getFlammability(level, pos, direction) > 0 || (!state.isWaterlogged(level, pos) && state.ignitedByLava());
     }
 
     /**
@@ -991,5 +992,9 @@ public interface IForgeBlock
     default PushReaction getPistonPushReaction(BlockState state)
     {
         return null;
+    }
+
+    default boolean isWaterlogged(BlockState state, BlockGetter level, BlockPos pos) {
+        return state.hasProperty(BlockStateProperties.WATERLOGGED) && state.getValue(BlockStateProperties.WATERLOGGED);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -766,4 +766,8 @@ public interface IForgeBlockState
     {
         return self().getBlock().getAppearance(self(), level, pos, side, queryState, queryPos);
     }
+
+    default boolean isWaterlogged(BlockGetter level, BlockPos pos) {
+        return self().getBlock().isWaterlogged(self(), level, pos);
+    }
 }


### PR DESCRIPTION
Fixes #9730 and supersedes #9733.

Introduced a method `isWaterlogged()` to both `IForgeBlock` and `IForgeBlockState` that allows modders to manually determine if a block should be considered waterlogged. Additionally, the `IForgeBlock.isFlammable()` method is fixed so that the `ignitedByLava()` check is ignored if the block is currently waterlogged.