### PR TITLE
[1.20.x] Improve mod description formatting in mods screen

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -80,7 +80,8 @@ public class ModInfo implements IModInfo, IConfigurable
         this.displayName = config.<String>getConfigElement("displayName")
                 .orElse(this.modId);
         this.description = config.<String>getConfigElement("description")
-                .orElse("MISSING DESCRIPTION");
+                .orElse("MISSING DESCRIPTION")
+                .replace("\r\n", "\n").stripIndent();
         this.logoFile = Optional.ofNullable(config.<String>getConfigElement("logoFile")
                 .orElseGet(() -> ownFile.flatMap(mf -> mf.<String>getConfigElement("logoFile"))
                         .orElse(null)));
@@ -205,7 +206,7 @@ public class ModInfo implements IModInfo, IConfigurable
         private final boolean mandatory;
         private final Ordering ordering;
         private final DependencySide side;
-        private Optional<URL> referralUrl;
+        private final Optional<URL> referralUrl;
 
         public ModVersion(final IModInfo owner, final IConfigurable config) {
             this.owner = owner;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,14 +1,14 @@
 modLoader="javafml"
 loaderVersion="[24,]"
-issueTrackerURL="http://www.minecraftforge.net/"
+issueTrackerURL="https://minecraftforge.net/"
 logoFile="forge_logo.png"
 license="LGPL v2.1"
 
 [[mods]]
     modId="forge"
-    # We use the global forge version
     version="${global.forgeVersion}"
     updateJSONURL="https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json"
+    displayURL="https://minecraftforge.net/"
     displayName="Forge"
     credits="Anyone who has contributed on Github and supports our development"
     authors="LexManos,cpw"


### PR DESCRIPTION
This PR fixes two issues:
1) mods.toml files saved with Windows line endings (CRLF) show a [CR] character at the end of each line
    - The fix for this is based on a downstream PR by Su5eD, but on this PR we skip a redundant check and lambda
2) Indentation formatting from mods.toml gets applied to the mods screen, resulting in inconsistent indentation of descriptions for different mods depending on how the mod author indented their mods.toml file
    - Intentional indentation is still properly displayed - only indentation common to all lines is stripped.

Before:
<img width="755" alt="image" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/914aa4c0-36ef-4746-bee0-647a458c8cd4">

After:
<img width="758" alt="image" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/b9c95416-4c49-4060-84e0-8f3ab982c17a">
