### PR TITLE
Optimize (un)register channel

### DIFF
--- a/src/main/java/net/minecraftforge/network/ChannelListManager.java
+++ b/src/main/java/net/minecraftforge/network/ChannelListManager.java
@@ -88,6 +88,7 @@ public class ChannelListManager {
     }
 
     private static void sendChannels(EventNetworkChannel channel, Connection connection, Collection<ResourceLocation> channels) {
+        if (channels.isEmpty()) return;
         var buf = new FriendlyByteBuf(Unpooled.buffer());
         for (var c : channels) {
             buf.writeBytes(c.toString().getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Remove the trailing \0 when registering channels.Currently the trailing \0 will lead to a forced disconnect on spigot/paper based servers.

[The protocol docs from wiki.vg](https://wiki.vg/Plugin_channels#minecraft:register) specified the list as: `Payload is a null (0x00) separated list of strings. `

This change should fix incompatibilities with servers using splitting the payload by \0. This should already raise a warning in the updateFrom method from forge.