### PR TITLE
Network for PersistentData of Entity for 1.20.2

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -1,6 +1,10 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -122,7 +_,7 @@
+@@ -119,10 +_,11 @@
+ import net.minecraft.world.phys.shapes.VoxelShape;
+ import net.minecraft.world.scores.PlayerTeam;
+ import net.minecraft.world.scores.Team;
++import net.minecraftforge.common.extensions.IForgeEntity;
  import org.joml.Vector3f;
  import org.slf4j.Logger;
  
@@ -36,7 +40,11 @@
        this.type = p_19870_;
        this.level = p_19871_;
        this.dimensions = p_19870_.getDimensions();
-@@ -257,6 +_,8 @@
+@@ -254,9 +_,12 @@
+       this.entityData.define(DATA_NO_GRAVITY, false);
+       this.entityData.define(DATA_POSE, Pose.STANDING);
+       this.entityData.define(DATA_TICKS_FROZEN, 0);
++      this.entityData.define(IForgeEntity.DATA_PERSISTENT_DATA,new CompoundTag());
        this.defineSynchedData();
        this.setPos(0.0D, 0.0D, 0.0D);
        this.eyeHeight = this.getEyeHeight(Pose.STANDING, this.dimensions);
@@ -259,7 +267,7 @@
  
 +         CompoundTag caps = serializeCaps();
 +         if (caps != null) p_20241_.put("ForgeCaps", caps);
-+         if (persistentData != null) p_20241_.put("ForgeData", persistentData.copy());
++         if (!getPersistentData().isEmpty())p_20241_.put("ForgeData", getPersistentData().copy());
 +
           this.addAdditionalSaveData(p_20241_);
           if (this.isVehicle()) {
@@ -268,7 +276,7 @@
                 this.setGlowingTag(p_20259_.getBoolean("Glowing"));
                 this.setTicksFrozen(p_20259_.getInt("TicksFrozen"));
                 this.hasVisualFire = p_20259_.getBoolean("HasVisualFire");
-+               if (p_20259_.contains("ForgeData", 10)) persistentData = p_20259_.getCompound("ForgeData");
++               if (p_20259_.contains("ForgeData", 10)) this.entityData.set(IForgeEntity.DATA_PERSISTENT_DATA,p_20259_.getCompound("ForgeData"));
 +               if (p_20259_.contains("CanUpdate", 99)) this.canUpdate(p_20259_.getBoolean("CanUpdate"));
 +               if (p_20259_.contains("ForgeCaps", 10)) deserializeCaps(p_20259_.getCompound("ForgeCaps"));
                 if (p_20259_.contains("Tags", 9)) {
@@ -531,7 +539,7 @@
     public float maxUpStep() {
        return this.maxUpStep;
     }
-@@ -3349,6 +_,109 @@
+@@ -3349,6 +_,106 @@
     public boolean mayInteract(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -558,12 +566,9 @@
 +      this.captureDrops = value;
 +      return ret;
 +   }
-+   private CompoundTag persistentData;
 +   @Override
 +   public CompoundTag getPersistentData() {
-+      if (persistentData == null)
-+         persistentData = new CompoundTag();
-+      return persistentData;
++      return this.entityData.get(IForgeEntity.DATA_PERSISTENT_DATA);
 +   }
 +   @Override
 +   public boolean canTrample(BlockState state, BlockPos pos, float fallDistance) {

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -1,10 +1,6 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -119,10 +_,11 @@
- import net.minecraft.world.phys.shapes.VoxelShape;
- import net.minecraft.world.scores.PlayerTeam;
- import net.minecraft.world.scores.Team;
-+import net.minecraftforge.common.extensions.IForgeEntity;
+@@ -122,7 +_,7 @@
  import org.joml.Vector3f;
  import org.slf4j.Logger;
  
@@ -44,7 +40,7 @@
        this.entityData.define(DATA_NO_GRAVITY, false);
        this.entityData.define(DATA_POSE, Pose.STANDING);
        this.entityData.define(DATA_TICKS_FROZEN, 0);
-+      this.entityData.define(IForgeEntity.DATA_PERSISTENT_DATA,new CompoundTag());
++      this.entityData.define(net.minecraftforge.common.extensions.IForgeEntity.DATA_PERSISTENT_DATA,new CompoundTag());
        this.defineSynchedData();
        this.setPos(0.0D, 0.0D, 0.0D);
        this.eyeHeight = this.getEyeHeight(Pose.STANDING, this.dimensions);
@@ -276,7 +272,7 @@
                 this.setGlowingTag(p_20259_.getBoolean("Glowing"));
                 this.setTicksFrozen(p_20259_.getInt("TicksFrozen"));
                 this.hasVisualFire = p_20259_.getBoolean("HasVisualFire");
-+               if (p_20259_.contains("ForgeData", 10)) this.entityData.set(IForgeEntity.DATA_PERSISTENT_DATA,p_20259_.getCompound("ForgeData"));
++               if (p_20259_.contains("ForgeData", 10)) this.entityData.set(net.minecraftforge.common.extensions.IForgeEntity.DATA_PERSISTENT_DATA,p_20259_.getCompound("ForgeData"));
 +               if (p_20259_.contains("CanUpdate", 99)) this.canUpdate(p_20259_.getBoolean("CanUpdate"));
 +               if (p_20259_.contains("ForgeCaps", 10)) deserializeCaps(p_20259_.getCompound("ForgeCaps"));
                 if (p_20259_.contains("Tags", 9)) {
@@ -568,7 +564,7 @@
 +   }
 +   @Override
 +   public CompoundTag getPersistentData() {
-+      return this.entityData.get(IForgeEntity.DATA_PERSISTENT_DATA);
++      return this.entityData.get(net.minecraftforge.common.extensions.IForgeEntity.DATA_PERSISTENT_DATA);
 +   }
 +   @Override
 +   public boolean canTrample(BlockState state, BlockPos pos, float fallDistance) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -39,7 +39,6 @@ import org.jetbrains.annotations.Nullable;
 
 public interface IForgeEntity extends ICapabilitySerializable<CompoundTag> {
     EntityDataAccessor<CompoundTag> DATA_PERSISTENT_DATA = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.COMPOUND_TAG);
-
     private Entity self() {
         return (Entity)this;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -8,6 +8,9 @@ package net.minecraftforge.common.extensions;
 import java.util.Collection;
 import java.util.function.BiPredicate;
 
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
@@ -35,6 +38,8 @@ import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.Nullable;
 
 public interface IForgeEntity extends ICapabilitySerializable<CompoundTag> {
+    EntityDataAccessor<CompoundTag> DATA_PERSISTENT_DATA = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.COMPOUND_TAG);
+
     private Entity self() {
         return (Entity)this;
     }


### PR DESCRIPTION
Synchronizing custom data from the server to the client is a very common requirement. If persistent data can be automatically synchronized, then modders do not need to manufacture their own wheels.
