### PR TITLE
Support dependency requirement type

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -221,7 +221,7 @@ public class ModInfo implements IModInfo, IConfigurable {
                         return true;  
                     }  
                 } else {  
-                    throw new RuntimeException("Missing required field mandatory or type in dependency.");  
+                    throw new InvalidModFileException("Missing required field mandatory or type in dependency.", getOwningFile());  
                 }  
                 return false;
             }); 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -213,8 +213,18 @@ public class ModInfo implements IModInfo, IConfigurable {
             this.owner = owner;
             this.modId = config.<String>getConfigElement("modId")
                     .orElseThrow(()->new InvalidModFileException("Missing required field modid in dependency", getOwningFile()));
-            this.mandatory = config.<Boolean>getConfigElement("mandatory")
-                    .orElseThrow(()->new InvalidModFileException("Missing required field mandatory in dependency", getOwningFile()));
+            this.mandatory = config.<Boolean>getConfigElement("mandatory").orElseGet(() -> {  
+                    Optional<String> typeOptional = config.getConfigElement("type");
+                if (typeOptional.isPresent()) {  
+                    String type = typeOptional.get();  
+                    if (type.equalsIgnoreCase("required")) {  
+                        return true;  
+                    }  
+                } else {  
+                    throw new RuntimeException("Missing required field mandatory or type in dependency.");  
+                }  
+                return false;
+            }); 
             this.versionRange = config.<String>getConfigElement("versionRange")
                     .map(MavenVersionAdapter::createFromVersionSpec)
                     .orElse(UNBOUNDED);


### PR DESCRIPTION
I am making an abstraction layer and in MC Forge discord itself some interest has been expressed for supporting the NeoForge style dependency format. Here is an implementation which will check if it is required and if so set to mandatory, optional is optional so is always false, though this does not have a warning for discouraged but still runs the mod anyhow. This is mostly a play at trying to make Neo mods.toml files parse correctly with the existing system rather than replacing it with Neo's.