### PR TITLE
Implemented ClientPauseEvent for 1.20.1

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -241,6 +241,14 @@
        }
  
        if (this.f_91056_ != null) {
+@@ -1157,6 +_,7 @@
+          }
+ 
+          this.f_91012_ = flag1;
++         net.minecraftforge.client.ForgeHooksClient.onClientPauseUpdate(this.f_91012_);
+       }
+ 
+       long l = Util.m_137569_();
 @@ -1240,10 +_,12 @@
        this.f_90990_.m_85378_((double)i);
        if (this.f_91080_ != null) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -76,7 +76,6 @@ import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.ChatTypeDecoration;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.PlayerChatMessage;
 import net.minecraft.network.chat.Style;
@@ -99,7 +98,6 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackLinkedSet;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.GameType;
@@ -115,6 +113,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.ClientPlayerChangeGameTypeEvent;
+import net.minecraftforge.client.event.ClientPauseUpdateEvent;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.ComputeFovModifierEvent;
 import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
@@ -258,6 +257,11 @@ public class ForgeHooksClient
         // and 10000 units for each layered Screen,
 
         return 1000.0F + 10000.0F * (1 + guiLayers.size());
+    }
+
+    public static void onClientPauseUpdate(boolean paused)
+    {
+        MinecraftForge.EVENT_BUS.post(new ClientPauseUpdateEvent(paused));
     }
 
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlot slot, String type)

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseUpdateEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * Fired when the client is {@linkplain Minecraft#pause paused and no longer performing ticks.
+ *
+ * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class ClientPauseUpdateEvent extends Event
+{
+    private final boolean paused;
+
+    public ClientPauseUpdateEvent(boolean isPaused)
+    {
+        this.paused = isPaused;
+    }
+
+    /**
+     * {@return game is paused}
+     */
+    public boolean isPaused()
+    {
+        return paused;
+    }
+}


### PR DESCRIPTION
Simple client hook, fired when the pause flag got updated by game (after a tick) indicating the game is no longer doing ticks

¿Why remake PR? 
seeing old PR was literally rotten i decide make a more cleanup PR with all suggested changes in 1 commit.
Note: i really tried to remove the fucking last line deletion change but always comes back, BTW most of the @PaintNinja commits has the same behavior so i dont really think it really matter.

Really important note: i didn't notice but the main reason of why imports got updated is because for some reason 1.18.2 -> 1.19.2 decide to unwrap `net.minecraftforge.client.events.*` into a individual imports for every single event, i am not sure if was intencional but doesn't look practical.