### PR TITLE
[1.18.x] Minor MDK changes

### DIFF
--- a/mdk/README.txt
+++ b/mdk/README.txt
@@ -16,14 +16,14 @@ Step 1: Open your command-line and browse to the folder where you extracted the 
 
 Step 2: You're left with a choice.
 If you prefer to use Eclipse:
-1. Run the following command: `gradlew genEclipseRuns` (`./gradlew genEclipseRuns` if you are on Mac/Linux)
-2. Open Eclipse, Import > Existing Gradle Project > Select Folder 
+1. Run the following command: `./gradlew genEclipseRuns`
+2. Open Eclipse, Import > Existing Gradle Project > Select Folder
    or run `gradlew eclipse` to generate the project.
 
 If you prefer to use IntelliJ:
 1. Open IDEA, and import project.
 2. Select your build.gradle file and have it import.
-3. Run the following command: `gradlew genIntellijRuns` (`./gradlew genIntellijRuns` if you are on Mac/Linux)
+3. Run the following command: `./gradlew genIntellijRuns`
 4. Refresh the Gradle Project in IDEA if required.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can 
@@ -40,7 +40,7 @@ https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
 
 Additional Resources: 
 =========================
-Community Documentation: http://mcforge.readthedocs.io/en/latest/gettingstarted/  
-LexManos' Install Video: https://www.youtube.com/watch?v=8VEdtQLuLO0  
-Forge Forum: https://forums.minecraftforge.net/  
-Forge Discord: https://discord.gg/UvedJ9m  
+Community Documentation: https://docs.minecraftforge.net/en/1.18.x/gettingstarted/
+LexManos' Install Video: https://youtu.be/8VEdtQLuLO0
+Forge Forums: https://forums.minecraftforge.net/
+Forge Discord: https://discord.minecraftforge.net/


### PR DESCRIPTION
Backport of https://github.com/MinecraftForge/MinecraftForge/pull/9750 to 1.18.2.

While 1.18.x is technically EoL, this PR doesn't change any code and directs people to the correct Discord server.