### PR TITLE
Fix texture UV values for obj models. Closes #9737

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/ObjModel.java
@@ -424,8 +424,8 @@ public class ObjModel extends SimpleUnbakedGeometry<ObjModel>
             quadBaker.vertex(position.x(), position.y(), position.z());
             quadBaker.color(tintedColor.x(), tintedColor.y(), tintedColor.z(), tintedColor.w());
             quadBaker.uv(
-                    texture.getU(texCoord.x * 16),
-                    texture.getV((flipV ? 1 - texCoord.y : texCoord.y) * 16)
+                    texture.getU(texCoord.x),
+                    texture.getV((flipV ? 1 - texCoord.y : texCoord.y))
             );
             quadBaker.uv2(uv2);
             quadBaker.normal(normal.x(), normal.y(), normal.z());

--- a/src/main/java/net/minecraftforge/client/textures/UnitTextureAtlasSprite.java
+++ b/src/main/java/net/minecraftforge/client/textures/UnitTextureAtlasSprite.java
@@ -27,11 +27,11 @@ public class UnitTextureAtlasSprite extends TextureAtlasSprite {
 
     @Override
     public float getU(float u) {
-        return u / 16;
+        return u;
     }
 
     @Override
     public float getV(float v) {
-        return v / 16;
+        return v;
     }
 }


### PR DESCRIPTION
Mojang moved the division of 16 further upstream and removed it from TextureAtlasSprite#getU() and getV(),
so there is no need to multiple by 16 when calling those methods.