### PR TITLE
[1.20.x] Make common config screen registration tasks easier

### DIFF
--- a/src/main/java/net/minecraftforge/client/ConfigScreenHandler.java
+++ b/src/main/java/net/minecraftforge/client/ConfigScreenHandler.java
@@ -13,10 +13,30 @@ import net.minecraftforge.forgespi.language.IModInfo;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public class ConfigScreenHandler
 {
-    public record ConfigScreenFactory(BiFunction<Minecraft, Screen, Screen> screenFunction) implements IExtensionPoint<ConfigScreenFactory> {}
+    /**
+     * @param screenFunction A function that takes the {@link Minecraft} client instance and the mods screen as
+     *                       arguments and returns your config screen to show when the player clicks the config button
+     *                       for your mod on the mods screen.
+     *                       <p>You should call {@link Minecraft#setScreen(Screen)} with the provided client instance
+     *                       and mods screen for the action of your close button.</p>
+     */
+    public record ConfigScreenFactory(BiFunction<Minecraft, Screen, Screen> screenFunction) implements IExtensionPoint<ConfigScreenFactory> {
+        /**
+         * @param screenFunction A function that takes the mods screen as an argument and returns your config screen to
+         *                       show when the player clicks the config button for your mod on the mods screen.
+         *                       <p>You should call {@link Minecraft#setScreen(Screen)} with the provided mods screen
+         *                       for the action of your close button, using {@link Screen#minecraft} to get the client
+         *                       instance.</p>
+         */
+        public ConfigScreenFactory(Function<Screen, Screen> screenFunction) {
+            this((mcClient, modsScreen) -> screenFunction.apply(modsScreen));
+        }
+    }
+
     public static Optional<BiFunction<Minecraft, Screen, Screen>> getScreenFactoryFor(IModInfo selectedMod)
     {
         return ModList.get().getModContainerById(selectedMod.getModId()).

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -5,10 +5,16 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
+import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.config.IConfigSpec;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.network.DualStackUtils;
 import net.minecraftforge.versions.forge.ForgeVersion;
@@ -16,6 +22,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class MinecraftForge
 {
@@ -45,6 +56,39 @@ public class MinecraftForge
        if (FMLEnvironment.dist == Dist.CLIENT) ClientCommandHandler.init();
        DualStackUtils.initialise();
    }
+
+    /**
+     * Register a config screen for the active mod container.
+     * @param screenFunction A function that takes the mods screen as an argument and returns your config screen to
+     *                       show when the player clicks the config button for your mod on the mods screen.
+     *                       <p>You should call {@link Minecraft#setScreen(Screen)} with the provided mods screen for the
+     *                       action of your close button, using {@link Screen#minecraft} to get the client instance.</p>
+     * @see ModLoadingContext#registerExtensionPoint(Class, Supplier)
+     * @see ModLoadingContext#registerConfig(ModConfig.Type, IConfigSpec)
+     */
+    public static void registerConfigScreen(Function<Screen, Screen> screenFunction) {
+        ModLoadingContext.get().registerExtensionPoint(
+                ConfigScreenHandler.ConfigScreenFactory.class,
+                () -> new ConfigScreenHandler.ConfigScreenFactory(screenFunction)
+        );
+    }
+
+    /**
+     * Register a config screen for the active mod container.
+     * @param screenFunction A function that takes the {@link Minecraft} client instance and the mods screen as
+     *                       arguments and returns your config screen to show when the player clicks the config button
+     *                       for your mod on the mods screen.
+     *                       <p>You should call {@link Minecraft#setScreen(Screen)} with the provided client instance
+     *                       and mods screen for the action of your close button.</p>
+     * @see ModLoadingContext#registerExtensionPoint(Class, Supplier)
+     * @see ModLoadingContext#registerConfig(ModConfig.Type, IConfigSpec)
+     */
+    public static void registerConfigScreen(BiFunction<Minecraft, Screen, Screen> screenFunction) {
+        ModLoadingContext.get().registerExtensionPoint(
+               ConfigScreenHandler.ConfigScreenFactory.class,
+               () -> new ConfigScreenHandler.ConfigScreenFactory(screenFunction)
+        );
+    }
 
 /*
    public static void preloadCrashClasses(ASMDataTable table, String modID, Set<String> classes)

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -67,10 +67,7 @@ public class MinecraftForge
      * @see ModLoadingContext#registerConfig(ModConfig.Type, IConfigSpec)
      */
     public static void registerConfigScreen(Function<Screen, Screen> screenFunction) {
-        ModLoadingContext.get().registerExtensionPoint(
-                ConfigScreenHandler.ConfigScreenFactory.class,
-                () -> new ConfigScreenHandler.ConfigScreenFactory(screenFunction)
-        );
+        registerConfigScreen((mcClient, modsScreen) -> screenFunction.apply(modsScreen));
     }
 
     /**


### PR DESCRIPTION
Before:
```java
ModLoadingContext.get().registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class, () -> new ConfigScreenHandler.ConfigScreenFactory((mc, modsScreen) -> new MyConfigScreen(modsScreen));
```

After:
```java
MinecraftForge.registerConfigScreen(MyConfigScreen::new);
// or
MinecraftForge.registerConfigScreen(modsScreen -> new MyConfigScreen(modsScreen));
```