### PR TITLE
[1.19.2] Fix TagsProvider not honoring replace attribute

### DIFF
--- a/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/tags/TagsProvider.java.patch
@@ -42,8 +42,9 @@
           if (!list1.isEmpty()) {
              throw new IllegalArgumentException(String.format(Locale.ROOT, "Couldn't define tag %s as it is missing following references: %s", p_236449_, list1.stream().map(Objects::toString).collect(Collectors.joining(","))));
           } else {
-             JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, false)).getOrThrow(false, f_126541_::error);
+-            JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, false)).getOrThrow(false, f_126541_::error);
 -            Path path = this.f_236439_.m_236048_(p_236449_);
++            JsonElement jsonelement = TagFile.f_215958_.encodeStart(JsonOps.INSTANCE, new TagFile(list, p_236450_.isReplace())).getOrThrow(false, f_126541_::error);
 +            Path path = this.getPath(p_236449_);
 +            if (path == null) return; // Forge: Allow running this data provider without writing it. Recipe provider needs valid tags.
  

--- a/patches/minecraft/net/minecraft/tags/TagBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagBuilder.java.patch
@@ -19,7 +19,7 @@
     private final List<TagEntry> f_215897_ = new ArrayList<>();
  
     public static TagBuilder m_215899_() {
-@@ -34,5 +_,16 @@
+@@ -34,5 +_,21 @@
  
     public TagBuilder m_215909_(ResourceLocation p_215910_) {
        return this.m_215902_(TagEntry.m_215953_(p_215910_));
@@ -34,5 +34,10 @@
 +   // FORGE: Shorthand version of replace(true)
 +   public TagBuilder replace() {
 +      return replace(true);
++   }
++
++   // FORGE: Is this tag set to replace or not?
++   public boolean isReplace() {
++      return this.replace;
     }
  }


### PR DESCRIPTION
hey good morning.

This is just a quick PR that fixes TagsProvider not respecting if the provided builder is marked as replace. These patches already exist in 1.19.4 and newer, it's just in my own personal interest to have it backported to this version as well. Thanks.