### PR TITLE
addOptionalTag/s methods that allow passing the TagKey itself instead of passing the location

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
@@ -29,6 +29,15 @@ public interface IForgeTagAppender<T>
         return self().addOptionalTag(value.location());
     }
 
+    @SuppressWarnings("unchecked")
+    default TagsProvider.TagAppender<T> addOptionalTags(TagKey<T>... values) {
+        TagsProvider.TagAppender<T> builder = self();
+        for (TagKey<T> value : values) {
+            builder.addOptionalTag(value.location());
+        }
+        return builder;
+    }
+
     default TagsProvider.TagAppender<T> replace() {
         return replace(true);
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
@@ -25,6 +25,10 @@ public interface IForgeTagAppender<T>
         return builder;
     }
 
+    default TagsProvider.TagAppender<T> addOptionalTag(TagKey<T> value) {
+        return self().addOptionalTag(value.location());
+    }
+
     default TagsProvider.TagAppender<T> replace() {
         return replace(true);
     }


### PR DESCRIPTION
Just makes things a bit easier by getting the location of the tag on Forge side instead of on the mod developers side.  Helps clean up some tag datagen by not having to use .location for each tag