### PR TITLE
[1.20.2] Fix `ignitedByLava` block property making blocks permanently flammable

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -40,7 +40,7 @@
     }
  
 +   private boolean isFlammable(LevelReader level, BlockPos pos, Direction face) {
-+      return pos.getY() >= level.getMinBuildHeight() && pos.getY() < level.getMaxBuildHeight() && !level.hasChunkAt(pos) ? false : level.getBlockState(pos).isFlammable(level, pos, face);
++      return pos.getY() >= level.getMinBuildHeight() && pos.getY() < level.getMaxBuildHeight() && !level.hasChunkAt(pos) ? false : level.getBlockState(pos).ignitedByLava() && level.getBlockState(pos).isFlammable(level, pos, face);
 +   }
 +
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -628,7 +628,7 @@ public interface IForgeBlock
      */
     default boolean isFlammable(BlockState state, BlockGetter level, BlockPos pos, Direction direction)
     {
-        return state.ignitedByLava() || state.getFlammability(level, pos, direction) > 0;
+        return state.getFlammability(level, pos, direction) > 0;
     }
 
     /**


### PR DESCRIPTION
Fixes #9730 and supersedes #9733 and #9734.

In the clean code, the `ignitedByLava` property is exclusively used by lava to check if it, and it alone, can ignite blocks with fire. This PR cleans up the issue of allowing to set waterlogged blocks on fire by removing the property check from `IForgeBlock.isFlammable()`, so that a block who declares that it is ignited by lava cannot *always* be set on fire.