### PR TITLE
[1.20.x] Fix rare crash with early display window, fixes #9673

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ import org.objectweb.asm.Opcodes
 plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.github.ben-manes.versions' version '0.46.0'
-    id 'net.minecraftforge.gradleutils' version '[2.1.3,)'
+    id 'net.minecraftforge.gradleutils' version '[2.2,2.3)'
     id 'eclipse'
     id 'de.undercouch.download' version '5.4.0'
     id 'net.minecraftforge.gradle.patcher' version '[6.0.16,6.2)' apply false


### PR DESCRIPTION
Port of the fix from downstream