### PR TITLE
Fix early window crash when parsing some forms of options.txt

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -76,7 +76,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger("EARLYDISPLAY");
     private final AtomicBoolean animationTimerTrigger = new AtomicBoolean(true);
 
-    private ColourScheme colourScheme;
+    private ColourScheme colourScheme = ColourScheme.RED;
     private ElementShader elementShader;
 
     private RenderElement.DisplayContext context;
@@ -135,13 +135,16 @@ public class DisplayWindow implements ImmediateWindowProvider {
             this.colourScheme = ColourScheme.BLACK;
         } else {
             try {
-                var optionLines = Files.readAllLines(FMLPaths.GAMEDIR.get().resolve(Paths.get("options.txt")));
-                var options = optionLines.stream().map(l -> l.split(":")).filter(a -> a.length == 2).collect(Collectors.toMap(a -> a[0], a -> a[1]));
-                var colourScheme = Boolean.parseBoolean(options.getOrDefault("darkMojangStudiosBackground", "false"));
-                this.colourScheme = colourScheme ? ColourScheme.BLACK : ColourScheme.RED;
-            } catch (IOException ioe) {
-                // No options
-                this.colourScheme = ColourScheme.RED; // default to red colourscheme
+                // check the options file for the colour scheme
+                var optionLines = Files.readAllLines(FMLPaths.GAMEDIR.get().resolve(Path.of("options.txt")));
+                for (String line : optionLines) {
+                    if (line.startsWith("darkMojangStudiosBackground:")) {
+                        this.colourScheme = line.endsWith("true") ? ColourScheme.BLACK : ColourScheme.RED;
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                this.colourScheme = ColourScheme.RED; // fallback to red colourScheme
             }
         }
         this.maximized = parsed.has(maximizedopt) || FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_MAXIMIZED);

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -137,9 +137,10 @@ public class DisplayWindow implements ImmediateWindowProvider {
             try {
                 // check the options file for the colour scheme
                 var optionLines = Files.readAllLines(FMLPaths.GAMEDIR.get().resolve(Path.of("options.txt")));
+                var keyName = "darkMojangStudiosBackground:";
                 for (String line : optionLines) {
-                    if (line.startsWith("darkMojangStudiosBackground:")) {
-                        this.colourScheme = line.endsWith("true") ? ColourScheme.BLACK : ColourScheme.RED;
+                    if (line.startsWith(keyName)) {
+                        this.colourScheme = line.startsWith("true", keyName.length()) ? ColourScheme.BLACK : ColourScheme.RED;
                         break;
                     }
                 }


### PR DESCRIPTION
The early window (aka early loading screen) currently parses the entire file into a HashMap just to grab a single value from it. This is inefficient and unnecessarily complicated, and causes a crash if there's a duplicate line inside the options.txt.

This PR rewrites that piece of code to something simpler which doesn't care about duplicates and early returns once it has parsed the line it's looking for.

More details here: https://discord.com/channels/1129059589325852724/1129069799545241703/1230866364965716021