### PR TITLE
[1.20.x] Early display fixes/workarounds for buggy drivers

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -364,14 +364,15 @@ public class DisplayWindow implements ImmediateWindowProvider {
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-        if (mcVersion != null) {
-            // this emulates what we would get without early progress window
-            // as vanilla never sets these, so GLFW uses the first window title
-            // set them explicitly to avoid it using "FML early loading progress" as the class
-            String vanillaWindowTitle = "Minecraft* " + mcVersion;
-            glfwWindowHintString(GLFW_X11_CLASS_NAME, vanillaWindowTitle);
-            glfwWindowHintString(GLFW_X11_INSTANCE_NAME, vanillaWindowTitle);
-        }
+
+        String vanillaWindowTitle = "Minecraft* ";
+        if (mcVersion != null) vanillaWindowTitle += mcVersion;
+
+        // this emulates what we would get without early progress window
+        // as vanilla never sets these, so GLFW uses the first window title
+        // set them explicitly to avoid it using "FML early loading progress" as the class
+        glfwWindowHintString(GLFW_X11_CLASS_NAME, vanillaWindowTitle);
+        glfwWindowHintString(GLFW_X11_INSTANCE_NAME, vanillaWindowTitle);
 
         long primaryMonitor = glfwGetPrimaryMonitor();
         if (primaryMonitor == 0) {
@@ -406,7 +407,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, GL_VERSIONS[versidx][1]);
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
             glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-            window = glfwCreateWindow(winWidth, winHeight, "Minecraft: Forge Loading...", 0L, 0L);
+            window = glfwCreateWindow(winWidth, winHeight, vanillaWindowTitle, 0L, 0L);
             var erridx = versidx;
             handleLastGLFWError((error, description) -> lastGLError[erridx] = String.format("Trying %d.%d: GLFW error: [0x%X]%s", GL_VERSIONS[erridx][0], GL_VERSIONS[erridx][1], error, description));
             if (lastGLError[versidx] != null) {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -390,7 +390,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         }, 10, TimeUnit.SECONDS);
         int versidx = 0;
         var skipVersions = FMLConfig.<String>getListConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SKIP_GL_VERSIONS);
-        boolean showHelpLog = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_HELP_LOG);
+        boolean showHelpLog = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_LOG_HELP_MSG);
         final String[] lastGLError = new String[GL_VERSIONS.length];
         do {
             final var glVersionToTry = GL_VERSIONS[versidx][0] + "." + GL_VERSIONS[versidx][1];
@@ -410,8 +410,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
                 C) Try reinstalling your graphics drivers
                 D) If still not working after trying all of the above, ask for further help on the Forge forums or Discord
                 
-                You can safely ignore this message if the game starts up successfully.
-                """);
+                You can safely ignore this message if the game starts up successfully.""");
             }
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, GL_VERSIONS[versidx][0]); // we try our versions one at a time
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, GL_VERSIONS[versidx][1]);
@@ -446,7 +445,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         this.window = window;
 
         if (showHelpLog)
