### PR TITLE
[1.20.4] Readded DatapackBuiltinEntriesProvider

### DIFF
--- a/patches/minecraft/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -11,6 +11,43 @@
     private RegistrySetBuilder.BuildState createState(RegistryAccess p_256400_) {
        RegistrySetBuilder.BuildState registrysetbuilder$buildstate = RegistrySetBuilder.BuildState.create(p_256400_, this.entries.stream().map(RegistrySetBuilder.RegistryStub::key));
        this.entries.forEach((p_255629_) -> {
+@@ -121,18 +_,24 @@
+             };
+             map.put(resourcekey, lazyholder);
+          });
+-         HolderLookup.RegistryLookup<T> registrylookup1 = p_313198_.lookupOrThrow(p_313093_);
+-         registrylookup1.listElements().forEach((p_308430_) -> {
+-            ResourceKey<T> resourcekey = p_308430_.key();
+-            map.computeIfAbsent(resourcekey, (p_308437_) -> {
+-               RegistrySetBuilder.LazyHolder<T> lazyholder = new RegistrySetBuilder.LazyHolder<>(p_312548_, resourcekey);
+-               lazyholder.supplier = () -> {
+-                  return cloner.clone((T)p_308430_.value(), p_313198_, p_311605_.getValue());
+-               };
+-               return lazyholder;
+-            });
+-         });
+-         Lifecycle lifecycle = registrylookup.registryLifecycle().add(registrylookup1.registryLifecycle());
++         Lifecycle lifecycle;
++         Optional<HolderLookup.RegistryLookup<T>> optional = p_313198_.lookup(p_313093_);
++         if (optional.isPresent()) {
++             HolderLookup.RegistryLookup<T> registrylookup1 = optional.get();
++             registrylookup1.listElements().forEach((p_308430_) -> {
++                 ResourceKey<T> resourcekey = p_308430_.key();
++                 map.computeIfAbsent(resourcekey, (p_308437_) -> {
++                     RegistrySetBuilder.LazyHolder<T> lazyholder = new RegistrySetBuilder.LazyHolder<>(p_312548_, resourcekey);
++                     lazyholder.supplier = () -> {
++                         return cloner.clone((T)p_308430_.value(), p_313198_, p_311605_.getValue());
++                     };
++                     return lazyholder;
++                 });
++             });
++             lifecycle = registrylookup.registryLifecycle().add(registrylookup1.registryLifecycle());
++         } else {
++             lifecycle = registrylookup.registryLifecycle();
++         }
+          return lookupFromMap(p_313093_, lifecycle, map);
+       }
+    }
 @@ -168,7 +_,7 @@
           RegistrySetBuilder.UniversalLookup registrysetbuilder$universallookup = new RegistrySetBuilder.UniversalLookup(registrysetbuilder$compositeowner);
           ImmutableMap.Builder<ResourceLocation, HolderGetter<?>> builder = ImmutableMap.builder();

--- a/patches/minecraft/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -11,39 +11,27 @@
     private RegistrySetBuilder.BuildState createState(RegistryAccess p_256400_) {
        RegistrySetBuilder.BuildState registrysetbuilder$buildstate = RegistrySetBuilder.BuildState.create(p_256400_, this.entries.stream().map(RegistrySetBuilder.RegistryStub::key));
        this.entries.forEach((p_255629_) -> {
-@@ -121,18 +_,24 @@
+@@ -121,18 +_,21 @@
              };
              map.put(resourcekey, lazyholder);
           });
 -         HolderLookup.RegistryLookup<T> registrylookup1 = p_313198_.lookupOrThrow(p_313093_);
--         registrylookup1.listElements().forEach((p_308430_) -> {
--            ResourceKey<T> resourcekey = p_308430_.key();
--            map.computeIfAbsent(resourcekey, (p_308437_) -> {
--               RegistrySetBuilder.LazyHolder<T> lazyholder = new RegistrySetBuilder.LazyHolder<>(p_312548_, resourcekey);
--               lazyholder.supplier = () -> {
++         HolderLookup.RegistryLookup<T> registrylookup1 = p_313198_.lookup(p_313093_).orElse(null);
++         Lifecycle lifecycle = registrylookup.registryLifecycle();
++         if (registrylookup1 != null) {
+          registrylookup1.listElements().forEach((p_308430_) -> {
+             ResourceKey<T> resourcekey = p_308430_.key();
+             map.computeIfAbsent(resourcekey, (p_308437_) -> {
+                RegistrySetBuilder.LazyHolder<T> lazyholder = new RegistrySetBuilder.LazyHolder<>(p_312548_, resourcekey);
+                lazyholder.supplier = () -> {
 -                  return cloner.clone((T)p_308430_.value(), p_313198_, p_311605_.getValue());
--               };
--               return lazyholder;
--            });
--         });
++                  return cloner.clone((T) p_308430_.value(), p_313198_, p_311605_.getValue());
+                };
+                return lazyholder;
+             });
+          });
 -         Lifecycle lifecycle = registrylookup.registryLifecycle().add(registrylookup1.registryLifecycle());
-+         Lifecycle lifecycle;
-+         Optional<HolderLookup.RegistryLookup<T>> optional = p_313198_.lookup(p_313093_);
-+         if (optional.isPresent()) {
-+             HolderLookup.RegistryLookup<T> registrylookup1 = optional.get();
-+             registrylookup1.listElements().forEach((p_308430_) -> {
-+                 ResourceKey<T> resourcekey = p_308430_.key();
-+                 map.computeIfAbsent(resourcekey, (p_308437_) -> {
-+                     RegistrySetBuilder.LazyHolder<T> lazyholder = new RegistrySetBuilder.LazyHolder<>(p_312548_, resourcekey);
-+                     lazyholder.supplier = () -> {
-+                         return cloner.clone((T)p_308430_.value(), p_313198_, p_311605_.getValue());
-+                     };
-+                     return lazyholder;
-+                 });
-+             });
-+             lifecycle = registrylookup.registryLifecycle().add(registrylookup1.registryLifecycle());
-+         } else {
-+             lifecycle = registrylookup.registryLifecycle();
++         lifecycle = registrylookup.registryLifecycle().add(registrylookup1.registryLifecycle());
 +         }
           return lookupFromMap(p_313093_, lifecycle, map);
        }

