### PR TITLE
add null check to TierSortingRegistry.java

### DIFF
--- a/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
+++ b/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
@@ -64,6 +64,8 @@ public class TierSortingRegistry {
      * @param before List of tiers to place this tier before (the tiers in the list will be considered better tiers)
      */
     public static synchronized Tier registerTier(Tier tier, ResourceLocation name, List<Object> after, List<Object> before) {
+        if (tier == null)
+            throw new NullPointerException("Registering a new Tier requires a nonnull tier! ResourceLocation name: " + name);
         if (tiers.containsKey(name))
             throw new IllegalStateException("Duplicate tier name " + name);
 
@@ -122,9 +124,7 @@ public class TierSortingRegistry {
             return isCorrectTierVanilla(tier, state);
 
         for (int x = sortedTiers.indexOf(tier) + 1; x < sortedTiers.size(); x++) {
-            var sortedTier = sortedTiers.get(x);
-            if (sortedTier == null) continue;
-            TagKey<Block> tag = sortedTier.getTag();
+            TagKey<Block> tag = sortedTiers.get(x).getTag();
             if (tag != null && state.is(tag))
                 return false;
         }

--- a/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
+++ b/src/main/java/net/minecraftforge/common/TierSortingRegistry.java
@@ -122,7 +122,9 @@ public class TierSortingRegistry {
             return isCorrectTierVanilla(tier, state);
 
         for (int x = sortedTiers.indexOf(tier) + 1; x < sortedTiers.size(); x++) {
-            TagKey<Block> tag = sortedTiers.get(x).getTag();
+            var sortedTier = sortedTiers.get(x);
+            if (sortedTier == null) continue;
+            TagKey<Block> tag = sortedTier.getTag();
             if (tag != null && state.is(tag))
                 return false;
         }


### PR DESCRIPTION
if `sortedTiers` contains `null` element, that were put by some mods, it can cause the whole game to crash because of NullPointerException.