### PR TITLE
Make non-Forge mods.toml detection more robust

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -52,7 +52,7 @@ public abstract class AbstractModProvider implements IModProvider {
             LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);
             mod = new ModFile(sj, this, ModFileParser::modsTomlParser);
             if (mod.getModFileInfo().getFileProperties().containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
-                LOGGER.warn(LogMarkers.SCAN, "Unable to load file \"{}\" because its mods.toml is requesting an invalid javafml loaderVersion (use \"*\" if you want to allow all versions) and is missing a forge modId dependency declaration (see the sample mods.toml in the MDK).", path);
+                LOGGER.error(LogMarkers.SCAN, "Unable to load file \"{}\" because its mods.toml is requesting an invalid javafml loaderVersion (use \"*\" if you want to allow all versions) and is missing a forge modId dependency declaration (see the sample mods.toml in the MDK).", path);
                 return new IModLocator.ModFileOrException(null, new ModFileLoadingException("File \"%s\" is not a Forge mod and cannot be loaded. Look for a Forge version of this mod or consider alternative mods.".formatted(mod.getFileName())));
             }
         } else if (type != null) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -52,6 +52,7 @@ public abstract class AbstractModProvider implements IModProvider {
             LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);
             mod = new ModFile(sj, this, ModFileParser::modsTomlParser);
             if (mod.getModFileInfo().getFileProperties().containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
+                LOGGER.warn(LogMarkers.SCAN, "Unable to load file \"{}\" because its mods.toml is requesting an invalid javafml loaderVersion (use \"*\" if you want to allow all versions) and is missing a forge modId dependency declaration (see the sample mods.toml in the MDK).", path);
                 return new IModLocator.ModFileOrException(null, new ModFileLoadingException("File \"%s\" is not a Forge mod and cannot be loaded. Look for a Forge version of this mod or consider alternative mods.".formatted(mod.getFileName())));
             }
         } else if (type != null) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -69,7 +69,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
         var modLoader = config.<String>getConfigElement("modLoader")
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader in file", this));
         // as is modloader version
-        var modLoaderVerStr = config.<String>getConfigElement("modLoaderVersion")
+        var modLoaderVerStr = config.<String>getConfigElement("loaderVersion")
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
         var modLoaderVersion = MavenVersionAdapter.createFromVersionSpec(modLoaderVerStr);
         this.languageSpecs = new ArrayList<>(List.of(new LanguageSpec(modLoader, modLoaderVersion)));

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -213,6 +213,15 @@ public class ModInfo implements IModInfo, IConfigurable {
             this.owner = owner;
             this.modId = config.<String>getConfigElement("modId")
                     .orElseThrow(()->new InvalidModFileException("Missing required field modid in dependency", getOwningFile()));
+            if (this.modId.equals("forge")) {
+                var fileProps = owner.getOwningFile().getFileProperties();
+                // Checking containsKey to avoid a possible exception if the property is not present (due to Collections.emptyMap())
+                if (fileProps.containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
+                    // if the mod has a dependency on Forge, but we thought it wasn't a Forge mod earlier, we were wrong
+                    // so remove the flag.
+                    fileProps.remove(ModFileInfo.NOT_A_FORGE_MOD_PROP);
+                }
+            }
             this.mandatory = config.<Boolean>getConfigElement("mandatory")
                     .orElseThrow(()->new InvalidModFileException("Missing required field mandatory in dependency", getOwningFile()));
             this.versionRange = config.<String>getConfigElement("versionRange")

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 @ApiStatus.Internal
@@ -222,8 +223,14 @@ public class ModInfo implements IModInfo, IConfigurable {
                     fileProps.remove(ModFileInfo.NOT_A_FORGE_MOD_PROP);
                 }
             }
-            this.mandatory = config.<Boolean>getConfigElement("mandatory")
-                    .orElseThrow(()->new InvalidModFileException("Missing required field mandatory in dependency", getOwningFile()));
+            var mandatory = config.<Boolean>getConfigElement("mandatory");
+            if (mandatory.isPresent()) {
+                this.mandatory = mandatory.get();
+            } else if (owner.getOwningFile().getFileProperties().containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
+                this.mandatory = true;
+            } else {
+                throw new InvalidModFileException("Missing required field mandatory in dependency", getOwningFile());
+            }
             this.versionRange = config.<String>getConfigElement("versionRange")
                     .map(MavenVersionAdapter::createFromVersionSpec)
                     .orElse(UNBOUNDED);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -216,7 +216,7 @@ public class ModInfo implements IModInfo, IConfigurable {
             if (this.modId.equals("forge")) {
                 var fileProps = owner.getOwningFile().getFileProperties();
                 // Checking containsKey to avoid a possible exception if the property is not present (due to Collections.emptyMap())
-                if (fileProps.containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
+                if (!fileProps.isEmpty() && fileProps.containsKey(ModFileInfo.NOT_A_FORGE_MOD_PROP)) {
                     // if the mod has a dependency on Forge, but we thought it wasn't a Forge mod earlier, we were wrong
                     // so remove the flag.
                     fileProps.remove(ModFileInfo.NOT_A_FORGE_MOD_PROP);


### PR DESCRIPTION
Hopefully third time's the charm...

First time it considered a mod non-Forge if mods.toml had
- modLoader: javafml
- loaderVersion: anything that contained v2

Second time prevented the detection from being triggered for `loaderVersion="*"`, but still reported false-positives for `[0,)` and `[1,)`.

This time it only triggers if all of the below apply:
- modLoader: javafml
- loaderVersion
    - not "*"
    - exactly "[2,)" - no contains checks
- missing forge dep
- clientSideOnly: false

When it triggers, it now logs an error message to help devs fix the issue if they're trying to make a Forge mod.

Stock MDK won't erroneously trigger the detection this time because it has a forge dep and the loaderVersion isn't "[2,)".

The only scenario I can think of where this would still trigger a false-positive is if someone manually removes the Forge dep from the MDK's mods.toml, sets the loader requirement to javafml `[2,)` for some bizarre reason *and* doesn't use clientSideOnly. In that case, they can either add a Forge dep (even `mandatory=false` or `versionRange=[0,)` is fine) or set the loaderVersion to `*` (or anything other than `[2,)`.

If we still get false-positives after this, I'll throw in the towel and remove the detection entirely.