### PR TITLE
[1.20.6] Prevent the `@OnlyIn` being misused on `@EventBusSubscriber` and `@Mod` annotated classes

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -143,21 +143,27 @@ public class RuntimeDistCleaner implements ILaunchPluginService
     }
 
     @SuppressWarnings("unchecked")
-    private static List<AnnotationNode> unpack(final List<AnnotationNode> anns) {
-        if (anns == null) {
+    private static List<AnnotationNode> unpack(final List<AnnotationNode> anns)
+    {
+        if (anns == null)
+        {
             return Collections.emptyList();
         }
 
         List<AnnotationNode> unpacked = new ArrayList<>();
 
-        for (var annotationNode : anns) {
-            if (Objects.equals(annotationNode.desc, ONLYINS)) {
+        for (var annotationNode : anns)
+        {
+            if (Objects.equals(annotationNode.desc, ONLYINS))
+            {
                 unpacked.add(annotationNode);
 
-                if (annotationNode.values != null) {
+                if (annotationNode.values != null)
+                {
                     List<AnnotationNode> subNodes = (List<AnnotationNode>) annotationNode.values.get(annotationNode.values.indexOf("value") + 1);
 
-                    if (subNodes != null) {
+                    if (subNodes != null)
+                    {
                         unpacked.addAll(subNodes);
                     }
                 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -60,7 +60,7 @@ public class RuntimeDistCleaner implements ILaunchPluginService
         if (!FMLEnvironment.production && hasOnlyInWithModAnnotation(classNode.visibleAnnotations))
         {
             LOGGER.error(DISTXFORM, "Attempted to load class {} with @Mod and @OnlyIn/@OnlyIns annotations", classNode.name);
-            throw new RuntimeException("Attempted to load class "+ classNode.name  + " with @Mod and @OnlyIn/@OnlyIns annotations you should instead use the side setting in the mods.toml");
+            throw new RuntimeException("Found @OnlyIn on @Mod class "+ classNode.name  + " - this is not allowed as it causes crashes. Remove the OnlyIn and consider setting clientSideOnly=true in the root of your mods.toml instead");
         }
 
         if (classNode.interfaces != null )

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -67,7 +67,7 @@ public class RuntimeDistCleaner implements ILaunchPluginService
         {
             unpack(classNode.visibleAnnotations).stream()
                 .filter(ann->Objects.equals(ann.desc, ONLYIN))
-                .filter(ann->ann.values.indexOf("_interface") != -1)
+                .filter(ann-> ann.values.contains("_interface"))
                 .filter(ann->!Objects.equals(((String[])ann.values.get(ann.values.indexOf("value") + 1))[1], DIST))
                 .map(ann -> ((Type)ann.values.get(ann.values.indexOf("_interface") + 1)).getInternalName())
                 .forEach(intf -> {

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -44,7 +44,7 @@ public class AutomaticEventSubscriber {
             .filter(data -> AUTO_SUBSCRIBER.equals(data.annotationType()))
             .toList();
 
-        var onlyIns = FMLEnvironment.production ? Collections.emptyList() : scanData.getAnnotations().stream()
+        var onlyIns = FMLEnvironment.production ? Collections.emptySet() : scanData.getAnnotations().stream()
                 .filter(data -> ONLY_IN_TYPE.equals(data.annotationType()))
                 .map(data -> data.clazz().getClassName())
                 .collect(Collectors.toSet());

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -57,7 +57,7 @@ public class AutomaticEventSubscriber {
 
         for (var data : targets) {
             if (!FMLEnvironment.production && onlyIns.contains(data.clazz().getClassName())) {
-                throw new RuntimeException("Found @OnlyIn on @EventBusSubscriber class " + data.clazz().getClassName() + " - this is not allowed you should instead use the dist parameter on EventBusSubscriber annotation");
+                throw new RuntimeException("Found @OnlyIn on @EventBusSubscriber class " + data.clazz().getClassName() + " - this is not allowed as it causes crashes. Remove the OnlyIn and set value=Dist.CLIENT in the EventBusSubscriber annotation instead");
             }
 
             var modId = modids.getOrDefault(data.clazz().getClassName(), mod.getModId());

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -43,7 +44,7 @@ public class AutomaticEventSubscriber {
             .filter(data -> AUTO_SUBSCRIBER.equals(data.annotationType()))
             .toList();
 
-        var onlyIns = scanData.getAnnotations().stream()
+        var onlyIns = FMLEnvironment.production ? Collections.emptyList() : scanData.getAnnotations().stream()
                 .filter(data -> ONLY_IN_TYPE.equals(data.annotationType()))
                 .map(data -> data.clazz().getClassName())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
Adds checks to prevent the OnlyIn annotation being used in erroneous places such as classes annotated with the `@Mod`, or `@EventBusSubscriber` as outlined [here](https://gist.github.com/PaintNinja/4d1a35c03b377e78a74c708184ce893e#forge)