### PR TITLE
[1.20.x] Make common DisplayTest registration tasks easier

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
@@ -96,5 +96,14 @@ public interface IExtensionPoint<T extends Record>
     @SuppressWarnings("JavadocReference") // reference to NetworkConstants, ForgeHooksClient
     record DisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) implements IExtensionPoint<DisplayTest> {
         public static final String IGNORESERVERONLY = "SERVER_ONLY";
+
+        /**
+         * An optional alternative to {@link #DisplayTest(Supplier, BiPredicate)} which accepts a constant version string
+         * instead of a {@link Supplier}.
+         * <p>Internally, the provided version string is wrapped in a Supplier for you.</p>
+         */
+        public DisplayTest(String version, BiPredicate<String, Boolean> remoteVersionTest) {
+            this(() -> version, remoteVersionTest);
+        }
     }
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
@@ -104,6 +104,8 @@ public interface IExtensionPoint<T extends Record>
 
         /**
          * Ignores all information and provides no information
+         * <p>Note: If your mod is purely client-side and has no multiplayer functionality (be it dedicated servers or
+         * Open to LAN), consider setting {@code clientSideOnly=true} in the root of your mods.toml.</p>
          */
         public static final Supplier<DisplayTest> IGNORE_ALL_VERSION = () -> new DisplayTest("", (remoteVersion, isFromServer) -> true);
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
@@ -98,6 +98,16 @@ public interface IExtensionPoint<T extends Record>
         public static final String IGNORESERVERONLY = "SERVER_ONLY";
 
         /**
+         * Ignores any version information coming from the server - use for server only mods
+         */
+        public static final Supplier<DisplayTest> IGNORE_SERVER_VERSION = () -> new DisplayTest(IGNORESERVERONLY, (remoteVersion, isFromServer) -> true);
+
+        /**
+         * Ignores all information and provides no information
+         */
+        public static final Supplier<DisplayTest> IGNORE_ALL_VERSION = () -> new DisplayTest("", (remoteVersion, isFromServer) -> true);
+
+        /**
          * An optional alternative to {@link #DisplayTest(Supplier, BiPredicate)} which accepts a constant version string
          * instead of a {@link Supplier}.
          * <p>Internally, the provided version string is wrapped in a Supplier for you.</p>

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -65,9 +65,9 @@ public abstract class ModContainer
                     () -> new IExtensionPoint.DisplayTest(() -> this.modInfo.getVersion().toString(),
                         (incoming, isNetwork) -> Objects.equals(incoming, this.modInfo.getVersion().toString()));
             case "IGNORE_SERVER_VERSION" -> // Ignores any version information coming from the server - use for server only mods
-                    () -> new IExtensionPoint.DisplayTest(IExtensionPoint.DisplayTest.IGNORESERVERONLY, (incoming, isNetwork) -> true);
+                    IExtensionPoint.DisplayTest.IGNORE_SERVER_VERSION;
             case "IGNORE_ALL_VERSION" -> // Ignores all information and provides no information
-                    () -> new IExtensionPoint.DisplayTest("", (incoming, isNetwork) -> true);
+                    IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION;
             case "NONE" -> null; // NO display test at all - use this if you're going to do your own display test
             default -> // any other value throws an exception
                     throw new IllegalArgumentException("Invalid displayTest value supplied in mods.toml");

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -152,6 +153,14 @@ public abstract class ModContainer
 
     public void registerDisplayTest(Supplier<IExtensionPoint.DisplayTest> displayTest) {
         registerExtensionPoint(IExtensionPoint.DisplayTest.class, displayTest);
+    }
+
+    public void registerDisplayTest(String version, BiPredicate<String, Boolean> remoteVersionTest) {
+        registerDisplayTest(new IExtensionPoint.DisplayTest(version, remoteVersionTest));
+    }
+
+    public void registerDisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) {
+        registerDisplayTest(new IExtensionPoint.DisplayTest(suppliedVersion, remoteVersionTest));
     }
 
     public void addConfig(final ModConfig modConfig) {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -146,6 +146,14 @@ public abstract class ModContainer
         extensionPoints.put(point, extension);
     }
 
+    public void registerDisplayTest(IExtensionPoint.DisplayTest displayTest) {
+        registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> displayTest);
+    }
+
+    public void registerDisplayTest(Supplier<IExtensionPoint.DisplayTest> displayTest) {
+        registerExtensionPoint(IExtensionPoint.DisplayTest.class, displayTest);
+    }
+
     public void addConfig(final ModConfig modConfig) {
        configs.put(modConfig.getType(), modConfig);
     }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -65,9 +65,9 @@ public abstract class ModContainer
                     () -> new IExtensionPoint.DisplayTest(() -> this.modInfo.getVersion().toString(),
                         (incoming, isNetwork) -> Objects.equals(incoming, this.modInfo.getVersion().toString()));
             case "IGNORE_SERVER_VERSION" -> // Ignores any version information coming from the server - use for server only mods
-                    () -> new IExtensionPoint.DisplayTest(() -> IExtensionPoint.DisplayTest.IGNORESERVERONLY, (incoming, isNetwork) -> true);
+                    () -> new IExtensionPoint.DisplayTest(IExtensionPoint.DisplayTest.IGNORESERVERONLY, (incoming, isNetwork) -> true);
             case "IGNORE_ALL_VERSION" -> // Ignores all information and provides no information
-                    () -> new IExtensionPoint.DisplayTest(() -> "", (incoming, isNetwork) -> true);
+                    () -> new IExtensionPoint.DisplayTest("", (incoming, isNetwork) -> true);
             case "NONE" -> null; // NO display test at all - use this if you're going to do your own display test
             default -> // any other value throws an exception
                     throw new IllegalArgumentException("Invalid displayTest value supplied in mods.toml");

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
@@ -50,6 +50,24 @@ public class ModLoadingContext
         getActiveContainer().registerExtensionPoint(point, extension);
     }
 
+    /**
+     * Register a {@link IExtensionPoint.DisplayTest} with the mod container.
+     * <p>A shorthand for registering a DisplayTest with {@link #registerExtensionPoint(Class, Supplier)}.</p>
+     * @param displayTest The {@link IExtensionPoint.DisplayTest} to register
+     */
+    public void registerDisplayTest(IExtensionPoint.DisplayTest displayTest) {
+        getActiveContainer().registerDisplayTest(() -> displayTest);
+    }
+
+    /**
+     * Register a {@link IExtensionPoint.DisplayTest} with the mod container.
+     * <p>A shorthand for registering a DisplayTest supplier with {@link #registerExtensionPoint(Class, Supplier)}.</p>
+     * @param displayTest The {@link Supplier<IExtensionPoint.DisplayTest>} to register
+     */
+    public void registerDisplayTest(Supplier<IExtensionPoint.DisplayTest> displayTest) {
+        getActiveContainer().registerDisplayTest(displayTest);
+    }
+
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> spec) {
         if (spec.isEmpty())
         {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.loading.FMLLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 public class ModLoadingContext
@@ -66,6 +67,26 @@ public class ModLoadingContext
      */
     public void registerDisplayTest(Supplier<IExtensionPoint.DisplayTest> displayTest) {
         getActiveContainer().registerDisplayTest(displayTest);
+    }
+
+    /**
+     * Register a {@link IExtensionPoint.DisplayTest} with the mod container.
+     * <p>A shorthand for registering a DisplayTest with {@link #registerExtensionPoint(Class, Supplier)} that also
+     * creates the DisplayTest instance for you using the provided parameters.</p>
+     * @see IExtensionPoint.DisplayTest#DisplayTest(String, BiPredicate)
+     */
+    public void registerDisplayTest(String version, BiPredicate<String, Boolean> remoteVersionTest) {
+        getActiveContainer().registerDisplayTest(new IExtensionPoint.DisplayTest(version, remoteVersionTest));
+    }
+
+    /**
+     * Register a {@link IExtensionPoint.DisplayTest} with the mod container.
+     * <p>A shorthand for registering a DisplayTest with {@link #registerExtensionPoint(Class, Supplier)} that also
+     * creates the DisplayTest instance for you using the provided parameters.</p>
+     * @see IExtensionPoint.DisplayTest#DisplayTest(Supplier, BiPredicate)
+     */
+    public void registerDisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) {
+        getActiveContainer().registerDisplayTest(new IExtensionPoint.DisplayTest(suppliedVersion, remoteVersionTest));
     }
 
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> spec) {


### PR DESCRIPTION
Before:
```java
ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> "", (remote, isServer) -> true));
```

After:
```java
ModLoadingContext.get().registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);
```

There are also varying amounts of suppliers depending on what you need:
```java
ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);
ModLoadingContext.get().registerDisplayTest(() -> new IExtensionPoint.DisplayTest(() -> "", (remote, isServer) -> true));
ModLoadingContext.get().registerDisplayTest(new IExtensionPoint.DisplayTest(() -> "", (remote, isServer) -> true));
ModLoadingContext.get().registerDisplayTest(new IExtensionPoint.DisplayTest("", (remote, isServer) -> true));
ModLoadingContext.get().registerDisplayTest(() -> "", (remote, isServer) -> true));
ModLoadingContext.get().registerDisplayTest("", (remote, isServer) -> true));
```