### PR TITLE
Update/fix ChunkWatchEvent to match their docs, and clean docs a little

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -31,14 +31,6 @@
              }
  
              return levelchunk;
-@@ -756,6 +_,7 @@
-       for(ServerPlayer serverplayer : this.playerMap.getAllPlayers()) {
-          if (serverplayer.getChunkTrackingView().contains(chunkpos)) {
-             markChunkPendingToSend(serverplayer, p_299599_);
-+            net.minecraftforge.event.ForgeEventFactory.fireChunkWatch(serverplayer, p_299599_, this.level);
-          }
-       }
- 
 @@ -823,6 +_,7 @@
  
              this.level.getProfiler().incrementCounter("chunkSave");
@@ -47,22 +39,6 @@
              this.write(chunkpos, compoundtag);
              this.markPosition(chunkpos, chunkstatus.getChunkType());
              return true;
-@@ -877,6 +_,7 @@
-       LevelChunk levelchunk = this.getChunkToSend(p_298062_.toLong());
-       if (levelchunk != null) {
-          markChunkPendingToSend(p_297974_, levelchunk);
-+         net.minecraftforge.event.ForgeEventFactory.fireChunkWatch(p_297974_, levelchunk, this.level);
-       }
- 
-    }
-@@ -1099,6 +_,7 @@
-             this.markChunkPendingToSend(p_301380_, p_296566_);
-          }, (p_296568_) -> {
-             dropChunk(p_301380_, p_296568_);
-+            net.minecraftforge.event.ForgeEventFactory.fireChunkUnWatch(p_301380_, p_296568_, this.level);
-          });
-          p_301380_.setChunkTrackingView(p_301057_);
-       }
 @@ -1118,7 +_,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/server/network/PlayerChunkSender.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/PlayerChunkSender.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/server/network/PlayerChunkSender.java
++++ b/net/minecraft/server/network/PlayerChunkSender.java
+@@ -45,6 +_,7 @@
+    public void dropChunk(ServerPlayer p_298166_, ChunkPos p_300687_) {
+       if (!this.pendingChunks.remove(p_300687_.toLong()) && p_298166_.isAlive()) {
+          p_298166_.connection.send(new ClientboundForgetLevelChunkPacket(p_300687_));
++         net.minecraftforge.event.ForgeEventFactory.fireChunkUnWatch(p_298166_, p_300687_, (ServerLevel) p_298166_.level());
+       }
+ 
+    }
+@@ -79,6 +_,7 @@
+       p_299748_.send(new ClientboundLevelChunkWithLightPacket(p_297712_, p_298120_.getLightEngine(), (BitSet)null, (BitSet)null));
+       ChunkPos chunkpos = p_297712_.getPos();
+       DebugPackets.sendPoiPacketsForChunk(p_298120_, chunkpos);
++      net.minecraftforge.event.ForgeEventFactory.fireChunkWatch(p_299748_.player, p_297712_, p_298120_);
+    }
+ 
+    private List<LevelChunk> collectChunksToSend(ChunkMap p_298180_, ChunkPos p_298514_) {

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -58,9 +58,7 @@ public class ChunkWatchEvent extends Event {
     }
 
     /**
-     * This event is fired whenever a {@link ServerPlayer} receives data packet of chunk.
-     * <p>
-     * This event is fired when chunk data is sent to the client (see {@link net.minecraft.server.network.PlayerChunkSender}).
+     * This event is fired when chunk data is sent to the {@link ServerPlayer} (see {@link net.minecraft.server.network.PlayerChunkSender}).
      * <p>
      * This event may be used to send additional chunk-related data to the client.
      * <p>
@@ -83,10 +81,7 @@ public class ChunkWatchEvent extends Event {
     }
 
     /**
-     * This event is fired whenever a {@link ServerPlayer} stops watching a chunk.
-     * <p>
-     * This event is fired when a chunk is removed from the watched chunks of an {@link ServerPlayer}
-     * in {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}.
+     * This event is fired when server sends "forget chunk" packet to the {@link ServerPlayer}.
      * <p>
      * This event is not {@linkplain Cancelable cancellable} and does not {@linkplain HasResult have a result}.
      * <p>

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -25,14 +25,12 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkWatchEvent extends Event
-{
+public class ChunkWatchEvent extends Event {
     private final ServerLevel level;
     private final ServerPlayer player;
     private final ChunkPos pos;
 
-    public ChunkWatchEvent(ServerPlayer player, ChunkPos pos, ServerLevel level)
-    {
+    public ChunkWatchEvent(ServerPlayer player, ChunkPos pos, ServerLevel level) {
         this.player = player;
         this.pos = pos;
         this.level = level;
@@ -41,33 +39,28 @@ public class ChunkWatchEvent extends Event
     /**
      * {@return the server player involved with the watch action}
      */
-    public ServerPlayer getPlayer()
-    {
+    public ServerPlayer getPlayer() {
         return this.player;
     }
 
     /**
      * {@return the chunk position this watch event is affecting}
      */
-    public ChunkPos getPos()
-    {
+    public ChunkPos getPos() {
         return this.pos;
     }
 
     /**
      * {@return the server level containing the chunk}
      */
-    public ServerLevel getLevel()
-    {
+    public ServerLevel getLevel() {
         return this.level;
     }
 
     /**
-     * This event is fired whenever a {@link ServerPlayer} begins watching a chunk.
+     * This event is fired whenever a {@link ServerPlayer} receives data packet of chunk.
      * <p>
-     * This event is fired when a chunk is added to the watched chunks of a {@link ServerPlayer}
-     * and the chunk's data is sent to the client (see
-     * {@code net.minecraft.server.level.ChunkMap#playerLoadedChunk(ServerPlayer, MutableObject, LevelChunk)}).
+     * This event is fired when chunk data is sent to the client (see {@link net.minecraft.server.network.PlayerChunkSender}).
      * <p>
      * This event may be used to send additional chunk-related data to the client.
      * <p>
@@ -76,18 +69,15 @@ public class ChunkWatchEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Watch extends ChunkWatchEvent
-    {
+    public static class Watch extends ChunkWatchEvent {
         private final LevelChunk chunk;
 
-        public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel level)
-        {
+        public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel level) {
             super(player, chunk.getPos(), level);
             this.chunk = chunk;
         }
 
-        public LevelChunk getChunk()
-        {
+        public LevelChunk getChunk() {
             return this.chunk;
         }
     }
@@ -103,8 +93,9 @@ public class ChunkWatchEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class UnWatch extends ChunkWatchEvent
-    {
-        public UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) {super(player, pos, level);}
+    public static class UnWatch extends ChunkWatchEvent {
+        public UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) {
+            super(player, pos, level);
+        }
     }
 }


### PR DESCRIPTION
ChunkWatchEvent patch didn't get proper port from 1.20.1 to 1.20.2, where Mojang added chunk send queue as part of their networking bandwidth optimization. With this fix, `ChunkWatchEvent.Watch` and `ChunkWatchEvent.UnWatch` will match their behavior from pre 1.20.2 (you will be able to send chunk-specific data inside `ChunkWatchEvent.Watch`)