### PR TITLE
Implemented ClientPauseEvent for 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import org.gradle.plugins.ide.eclipse.model.SourceFolder
 plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.github.ben-manes.versions' version '0.46.0'
-    id 'net.minecraftforge.gradleutils' version '2.+'
+    id 'net.minecraftforge.gradleutils' version '[2.2,2.3)'
     id 'eclipse'
     id 'de.undercouch.download' version '5.4.0'
     id 'net.minecraftforge.gradle.patcher' version '[6.0,6.2)' apply false

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -209,6 +209,14 @@
        }
  
        if (this.f_91056_ != null) {
+@@ -1127,6 +_,7 @@
+          }
+ 
+          this.f_91012_ = flag;
++         net.minecraftforge.client.ForgeHooksClient.onClientPauseUpdate(this.f_91012_);
+       }
+ 
+       long i1 = Util.m_137569_();
 @@ -1210,10 +_,12 @@
        this.f_90990_.m_85378_((double)i);
        if (this.f_91080_ != null) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -111,6 +111,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.ClientPlayerChangeGameTypeEvent;
+import net.minecraftforge.client.event.ClientPauseUpdateEvent;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.ComputeFovModifierEvent;
 import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
@@ -245,6 +246,11 @@ public class ForgeHooksClient
         // and 2000 units for each layered Screen,
 
         return 1000.0F + 2000.0F * (1 + guiLayers.size());
+    }
+
+    public static void onClientPauseUpdate(boolean paused)
+    {
+        MinecraftForge.EVENT_BUS.post(new ClientPauseUpdateEvent(paused));
     }
 
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlot slot, String type)

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseUpdateEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * Fired when the client is {@linkplain Minecraft#pause paused} and no longer performing ticks.
+ *
+ * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class ClientPauseUpdateEvent extends Event
+{
+    private final boolean paused;
+
+    public ClientPauseUpdateEvent(boolean isPaused)
+    {
+        this.paused = isPaused;
+    }
+
+    /**
+     * {@return game is paused}
+     */
+    public boolean isPaused()
+    {
+        return paused;
+    }
+}


### PR DESCRIPTION
Simple client hook, fired when the pause flag got updated by game (after a tick) indicating the game is no longer doing ticks

same as #9779