### PR TITLE
Implemented ClientPauseEvent for 1.20.x

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -200,6 +200,14 @@
        }
  
        if (this.fpsPieResults != null) {
+@@ -1223,6 +_,7 @@
+          }
+ 
+          this.pause = flag1;
++         net.minecraftforge.client.ForgeHooksClient.onClientPauseUpdate(this.pause);
+       }
+ 
+       long l = Util.getNanos();
 @@ -1302,10 +_,12 @@
        this.window.setGuiScale((double)i);
        if (this.screen != null) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -111,6 +111,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.client.event.ClientPauseEvent;
 import net.minecraftforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.ComputeFovModifierEvent;
@@ -246,6 +247,11 @@ public class ForgeHooksClient {
         // and 10000 units for each layered Screen,
 
         return 1000.0F + 10000.0F * (1 + guiLayers.size());
+    }
+
+    public static void onClientPauseUpdate(boolean paused)
+    {
+        MinecraftForge.EVENT_BUS.post(new ClientPauseEvent(paused));
     }
 
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlot slot, String type) {

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.LogicalSide;
+
+/**
+ * Fired when {@linkplain Minecraft#pause Minecraft.pause} value got updated by
+ * the {@linkplain Minecraft#runTick(boolean) Minecraft.runTick(...)} on a single-player world
+ *
+ * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class ClientPauseEvent extends Event
+{
+    private final boolean paused;
+
+    public ClientPauseEvent(boolean isPaused)
+    {
+        this.paused = isPaused;
+    }
+
+    /**
+     * {@return game is paused}
+     */
+    public boolean isPaused()
+    {
+        return paused;
+    }
+}


### PR DESCRIPTION
Simple client hook, fired when the pause flag got updated by game (after a tick) indicating the game is no longer doing ticks

see #9779