### PR TITLE
Fix Melon/Pumpkin stems remain after trampling the farmland, produce …

### DIFF
--- a/src/main/java/net/minecraftforge/common/IPlantable.java
+++ b/src/main/java/net/minecraftforge/common/IPlantable.java
@@ -8,6 +8,7 @@ package net.minecraftforge.common;
 import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.FlowerBlock;
 import net.minecraft.world.level.block.SaplingBlock;
+import net.minecraft.world.level.block.AttachedStemBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.core.BlockPos;
@@ -17,6 +18,7 @@ public interface IPlantable
 {
     default PlantType getPlantType(BlockGetter level, BlockPos pos) {
         if (this instanceof CropBlock) return PlantType.CROP;
+        if (this instanceof AttachedStemBlock) return PlantType.CROP;
         if (this instanceof SaplingBlock) return PlantType.PLAINS;
         if (this instanceof FlowerBlock) return PlantType.PLAINS;
         if (this == Blocks.DEAD_BUSH)      return PlantType.DESERT;


### PR DESCRIPTION
This PR fixes an issue #9495 with Melon/Pumpkin stems remain after trampling the farmland and simultaneously solving another problem in this issue.

The reason for the bug is that it is `AttachedStemBlock` above the farmland but `AttachedStemBlock` is `PlantType.PLAINS`. So after trampling the farmland the `canSustainPlant` is called and it execute 
```
else if (net.minecraftforge.common.PlantType.PLAINS.equals(type)) {
         return this == Blocks.GRASS_BLOCK || this.defaultBlockState().is(BlockTags.DIRT) || this == Blocks.FARMLAND;
```
, instead of 
```
 else if (net.minecraftforge.common.PlantType.CROP.equals(type)) {
         return state.is(Blocks.FARMLAND);
```
Therefore, it mistakenly returned true and stem was mistakenly preserved.

The fix change `AttachedStemBlock`'s `PlantType` from `PlantType.PLAINS` to `PlantType.CROP`. Also It's reasonable that `AttachedStemBlock` is a crop.