### PR TITLE
Add global server config + remove defaultconfigs feature

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -11,8 +11,6 @@ import com.electronwill.nightconfig.core.file.FileWatcher;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.mojang.logging.LogUtils;
-import net.minecraftforge.fml.loading.FMLConfig;
-import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 
@@ -25,8 +23,7 @@ import static net.minecraftforge.fml.config.ConfigTracker.CONFIG;
 
 public class ConfigFileTypeHandler {
     private static final Logger LOGGER = LogUtils.getLogger();
-    static ConfigFileTypeHandler TOML = new ConfigFileTypeHandler();
-    private static final Path defaultConfigPath = FMLPaths.GAMEDIR.get().resolve(FMLConfig.getConfigValue(FMLConfig.ConfigValue.DEFAULT_CONFIG_PATH));
+    final static ConfigFileTypeHandler TOML = new ConfigFileTypeHandler();
 
     public Function<ModConfig, CommentedFileConfig> reader(Path configBasePath) {
         return (c) -> {
@@ -67,15 +64,8 @@ public class ConfigFileTypeHandler {
     }
 
     private boolean setupConfigFile(final ModConfig modConfig, final Path file, final ConfigFormat<?> conf) throws IOException {
-        Files.createDirectories(file.getParent());
-        Path p = defaultConfigPath.resolve(modConfig.getFileName());
-        if (Files.exists(p)) {
-            LOGGER.info(CONFIG, "Loading default config file from path {}", p);
-            Files.copy(p, file);
-        } else {
-            Files.createFile(file);
-            conf.initEmptyFile(file);
-        }
+        Files.createFile(file);
+        conf.initEmptyFile(file);
         return true;
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -30,6 +30,7 @@ public class FMLConfig
         VERSION_CHECK("versionCheck", Boolean.TRUE, "Enable forge global version checking"),
         DEFAULT_CONFIG_PATH("defaultConfigPath", "defaultconfigs", "Default config path for servers"),
         DISABLE_OPTIMIZED_DFU("disableOptimizedDFU", Boolean.TRUE, "Disables Optimized DFU client-side - already disabled on servers"),
+        GLOBAL_SERVER_CONFIG("globalServerConfig", false, "Set this to true to enable global server config so that generates server config in default config folder (./config) instead of world folder"),
         EARLY_WINDOW_PROVIDER("earlyWindowProvider", "fmlearlywindow", "Early window provider"),
         EARLY_WINDOW_WIDTH("earlyWindowWidth", 854, "Early window width"),
         EARLY_WINDOW_HEIGHT("earlyWindowHeight", 480, "Early window height"),

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -30,7 +30,7 @@ public class FMLConfig
         VERSION_CHECK("versionCheck", Boolean.TRUE, "Enable forge global version checking"),
         DEFAULT_CONFIG_PATH("defaultConfigPath", "defaultconfigs", "Default config path for servers"),
         DISABLE_OPTIMIZED_DFU("disableOptimizedDFU", Boolean.TRUE, "Disables Optimized DFU client-side - already disabled on servers"),
-        GLOBAL_SERVER_CONFIG("globalServerConfig", false, "Set this to true to enable global server config so that generates server config in default config folder (./config) instead of world folder"),
+        GLOBAL_SERVER_CONFIG("globalServerConfig", Boolean.TRUE, "Set this to true to enable global server config so that generates server config in default config folder (./config) instead of world folder"),
         EARLY_WINDOW_PROVIDER("earlyWindowProvider", "fmlearlywindow", "Early window provider"),
         EARLY_WINDOW_WIDTH("earlyWindowWidth", 854, "Early window width"),
         EARLY_WINDOW_HEIGHT("earlyWindowHeight", 480, "Early window height"),

--- a/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
@@ -26,6 +26,8 @@ import net.minecraftforge.common.world.StructureModifier;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.common.util.LogicalSidedProvider;
 import net.minecraftforge.common.world.BiomeModifier;
+import net.minecraftforge.fml.loading.FMLConfig;
+import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.network.ConnectionType;
 import net.minecraftforge.network.NetworkContext;
 import net.minecraftforge.network.NetworkRegistry;
@@ -61,7 +63,13 @@ public class ServerLifecycleHooks {
     private static MinecraftServer currentServer;
 
     private static Path getServerConfigPath(final MinecraftServer server) {
-        final Path serverConfig = server.getWorldPath(SERVERCONFIG);
+        final Path serverConfig;
+        if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.GLOBAL_SERVER_CONFIG)) {
+            serverConfig = FMLPaths.CONFIGDIR.get();
+        } else {
+            serverConfig = server.getWorldPath(SERVERCONFIG);
+        }
+
         if (!Files.isDirectory(serverConfig)) {
             try {
                 Files.createDirectories(serverConfig);


### PR DESCRIPTION
this PR adds global serverconfig option which places server config files in CONFIGDIR instead of worlddir
also removes defaultconfigs because
1. nobody know how it works
2. nobody uses it
3. why? the only viable purpose is help modpackers to generate preferred default config files when these doesn't exist, but they already wrap generated config files, and the only reason to use that feature is for serverconfigs (and again, with the global server config option it has NO SENSE.

This was intended as a breaking change for 1.20.5+
is not humanly possible (without a lot of hackery) to keep compatibility.
Can be backported the global serverconfig doing a small check if file exists and if was a server config file to add manually the server.toml suffix and prevent duplicate filenames (if was even a problem) but is not something i will care about