### PR TITLE
[1.20.4] Optimise capabilities a tad

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -732,7 +732,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.isAlive() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.isAlive()) {
 +         if (facing == null) return handlers[2].cast();
 +         else if (facing.getAxis().isVertical()) return handlers[0].cast();
 +         else if (facing.getAxis().isHorizontal()) return handlers[1].cast();

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -50,7 +50,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.isAlive() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && itemHandler != null)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && itemHandler != null && this.isAlive())
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -452,7 +452,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.isAlive() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.isAlive()) {
 +         if (facing == null) return playerJoinedHandler.cast();
 +         else if (facing.getAxis().isVertical()) return playerMainHandler.cast();
 +         else if (facing.getAxis().isHorizontal()) return playerEquipmentHandler.cast();

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
@@ -19,7 +19,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.isAlive() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.isAlive())
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
@@ -9,7 +9,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.isAlive() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.isAlive())
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -154,7 +154,7 @@
        }
     }
  
-@@ -496,5 +_,34 @@
+@@ -496,5 +_,33 @@
           p_58342_.accountStack(itemstack);
        }
  
@@ -165,13 +165,12 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.remove && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
-+         if (facing == Direction.UP)
-+            return handlers[0].cast();
-+         else if (facing == Direction.DOWN)
-+            return handlers[1].cast();
-+         else
-+            return handlers[2].cast();
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && facing != null && !this.remove) {
++          return switch (facing) {
++              case UP -> handlers[0].cast();
++              case DOWN -> handlers[1].cast();
++              default -> handlers[2].cast();
++          };
 +      }
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
@@ -11,7 +11,7 @@
 +   }
 +
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
-+      if (!this.remove && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.remove)
 +         return itemHandler.cast();
 +      return super.getCapability(cap, side);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -51,7 +51,7 @@
        }
     }
  
-@@ -255,5 +_,34 @@
+@@ -255,5 +_,33 @@
  
     protected AbstractContainerMenu createMenu(int p_58990_, Inventory p_58991_) {
        return new BrewingStandMenu(p_58990_, p_58991_, this, this.dataAccess);
@@ -62,13 +62,12 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.remove && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
-+         if (facing == Direction.UP)
-+            return handlers[0].cast();
-+         else if (facing == Direction.DOWN)
-+            return handlers[1].cast();
-+         else
-+            return handlers[2].cast();
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && facing != null && !this.remove) {
++          return switch (facing) {
++              case UP -> handlers[0].cast();
++              case DOWN -> handlers[1].cast();
++              default -> handlers[2].cast();
++          };
 +      }
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
@@ -17,7 +17,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, Direction side) {
-+       if (!this.remove && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++       if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.remove) {
 +          if (this.chestHandler == null)
 +             this.chestHandler = net.minecraftforge.common.util.LazyOptional.of(this::createHandler);
 +          return this.chestHandler.cast();
@@ -27,10 +27,10 @@
 +
 +   private net.minecraftforge.items.IItemHandlerModifiable createHandler() {
 +      BlockState state = this.getBlockState();
-+      if (!(state.getBlock() instanceof ChestBlock)) {
++      if (!(state.getBlock() instanceof ChestBlock chestBlock)) {
 +         return new net.minecraftforge.items.wrapper.InvWrapper(this);
 +      }
-+      Container inv = ChestBlock.getContainer((ChestBlock) state.getBlock(), state, getLevel(), getBlockPos(), true);
++      Container inv = ChestBlock.getContainer(chestBlock, state, getLevel(), getBlockPos(), true);
 +      return new net.minecraftforge.items.wrapper.InvWrapper(inv == null ? this : inv);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
@@ -12,7 +12,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
-+      if (!this.remove && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.remove)
 +         return itemHandler.cast();
 +      return super.getCapability(cap, side);
 +   }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -7,11 +7,10 @@ package net.minecraftforge.common.capabilities;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import com.google.common.collect.Lists;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.Tag;
@@ -36,9 +35,9 @@ import org.jetbrains.annotations.Nullable;
 @MethodsReturnNonnullByDefault
 public final class CapabilityDispatcher implements INBTSerializable<CompoundTag>, ICapabilityProvider
 {
-    private ICapabilityProvider[] caps;
-    private INBTSerializable<Tag>[] writers;
-    private String[] names;
+    private final ICapabilityProvider[] caps;
+    private final INBTSerializable<Tag>[] writers;
+    private final String[] names;
     private final List<Runnable> listeners;
 
     public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider> list, List<Runnable> listeners)
@@ -49,9 +48,9 @@ public final class CapabilityDispatcher implements INBTSerializable<CompoundTag>
     @SuppressWarnings("unchecked")
     public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider> list, List<Runnable> listeners, @Nullable ICapabilityProvider parent)
     {
-        List<ICapabilityProvider> lstCaps = Lists.newArrayList();
-        List<INBTSerializable<Tag>> lstWriters = Lists.newArrayList();
-        List<String> lstNames = Lists.newArrayList();
+        List<ICapabilityProvider> lstCaps = new ArrayList<>();
+        List<INBTSerializable<Tag>> lstWriters = new ArrayList<>();
+        List<String> lstNames = new ArrayList<>();
         this.listeners = listeners;
 
         if (parent != null) // Parents go first!

--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -47,7 +47,7 @@ public class LazyOptional<T> {
     // non-null and contains non-null value -> resolved
     // non-null and contains null -> resolved, but supplier returned null (contract violation)
     private Mutable<T> resolved;
-    private Set<NonNullConsumer<LazyOptional<T>>> listeners = new HashSet<>();
+    private final Set<NonNullConsumer<LazyOptional<T>>> listeners = new HashSet<>();
     private boolean isValid = true;
 
     private static final @NotNull LazyOptional<Void> EMPTY = new LazyOptional<>(null);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -532,7 +532,7 @@ public class ForgeEventFactory {
     @Nullable
     private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
         post(event);
-        return event.getCapabilities().size() > 0 || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
+        return !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
     }
 
     public static boolean fireSleepingLocationCheck(LivingEntity player, BlockPos sleepingLocation) {


### PR DESCRIPTION
Currently the ordering of checks for `getCapability()` are inconsistent and often call `this.isAlive()` first, which can sometimes end up reading synced entity data unnecessarily.

Noticed this while searching for optimisation opportunities for the "epic fight" mod that I'm doing PRs to at the moment.

This PR changes the ordering so that all constant checks are done first and in a consistent order, to avoid unnecessary checks and help the JIT inline them. Also added a bunch of missing finals and converted some else-ifs to switches while I was at it.