### PR TITLE
[1.20.x] More buildscript clean-up

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -3,7 +3,7 @@ Minecraft Forge: Credits/Thank You
 Forge is a set of tools and modifications to the Minecraft base game code to assist 
 mod developers in creating new and exciting content. It has been in development for 
 several years now, but I would like to take this time thank a few people who have 
-helped it along it's way.
+helped it along its way.
 
 First, the people who originally created the Forge projects way back in Minecraft 
 alpha. Eloraam of RedPower, and SpaceToad of Buildcraft, without their acceptiance 
@@ -11,7 +11,7 @@ of me taking over the project, who knows what Minecraft modding would be today.
 
 Secondly, someone who has worked with me, and developed some of the core features
 that allow modding to be as functional, and as simple as it is, cpw. For developing
-FML, which stabelized the client and server modding ecosystem. As well as the base
+FML, which stabilized the client and server modding ecosystem. As well as the base
 loading system that allows us to modify Minecraft's code as elegently as possible.
 
 Mezz, who has stepped up as the issue and pull request manager. Helping to keep me
@@ -45,11 +45,11 @@ and minecraft clients.
 The code is authored by cpw.
 
 It began by partially implementing an API defined by the client side ModLoader, authored by Risugami.
-http://www.minecraftforum.net/topic/75440-
+https://www.minecraftforum.net/topic/75440-
 This support has been dropped as of Minecraft release 1.7, as Risugami no longer maintains ModLoader.
 
 It also contains suggestions and hints and generous helpings of code from LexManos, author of MinecraftForge.
