### PR TITLE
Backport DisplayTest option for 1.16.5

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,5 +1,7 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubIssues
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
 
 /*
 The settings script is an entry point for defining a TeamCity
@@ -30,11 +32,13 @@ project {
     buildType(Build)
     buildType(BuildSecondaryBranches)
     buildType(PullRequests)
+    buildType(PullRequestChecks)
+    buildType(PullRequestCompatibility)
 
     params {
         text("docker_jdk_version", "8", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
-        text("docker_gradle_version", "7.3.3", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
-        text("git_main_branch", "1.18.x", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_gradle_version", "7.5.1", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("git_main_branch", "1.16.x5", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("git_branch_spec", """
                 +:refs/heads/(main*)
                 +:refs/heads/(master*)
@@ -46,9 +50,9 @@ project {
         text("env.PUBLISHED_JAVA_GROUP", "net.minecraftforge", label = "Published group", description = "The maven coordinate group that has been published by this build. Can not be empty.", allowEmpty = false)
         //These are references and not actually keys
         password("env.CROWDIN_KEY", "credentialsJSON:a3102dbe-805d-4177-9f54-3d2c2eb08fd5", display = ParameterDisplay.HIDDEN)
-        password("env.LEGACY_KEYSTORE_URL", "credentialsJSON:a2d2efc7-4492-47b6-9826-d14b2c1243a0", display = ParameterDisplay.HIDDEN)
-        password("env.LEGACY_KEYSTORE_PASSWORD", "credentialsJSON:9f9a1a9e-f91b-40d5-b888-8ebc79a99ded", display = ParameterDisplay.HIDDEN)
-        text("additional_publishing_gradle_parameters", "-PcrowdinKey=%env.CROWDIN_KEY% -PkeystoreKeyPass=%env.LEGACY_KEYSTORE_PASSWORD% -PkeystoreStorePass=%env.LEGACY_KEYSTORE_PASSWORD% -Pkeystore=%env.LEGACY_KEYSTORE_URL%", label = "Additional gradle parameters for publish", description = "Contains the additional gradle parameters used during publishing.", display = ParameterDisplay.HIDDEN, allowEmpty = true)
+        password("env.KEYSTORE_URL", "credentialsJSON:a7ae1c82-8058-4061-8d12-7f6bc2618d2e", display = ParameterDisplay.HIDDEN)
+        password("env.KEYSTORE_PASSWORD", "credentialsJSON:d7b964e3-a1fd-47a8-b892-6f601fe47479", display = ParameterDisplay.HIDDEN)
+        text("additional_publishing_gradle_parameters", "-PcrowdinKey=%env.CROWDIN_KEY% -PkeystoreKeyPass=%env.KEYSTORE_PASSWORD% -PkeystoreStorePass=%env.KEYSTORE_PASSWORD% -Pkeystore=%env.KEYSTORE_URL%", label = "Additional gradle parameters for publish", description = "Contains the additional gradle parameters used during publishing.", display = ParameterDisplay.HIDDEN, allowEmpty = true)
 
         checkbox("should_execute_build", "false", label = "Should build", description = "Indicates if the build task should be executed.", display = ParameterDisplay.HIDDEN,
             checked = "true", unchecked = "false")
@@ -109,5 +113,47 @@ object PullRequests : BuildType({
             display = ParameterDisplay.HIDDEN,
             allowEmpty = false
         )
+    }
+
+    vcs {
+        branchFilter = """
+            +:*
+            -:1.*
+            -:<default>
+        """.trimIndent()
+    }
+})
+
+object PullRequestChecks : BuildType({
+    templates(AbsoluteId("MinecraftForge_BuildPullRequests"), AbsoluteId("MinecraftForge_SetupGradleUtilsCiEnvironmen"), AbsoluteId("MinecraftForge_BuildWithDiscordNotifications"), AbsoluteId("MinecraftForge_SetupProjectUsingGradle"))
+    id("MinecraftForge_MinecraftForge__PullRequestChecks")
+    name = "Pull Requests (Checks)"
+    description = "Checks pull requests for the project"
+
+    steps {
+        gradle {
+            name = "Check"
+            id = "RUNNER_10_Check"
+
+            tasks = "checkAll"
+            gradleParams = "--continue %gradle_custom_args%"
+            enableStacktrace = true
+            dockerImage = "%docker_gradle_image%"
+            dockerRunParameters = """
+                -v "/opt/cache/agent/gradle:/home/gradle/.gradle"
+                -v "/opt/cache/shared/gradle:/home/gradle/rocache:ro"
+                --network=host
+                -u 1000:1000
+                %docker_additional_args%
+            """.trimIndent()
+        }
+    }
+
+    vcs {
+        branchFilter = """
+            +:*
+            -:1.*
+            -:<default>
+        """.trimIndent()
     }
 })

--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,16 +1,2 @@
-Minecraft Forge
-Copyright (c) 2016-${year}.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation version 2.1
-of the License.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+Copyright (c) Forge Development LLC and contributors
+SPDX-License-Identifier: LGPL-2.1-only

--- a/build.gradle
+++ b/build.gradle
@@ -563,6 +563,11 @@ project(':forge') {
         lineEnding = '\n'
     }
 
+    task checkJarCompatibility() {
+        def yep = true
+        // TODO: standing empty make it work?
+    }
+
     task launcherJson(dependsOn: ['signUniversalJar', 'signLauncherJar']) {
         inputs.file universalJar.archiveFile
         inputs.file { launcherJar.archiveFile }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ import org.gradle.plugins.ide.eclipse.model.SourceFolder
 plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.github.ben-manes.versions' version '0.36.0'
-    id 'net.minecraftforge.gradleutils' version '2.+'
+    id 'net.minecraftforge.gradleutils' version '[2.2,2.3)'
     id 'eclipse'
 }
 

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -32,6 +32,14 @@ logoFile="examplemod.png" #optional
 credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
 authors="Love, Cheese and small house plants" #optional
+# Display Test controls the display for your mod in the server connection screen
+# MATCH_VERSION means that your mod will cause a red X if the versions on client and server differ. This is the default behaviour and should be what you choose if you have server and client elements to your mod.
+# IGNORE_SERVER_VERSION means that your mod will not cause a red X if it's present on the server but not on the client. This is what you should use if you're a server only mod.
+# IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
+# NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
+# IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
+#displayTest="MATCH_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
+
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 This is a long form description of the mod. You can write whatever you want here

--- a/src/test/java/net/minecraftforge/debug/client/AudioStreamTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/AudioStreamTest.java
@@ -1,7 +1,7 @@
- /*
-  * Copyright (c) Forge Development LLC and contributors
-  * SPDX-License-Identifier: LGPL-2.1-only
-  */
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 
 package net.minecraftforge.debug.client;
 


### PR DESCRIPTION
Important: Depends on #9784

Backport of the DisplayTest feature added in #8656. Of course code was adapted to work on Java 8 and Pair system used on 1.16.5
Already tested and works fine

I modified AppleSkin mods.toml to use "MATCH_VERSION" and "IGNORE_SERVER_VERSION" and this is how it looks (ordered)
![image](https://github.com/MinecraftForge/MinecraftForge/assets/29090346/75f8f59f-24c2-4cb4-b240-f0261658f659)

![image](https://github.com/MinecraftForge/MinecraftForge/assets/29090346/a43e84ec-0184-40bb-8a2b-ca45f6323a6e)



