### PR TITLE
[1.20.x] Add helper method to `OnDatapackSyncEvent`

### DIFF
--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -15,14 +15,13 @@ import org.jetbrains.annotations.Nullable;
  * before tags and crafting recipes are sent to the client. Send datapack data
  * to clients when this event fires.
  */
-public class OnDatapackSyncEvent extends Event
-{
+public class OnDatapackSyncEvent extends Event {
     private final PlayerList playerList;
+
     @Nullable
     private final ServerPlayer player;
 
-    public OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player)
-    {
+    public OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player) {
         this.playerList = playerList;
         this.player = player;
     }
@@ -30,8 +29,7 @@ public class OnDatapackSyncEvent extends Event
     /**
      * @return The server's player list to get a view of all players.
      */
-    public PlayerList getPlayerList()
-    {
+    public PlayerList getPlayerList() {
         return this.playerList;
     }
 
@@ -40,8 +38,7 @@ public class OnDatapackSyncEvent extends Event
      *         such as when the reload command runs.
      */
     @Nullable
-    public ServerPlayer getPlayer()
-    {
+    public ServerPlayer getPlayer() {
         return this.player;
     }
 }

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.server.players.PlayerList;
 import net.minecraftforge.eventbus.api.Event;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * Fires when a player joins the server or when the reload command is ran,
  * before tags and crafting recipes are sent to the client. Send datapack data
@@ -40,5 +42,13 @@ public class OnDatapackSyncEvent extends Event {
     @Nullable
     public ServerPlayer getPlayer() {
         return this.player;
+    }
+
+    /**
+     * @return A list of players that should receive data during this event, which is the specified player (if not null)
+     *         or all players otherwise.
+     */
+    public List<ServerPlayer> getRelevantPlayers() {
+        return this.player == null ? this.playerList.getPlayers() : List.of(this.player);
     }
 }

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -48,7 +48,7 @@ public class OnDatapackSyncEvent extends Event {
      * @return A list of players that should receive data during this event, which is the specified player (if not null)
      *         or all players otherwise.
      */
-    public List<ServerPlayer> getRelevantPlayers() {
+    public List<ServerPlayer> getPlayers() {
         return this.player == null ? this.playerList.getPlayers() : List.of(this.player);
     }
 }


### PR DESCRIPTION
Adds a small helper method that optionally makes usage more unified.

Before:
```java
if (event.getPlayer() != null) {
    // do thing with the player
} else {
    for (var serverPlayer : event.getPlayerList().getPlayers()) {
        // do thing with the players
    }
}
```

After:
```java
for (var serverPlayer : event.getRelevantPlayers()) {
    // do thing with the player(s)
}
```