### PR TITLE
Choose default JarJar mod file type based on parent JAR

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -37,11 +37,15 @@ public abstract class AbstractModProvider implements IModProvider {
     protected static final String MODS_TOML = "META-INF/mods.toml";
 
     protected IModLocator.ModFileOrException createMod(Path path) {
-        return createMod(path, getDefaultJarModType(), false);
+        return createMod(path, false);
+    }
+
+    protected IModLocator.ModFileOrException createMod(Path path, boolean ignoreUnknown) {
+        return createMod(path, false, getDefaultJarModType());
     }
 
     @Nullable
-    protected IModLocator.ModFileOrException createMod(Path path, String defaultType, boolean ignoreUnknown) {
+    protected IModLocator.ModFileOrException createMod(Path path, boolean ignoreUnknown, String defaultType) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(
             jar -> jar.moduleDataProvider().findFile(MODS_TOML).isPresent() ? mjm : JarMetadata.from(jar, path),

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -37,11 +37,11 @@ public abstract class AbstractModProvider implements IModProvider {
     protected static final String MODS_TOML = "META-INF/mods.toml";
 
     protected IModLocator.ModFileOrException createMod(Path path) {
-        return createMod(path, false);
+        return createMod(path, getDefaultJarModType(), false);
     }
 
     @Nullable
-    protected IModLocator.ModFileOrException createMod(Path path, boolean ignoreUnknown) {
+    protected IModLocator.ModFileOrException createMod(Path path, String defaultType, boolean ignoreUnknown) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(
             jar -> jar.moduleDataProvider().findFile(MODS_TOML).isPresent() ? mjm : JarMetadata.from(jar, path),
@@ -51,7 +51,7 @@ public abstract class AbstractModProvider implements IModProvider {
         IModFile mod;
         var type = sj.moduleDataProvider().getManifest().getMainAttributes().getValue(ModFile.TYPE);
         if (type == null)
-            type = getDefaultJarModType();
+            type = defaultType;
 
         if (sj.moduleDataProvider().findFile(MODS_TOML).isPresent()) {
             LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -26,11 +26,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,7 +79,14 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
             final Map<String, ?> outerFsArgs = ImmutableMap.of("packagePath", pathInModFile);
             final FileSystem zipFS = FileSystems.newFileSystem(filePathUri, outerFsArgs);
             final Path pathInFS = zipFS.getPath("/");
-            return Optional.of(createMod(pathInFS).file());
+            final IModFile.Type parentType = file.getType();
+            final String modType;
+            if (parentType == IModFile.Type.LIBRARY || parentType == IModFile.Type.LANGPROVIDER) {
+                modType = IModFile.Type.LIBRARY.name();
+            } else {
+                modType = IModFile.Type.GAMELIBRARY.name();
+            }
+            return Optional.of(createMod(pathInFS, modType, false).file());
         } catch (Exception e) {
             LOGGER.error("Failed to load mod file {} from {}", path, file.getFileName());
             final RuntimeException exception = new ModFileLoadingException("Failed to load mod file " + file.getFileName());

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -26,7 +26,11 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -86,7 +90,7 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
             } else {
                 modType = IModFile.Type.GAMELIBRARY.name();
             }
-            return Optional.of(createMod(pathInFS, modType, false).file());
+            return Optional.of(createMod(pathInFS, false, modType).file());
         } catch (Exception e) {
             LOGGER.error("Failed to load mod file {} from {}", path, file.getFileName());
             final RuntimeException exception = new ModFileLoadingException("Failed to load mod file " + file.getFileName());


### PR DESCRIPTION
Fixes #8878 

EDIT: This PR now implements the solution described by Lex:
> Instead of having a hardcoded default, make the default propagate from the containing jar file

Currently, when a library is included in a mod via JarJar, its FMLModType is assumed to be GAMELIBRARY if none is specified in the library's manifest file. This can be problematic for Lanuage Providers, like Kotlin for Forge. Its code is written in Kotlin, which makes calls to certain classes in the Kotlin standard library, which KFF must include because it provides the Kotlin language. It currently shades the Kotlin libraries, which causes incompatibilities with any other mod that tries to shade or JarJar Kotlin. Not good. 

Since Forge made the jump to JPMS back in Minecraft 1.17, including the Kotlin libraries with JarJar was impossible. This is because JarJar loads the Kotlin libraries as GAMELIBRARY files, which are loaded in the GAME module layer, while LANGPROVIDER and LIBRARY files are loaded in the PLUGIN layer, which is a parent of the GAME layer. Due to the way JPMS works, classes in the GAME layer can access classes from the PLUGIN layer, but not vice versa. Since Kotlin's language provider component is in the PLUGIN layer, it throws an IllegalAccessError whenever it tries to reference the Kotlin libs from JarJar.

~~Solving this issue is pretty straightforward; change the default FMLModType of a JarJar file from GAMELIBRARY to LIBRARY. There is no reason to use GAMELIBRARY by default when LIBRARY is still accessible from the GAME layer, just like GAMELIBRARY files are. In nearly every case of a library not specifying its FMLModType, it is because that library is a non-Minecraft library that does not need access to Minecraft classes.~~

It was brought up in the Discord that this change is bad because "it doesn[']t support game libraries." If you would like to include a GAMELIBRARY, then that file should specify its FMLModType explicitly in its manifest. It is unreasonable to expect Jetbrains to specify FMLModType for the Kotlin libraries; it is, however, reasonable to expect a mod author to specify FMLModType.

Another suggestion that was mentioned in the Discord was to "allow the metadata to specify what layer the library needs to go into." This was my first idea for solving the problem, too. However, this solution would cause conflicts when two mods JarJar the same library but specify that it should go into a different plugin layer. This could potentially be resolved by choosing the earliest ancestor layer, for example, in the case of two mods specifying a file goes into GAME and PLUGIN layers, then the PLUGIN layer would be chosen. If I misinterpreted this comment and the suggestion was to allow libraries to define which layer they're loaded into, then that is functionally equivalent to them specifying FMLModType.

~~I think this is the simplest and best solution that doesn't require much maintenance effort. The only breaking change would be for mods that actually use GAMELIBRARIES (which I have never seen deliberately used), in which case those mods should update their manifests.~~