### PR TITLE
[1.20.x] getDataTagRaw method and CompoundTag provided to ForgeHooks#readAdditionalLevelSaveData

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java
 +++ b/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java
-@@ -280,12 +_,19 @@
+@@ -280,12 +_,18 @@
     }
  
     private void loadLevel(LevelStorageSource.LevelStorageAccess p_309733_, Dynamic<?> p_312455_, boolean p_310657_, boolean p_309504_, Runnable p_309915_) {
@@ -11,10 +11,9 @@
        this.minecraft.forceSetScreen(new GenericDirtMessageScreen(Component.translatable("selectWorld.resource_load")));
        PackRepository packrepository = ServerPacksSource.createPackRepository(p_309733_);
  
-+      net.minecraftforge.common.ForgeHooks.readAdditionalLevelSaveData(p_312455_, p_309733_.getLevelDirectory());
-+
        WorldStem worldstem;
        try {
++         net.minecraftforge.common.ForgeHooks.readAdditionalLevelSaveData(p_309733_.getDataTagRaw(), p_309733_.getLevelDirectory());
           worldstem = this.loadWorldStem(p_312455_, p_310657_, packrepository);
 +         if (confirmExperimentalWarning && worldstem.worldData() instanceof PrimaryLevelData pld) pld.withConfirmedWarning(true);
        } catch (Exception exception) {

--- a/patches/minecraft/net/minecraft/server/Main.java.patch
+++ b/patches/minecraft/net/minecraft/server/Main.java.patch
@@ -59,15 +59,14 @@
           LevelStorageSource levelstoragesource = LevelStorageSource.createDefault(file1.toPath());
           LevelStorageSource.LevelStorageAccess levelstoragesource$levelstorageaccess = levelstoragesource.validateAndCreateAccess(s);
           Dynamic<?> dynamic;
-@@ -165,6 +_,8 @@
+@@ -167,6 +_,7 @@
  
-          PackRepository packrepository = ServerPacksSource.createPackRepository(levelstoragesource$levelstorageaccess);
- 
-+         if (dynamic != null)
-+             net.minecraftforge.common.ForgeHooks.readAdditionalLevelSaveData(dynamic, levelstoragesource$levelstorageaccess.getLevelDirectory());
           WorldStem worldstem;
           try {
++            net.minecraftforge.common.ForgeHooks.readAdditionalLevelSaveData(levelstoragesource$levelstorageaccess.getDataTagRaw(), levelstoragesource$levelstorageaccess.getLevelDirectory());
              WorldLoader.InitConfig worldloader$initconfig = loadOrCreateConfig(dedicatedserversettings.getProperties(), dynamic1, flag, packrepository);
+             worldstem = Util.blockUntilDone((p_248086_) -> {
+                return WorldLoader.load(worldloader$initconfig, (p_308589_) -> {
 @@ -190,6 +_,9 @@
                          worlddimensions = dedicatedserverproperties.createDimensions(p_308589_.datapackWorldgen());
                       }

--- a/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,5 +1,25 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
+@@ -475,6 +_,19 @@
+          return LevelStorageSource.readLevelDataTagFixed(p_310699_ ? this.levelDirectory.oldDataFile() : this.levelDirectory.dataFile(), LevelStorageSource.this.fixerUpper);
+       }
+ 
++      public CompoundTag getDataTagRaw() throws IOException {
++         return this.getDataTagRaw(false);
++      }
++
++      public CompoundTag getDataTagRawFallback() throws IOException {
++         return this.getDataTagRaw(true);
++      }
++
++      private CompoundTag getDataTagRaw(boolean p_310699_) throws IOException {
++         this.checkLock();
++         return LevelStorageSource.readLevelDataTagRaw(p_310699_ ? this.levelDirectory.oldDataFile() : this.levelDirectory.dataFile());
++      }
++
+       public void saveDataTag(RegistryAccess p_78288_, WorldData p_78289_) {
+          this.saveDataTag(p_78288_, p_78289_, (CompoundTag)null);
+       }
 @@ -483,6 +_,7 @@
           CompoundTag compoundtag = p_78292_.createTag(p_78291_, p_78293_);
           CompoundTag compoundtag1 = new CompoundTag();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -125,6 +125,7 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.crafting.conditions.ICondition.IContext;
 import net.minecraftforge.common.crafting.ingredients.IIngredientSerializer;
+import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.common.util.BrainBuilder;
 import net.minecraftforge.common.util.Lazy;
@@ -979,8 +980,7 @@ public class ForgeHooks {
     }
 
     @ApiStatus.Internal
-    public static void readAdditionalLevelSaveData(Dynamic<?> data, LevelStorageSource.LevelDirectory levelDirectory) {
-        CompoundTag rootTag = (CompoundTag)data.convert(NbtOps.INSTANCE).getValue();
+    public static void readAdditionalLevelSaveData(CompoundTag rootTag, LevelStorageSource.LevelDirectory levelDirectory) {
         CompoundTag tag = rootTag.getCompound("fml");
         if (tag.contains("LoadingModList")) {
             ListTag modList = tag.getList("LoadingModList", net.minecraft.nbt.Tag.TAG_COMPOUND);


### PR DESCRIPTION
This PR introduces the getDataTagRaw method in LevelStorageAccess to get the root level NBT tag. This tag is then provided to the ForgeHooks#readAdditionalLevelSaveData method, instead of a Dynamic object, to fix an issue that prevents a modded level to be read correctly, causing some events (like the MissingMappingsEvent) to not being fired