### PR TITLE
ref(event): change tick event to have pre/post classes

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -51,8 +51,13 @@ public class ForgeInternalHandler {
     }
 
     @SubscribeEvent
-    public void onServerTick(ServerTickEvent event) {
-        WorldWorkerManager.tick(event.phase == TickEvent.Phase.START);
+    public void onServerTick(ServerTickEvent.Pre event) {
+        WorldWorkerManager.tick(true);
+    }
+
+    @SubscribeEvent
+    public void onServerTick(ServerTickEvent.Post event) {
+        WorldWorkerManager.tick(false);
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -799,43 +799,43 @@ public final class ForgeEventFactory {
     }
 
     public static void onRenderTickStart(float timer) {
-        post(new TickEvent.RenderTickEvent(TickEvent.Phase.START, timer));
+        post(new TickEvent.RenderTickEvent.Pre(timer));
     }
 
     public static void onRenderTickEnd(float timer) {
-        post(new TickEvent.RenderTickEvent(TickEvent.Phase.END, timer));
+        post(new TickEvent.RenderTickEvent.Post(timer));
     }
 
     public static void onPlayerPreTick(Player player) {
-        post(new TickEvent.PlayerTickEvent(TickEvent.Phase.START, player));
+        post(new TickEvent.PlayerTickEvent.Pre(player));
     }
 
     public static void onPlayerPostTick(Player player) {
-        post(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+        post(new TickEvent.PlayerTickEvent.Post(player));
     }
 
     public static void onPreLevelTick(Level level, BooleanSupplier haveTime) {
-        post(new TickEvent.LevelTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.START, level, haveTime));
+        post(new TickEvent.LevelTickEvent.Pre(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
     }
 
     public static void onPostLevelTick(Level level, BooleanSupplier haveTime) {
-        post(new TickEvent.LevelTickEvent(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, TickEvent.Phase.END, level, haveTime));
+        post(new TickEvent.LevelTickEvent.Post(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
     }
 
     public static void onPreClientTick() {
-        post(new TickEvent.ClientTickEvent(TickEvent.Phase.START));
+        post(TickEvent.ClientTickEvent.Pre.get());
     }
 
     public static void onPostClientTick() {
-        post(new TickEvent.ClientTickEvent(TickEvent.Phase.END));
+        post(TickEvent.ClientTickEvent.Post.get());
     }
 
     public static void onPreServerTick(BooleanSupplier haveTime, MinecraftServer server) {
-        post(new TickEvent.ServerTickEvent(TickEvent.Phase.START, haveTime, server));
+        post(new TickEvent.ServerTickEvent.Pre(haveTime, server));
     }
 
     public static void onPostServerTick(BooleanSupplier haveTime, MinecraftServer server) {
-        post(new TickEvent.ServerTickEvent(TickEvent.Phase.END, haveTime, server));
+        post(new TickEvent.ServerTickEvent.Post(haveTime, server));
     }
 
     public static WeightedRandomList<MobSpawnSettings.SpawnerData> getPotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedRandomList<MobSpawnSettings.SpawnerData> oldList) {

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -21,26 +21,22 @@ public class TickEvent extends Event
         LEVEL, PLAYER, CLIENT, SERVER, RENDER;
     }
 
-    public enum Phase {
-        START, END;
-    }
     public final Type type;
     public final LogicalSide side;
-    public final Phase phase;
-    public TickEvent(Type type, LogicalSide side, Phase phase)
+
+    public TickEvent(Type type, LogicalSide side)
     {
         this.type = type;
         this.side = side;
-        this.phase = phase;
     }
 
     public static class ServerTickEvent extends TickEvent {
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
-        public ServerTickEvent(Phase phase, BooleanSupplier haveTime, MinecraftServer server)
+        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server)
         {
-            super(Type.SERVER, LogicalSide.SERVER, phase);
+            super(Type.SERVER, LogicalSide.SERVER);
             this.haveTime = haveTime;
             this.server = server;
         }
@@ -54,7 +50,7 @@ public class TickEvent extends Event
         {
             return this.haveTime.getAsBoolean();
         }
-        
+
         /**
          * {@return the server instance}
          */
@@ -62,12 +58,58 @@ public class TickEvent extends Event
         {
             return server;
         }
+
+        public static class Pre extends ServerTickEvent {
+
+            public Pre(BooleanSupplier haveTime, MinecraftServer server)
+            {
+                super(haveTime, server);
+            }
+        }
+
+        public static class Post extends ServerTickEvent {
+
+            public Post(BooleanSupplier haveTime, MinecraftServer server)
+            {
+                super(haveTime, server);
+            }
+        }
     }
 
     public static class ClientTickEvent extends TickEvent {
-        public ClientTickEvent(Phase phase)
+        protected ClientTickEvent()
         {
-            super(Type.CLIENT, LogicalSide.CLIENT, phase);
+            super(Type.CLIENT, LogicalSide.CLIENT);
+        }
+
+        public static class Pre extends ClientTickEvent {
+
+            private static final Pre INSTANCE = new Pre();
+
+            private Pre()
+            {
+                super();
+            }
+
+            public static Pre get()
+            {
+                return INSTANCE;
+            }
+        }
+
+        public static class Post extends ClientTickEvent {
+
+            private static final Post INSTANCE = new Post();
+
+            private Post()
+            {
+                super();
+            }
+
+            public static Post get()
+            {
+                return INSTANCE;
+            }
         }
     }
 
@@ -75,9 +117,9 @@ public class TickEvent extends Event
         public final Level level;
         private final BooleanSupplier haveTime;
 
-        public LevelTickEvent(LogicalSide side, Phase phase, Level level, BooleanSupplier haveTime)
+        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime)
         {
-            super(Type.LEVEL, side, phase);
+            super(Type.LEVEL, side);
             this.level = level;
             this.haveTime = haveTime;
         }
@@ -93,23 +135,65 @@ public class TickEvent extends Event
         {
             return this.haveTime.getAsBoolean();
         }
+
+        public static class Pre extends LevelTickEvent {
+            public Pre(LogicalSide side, Level level, BooleanSupplier haveTime)
+            {
+                super(side, level, haveTime);
+            }
+        }
+
+        public static class Post extends LevelTickEvent {
+            public Post(LogicalSide side, Level level, BooleanSupplier haveTime)
+            {
+                super(side, level, haveTime);
+            }
+        }
     }
     public static class PlayerTickEvent extends TickEvent {
         public final Player player;
 
-        public PlayerTickEvent(Phase phase, Player player)
+        protected PlayerTickEvent(Player player)
         {
-            super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT, phase);
+            super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT);
             this.player = player;
+        }
+
+        public static class Pre extends PlayerTickEvent {
+            public Pre(Player player)
+            {
+                super(player);
+            }
+        }
+
+        public static class Post extends PlayerTickEvent {
+            public Post(Player player)
+            {
+                super(player);
+            }
         }
     }
 
     public static class RenderTickEvent extends TickEvent {
         public final float renderTickTime;
-        public RenderTickEvent(Phase phase, float renderTickTime)
+        protected RenderTickEvent(float renderTickTime)
         {
-            super(Type.RENDER, LogicalSide.CLIENT, phase);
+            super(Type.RENDER, LogicalSide.CLIENT);
             this.renderTickTime = renderTickTime;
+        }
+
+        public static class Pre extends RenderTickEvent {
+            public Pre(float renderTickTime)
+            {
+                super(renderTickTime);
+            }
+        }
+
+        public static class Post extends RenderTickEvent {
+            public Post(float renderTickTime)
+            {
+                super(renderTickTime);
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -38,6 +38,10 @@ public class TickEvent extends Event {
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
+        @Deprecated(forRemoval = true, since = "1.20.6")
+        public ServerTickEvent(Phase phase, BooleanSupplier haveTime, MinecraftServer server) {
+            this(haveTime, server, phase);
+        }
         protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server, Phase phase) {
             super(Type.SERVER, LogicalSide.SERVER, phase);
             this.haveTime = haveTime;

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -15,8 +15,7 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
-public class TickEvent extends Event
-{
+public class TickEvent extends Event {
     public enum Type {
         LEVEL, PLAYER, CLIENT, SERVER, RENDER;
     }
@@ -24,8 +23,7 @@ public class TickEvent extends Event
     public final Type type;
     public final LogicalSide side;
 
-    public TickEvent(Type type, LogicalSide side)
-    {
+    public TickEvent(Type type, LogicalSide side) {
         this.type = type;
         this.side = side;
     }
@@ -34,8 +32,7 @@ public class TickEvent extends Event
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
-        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server)
-        {
+        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server) {
             super(Type.SERVER, LogicalSide.SERVER);
             this.haveTime = haveTime;
             this.server = server;
@@ -43,42 +40,37 @@ public class TickEvent extends Event
 
         /**
          * @return {@code true} whether the server has enough time to perform any
-         *         additional tasks (usually IO related) during the current tick,
-         *         otherwise {@code false}
+         * additional tasks (usually IO related) during the current tick,
+         * otherwise {@code false}
          */
-        public boolean haveTime()
-        {
+        public boolean haveTime() {
             return this.haveTime.getAsBoolean();
         }
 
         /**
          * {@return the server instance}
          */
-        public MinecraftServer getServer()
-        {
+        public MinecraftServer getServer() {
             return server;
         }
 
         public static class Pre extends ServerTickEvent {
 
-            public Pre(BooleanSupplier haveTime, MinecraftServer server)
-            {
+            public Pre(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server);
             }
         }
 
         public static class Post extends ServerTickEvent {
 
-            public Post(BooleanSupplier haveTime, MinecraftServer server)
-            {
+            public Post(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server);
             }
         }
     }
 
     public static class ClientTickEvent extends TickEvent {
-        protected ClientTickEvent()
-        {
+        protected ClientTickEvent() {
             super(Type.CLIENT, LogicalSide.CLIENT);
         }
 
@@ -86,13 +78,9 @@ public class TickEvent extends Event
 
             private static final Pre INSTANCE = new Pre();
 
-            private Pre()
-            {
-                super();
-            }
+            private Pre() {}
 
-            public static Pre get()
-            {
+            public static Pre get() {
                 return INSTANCE;
             }
         }
@@ -101,13 +89,9 @@ public class TickEvent extends Event
 
             private static final Post INSTANCE = new Post();
 
-            private Post()
-            {
-                super();
-            }
+            private Post() {}
 
-            public static Post get()
-            {
+            public static Post get() {
                 return INSTANCE;
             }
         }
@@ -117,8 +101,7 @@ public class TickEvent extends Event
         public final Level level;
         private final BooleanSupplier haveTime;
 
-        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime)
-        {
+        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime) {
             super(Type.LEVEL, side);
             this.level = level;
             this.haveTime = haveTime;
@@ -126,49 +109,43 @@ public class TickEvent extends Event
 
         /**
          * @return {@code true} whether the server has enough time to perform any
-         *         additional tasks (usually IO related) during the current tick,
-         *         otherwise {@code false}
-         *
+         * additional tasks (usually IO related) during the current tick,
+         * otherwise {@code false}
          * @see ServerTickEvent#haveTime()
          */
-        public boolean haveTime()
-        {
+        public boolean haveTime() {
             return this.haveTime.getAsBoolean();
         }
 
         public static class Pre extends LevelTickEvent {
-            public Pre(LogicalSide side, Level level, BooleanSupplier haveTime)
-            {
+            public Pre(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime);
             }
         }
 
         public static class Post extends LevelTickEvent {
-            public Post(LogicalSide side, Level level, BooleanSupplier haveTime)
-            {
+            public Post(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime);
             }
         }
     }
+
     public static class PlayerTickEvent extends TickEvent {
         public final Player player;
 
-        protected PlayerTickEvent(Player player)
-        {
+        protected PlayerTickEvent(Player player) {
             super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT);
             this.player = player;
         }
 
         public static class Pre extends PlayerTickEvent {
-            public Pre(Player player)
-            {
+            public Pre(Player player) {
                 super(player);
             }
         }
 
         public static class Post extends PlayerTickEvent {
-            public Post(Player player)
-            {
+            public Post(Player player) {
                 super(player);
             }
         }
@@ -176,22 +153,20 @@ public class TickEvent extends Event
 
     public static class RenderTickEvent extends TickEvent {
         public final float renderTickTime;
-        protected RenderTickEvent(float renderTickTime)
-        {
+
+        protected RenderTickEvent(float renderTickTime) {
             super(Type.RENDER, LogicalSide.CLIENT);
             this.renderTickTime = renderTickTime;
         }
 
         public static class Pre extends RenderTickEvent {
-            public Pre(float renderTickTime)
-            {
+            public Pre(float renderTickTime) {
                 super(renderTickTime);
             }
         }
 
         public static class Post extends RenderTickEvent {
-            public Post(float renderTickTime)
-            {
+            public Post(float renderTickTime) {
                 super(renderTickTime);
             }
         }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -20,20 +20,26 @@ public class TickEvent extends Event {
         LEVEL, PLAYER, CLIENT, SERVER, RENDER;
     }
 
+    public enum Phase {
+        START, END;
+    }
+
     public final Type type;
     public final LogicalSide side;
-
-    public TickEvent(Type type, LogicalSide side) {
+    @Deprecated(forRemoval = true)
+    public final Phase phase;
+    public TickEvent(Type type, LogicalSide side, Phase phase) {
         this.type = type;
         this.side = side;
+        this.phase = phase;
     }
 
     public static class ServerTickEvent extends TickEvent {
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
-        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server) {
-            super(Type.SERVER, LogicalSide.SERVER);
+        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server, Phase phase) {
+            super(Type.SERVER, LogicalSide.SERVER, phase);
             this.haveTime = haveTime;
             this.server = server;
         }
@@ -57,28 +63,30 @@ public class TickEvent extends Event {
         public static class Pre extends ServerTickEvent {
 
             public Pre(BooleanSupplier haveTime, MinecraftServer server) {
-                super(haveTime, server);
+                super(haveTime, server, Phase.START);
             }
         }
 
         public static class Post extends ServerTickEvent {
 
             public Post(BooleanSupplier haveTime, MinecraftServer server) {
-                super(haveTime, server);
+                super(haveTime, server, Phase.END);
             }
         }
     }
 
     public static class ClientTickEvent extends TickEvent {
-        protected ClientTickEvent() {
-            super(Type.CLIENT, LogicalSide.CLIENT);
+        protected ClientTickEvent(Phase phase) {
+            super(Type.CLIENT, LogicalSide.CLIENT, phase);
         }
 
         public static class Pre extends ClientTickEvent {
 
             private static final Pre INSTANCE = new Pre();
 
-            private Pre() {}
+            private Pre() {
+                super(Phase.START);
+            }
 
             public static Pre get() {
                 return INSTANCE;
@@ -89,7 +97,9 @@ public class TickEvent extends Event {
 
             private static final Post INSTANCE = new Post();
 
-            private Post() {}
+            private Post() {
+                super(Phase.END);
+            }
 
             public static Post get() {
                 return INSTANCE;
@@ -101,8 +111,8 @@ public class TickEvent extends Event {
         public final Level level;
         private final BooleanSupplier haveTime;
 
-        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime) {
-            super(Type.LEVEL, side);
+        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime, Phase phase) {
+            super(Type.LEVEL, side, phase);
             this.level = level;
             this.haveTime = haveTime;
         }
@@ -119,13 +129,13 @@ public class TickEvent extends Event {
 
         public static class Pre extends LevelTickEvent {
             public Pre(LogicalSide side, Level level, BooleanSupplier haveTime) {
-                super(side, level, haveTime);
+                super(side, level, haveTime, Phase.START);
             }
         }
 
         public static class Post extends LevelTickEvent {
             public Post(LogicalSide side, Level level, BooleanSupplier haveTime) {
-                super(side, level, haveTime);
+                super(side, level, haveTime, Phase.END);
             }
         }
     }
@@ -133,20 +143,20 @@ public class TickEvent extends Event {
     public static class PlayerTickEvent extends TickEvent {
         public final Player player;
 
-        protected PlayerTickEvent(Player player) {
-            super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT);
+        protected PlayerTickEvent(Player player, Phase phase) {
+            super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT, phase);
             this.player = player;
         }
 
         public static class Pre extends PlayerTickEvent {
             public Pre(Player player) {
-                super(player);
+                super(player, Phase.START);
             }
         }
 
         public static class Post extends PlayerTickEvent {
             public Post(Player player) {
-                super(player);
+                super(player, Phase.END);
             }
         }
     }
@@ -154,20 +164,20 @@ public class TickEvent extends Event {
     public static class RenderTickEvent extends TickEvent {
         public final float renderTickTime;
 
-        protected RenderTickEvent(float renderTickTime) {
-            super(Type.RENDER, LogicalSide.CLIENT);
+        protected RenderTickEvent(float renderTickTime, Phase phase) {
+            super(Type.RENDER, LogicalSide.CLIENT, phase);
             this.renderTickTime = renderTickTime;
         }
 
         public static class Pre extends RenderTickEvent {
             public Pre(float renderTickTime) {
-                super(renderTickTime);
+                super(renderTickTime, Phase.START);
             }
         }
 
         public static class Post extends RenderTickEvent {
             public Post(float renderTickTime) {
-                super(renderTickTime);
+                super(renderTickTime, Phase.END);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -26,7 +26,7 @@ public class TickEvent extends Event {
 
     public final Type type;
     public final LogicalSide side;
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.20.6")
     public final Phase phase;
     public TickEvent(Type type, LogicalSide side, Phase phase) {
         this.type = type;
@@ -80,7 +80,8 @@ public class TickEvent extends Event {
     }
 
     public static class ClientTickEvent extends TickEvent {
-        protected ClientTickEvent(Phase phase) {
+        @Deprecated(forRemoval = true, since = "1.20.6")
+        public ClientTickEvent(Phase phase) {
             super(Type.CLIENT, LogicalSide.CLIENT, phase);
         }
 
@@ -115,6 +116,12 @@ public class TickEvent extends Event {
         public final Level level;
         private final BooleanSupplier haveTime;
 
+        @Deprecated(forRemoval = true, since = "1.20.6")
+        public LevelTickEvent(LogicalSide side, Phase phase, Level level, BooleanSupplier haveTime) {
+            super(Type.LEVEL, side, phase);
+            this.level = level;
+            this.haveTime = haveTime;
+        }
         protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime, Phase phase) {
             super(Type.LEVEL, side, phase);
             this.level = level;
@@ -147,6 +154,10 @@ public class TickEvent extends Event {
     public static class PlayerTickEvent extends TickEvent {
         public final Player player;
 
+        @Deprecated(forRemoval = true, since = "1.20.6")
+        public PlayerTickEvent(Phase phase, Player player) {
+            this(player, phase);
+        }
         protected PlayerTickEvent(Player player, Phase phase) {
             super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT, phase);
             this.player = player;
@@ -168,6 +179,11 @@ public class TickEvent extends Event {
     public static class RenderTickEvent extends TickEvent {
         public final float renderTickTime;
 
+        @Deprecated(forRemoval = true, since = "1.20.6")
+        public RenderTickEvent(Phase phase, float renderTickTime) {
+            super(Type.RENDER, LogicalSide.CLIENT, phase);
+            this.renderTickTime = renderTickTime;
+        }
         protected RenderTickEvent(float renderTickTime, Phase phase) {
             super(Type.RENDER, LogicalSide.CLIENT, phase);
             this.renderTickTime = renderTickTime;


### PR DESCRIPTION
Removes the phase variable in the TickEvent class and changes all the sub classes to have Pre/Post classes, as mentioned in [here](https://gist.github.com/PaintNinja/4d1a35c03b377e78a74c708184ce893e#forge)

Theoretically this would give a **minor** performance boost due to the singleton nature of the `ClientTickEvent`, however as that was not the primary goal of this I've not included any numbers and only mention this as an extra benefit