### PR TITLE
[1.16.5] Generate SRG named redirects for TransformationMatrix methods in userdev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -960,7 +960,7 @@ project(':forge') {
     }
     
     task downloadInstaller(type: DownloadMavenArtifact) {
-        artifact = 'net.minecraftforge:installer:2.1.+:shrunk'
+        artifact = 'net.minecraftforge:installer:2.2.+:fatjar'
         changing = true
     }
     

--- a/src/main/resources/coremods/add_bouncer_method.js
+++ b/src/main/resources/coremods/add_bouncer_method.js
@@ -45,7 +45,9 @@ function addBouncer(className, conflictedName, expectedName, descriptor, signatu
    }
 }
 
-// Generate a method with name oldName that redirects to expectedName. oldName is remapped, expectedName isn't.
+// Generate a method with name oldName that redirects to expectedName. expectedName is not remapped.
+// A redirect will be generated for oldName and whatever deobfuscated name it maps to,
+// provided these methods do not exist already.
 function addRedirect(className, oldName, expectedName, descriptor, numArgs) {
     return {
        'target': {
@@ -55,21 +57,39 @@ function addRedirect(className, oldName, expectedName, descriptor, numArgs) {
        'transformer': function(node) {
             var mappedName = ASMAPI.mapMethod(oldName);
 
-            var method = new MethodNode(
-                /* access = */ Opcodes.ACC_PUBLIC,
-                /* name = */ mappedName,
-                /* descriptor = */ descriptor,
-                /* signature = */ descriptor,
-                /* exceptions = */ null
-            );
+            var names = [oldName, mappedName];
 
-            for(var i = 0; i < numArgs; i++) {
-                 method.instructions.add(new VarInsnNode(Opcodes.ALOAD, i));
+            for(var i = 0; i < names.length; i++) {
+                var name = names[i];
+
+                var exists = false;
+                for(var j = 0; j < node.methods.length; j++) {
+                    if(node.methods[i].name == name) {
+                        exists = true;
+                        break;
+                    }
+                }
+
+                if(exists) {
+                    continue;
+                }
+
+                var method = new MethodNode(
+                    /* access = */ Opcodes.ACC_PUBLIC,
+                    /* name = */ name,
+                    /* descriptor = */ descriptor,
+                    /* signature = */ descriptor,
+                    /* exceptions = */ null
+                );
+
+                for(var i = 0; i < numArgs; i++) {
+                     method.instructions.add(new VarInsnNode(Opcodes.ALOAD, i));
+                }
+                method.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, className.replaceAll("\\.","/"), expectedName, descriptor));
+                method.instructions.add(new InsnNode(Opcodes.ARETURN));
+
+                node.methods.add(method);
             }
-            method.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, className.replaceAll("\\.","/"), expectedName, descriptor));
-            method.instructions.add(new InsnNode(Opcodes.ARETURN));
-
-            node.methods.add(method);
 
             return node;
        }

--- a/src/main/resources/coremods/add_bouncer_method.js
+++ b/src/main/resources/coremods/add_bouncer_method.js
@@ -62,6 +62,7 @@ function addRedirect(className, oldName, expectedName, descriptor, numArgs) {
             for(var i = 0; i < names.length; i++) {
                 var name = names[i];
 
+                // Skip generating stub if method name exists in this class
                 var exists = false;
                 for(var j = 0; j < node.methods.length; j++) {
                     if(node.methods[i].name == name) {
@@ -73,6 +74,8 @@ function addRedirect(className, oldName, expectedName, descriptor, numArgs) {
                 if(exists) {
                     continue;
                 }
+
+                // Generate stub
 
                 var method = new MethodNode(
                     /* access = */ Opcodes.ACC_PUBLIC,


### PR DESCRIPTION
As of #9825, we delete some vanilla methods in `TransformationMatrix` to prevent reobfuscation issues with the `IForgeTransformationMatrix` interface, and inject appropriately mapped dummy stubs at runtime with a coremod. However, it seems that userdev does still attempt to reference the SRG-named versions of these methods in some classes. This causes crashes in userdev workspaces:

```
Caused by: java.lang.NoSuchMethodError: net.minecraft.util.math.vector.TransformationMatrix.func_227987_b_()Lnet/minecraft/util/math/vector/TransformationMatrix;
	at net.minecraft.client.renderer.model.UVTransformationUtil.lambda$static$1(UVTransformationUtil.java:28) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.util.Util.make(Util.java:283) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading}
	at net.minecraft.client.renderer.model.UVTransformationUtil.<clinit>(UVTransformationUtil.java:26) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.model.FaceBakery.recomputeUVs(FaceBakery.java:51) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.model.FaceBakery.bakeQuad(FaceBakery.java:27) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.model.BlockModel.bakeFace(BlockModel.java:219) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.model.BlockModel.bakeVanilla(BlockModel.java:209) ~[forge-1.16.5-36.2.41_mapped_official_1.16.5.jar:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner
```

The simplest solution I can think of is to just generate the redirect stubs for both the SRG name and mapped name if needed, which is what this PR does. This won't change behavior in production, where the SRG name would always have been used anyway.