### PR TITLE
[1.20.4] Add CPU usage config option to early window

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -598,8 +598,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         var fm = layer.findModule("forge").orElseThrow();
         getClass().getModule().addReads(fm);
         var clz = FMLLoader.getGameLayer().findModule("forge").map(l->Class.forName(l, "net.minecraftforge.client.loading.ForgeLoadingOverlay")).orElseThrow();
-        var methods = Arrays.stream(clz.getMethods()).filter(m-> Modifier.isStatic(m.getModifiers())).collect(Collectors.toMap(Method::getName, Function.identity()));
-        loadingOverlay = methods.get("newInstance");
+        loadingOverlay = Arrays.stream(clz.getDeclaredMethods()).filter(m-> Modifier.isStatic(m.getModifiers()) && m.getName().equals("newInstance")).findFirst().orElseThrow();
     }
 
     public int getFramebufferTextureId() {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -229,7 +229,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
             LOGGER.error("Crash during font initialization", t);
             crashElegantly("An error occurred initializing a font for rendering. "+t.getMessage());
         }
-        this.elements = new ArrayList<>(Arrays.asList(
+        this.elements = new ArrayList<>(List.of(
             RenderElement.anvil(font),
             RenderElement.logMessageOverlay(font),
             RenderElement.forgeVersionOverlay(font, mcVersion + "-" + forgeVersion),

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.fml.earlydisplay;
 
 import com.sun.management.OperatingSystemMXBean;
+import net.minecraftforge.fml.loading.FMLConfig;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -13,19 +14,28 @@ import java.lang.management.MemoryUsage;
 
 public class PerformanceInfo {
 
+    private final boolean showCPUUsage;
     private final OperatingSystemMXBean osBean;
     private final MemoryMXBean memoryBean;
-    float memory;
+
+    private float memory;
     private String text;
 
     PerformanceInfo() {
-        osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
+        showCPUUsage = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_CPU);
+        osBean = showCPUUsage ? ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class) : null;
         memoryBean = ManagementFactory.getMemoryMXBean();
     }
 
     void update() {
         final MemoryUsage heapusage = memoryBean.getHeapMemoryUsage();
         memory = (float) heapusage.getUsed() / heapusage.getMax();
+
+        if (!showCPUUsage) {
+            text = String.format("Heap: %d/%d MB (%.1f%%) OffHeap: %d MB", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20);
+            return;
+        }
+
         var cpuLoad = osBean.getProcessCpuLoad();
         String cpuText;
         if (cpuLoad == -1) {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -32,19 +32,19 @@ public class PerformanceInfo {
         memory = (float) heapusage.getUsed() / heapusage.getMax();
 
         if (!showCPUUsage) {
-            text = String.format("Heap: %d/%d MB (%.1f%%) OffHeap: %d MB", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20);
+            text = "Heap: %d/%d MB (%.1f%%) OffHeap: %d MB".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20);
             return;
         }
 
         var cpuLoad = osBean.getProcessCpuLoad();
         String cpuText;
         if (cpuLoad == -1) {
-            cpuText = String.format("*CPU: %.1f%%", osBean.getCpuLoad() * 100f);
+            cpuText = "*CPU: %.1f%%".formatted(osBean.getCpuLoad() * 100f);
         } else {
-            cpuText = String.format("CPU: %.1f%%", cpuLoad * 100f);
+            cpuText = "CPU: %.1f%%".formatted(cpuLoad * 100f);
         }
 
-        text = String.format("Heap: %d/%d MB (%.1f%%) OffHeap: %d MB  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
+        text = "Heap: %d/%d MB (%.1f%%) OffHeap: %d MB  %s".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
     }
 
     String text() {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
@@ -280,7 +280,7 @@ public class RenderElement {
         if (num < min) {
             return min;
         } else {
-            return num > max ? max : num;
+            return Math.min(num, max);
         }
     }
 
@@ -288,7 +288,7 @@ public class RenderElement {
         if (num < min) {
             return min;
         } else {
-            return num > max ? max : num;
+            return Math.min(num, max);
         }
     }
 

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
@@ -34,11 +34,14 @@ public class RenderElement {
             };
         }
     }
+    @FunctionalInterface
     interface TextureRenderer {
         void accept(SimpleBufferBuilder bb, DisplayContext context, int[] size, int frame);
     }
+    @FunctionalInterface
     interface Initializer extends Supplier<Renderer> {}
 
+    @FunctionalInterface
     interface TextGenerator {
         void accept(SimpleBufferBuilder bb, SimpleFont fh, DisplayContext ctx);
     }
@@ -201,14 +204,17 @@ public class RenderElement {
         bar.then(label).accept(buffer, context, frameNumber);
     }
 
+    @FunctionalInterface
     interface ColourFunction {
         int colour(int frame);
     }
 
+    @FunctionalInterface
     interface ProgressDisplay {
         float[] progress(int frame);
     }
 
+    @FunctionalInterface
     interface BarPosition {
         int[] location(DisplayContext context);
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -36,7 +36,8 @@ public class FMLConfig
         EARLY_WINDOW_FBSCALE("earlyWindowFBScale", 1, "Early window framebuffer scale"),
         EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", Boolean.FALSE, "Early window starts maximized"),
         EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers"),
-        EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?")
+        EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?"),
+        EARLY_WINDOW_SHOW_CPU("earlyWindowShowCPU", Boolean.FALSE, "Whether to show CPU usage stats in early window"),
         ;
 
         private final String entry;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -44,7 +44,7 @@ public class FMLLoader {
     private static LoadingModList loadingModList;
     private static RuntimeDistCleaner runtimeDistCleaner;
     private static Path gamePath;
-    private static VersionInfo versionInfo = VersionInfo.detect();
+    private static final VersionInfo versionInfo = VersionInfo.detect();
     private static String launchHandlerName;
     private static CommonLaunchHandler commonLaunchHandler;
     public static Runnable progressWindowTick;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/VersionInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/VersionInfo.java
@@ -25,7 +25,7 @@ public record VersionInfo(String forgeVersion, String mcVersion, String mcpVersi
     /*==========================================================================*
      *                        INTERNAL SHIT                                     *
      *==========================================================================*/
-    private static Gson GSON = new GsonBuilder().create();
+    private static final Gson GSON = new GsonBuilder().create();
     private static <T> T readJson(String path, Class<T> type) {
         try (var is = VersionInfo.class.getResourceAsStream(path)) {
             if (is == null)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/progress/ProgressMeter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/progress/ProgressMeter.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class ProgressMeter {
     private final String name;
     private final int steps;
-    private AtomicInteger current;
+    private final AtomicInteger current;
     private Message label;
 
     public ProgressMeter(String name, int steps, int current, Message label) {


### PR DESCRIPTION
Adds the option to toggle CPU usage stats on the early loading window for a cleaner look. Also did a bunch of minor performance improvements and code clean-up.

<img width="429" alt="image" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/68126b92-5bfb-4df8-aeb3-2b45280213f7">