-http://www.minecraftforge.net/
+https://minecraftforge.net/
 
 Additionally, it contains an implementation of topological sort based on that 
 published at http://keithschwarz.com/interesting/code/?dir=topological-sort

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,6 @@ ext {
     GIT_INFO = gradleutils.gitInfo
     VERSION = gradleutils.getFilteredMCTagOffsetBranchVersion(true, '[0-9]', MC_VERSION)
     FORGE_VERSION = VERSION.substring(MC_VERSION.length() + 1)
-
-    BINPATCH_TOOL = 'net.minecraftforge:binarypatcher:1.2.0:fatjar'
-    INSTALLER_TOOLS = 'net.minecraftforge:installertools:1.4.0'
-    FART = 'net.minecraftforge:ForgeAutoRenamingTool:1.0.6'
 }
 
 changelog {
@@ -50,7 +46,7 @@ project(':mcp') {
 
 if (System.env.TEAMCITY_VERSION) {
     //Only setup the CI environment if and only if the environment variables are set.
-    tasks.configureTeamCity {
+    tasks.named('configureTeamCity').configure {
         doLast {
             println "##teamcity[buildNumber '${project(':forge').version}']"
             println "##teamcity[setParameter name='env.PUBLISHED_JAVA_ARTIFACT_VERSION' value='${project(':forge').version}']"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,10 +4,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.ow2.asm:asm:9.5'
-    implementation 'org.ow2.asm:asm-tree:9.5'
+    implementation 'org.ow2.asm:asm:9.6'
+    implementation 'org.ow2.asm:asm-tree:9.6'
     implementation 'net.minecraftforge:srgutils:0.5.+'
-    implementation 'commons-io:commons-io:2.12.0'
+    implementation 'commons-io:commons-io:2.13.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/BytecodeFinder.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/BytecodeFinder.groovy
@@ -1,6 +1,7 @@
 package net.minecraftforge.forge.tasks
 
 import groovy.json.JsonBuilder
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
@@ -10,6 +11,7 @@ import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.MethodNode
 
+@CompileStatic
 abstract class BytecodeFinder extends DefaultTask {
     @InputFile abstract RegularFileProperty getJar()
     // It should be fine to mark the output as internal as we want to control when we run it anyways.
@@ -24,13 +26,13 @@ abstract class BytecodeFinder extends DefaultTask {
     protected void exec() {
         Util.init()
 
-        def outputFile = output.get().asFile
+        var outputFile = output.get().asFile
         if (outputFile.exists())
             outputFile.delete()
 
         pre()
 
-        Util.processClassNodes(jar.get().asFile, this::process)
+        Util.processClassNodes(jar.get().asFile, this.&process)
 
         post()
         outputFile.text = new JsonBuilder(getData()).toPrettyString()
@@ -38,8 +40,8 @@ abstract class BytecodeFinder extends DefaultTask {
 
 
     protected process(ClassNode node) {
-        if (node.fields != null) node.fields.each { process(node, it) }
-        if (node.methods != null) node.methods.each { process(node, it) }
+        if (node.fields !== null) node.fields.each { process(node, it) }
+        if (node.methods !== null) node.methods.each { process(node, it) }
     }
 
     protected pre() {}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/BytecodePredicateFinder.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/BytecodePredicateFinder.groovy
@@ -12,7 +12,7 @@ abstract class BytecodePredicateFinder extends BytecodeFinder {
     @Internal
     abstract Property<Closure<Boolean>> getPredicate()
 
-    private final Set<String> matches = new HashSet()
+    private final Set<String> matches = new HashSet<>()
 
     @Override
     protected process(ClassNode parent, MethodNode node) {

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/CleanProperties.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/CleanProperties.groovy
@@ -1,5 +1,8 @@
 package net.minecraftforge.forge.tasks;
 
+import groovy.transform.CompileDynamic;
+import groovy.transform.CompileStatic;
+
 import java.util.Properties;
 import java.util.Enumeration;
 import java.util.Map;
@@ -26,6 +29,7 @@ import java.util.Set;
  * This does the same thing, as well as sorting alphabetically.
  * It also ignores all comments. We can add them latter if someone cares.
  */
+@CompileStatic
 public class CleanProperties extends Properties {
     private static final long serialVersionUID = 1L;
     private static final String LINE_SEP = System.getProperty("line.separator");
@@ -58,6 +62,7 @@ public class CleanProperties extends Properties {
         return Collections.enumeration(ret);
     }
 
+    @CompileDynamic
     @Override
     public Set<Map.Entry<Object, Object>> entrySet() {
         Set<Map.Entry<Object, Object>> ret = new TreeSet<>((l, r) -> ((String)l.getKey()).compareTo((String)r.getKey()));

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ClosureHelper.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ClosureHelper.groovy
@@ -1,5 +1,7 @@
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.stc.FirstParam
+
 import java.util.function.BiConsumer
 
 public class ClosureHelper {
@@ -22,7 +24,7 @@ public class ClosureHelper {
         }
     }
     
-    static <T> T apply(T obj, Closure cl) {
+    static <T> T apply(T obj, @DelegatesTo(value = FirstParam, strategy = Closure.DELEGATE_FIRST) Closure cl) {
         cl.delegate = obj
         cl.resolveStrategy = Closure.DELEGATE_FIRST
         cl()

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/DownloadLibraries.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/DownloadLibraries.groovy
@@ -27,7 +27,7 @@ abstract class DownloadLibraries extends DefaultTask {
     def run() {
 		Util.init()
 		File outputDir = output.get().asFile
-        def libraries = new ArrayList()
+        var libraries = new ArrayList<String>()
 
 		def json = input.get().asFile.json().libraries.each { lib ->
 		    //TODO: Thread?
@@ -35,7 +35,7 @@ abstract class DownloadLibraries extends DefaultTask {
 			artifacts.each{ art -> 
 				def target = new File(outputDir, art.path)
 				libraries.add(target.absolutePath)
-				if (!target.exists() || !art.sha1.equals(target.sha1())) {
+				if (!target.exists() || art.sha1 != target.sha1()) {
 					project.logger.lifecycle("Downloading ${art.url}")
 					if (!target.parentFile.exists()) {
 						target.parentFile.mkdirs()
@@ -43,7 +43,7 @@ abstract class DownloadLibraries extends DefaultTask {
 					new URL(art.url).withInputStream { i ->
 						target.withOutputStream { it << i }
 					}
-					if (!art.sha1.equals(target.sha1())) {
+					if (art.sha1 != target.sha1()) {
 						throw new IllegalStateException("Failed to download ${art.url} to ${target.canonicalPath} SHA Mismatch")
 					}
 				}

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ExtractFile.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ExtractFile.groovy
@@ -1,10 +1,14 @@
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
+import java.util.zip.ZipFile
+
+@CompileStatic
 abstract class ExtractFile extends DefaultTask {
     @InputFile abstract RegularFileProperty getInput()
     @Input abstract Property<String> getTarget()
@@ -12,11 +16,11 @@ abstract class ExtractFile extends DefaultTask {
 
     @TaskAction
     protected void exec() {
-        def zip = new java.util.zip.ZipFile(input.get().asFile);
-        def entry = zip.getEntry(target.get())
+        var zip = new ZipFile(input.get().asFile);
+        var entry = zip.getEntry(target.get())
         if (entry == null)
             throw new IllegalStateException(input.get().asFile.absolutePath + " does not contain " + target.get())
-        def stream = zip.getInputStream(entry)
+        var stream = zip.getInputStream(entry)
         output.get().asFile.withOutputStream { out ->
             stream.transferTo(out)
         }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FieldCompareFinder.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FieldCompareFinder.groovy
@@ -1,20 +1,11 @@
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 
-import java.util.ArrayList
-import java.util.HashMap
-import java.util.TreeMap
-import java.util.TreeSet
-import java.util.function.BiConsumer
-
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.*
-
-import org.objectweb.asm.Opcodes
-import org.objectweb.asm.Type
+import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
-import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.MethodNode
 
 import static org.objectweb.asm.Opcodes.*
@@ -34,17 +25,17 @@ abstract class FieldCompareFinder extends BytecodeFinder {
     
     @Override
     protected process(ClassNode parent, MethodNode node) {
-        def last = null
+        AbstractInsnNode last = null
         def parentInstance = new ObjectTarget(owner: parent.name, name: '', desc: '')
         for (int x = 0; x < node.instructions.size(); x++) {
             def current = node.instructions.get(x)
-            if (current.opcode == IF_ACMPEQ || current.opcode == IF_ACMPNE) {
-                if (last != null && (last.opcode == GETSTATIC || last.opcode == GETFIELD)) {
+            if (current.opcode === IF_ACMPEQ || current.opcode === IF_ACMPNE) {
+                if (last !== null && (last.opcode === GETSTATIC || last.opcode === GETFIELD)) {
                     def target = new Search(cls: last.owner, name: last.name)
                     def wanted = fieldsReverse.get(target)
                     def original = fields.get(wanted)
                     def instance = new ObjectTarget(owner: parent.name, name: node.name, desc: node.desc)
-                    if (wanted != null && (original.blacklist == null || (!original.blacklist.contains(instance) && !original.blacklist.contains(parentInstance)))) {
+                    if (wanted !== null && (original.blacklist === null || (!original.blacklist.contains(instance) && !original.blacklist.contains(parentInstance)))) {
                         targets.computeIfAbsent(wanted, { k -> new TreeSet() }).add(instance)
                     }
                 }
@@ -68,9 +59,10 @@ abstract class FieldCompareFinder extends BytecodeFinder {
 		}
         return ret
     }
-    
+
+    @CompileStatic
     @EqualsAndHashCode(excludes = ['replacement', 'blacklist'])
-    public static class Search {
+    static class Search {
         @Input
         String cls
         
@@ -89,17 +81,17 @@ abstract class FieldCompareFinder extends BytecodeFinder {
             return cls + '.' + name
         }
         
-        def blacklist(def owner, def name, def desc) {
-            if (blacklist == null)
-                blacklist = new HashSet()
+        def blacklist(String owner, String name, String desc) {
+            if (blacklist === null)
+                blacklist = new HashSet<>()
             blacklist.add(new ObjectTarget(owner: owner, name: name, desc: desc))
         }
-        def blacklist(def owner) {
+        def blacklist(String owner) {
             blacklist(owner, '', '')
         }
     }
     
-    def fields(Closure cl) {
+    void fields(Closure cl) {
         new ClosureHelper(cl, {name, ccl ->
             def search = ClosureHelper.apply(new Search(), ccl)
             this.fields.put(name, search)

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJar.groovy
@@ -1,6 +1,7 @@
 package net.minecraftforge.forge.tasks
 
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.*
 import org.gradle.api.DefaultTask
@@ -43,7 +44,7 @@ abstract class InstallerJar extends Zip {
                 // I should make it allow downloads but thats a spec break, and this is just a ~14KB jar
                 [
                     project.tasks.serverShimJar // Server bootstrap executable jar
-                ].forEach { packed ->
+                ].forEach { AbstractArchiveTask packed ->
                     def path = Util.getMavenInfoFromTask(packed).path
                     from(packed) {
                         rename { "maven/$path" }
@@ -68,7 +69,7 @@ abstract class InstallerJar extends Zip {
             ].each { task ->
                 def json = task.output.get().asFile.json
                 json.libraries.each { lib -> 
-                    if (lib.downloads?.artifact?.url != null && !lib.downloads.artifact.url.isEmpty())
+                    if (lib.downloads?.artifact?.url !== null && !lib.downloads.artifact.url.isEmpty())
                         deps.put(lib.name, lib.downloads.artifact)
                 }
             }
@@ -77,10 +78,10 @@ abstract class InstallerJar extends Zip {
             [
                 project.tasks.universalJar, // Forge runtime code
                 project.tasks.serverShimJar // Shim jar for dedicated server
-            ].forEach { packed ->
+            ].forEach { AbstractArchiveTask packed ->
                 def name = Util.getMavenInfoFromTask(packed).name
                 def info = deps.remove(name)
-                if (info != null) {
+                if (info !== null) {
                     println("Adding: $packed.path $name")
                     parent.from(packed) {
                         rename { "maven/$info.path" }
@@ -97,7 +98,7 @@ abstract class InstallerJar extends Zip {
                 //println('')
                 def resolved = cfg.resolvedConfiguration.resolvedArtifacts
                 int found = 0
-                for (var dep : resolved) {
+                for (def dep : resolved) {
                     def name = Util.getMavenInfoFromDep(dep).name
                     def info = deps.remove(name)
                     if (info == null) {
@@ -133,13 +134,13 @@ abstract class InstallerJar extends Zip {
         }
         
         void addFile(file, info) {
-            def pack = parent.offline.get() || info.url.isEmpty()
+            boolean pack = parent.offline.get() || info.url.isEmpty()
             
             // If it's a offline jar just always pack
             if (!pack) {
                 try {
-                    def remote = new URL("${info.url}.sha1").getText('UTF-8')
-                    pack = !info.sha1.equals(remote)
+                    var remote = new URL("${info.url}.sha1").getText('UTF-8')
+                    pack = info.sha1 != remote
                 } catch (FileNotFoundException e) {
                     pack = !info.url.startsWith('https://libraries.minecraft.net/')
                     // Oh noes its not there!

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJson.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/InstallerJson.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 import java.nio.file.Files
 
@@ -45,7 +46,7 @@ abstract class InstallerJson extends DefaultTask {
         [
             project.tasks.universalJar,
             project.tasks.serverShimJar
-        ].forEach { packed ->
+        ].forEach { AbstractArchiveTask packed ->
             def info = Util.getMavenInfoFromTask(packed)
             libs.put(info.name, [
                 name: info.name,

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/LauncherJson.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/LauncherJson.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 import java.nio.file.Files
 
@@ -58,38 +59,35 @@ abstract class LauncherJson extends DefaultTask {
 
     @TaskAction
     protected void exec() {
-        [
-            project.tasks.universalJar
-        ].forEach { packed ->
-            def info = Util.getMavenInfoFromTask(packed)
-            json.libraries.add([
-                name: info.name,
-                downloads: [
-                    artifact: [
-                        path: info.path,
-                        url: "https://maven.minecraftforge.net/$info.path",
-                        sha1: packed.archiveFile.get().asFile.sha1(),
-                        size: packed.archiveFile.get().asFile.length()
-                    ]
+        var packed = (AbstractArchiveTask) project.tasks.universalJar
+        def info = Util.getMavenInfoFromTask(packed)
+        json.libraries.add([
+            name: info.name,
+            downloads: [
+                artifact: [
+                    path: info.path,
+                    url: "https://maven.minecraftforge.net/$info.path",
+                    sha1: packed.archiveFile.get().asFile.sha1(),
+                    size: packed.archiveFile.get().asFile.length()
                 ]
-            ])
-        }
-        [
-            'client': project.tasks.applyClientBinPatches
-        ].forEach { classifier, genned ->
-            def info = Util.getMavenInfoFromTask(genned, classifier)
-            json.libraries.add([
-                name: info.name,
-                downloads: [
-                    artifact: [
-                        path: info.path,
-                        url: "",
-                        sha1: genned.output.get().asFile.sha1(),
-                        size: genned.output.get().asFile.length()
-                    ]
+            ]
+        ])
+
+        var classifier = 'client'
+        var genned = project.tasks.applyClientBinPatches
+        info = Util.getMavenInfoFromTask(genned, classifier)
+        json.libraries.add([
+            name: info.name,
+            downloads: [
+                artifact: [
+                    path: info.path,
+                    url: "",
+                    sha1: genned.output.get().asFile.sha1(),
+                    size: genned.output.get().asFile.length()
                 ]
-            ])
-        }
+            ]
+        ])
+
         getArtifacts(project, project.configurations.installer).each { key, lib -> 
             json.libraries.add(lib)
         }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/LauncherJson.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/LauncherJson.groovy
@@ -88,9 +88,7 @@ abstract class LauncherJson extends DefaultTask {
             ]
         ])
 
-        getArtifacts(project, project.configurations.installer).each { key, lib -> 
-            json.libraries.add(lib)
-        }
+        json.libraries.addAll(getArtifacts(project.configurations.installer).values())
         Files.writeString(output.get().asFile.toPath(), new JsonBuilder(json).toPrettyString())
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/MergeJars.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/MergeJars.groovy
@@ -1,5 +1,6 @@
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.CompileStatic
 import org.apache.commons.io.IOUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -12,6 +13,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
+@CompileStatic
 abstract class MergeJars extends DefaultTask {
     MergeJars() {
         output.convention(project.layout.buildDirectory.dir(name).map { it.file('output.jar') })
@@ -24,8 +26,8 @@ abstract class MergeJars extends DefaultTask {
         try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(output.get().asFile))) {
             for (def jar : jars) {
                 try (ZipInputStream zin = new ZipInputStream(new FileInputStream(jar))) {
-                    def entry
-                    while ((entry = zin.getNextEntry()) != null) {
+                    ZipEntry entry
+                    while ((entry = zin.getNextEntry()) !== null) {
                         ZipEntry _new = new ZipEntry(entry.getName())
                         _new.setTime(0) //SHOULD be the same time as the main entry, but NOOOO _new.setTime(entry.getTime()) throws DateTimeException, so you get 0, screw you!
                         zout.putNextEntry(_new)

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ObjectTarget.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ObjectTarget.groovy
@@ -27,6 +27,6 @@ public class ObjectTarget implements Comparable<ObjectTarget> {
     
     @Override
     int compareTo(ObjectTarget o) {
-        return toString().compareTo(o.toString())
+        return toString() <=> o.toString()
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/SetupCheckJarCompatibility.groovy
@@ -16,7 +16,7 @@ abstract class SetupCheckJarCompatibility extends DefaultTask {
     SetupCheckJarCompatibility() {
         group = 'jar compatibility'
         onlyIf {
-            inputVersion.getOrNull() != null
+            inputVersion.getOrNull() !== null
         }
         outputs.upToDateWhen { false } // Never up to date, because this setup task should always run
 

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
@@ -89,7 +89,7 @@ final class Util {
             var domain = 'libraries.minecraft.net'
             var url = "https://$domain/$info.path"
             if (!checkExists(url))
-                url.values[0] = 'files.minecraftforge.net'
+                url.values[0] = 'maven.minecraftforge.net'
 
             var sha1 = sha1(dep.file)
 

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
@@ -2,35 +2,46 @@ package net.minecraftforge.forge.tasks
 
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode
 
-import java.io.File
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
-public class Util {
-    static final ASM_LEVEL = Opcodes.ASM9
+final class Util {
+    public static final int ASM_LEVEL = Opcodes.ASM9
+    private static final HttpClient HTTP = HttpClient.newBuilder().build()
 
     static void init() {
         File.metaClass.sha1 = { ->
             MessageDigest md = MessageDigest.getInstance('SHA-1')
-            delegate.eachByte 4096, {bytes, size ->
+            delegate.eachByte(4096) { byte[] bytes, int size ->
                 md.update(bytes, 0, size)
             }
-            return md.digest().collect {String.format "%02x", it}.join()
+            return md.digest().collect(this.&toHex).join('')
         }
         File.metaClass.getSha1 = { !delegate.exists() ? null : delegate.sha1() }
         File.metaClass.sha256 = { ->
             MessageDigest md = MessageDigest.getInstance('SHA-256')
-            delegate.eachByte 4096, {bytes, size ->
+            delegate.eachByte(4096) { byte[] bytes, int size ->
                 md.update(bytes, 0, size)
             }
-            return md.digest().collect {String.format "%02x", it}.join()
+            return md.digest().collect(this.&toHex).join('')
         }
         File.metaClass.getSha256 = { !delegate.exists() ? null : delegate.sha256() }
 
@@ -39,16 +50,17 @@ public class Util {
         File.metaClass.setJson = { json -> delegate.text = new JsonBuilder(json).toPrettyString() }
 
         Date.metaClass.iso8601 = { ->
-            def format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-            def result = format.format(delegate)
+            var format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+            var result = format.format(delegate)
             return result[0..21] + ':' + result[22..-1]
         }
 
         String.metaClass.rsplit = { String del, int limit = -1 ->
-            def lst = new ArrayList()
-            def x = 0, idx
-            def tmp = delegate
-            while ((idx = tmp.lastIndexOf(del)) != -1 && (limit == -1 || x++ < limit)) {
+            var lst = new ArrayList<String>()
+            int x = 0
+            int idx
+            String tmp = delegate
+            while ((idx = tmp.lastIndexOf(del)) != -1 && (limit === -1 || x++ < limit)) {
                 lst.add(0, tmp.substring(idx + del.length(), tmp.length()))
                 tmp = tmp.substring(0, idx)
             }
@@ -57,7 +69,7 @@ public class Util {
         }
     }
 
-    public static String[] getClasspath(project, libs, artifact) {
+    static String[] getClasspath(Project project, Map libs, String artifact) {
         def ret = []
         artifactTree(project, artifact).each { key, lib ->
             libs[lib.name] = lib
@@ -67,30 +79,32 @@ public class Util {
         return ret
     }
 
-    public static def getArtifacts(project, config) {
-        def ret = [:]
-        config.resolvedConfiguration.resolvedArtifacts.each { dep ->
-            def info = getMavenInfoFromDep(dep)
-            def url = "https://libraries.minecraft.net/$info.path"
+    @CompileStatic
+    static Map getArtifacts(Project project, Configuration config) {
+        var ret = new ConcurrentHashMap()
+        config.resolvedConfiguration.resolvedArtifacts.parallelStream().forEach(dep -> {
+            var info = getMavenInfoFromDep(dep)
+            var url = "https://libraries.minecraft.net/$info.path"
             if (!checkExists(url))
                 url = "https://maven.minecraftforge.net/$info.path"
-                
+
             ret[info.key] = [
                 name: info.name,
                 downloads: [
                     artifact: [
                         path: info.path,
-                        url: url,
-                        sha1: dep.file.sha1(),
+                        url: url.toString(),
+                        sha1: sha1(dep.file),
                         size: dep.file.length()
                     ]
                 ]
             ]
-        }
+        })
         return ret
     }
-    
-    public static Map getMavenInfoFromDep(dep) {
+
+    @CompileStatic
+    static Map getMavenInfoFromDep(ResolvedArtifact dep) {
         return getMavenInfoFromMap([
             group: dep.moduleVersion.id.group,
             name: dep.moduleVersion.id.name,
@@ -99,58 +113,69 @@ public class Util {
             extension: dep.extension
         ])
     }
-    public static Map getMavenInfoFromTask(task) {
+
+    @CompileStatic
+    static Map getMavenInfoFromTask(AbstractArchiveTask task) {
         return getMavenInfoFromMap([
-            group: task.project.group,
+            group: task.project.group.toString(),
             name: task.project.name,
-            version: task.project.version,
+            version: task.project.version.toString(),
             classifier: task.archiveClassifier.get(),
             extension: task.archiveExtension.get()
         ])
     }
-    public static Map getMavenInfoFromTask(task,classifier) {
+
+    @CompileStatic
+    static Map getMavenInfoFromTask(Task task, String classifier) {
         return getMavenInfoFromMap([
-            group: task.project.group,
+            group: task.project.group.toString(),
             name: task.project.name,
-            version: task.project.version,
+            version: task.project.version.toString(),
             classifier: classifier,
             extension: 'jar'
         ])
     }
-    
-    private static Map getMavenInfoFromMap(art) {
-        def key = "$art.group:$art.name"
-        def name = "$art.group:$art.name:$art.version"
-        def path = "${art.group.replace('.', '/')}/$art.name/$art.version/$art.name-$art.version"
-        if (art.classifier != null) {
+
+    @CompileStatic
+    private static Map getMavenInfoFromMap(Map<String, String> art) {
+        var key = "$art.group:$art.name"
+        var name = "$art.group:$art.name:$art.version"
+        var path = "${art.group.replace('.', '/')}/$art.name/$art.version/$art.name-$art.version"
+        if (art.classifier !== null) {
             name += ":$art.classifier"
             path += "-$art.classifier"
         }
-        if (!'jar'.equals(art.extension)) {
+        if ('jar' != art.extension) {
             name += "@$art.extension"
             path += ".$art.extension"
         } else {
             path += ".jar"
         }
         return [
-            key: key,
-            name: name,
-            path: path,
+            key: key.toString(),
+            name: name.toString(),
+            path: path.toString(),
             art: art
         ]
     }
 
-    public static def iso8601Now() { new Date().iso8601() }
+    static String iso8601Now() { new Date().iso8601() }
 
-    public static def sha1(file) {
+    @CompileStatic
+    static String sha1(File file) {
         MessageDigest md = MessageDigest.getInstance('SHA-1')
-        file.eachByte 4096, {bytes, size ->
+        file.eachByte(4096) { byte[] bytes, int size ->
             md.update(bytes, 0, size)
         }
-        return md.digest().collect {String.format "%02x", it}.join()
+        return md.digest().collect(this.&toHex).join('')
     }
 
-    private static def artifactTree(project, artifact, transitive = true) {
+    @CompileStatic
+    private static String toHex(byte bite) {
+        return String.format('%02x', bite)
+    }
+
+    private static Map artifactTree(Project project, String artifact, boolean transitive = true) {
         if (!project.ext.has('tree_resolver'))
             project.ext.tree_resolver = 1
         def cfg = project.configurations.create('tree_resolver_' + project.ext.tree_resolver++)
@@ -161,34 +186,33 @@ public class Util {
         return getArtifacts(project, cfg)
     }
 
-    static boolean checkExists(url) {
+    @CompileStatic
+    static boolean checkExists(String url) {
         try {
-            def code = new URL(url).openConnection().with {
-                requestMethod = 'HEAD'
-                connect()
-                responseCode
-            }
-            return code == 200
+            return HTTP.send(HttpRequest.newBuilder(new URI(url))
+                    .method('HEAD', HttpRequest.BodyPublishers.noBody()).build(), HttpResponse.BodyHandlers.discarding()
+            ).statusCode() === 200
         } catch (Exception e) {
             if (e.toString().contains('unable to find valid certification path to requested target'))
-                throw new RuntimeException('Failed to connect to ' + url + ': Missing certificate root authority, try updating java')
+                throw new RuntimeException("Failed to connect to $url: Missing certificate root authority, try updating Java")
             throw e
         }
     }
 
-    static String getLatestForgeVersion(mcVersion) {
+    static String getLatestForgeVersion(String mcVersion) {
         final json = new JsonSlurper().parseText(new URL('https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json').getText('UTF-8'))
         final ver = json.promos["$mcVersion-latest"]
         ver === null ? null : (mcVersion + '-' + ver)
     }
 
-    static void processClassNodes(File file, Closure process) {
+    @CompileStatic
+    static void processClassNodes(File file, @ClosureParams(value = SimpleType, options = 'org.objectweb.asm.tree.ClassNode') Closure process) {
         file.withInputStream { i ->
             new ZipInputStream(i).withCloseable { zin ->
                 ZipEntry zein
-                while ((zein = zin.nextEntry) != null) {
+                while ((zein = zin.nextEntry) !== null) {
                     if (zein.name.endsWith('.class')) {
-                        def node = new ClassNode(ASM_LEVEL)
+                        var node = new ClassNode(ASM_LEVEL)
                         new ClassReader(zin).accept(node, 0)
                         process(node)
                     }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/Util.groovy
@@ -190,7 +190,7 @@ final class Util {
         def dep = project.dependencies.create(artifact)
         cfg.dependencies.add(dep)
         def files = cfg.resolve()
-        return getArtifacts(project, cfg)
+        return getArtifacts(cfg)
     }
 
     @CompileStatic

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/ValidateDeprecations.groovy
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.CompileStatic
 import net.minecraftforge.srgutils.MinecraftVersion
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -28,8 +29,8 @@ abstract class ValidateDeprecations extends DefaultTask {
 
     @TaskAction
     protected void exec() {
-        def mcVer = MinecraftVersion.from(mcVersion.get())
-        def errors = []
+        var mcVer = MinecraftVersion.from(mcVersion.get())
+        List<String> errors = []
 
         Util.processClassNodes(input.get().asFile) {
             processNode(mcVer, errors, it)
@@ -65,7 +66,7 @@ abstract class ValidateDeprecations extends DefaultTask {
         }
     }
 
-    private static void processAnnotations(AnnotationNode annotation, MinecraftVersion mcVer, List<String> errors, Closure context) {
+    private static void processAnnotations(AnnotationNode annotation, MinecraftVersion mcVer, List<String> errors, Closure<String> context) {
         def values = annotation.values
         if (values === null)
             return
@@ -73,7 +74,7 @@ abstract class ValidateDeprecations extends DefaultTask {
         int since = values.indexOf('since')
         if (annotation.desc == 'Ljava/lang/Deprecated;' && forRemoval !== -1 && since !== -1 && values.size() >= 4 && values[forRemoval + 1] === true) {
             def oldVersion = MinecraftVersion.from(values[since + 1])
-            def split = ValidateDeprecations.splitDots(oldVersion.toString())
+            int[] split = ValidateDeprecations.splitDots(oldVersion.toString())
             if (split.length < 2)
                 return
             def removeVersion = MinecraftVersion.from("${split[0]}.${split[1] + 1}")
@@ -82,6 +83,7 @@ abstract class ValidateDeprecations extends DefaultTask {
         }
     }
 
+    @CompileStatic
     private static int[] splitDots(String version) {
         String[] pts = version.split('\\.')
         int[] values = new int[pts.length]

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
@@ -1,6 +1,5 @@
 package net.minecraftforge.forge.tasks.checks
 
-import groovy.transform.CompileStatic
 import net.minecraftforge.forge.tasks.Util
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -27,12 +26,12 @@ abstract class CheckExcs extends CheckTask {
         excs.each { f ->
             final lines = []
             f.eachLine { line ->
-                def idx = line.indexOf('#')
-                if (idx == 0 || line.isEmpty()) {
+                int idx = line.indexOf('#')
+                if (idx === 0 || line.isEmpty()) {
                     return
                 }
 
-                if (idx != -1) line = line.substring(0, idx - 1)
+                if (idx !== -1) line = line.substring(0, idx - 1)
 
                 if (!line.contains('=')) {
                     reporter.report("Invalid: $line")
@@ -59,13 +58,14 @@ abstract class CheckExcs extends CheckTask {
                     return
                 }
                 lines.add(line)
+
+                return
             }
 
             if (fix) f.text = lines.sort().join('\n')
         }
     }
 
-    @CompileStatic
     private void collectKnown(Collection<String> known) {
         binary.get().asFile.withInputStream { i ->
             new ZipInputStream(i).withCloseable { zin ->

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckExcs.groovy
@@ -1,5 +1,6 @@
 package net.minecraftforge.forge.tasks.checks
 
+import groovy.transform.CompileStatic
 import net.minecraftforge.forge.tasks.Util
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -64,6 +65,7 @@ abstract class CheckExcs extends CheckTask {
         }
     }
 
+    @CompileStatic
     private void collectKnown(Collection<String> known) {
         binary.get().asFile.withInputStream { i ->
             new ZipInputStream(i).withCloseable { zin ->

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckMode.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckMode.groovy
@@ -6,4 +6,6 @@ import groovy.transform.CompileStatic
 enum CheckMode {
     CHECK,
     FIX
+
+    CheckMode() {}
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckPatches.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckPatches.groovy
@@ -36,13 +36,13 @@ abstract class CheckPatches extends CheckTask {
         }
     }
     
-    def accessChange(previous, current) {
+    static boolean accessChange(String previous, String current) {
         //return ACCESS_MAP[previous] < ACCESS_MAP[current]
         return previous != current
     }
 
     void verifyPatch(Path patch, Reporter reporter, boolean fix, String patchPath, boolean hasS2SArtifact) {
-        final oldFixedErrors = reporter.fixed.size()
+        int oldFixedErrors = reporter.fixed.size()
 
         final lines = Files.readAllLines(patch)
 

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckSAS.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckSAS.groovy
@@ -94,7 +94,7 @@ abstract class CheckSAS extends CheckTask {
         }
     }
 
-    protected static isSided(Annotatable annotatable) {
+    protected static boolean isSided(Annotatable annotatable) {
         if (annotatable === null) return false
         for (ann in annotatable.annotations) {
             if ('Lnet/minecraftforge/api/distmarker/OnlyIn;' == ann.desc)
@@ -104,7 +104,7 @@ abstract class CheckSAS extends CheckTask {
     }
     
     protected static findChildMethods(Map<String, InheritanceData> json, String cls, String desc) {
-        return json.values().findAll{ it.methods != null && it.methods[desc] != null && it.methods[desc].override == cls && isSided(it.methods[desc]) }
+        return json.values().findAll{ it.methods !== null && it.methods[desc] !== null && it.methods[desc].override == cls && isSided(it.methods[desc]) }
                 .collect { it.name + ' ' + desc.replace(' ', '') } as TreeSet
     }
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckTask.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/checks/CheckTask.groovy
@@ -1,6 +1,8 @@
 package net.minecraftforge.forge.tasks.checks
 
 import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.ThirdParam
 import net.minecraftforge.forge.tasks.Util
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
@@ -33,7 +35,7 @@ abstract class CheckTask extends DefaultTask implements VerificationTask {
     void run() {
         Util.init()
 
-        final doFix = getMode().get() === CheckMode.FIX
+        boolean doFix = getMode().get() === CheckMode.FIX
         final Reporter reporter = new Reporter(doFix)
         check(reporter, doFix)
 
@@ -88,7 +90,8 @@ abstract class CheckTask extends DefaultTask implements VerificationTask {
     }
 
     static <T extends CheckTask> void registerTask(TaskContainer tasks, String taskName, @DelegatesTo.Target('type') Class<T> clazz,
-                                                   @DelegatesTo(genericTypeIndex = 0, target = 'type') Closure configuration) {
+                                                   @DelegatesTo(genericTypeIndex = 0, target = 'type')
+                                                   @ClosureParams(ThirdParam.FirstGenericType) Closure configuration) {
         taskName = taskName.capitalize()
         tasks.register("check$taskName", clazz) { CheckTask task ->
             def castedTask = task as T

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -5,8 +5,7 @@ import net.minecraftforge.forge.tasks.checks.CheckPatches
 import net.minecraftforge.forge.tasks.checks.CheckSAS
 import net.minecraftforge.forge.tasks.checks.CheckTask
 
-import java.util.Date
-import java.util.LinkedHashMap
+import java.nio.file.Files
 import net.minecraftforge.forge.tasks.*
 import static net.minecraftforge.forge.tasks.Util.*
 import net.minecraftforge.gradle.common.tasks.ApplyBinPatches
@@ -70,21 +69,27 @@ sourceSets {
     }
 }
 
-ext {
-    SPEC_VERSION = gradleutils.gitInfo.tag
-    // The new versioning sceme is <MCVersion>-<ForgeMC>.<RB>.<CommitsSinceRB>
-    // ForgeMC is a unique identifier for every MC version we have supported.
-    // Essentially, the same as the old, except dropping the first number, and the builds are no longer unique.
-    MCP_ARTIFACT = project(':mcp').mcp.config.get()
+final String SPEC_VERSION = gradleutils.gitInfo.tag
 
-    EXTRA_TXTS = [
+// The new versioning sceme is <MCVersion>-<ForgeMC>.<RB>.<CommitsSinceRB>
+// ForgeMC is a unique identifier for every MC version we have supported.
+// Essentially, the same as the old, except dropping the first number, and the builds are no longer unique.
+final def MCP_ARTIFACT = project(':mcp').mcp.config.get()
+
+final List<File> EXTRA_TXTS = [
         rootProject.file('CREDITS.txt'),
         rootProject.file('LICENSE.txt'),
         rootProject.tasks.createChangelog.outputFile
-    ]
+]
 
+ext {
     MAVEN_PATH = "${group.toString().replace('.', '/')}/${project.name}/${VERSION}".toString()
 }
+final String MAVEN_PATH = ext.MAVEN_PATH
+
+final String BINPATCH_TOOL = 'net.minecraftforge:binarypatcher:1.2.0:fatjar'
+final String INSTALLER_TOOLS = 'net.minecraftforge:installertools:1.4.0'
+final String FART = 'net.minecraftforge:ForgeAutoRenamingTool:1.0.6'
 
 configurations {
     // Don't pull all libraries, if we're missing something, add it to the installer list so the installer knows to download it.
@@ -280,7 +285,7 @@ tasks.userdevConfig.configure {
     }
 }
 
-for (def run : patcher.runs + tasks.userdevConfig.runs) {
+for (def run in patcher.runs + tasks.userdevConfig.runs) {
     if (run.parents) continue // We already added this to the parent run config
     //run.property 'bsl.debug', 'true'
     run.args '--gameDir', '.'
@@ -312,7 +317,7 @@ tasks.register('downloadVersionManifest', Download) {
 tasks.register('downloadJson', Download) {
     dependsOn downloadVersionManifest
     inputs.file downloadVersionManifest.dest
-    src { downloadVersionManifest.dest.json.versions.find{ it.id == MC_VERSION }.url }
+    src { downloadVersionManifest.dest.json.versions.find { it.id == MC_VERSION }.url }
     dest file("build/versions/$MC_VERSION/version.json")
     useETag 'all'
     onlyIfModified true
@@ -352,8 +357,8 @@ tasks.register('extractInheritance', ExtractInheritance) {
     tool = INSTALLER_TOOLS + ':fatjar'
     args.add '--annotations'
     input = genJoinedBinPatches.cleanJar
-    libraries.addAll downloadLibraries.librariesOutput.map { rf -> 
-        java.nio.file.Files.readAllLines(rf.asFile.toPath()).stream().map(File::new).collect(java.util.stream.Collectors.toList()) 
+    libraries.addAll downloadLibraries.librariesOutput.map { rf ->
+        Files.readAllLines(rf.asFile.toPath()).stream().map(File::new).toList()
     }
 }
 tasks.register("findFieldInstanceChecks", FieldCompareFinder) {
@@ -380,16 +385,18 @@ tasks.register("findFinalizeSpawnTargets", BytecodePredicateFinder) {
     predicate = {
         parent, node, insn ->
             'net/minecraft/world/level/BaseSpawner' != parent.name // Ignore this class as we special case it.
-            && insn.getOpcode() == Opcodes.INVOKEVIRTUAL
-            && insn.name.equals('m_6518_')
-            && insn.desc.equals('(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/entity/SpawnGroupData;')
+            && insn.getOpcode() === Opcodes.INVOKEVIRTUAL
+            && insn.name == 'm_6518_'
+            && insn.desc == '(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/entity/SpawnGroupData;'
     }
 }
 tasks.register('validateDeprecations', ValidateDeprecations) {
     input = tasks.jar.archiveFile
     mcVersion = MC_VERSION
 }
-tasks.jar.finalizedBy 'validateDeprecations'
+tasks.named('jar', Jar).configure {
+    finalizedBy 'validateDeprecations'
+}
 tasks.register("downloadInstaller", DownloadMavenArtifact) {
     artifact = "net.minecraftforge:installer:2.2.+:fatjar"
     changing = true
@@ -539,7 +546,7 @@ CheckTask.registerTask(tasks, 'Excs', CheckExcs) {
 }
 
 CheckTask.registerTask(tasks, 'Patches', CheckPatches) {
-    dependsOn genPatches
+    dependsOn 'genPatches'
     patchDir = file("$rootDir/patches")
     patchesWithS2SArtifact = [
             'minecraft/net/minecraft/client/renderer/ViewArea.java.patch',
@@ -547,7 +554,7 @@ CheckTask.registerTask(tasks, 'Patches', CheckPatches) {
     ]
 }
 
-genPatches {
+tasks.named('genPatches', GeneratePatches).configure {
     finalizedBy checkAndFixPatches
     autoHeader true
     lineEnding = '\n'
@@ -556,10 +563,10 @@ genPatches {
 def baseForgeVersionProperty = project.objects.property(String)
 baseForgeVersionProperty.set(project.provider { TeamcityRequests.attemptFindBase(rootDir) ?: getLatestForgeVersion(MC_VERSION) })
 baseForgeVersionProperty.finalizeValueOnRead()
-def jarCompatibilityTaskSetup = { task ->
+final jarCompatibilityTaskSetup = { Task task ->
     task.group = 'jar compatibility'
     task.onlyIf {
-        baseForgeVersionProperty.getOrNull() != null
+        baseForgeVersionProperty.getOrNull() !== null
     }
 }
 
@@ -643,8 +650,8 @@ tasks.register('installerJson', InstallerJson) {
     input.from(applyClientBinPatches.output, applyServerBinPatches.output, genClientBinPatches.toolJar)
 
     doFirst {
-        def libs = libraries
-        def INSTALLER_TOOLS_CLASSPATH = getClasspath(project, libs, INSTALLER_TOOLS)
+        var libs = libraries
+        String[] INSTALLER_TOOLS_CLASSPATH = getClasspath(project, libs, INSTALLER_TOOLS)
         json.putAll([
             _comment: launcherJson.json._comment,
             hideExtract: true,
@@ -831,7 +838,7 @@ tasks.register('installerJson', InstallerJson) {
 
 tasks.named('universalJar').configure {
     dependsOn downloadCrowdin
-        from zipTree(downloadCrowdin.dest).matching {
+    from zipTree(downloadCrowdin.dest).matching {
         include 'assets/forge/lang/*.json'
     }
 
@@ -1060,6 +1067,6 @@ publishing {
 
 // Make sure we run bin compat checking during local testing.
 if (!System.env.MAVEN_USER || !System.env.MAVEN_PASSWORD)
-    publish.dependsOn(':forge:checkJarCompatibility')
+    tasks.named('publish').configure { dependsOn(':forge:checkJarCompatibility') }
 
 apply from: rootProject.file('build_forge_eclipse.gradle')

--- a/build_forge_eclipse.gradle
+++ b/build_forge_eclipse.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 eclipse {
     classpath.file.whenMerged {
         def minecraft = entries.find { it.path == 'src/main/java' }
-        if (minecraft == null) throw new IllegalStateException("You must run `setup` task before importing")
+        if (minecraft === null) throw new IllegalStateException("You must run `setup` task before importing")
         // Disable optional warnings on the minecraft decompiled source code. It just muddies the warning window and hides warnings in our own codebase
         minecraft.entryAttributes['ignore_optional_problems'] = 'true'
         

--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -40,8 +40,8 @@ tasks.register('generateResources') {
 
 // Make sure out manifests get written before compiling the code, IDEA calls this task if you tell it to use the gradle build.
 tasks.withType(JavaCompile).configureEach {
-    dependsOn(generateResources)
-    dependsOn(processResources) // Needed because we merge the output of this with the output of the compile task. And gradle detects downstream tasks using the output without a hard dep
+    dependsOn 'generateResources'
+    dependsOn 'processResources' // Needed because we merge the output of this with the output of the compile task. And gradle detects downstream tasks using the output without a hard dep
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
     options.warnings = false // Shutup deprecated for removal warnings
 }
@@ -61,7 +61,7 @@ tasks.register('copyEclipseSettings') {
             def temp = new CleanProperties().load(file)
             def exst = new CleanProperties().load(target)
             exst.put('eclipse.preferences.version', '1')
-            temp.forEach(exst::put)
+            exst.putAll(temp)
             exst.store(target)
         }
     }

--- a/fmlcore/build.gradle
+++ b/fmlcore/build.gradle
@@ -40,7 +40,7 @@ tasks.named('jar', Jar).configure {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:-unchecked'
 }
 

--- a/fmlearlydisplay/build.gradle
+++ b/fmlearlydisplay/build.gradle
@@ -44,11 +44,11 @@ dependencies {
     testRuntimeOnly("org.lwjgl:lwjgl-stb::$lwjglNatives")
 }
 
-test {
+tasks.named('test', Test).configure {
     useJUnitPlatform()
 }
 
-jar {
+tasks.named('jar', Jar).configure {
     manifest {
         attributes([
             'Automatic-Module-Name': 'net.minecraftforge.earlydisplay',
@@ -65,7 +65,7 @@ jar {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked'
 }
 

--- a/fmlloader/build.gradle
+++ b/fmlloader/build.gradle
@@ -65,7 +65,7 @@ tasks.named('jar', Jar).configure {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked'
 }
 
@@ -94,10 +94,10 @@ publishing {
 tasks.register('writeForgeVersionJson') {
     doLast {
         file('src/main/resources/forge_version.json').json = [
-            'forge': FORGE_VERSION,
-            'mc': MC_VERSION,
-            'mcp': MCP_VERSION
-        ] as LinkedHashMap
+            forge: FORGE_VERSION,
+            mc: MC_VERSION,
+            mcp: MCP_VERSION
+        ]
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+org.gradle.parallel=true
 
 JAVA_VERSION=17
 MC_VERSION=1.20.4

--- a/javafmllanguage/build.gradle
+++ b/javafmllanguage/build.gradle
@@ -37,7 +37,7 @@ tasks.named('jar', Jar).configure {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked'
 }
 

--- a/lowcodelanguage/build.gradle
+++ b/lowcodelanguage/build.gradle
@@ -38,7 +38,7 @@ tasks.named('jar', Jar).configure {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked'
 }
 

--- a/mclanguage/build.gradle
+++ b/mclanguage/build.gradle
@@ -37,7 +37,7 @@ tasks.named('jar', Jar).configure {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked'
 }
 


### PR DESCRIPTION
Dev scenario (some stuff cached)
Before: https://scans.gradle.com/s/v56a57ffzlnbw (1m 24s)
After: https://scans.gradle.com/s/77ndslyrqrmik (1m 11s)

CI scenario (`gradlew clean` ran first)
Before: https://scans.gradle.com/s/yu2klxvlx2nos (2m 5s)
After: https://scans.gradle.com/s/masboziv56uam (1m 41s)

This PR does various misc. buildscript cleanup, mostly focused on the Groovy side of things. IDE support is improved and performance is a bit better, too. Made as a PR rather than a direct commit to verify it works on CI first and to allow it to be merged alongside something else in one go.

- More lazy task registration and configuration
- Sync buildSrc deps with build deps
- More types and static compilation for better performance and IDE support
- Replace more ext entries with typed local variables
- Do maven artifact checkExists in parallel and use HTTPClient
- Avoid expensive dynamic Groovy method calls for basic null checks, reduce boxing
- Avoid loops for single items and other minor stuff

Known side-effects (noting in case it matters):
- ~~Ordering of launcher json entries is no longer consistent~~ Fixed