### PR TITLE
Make BakedModelWrapper.applyTransform return itself

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
@@ -103,7 +103,8 @@ public abstract class BakedModelWrapper<T extends BakedModel> implements BakedMo
     @Override
     public BakedModel applyTransform(ItemDisplayContext cameraTransformType, PoseStack poseStack, boolean applyLeftHandTransform)
     {
-        return originalModel.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform);
+        originalModel.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
This is how `IForgeBakedModel` works.
The current behavior of `BakedModelWrapper.applyTransform` replaces `BakedModelWrapper` with `originalModel`, instead of returning itself.
This is an issue I faced while writing a custom item model, and my overridden methods weren't invoked while rendering the item, because the model was replaced.