### PR TITLE
Fix edge-case regression with single-jar multiloader mods

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -75,7 +75,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
 
         // the remaining properties are optional with sensible defaults
         boolean notAForgeMod = false;
-        if (modLoader.equals(JAVAFML) && modLoaderVersion.containsVersion(NOT_JAVAFML_VER)) {
+        if (modLoader.equals(JAVAFML) && modLoaderVersion.hasRestrictions() && modLoaderVersion.containsVersion(NOT_JAVAFML_VER)) {
             notAForgeMod = true;
             this.properties = Map.of(NOT_A_FORGE_MOD_PROP, true);
         } else {


### PR DESCRIPTION
Some single-jar multiloader mods rely on an edge-case I wasn't aware of, that allows the same mods.toml to work on both Forge and non-Forge. This tiny change accounts for that, by skipping the version check if `loaderVersion="*"`

Test installer: [forge-1.20.4-49.0.47-1.20.x-fix-edge-case-regression-multiloader-jars-installer.zip](https://github.com/MinecraftForge/MinecraftForge/files/15040854/forge-1.20.4-49.0.47-1.20.x-fix-edge-case-regression-multiloader-jars-installer.zip)
Mod test case: [Collective by Serilum](https://www.curseforge.com/minecraft/mc-mods/collective)

More details on Discord: https://discord.com/channels/1129059589325852724/1129059590156337154/1230846312359006240