### PR TITLE
Fixed wrong LICENSE-header.txt content + files license for 1.16.5

### DIFF
--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,16 +1,2 @@
-Minecraft Forge
-Copyright (c) 2016-${year}.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation version 2.1
-of the License.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+Copyright (c) Forge Development LLC and contributors
+SPDX-License-Identifier: LGPL-2.1-only

--- a/src/test/java/net/minecraftforge/debug/client/AudioStreamTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/AudioStreamTest.java
@@ -1,7 +1,7 @@
- /*
-  * Copyright (c) Forge Development LLC and contributors
-  * SPDX-License-Identifier: LGPL-2.1-only
-  */
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 
 package net.minecraftforge.debug.client;
 


### PR DESCRIPTION
TheCurle in https://github.com/MinecraftForge/MinecraftForge/commit/4e47eab41e57460f06342c634309a16e16a72b3f updates license header for all files but he forgot to update LICENSE-header.txt. making not begin able to build 1.16.5.

Also, 1 file has a space and compiler considers it invalid, so is also fixed.