### PR TITLE
[1.20.6] Remove deprecated compressLanIPv6Addresses config option

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -103,9 +103,6 @@ public class ForgeConfig {
 
         public final BooleanValue useCombinedDepthStencilAttachment;
 
-        @Deprecated(since = "1.20.1", forRemoval = true) // Config option ignored.
-        public final BooleanValue compressLanIPv6Addresses;
-
         public final BooleanValue calculateAllNormals;
 
         public final BooleanValue stabilizeDirectionGetNearest;
@@ -136,11 +133,6 @@ public class ForgeConfig {
                     .comment("Set to true to use a combined DEPTH_STENCIL attachment instead of two separate ones.")
                     .translation("forge.configgui.useCombinedDepthStencilAttachment")
                     .define("useCombinedDepthStencilAttachment", false);
-
-            compressLanIPv6Addresses = builder
-                    .comment("[DEPRECATED] Does nothing anymore, IPv6 addresses will be compressed always")
-                    .translation("forge.configgui.compressLanIPv6Addresses")
-                    .define("compressLanIPv6Addresses", true);
 
             calculateAllNormals = builder
                     .comment("During block model baking, manually calculates the normal for all faces.",


### PR DESCRIPTION
Forgot to remove this during the initial port. The config option is ignored and addresses are always compressed, so it's redundant.