### PR TITLE
[1.16.5] Backport of DisplayTest feature

### DIFF
--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -30,6 +30,13 @@ displayName="${mod_name}" #mandatory
 #credits="" #optional
 # A text field displayed in the mod UI
 authors="${mod_authors}" #optional
+# Display Test controls the display for your mod in the server connection screen
+# MATCH_VERSION means that your mod will cause a red X if the versions on client and server differ. This is the default behaviour and should be what you choose if you have server and client elements to your mod.
+# IGNORE_SERVER_VERSION means that your mod will not cause a red X if it's present on the server but not on the client. This is what you should use if you're a server only mod.
+# IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
+# NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
+# IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
+#displayTest="MATCH_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
 
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''


### PR DESCRIPTION
I remade the PR, having gradle fix with feature addition

Backport of the DisplayTest feature added in #8656. Of course code was adapted to work on Java 8 and Pair system used on 1.16.5
Already tested and works fine

I modified AppleSkin mods.toml to use "MATCH_VERSION" and "IGNORE_SERVER_VERSION" and this is how it looks (ordered)
![image](https://github.com/MinecraftForge/MinecraftForge/assets/29090346/75f8f59f-24c2-4cb4-b240-f0261658f659)

![image](https://github.com/MinecraftForge/MinecraftForge/assets/29090346/a43e84ec-0184-40bb-8a2b-ca45f6323a6e)



