### PR TITLE
[1.20.x] Fix Slot Index for Inventory Ticking Items

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -19,15 +19,21 @@
           if (p_36049_.hasTag()) {
              itemstack.setTag(p_36049_.getTag().copy());
           }
-@@ -225,7 +_,7 @@
+@@ -222,11 +_,13 @@
+    }
+ 
+    public void tick() {
++      int idx = 0;
        for(NonNullList<ItemStack> nonnulllist : this.compartments) {
           for(int i = 0; i < nonnulllist.size(); ++i) {
              if (!nonnulllist.get(i).isEmpty()) {
 -               nonnulllist.get(i).inventoryTick(this.player.level(), this.player, i, this.selected == i);
-+               nonnulllist.get(i).onInventoryTick(this.player.level(), this.player, i, this.selected);
++               nonnulllist.get(i).onInventoryTick(this.player.level(), this.player, idx, this.selected);
              }
++            idx++;
           }
        }
+ 
 @@ -277,6 +_,8 @@
           } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Adding item to inventory");

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -19,16 +19,12 @@
           if (p_36049_.hasTag()) {
              itemstack.setTag(p_36049_.getTag().copy());
           }
-@@ -222,10 +_,11 @@
-    }
- 
-    public void tick() {
-+      int idx = 0;
+@@ -225,7 +_,7 @@
        for(NonNullList<ItemStack> nonnulllist : this.compartments) {
           for(int i = 0; i < nonnulllist.size(); ++i) {
              if (!nonnulllist.get(i).isEmpty()) {
 -               nonnulllist.get(i).inventoryTick(this.player.level(), this.player, i, this.selected == i);
-+               nonnulllist.get(i).onInventoryTick(this.player.level(), this.player, idx++, this.selected);
++               nonnulllist.get(i).onInventoryTick(this.player.level(), this.player, i, this.selected);
              }
           }
        }


### PR DESCRIPTION
The current slot index parameter is the number of non-empty items before the ticking item. I doubt this is the intended functionality, as that implementation seems a bit pointless. In addition, it stops most armor item ticks from calling `IForgeItem.onArmorTick` from `IForgeItem.onInventoryTick`. Looking at `IForgeItem.onInventoryTick`, I believe this is the correct implementation. 