-            FMLConfig.updateConfig(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_HELP_LOG, false);
+            FMLConfig.updateConfig(FMLConfig.ConfigValue.EARLY_WINDOW_LOG_HELP_MSG, false);
 
         int[] x = new int[1];
         int[] y = new int[1];

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -452,19 +452,19 @@ public class DisplayWindow implements ImmediateWindowProvider {
         glfwSetWindowPos(window, (vidmode.width() - this.winWidth) / 2 + monitorX, (vidmode.height() - this.winHeight) / 2 + monitorY);
 
         // Attempt setting the icon
-        int[] channels = new int[1];
-        try (var glfwImgBuffer = GLFWImage.create(MemoryUtil.getAllocator().malloc(GLFWImage.SIZEOF), 1)) {
-            final ByteBuffer imgBuffer;
-            try (GLFWImage glfwImages = GLFWImage.malloc()) {
-                imgBuffer = STBHelper.loadImageFromClasspath("forge_logo.png", 20000, x, y, channels);
-                glfwImgBuffer.put(glfwImages.set(x[0], y[0], imgBuffer));
-                glfwSetWindowIcon(window, glfwImgBuffer);
-                STBImage.stbi_image_free(imgBuffer);
-            }
-        } catch (NullPointerException e) {
-            System.err.println("Failed to load forge logo");
-        }
-        handleLastGLFWError((error, description) -> LOGGER.debug(String.format("Suppressing GLFW icon error: [0x%X]%s", error, description)));
+//        int[] channels = new int[1];
+//        try (var glfwImgBuffer = GLFWImage.create(MemoryUtil.getAllocator().malloc(GLFWImage.SIZEOF), 1)) {
+//            final ByteBuffer imgBuffer;
+//            try (GLFWImage glfwImages = GLFWImage.malloc()) {
+//                imgBuffer = STBHelper.loadImageFromClasspath("forge_logo.png", 20000, x, y, channels);
+//                glfwImgBuffer.put(glfwImages.set(x[0], y[0], imgBuffer));
+//                glfwSetWindowIcon(window, glfwImgBuffer);
+//                STBImage.stbi_image_free(imgBuffer);
+//            }
+//        } catch (NullPointerException e) {
+//            System.err.println("Failed to load forge logo");
+//        }
+//        handleLastGLFWError((error, description) -> LOGGER.debug(String.format("Suppressing GLFW icon error: [0x%X]%s", error, description)));
 
         glfwSetFramebufferSizeCallback(window, this::fbResize);
         glfwSetWindowPosCallback(window, this::winMove);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -38,6 +38,7 @@ public class FMLConfig
         EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers"),
         EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?"),
         EARLY_WINDOW_SHOW_CPU("earlyWindowShowCPU", Boolean.FALSE, "Whether to show CPU usage stats in early window"),
+        EARLY_WINDOW_SHOW_HELP_LOG("earlyWindowShowHelpLog", Boolean.TRUE, "Whether to log a help text on first attempt, to aid troubleshooting. This setting should automatically disable itself after a successful launch"),
         ;
 
         private final String entry;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -38,7 +38,7 @@ public class FMLConfig
         EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers"),
         EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?"),
         EARLY_WINDOW_SHOW_CPU("earlyWindowShowCPU", Boolean.FALSE, "Whether to show CPU usage stats in early window"),
-        EARLY_WINDOW_SHOW_HELP_LOG("earlyWindowShowHelpLog", Boolean.TRUE, "Whether to log a help text on first attempt, to aid troubleshooting. This setting should automatically disable itself after a successful launch"),
+        EARLY_WINDOW_LOG_HELP_MSG("earlyWindowLogHelpMessage", Boolean.TRUE, "Whether to log a help message on first attempt, to aid troubleshooting. This setting should automatically disable itself after a successful launch"),
         ;
 
         private final String entry;

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -96,7 +96,7 @@
        StringBuilder stringbuilder = new StringBuilder("Minecraft");
        if (checkModStatus().shouldReportAsModified()) {
 -         stringbuilder.append("*");
-+         stringbuilder.append(" Forge").append('*');
++         stringbuilder.append('*').append(" Forge");
        }
  
        stringbuilder.append(" ");


### PR DESCRIPTION
This PR does some stuff that might help broken drivers detect Forge properly. Testing welcome.

- Comment out broken icon code
    - It always fails to set the icon because it doesn't exist, so don't bother running it. Best case it helps some drivers, worst case we skip wasting cycles for something we know doesn't work.
- Use the Vanilla window title initially
    - A window hint string is set for the title, but a completely different actual window title was set.
    - Now sets the window title to "Minecraft* 1.20.4" when creating the window, which might help
- Move the asterisk on the final window title
    - Forge used to set the title to "Minecraft Forge* 1.20.4", but this might be tripping up drivers that rely on the window title starting with "Minecraft*" to know if it's a modded environment
- Show a one-time help log immediately before the first attempt
    - Helps users that look at their debug.log/latest.log and just see `[main/INFO] [EARLYDISPLAY/]: Trying GL version 4.6` at the end with seemingly no error
    - Automatically turns itself off once a successful launch happens. Can be manually turned back on again in fml.toml (handy for swapping graphics cards for example)