--- a/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
@@ -1,13 +1,10 @@
 --- a/net/minecraft/data/registries/RegistryPatchGenerator.java
 +++ b/net/minecraft/data/registries/RegistryPatchGenerator.java
-@@ -17,9 +_,7 @@
-       return p_310881_.thenApply((p_309945_) -> {
-          RegistryAccess.Frozen registryaccess$frozen = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
-          Cloner.Factory cloner$factory = new Cloner.Factory();
--         RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((p_313050_) -> {
--            p_313050_.runWithArguments(cloner$factory::addCodec);
--         });
-+         net.minecraftforge.registries.DataPackRegistriesHooks.getDataPackRegistriesWithDimensions().forEach(registryData -> registryData.runWithArguments(cloner$factory::addCodec));
+@@ -20,6 +_,7 @@
+          RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((p_313050_) -> {
+             p_313050_.runWithArguments(cloner$factory::addCodec);
+          });
++         RegistryDataLoader.DIMENSION_REGISTRIES.forEach(reg -> reg.runWithArguments(cloner$factory::addCodec);
           RegistrySetBuilder.PatchedRegistries registrysetbuilder$patchedregistries = p_310262_.buildPatch(registryaccess$frozen, p_309945_, cloner$factory);
           HolderLookup.Provider holderlookup$provider = registrysetbuilder$patchedregistries.full();
           Optional<HolderLookup.RegistryLookup<Biome>> optional = holderlookup$provider.lookup(Registries.BIOME);

--- a/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/data/registries/RegistryPatchGenerator.java
++++ b/net/minecraft/data/registries/RegistryPatchGenerator.java
+@@ -17,9 +_,7 @@
+       return p_310881_.thenApply((p_309945_) -> {
+          RegistryAccess.Frozen registryaccess$frozen = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+          Cloner.Factory cloner$factory = new Cloner.Factory();
+-         RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((p_313050_) -> {
+-            p_313050_.runWithArguments(cloner$factory::addCodec);
+-         });
++         net.minecraftforge.registries.DataPackRegistriesHooks.getDataPackRegistriesWithDimensions().forEach(registryData -> registryData.runWithArguments(cloner$factory::addCodec));
+          RegistrySetBuilder.PatchedRegistries registrysetbuilder$patchedregistries = p_310262_.buildPatch(registryaccess$frozen, p_309945_, cloner$factory);
+          HolderLookup.Provider holderlookup$provider = registrysetbuilder$patchedregistries.full();
+          Optional<HolderLookup.RegistryLookup<Biome>> optional = holderlookup$provider.lookup(Registries.BIOME);

--- a/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
+++ b/patches/minecraft/net/minecraft/data/registries/RegistryPatchGenerator.java.patch
@@ -4,7 +4,7 @@
           RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((p_313050_) -> {
              p_313050_.runWithArguments(cloner$factory::addCodec);
           });
-+         RegistryDataLoader.DIMENSION_REGISTRIES.forEach(reg -> reg.runWithArguments(cloner$factory::addCodec);
++         RegistryDataLoader.DIMENSION_REGISTRIES.forEach(reg -> reg.runWithArguments(cloner$factory::addCodec));
           RegistrySetBuilder.PatchedRegistries registrysetbuilder$patchedregistries = p_310262_.buildPatch(registryaccess$frozen, p_309945_, cloner$factory);
           HolderLookup.Provider holderlookup$provider = registrysetbuilder$patchedregistries.full();
           Optional<HolderLookup.RegistryLookup<Biome>> optional = holderlookup$provider.lookup(Registries.BIOME);

--- a/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
@@ -5,11 +5,12 @@
 
 package net.minecraftforge.common.data;
 
-import net.minecraft.core.HolderLookup;
-import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.*;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.registries.RegistriesDatapackGenerator;
 import net.minecraft.data.registries.RegistryPatchGenerator;
+import net.minecraft.data.worldgen.features.OreFeatures;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
@@ -55,7 +56,13 @@ public class DatapackBuiltinEntriesProvider extends RegistriesDatapackGenerator
     }
 
     /**
-     * Gets the future of the full registry lookup containing all added elements.
+     * Gets the future of the full registry lookup containing all added elements.<br>
+     * Example usage:<br>
+     * <pre>{@code
+     * HolderLookup.Provider provider = this.fullRegistries.join();
+     * Holder<?> holder = provider.lookupOrThrow(Registries.CONFIGURED_FEATURE).getOrThrow(ResourceKey to a modded feature);
+     * // The returned holder can then be used to register a PlacedFeature
+     * }</pre>
      * @return the future of the full registry lookup
      */
     public CompletableFuture<HolderLookup.Provider> getFullRegistries()

--- a/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
@@ -7,10 +7,15 @@ package net.minecraftforge.common.data;
 
 import net.minecraft.core.*;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.data.DataGenerator;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.registries.RegistriesDatapackGenerator;
 import net.minecraft.data.registries.RegistryPatchGenerator;
+import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.data.worldgen.features.OreFeatures;
+import net.minecraftforge.data.event.GatherDataEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
@@ -57,12 +62,11 @@ public class DatapackBuiltinEntriesProvider extends RegistriesDatapackGenerator
 
     /**
      * Gets the future of the full registry lookup containing all added elements.<br>
-     * Example usage:<br>
+     * The returned full registry lookup can also be used for other data providers.<br>
      * <pre>{@code
-     * HolderLookup.Provider provider = this.fullRegistries.join();
-     * Holder<?> holder = provider.lookupOrThrow(Registries.CONFIGURED_FEATURE).getOrThrow(ResourceKey to a modded feature);
-     * // The returned holder can then be used to register a PlacedFeature
+     * var provider = new DatapackBuiltinEntriesProvider(generator.getPackOutput(), event.getLookupProvider(), new RegistrySetBuilder(), Set.of("example_mod"));
      * }</pre>
+     * An example use case is the {@link TagsProvider}.
      * @return the future of the full registry lookup
      */
     public CompletableFuture<HolderLookup.Provider> getFullRegistries()

--- a/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/DatapackBuiltinEntriesProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.data;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.registries.RegistriesDatapackGenerator;
+import net.minecraft.data.registries.RegistryPatchGenerator;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An extension of the {@link RegistriesDatapackGenerator} which properly handles
+ * referencing existing dynamic registry objects within another dynamic registry
+ * object.
+ */
+public class DatapackBuiltinEntriesProvider extends RegistriesDatapackGenerator
+{
+
+    private final CompletableFuture<HolderLookup.Provider> fullRegistries;
+
+    /**
+     * Constructs a new datapack provider which generates all registry objects
+     * from the provided mods using the holder.
+     *
+     * @param output the target directory of the data generator
+     * @param registries a future of patched registries
+     * @param modIds a set of mod ids to generate the dynamic registry objects of
+     */
+    public DatapackBuiltinEntriesProvider(PackOutput output, CompletableFuture<RegistrySetBuilder.PatchedRegistries> registries, Set<String> modIds)
+    {
+        super(output, registries.thenApply(RegistrySetBuilder.PatchedRegistries::patches), modIds);
+        this.fullRegistries = registries.thenApply(RegistrySetBuilder.PatchedRegistries::full);
+    }
+
+    /**
+     * Constructs a new datapack provider which generates all registry objects
+     * from the provided mods using the holder. All entries that need to be
+     * bootstrapped are provided within the {@link RegistrySetBuilder}.
+     *
+     * @param output the target directory of the data generator
+     * @param registries a future of a lookup for registries and their objects
+     * @param registryBuilder a builder containing the dynamic registry objects added by this provider
+     * @param modIds a set of mod ids to generate the dynamic registry objects of
+     */
+    public DatapackBuiltinEntriesProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, RegistrySetBuilder registryBuilder, Set<String> modIds)
+    {
+        this(output, RegistryPatchGenerator.createLookup(registries, registryBuilder), modIds);
+    }
+
+    /**
+     * Gets the future of the full registry lookup containing all added elements.
+     * @return the future of the full registry lookup
+     */
+    public CompletableFuture<HolderLookup.Provider> getFullRegistries()
+    {
+        return this.fullRegistries;
+    }
+}


### PR DESCRIPTION
The `DatapackBuiltinEntriesProvider` was removed during the update from 1.20.2 to 1.20.3. 
This PR adds the DatapackBuiltinEntriesProvider back.

Why do we need the DatapackBuiltinEntriesProvider?
It simplifies the generation of built-in data such as ConfiguredFeatures, PlacedFeatures, Biome(Modifier)s, etc.
In addition, several data based registry types can be generated with just one provider (from different mod ids).

The PR also fixes the `RegistryPatchGenerator` and `RegistrySetBuilder` to prevent the registries added by Forge from causing problems during the creation of a patched `HolderLookup.Provider` (which includes the forge registries).
Both patches are required for the DatapackBuiltinEntriesProvider to work properly.