### PR TITLE
[1.20.6] Remove zombie chance config options

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -73,21 +73,3 @@
                  if (!this.isSilent()) {
                      p_219160_.levelEvent(null, 1026, this.blockPosition(), 0);
                  }
-@@ -487,7 +_,7 @@
-     }
- 
-     public static boolean getSpawnAsBabyOdds(RandomSource p_219163_) {
--        return p_219163_.nextFloat() < 0.05F;
-+        return p_219163_.nextFloat() < net.minecraftforge.common.ForgeConfig.SERVER.zombieBabyChance.get();
-     }
- 
-     protected void handleAttributes(float p_34340_) {
-@@ -510,7 +_,7 @@
-     }
- 
-     protected void randomizeReinforcementsChance() {
--        this.getAttribute(Attributes.SPAWN_REINFORCEMENTS_CHANCE).setBaseValue(this.random.nextDouble() * 0.1F);
-+        this.getAttribute(Attributes.SPAWN_REINFORCEMENTS_CHANCE).setBaseValue(this.random.nextDouble() * net.minecraftforge.common.ForgeConfig.SERVER.zombieBaseSummonChance.get());
-     }
- 
-     @Override

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
-import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class ForgeConfig {
@@ -22,9 +21,6 @@ public class ForgeConfig {
         public final BooleanValue removeErroringEntities;
 
         public final BooleanValue fullBoundingBoxLadders;
-
-        public final DoubleValue zombieBaseSummonChance;
-        public final DoubleValue zombieBabyChance;
 
         public final ConfigValue<String> permissionHandler;
 
@@ -51,18 +47,6 @@ public class ForgeConfig {
                     .translation("forge.configgui.fullBoundingBoxLadders")
                     .worldRestart()
                     .define("fullBoundingBoxLadders", false);
-
-            zombieBaseSummonChance = builder
-                    .comment("Base zombie summoning spawn chance. Allows changing the bonus zombie summoning mechanic.")
-                    .translation("forge.configgui.zombieBaseSummonChance")
-                    .worldRestart()
-                    .defineInRange("zombieBaseSummonChance", 0.1D, 0.0D, 1.0D);
-
-            zombieBabyChance = builder
-                    .comment("Chance that a zombie (or subclass) is a baby. Allows changing the zombie spawning mechanic.")
-                    .translation("forge.configgui.zombieBabyChance")
-                    .worldRestart()
-                    .defineInRange("zombieBabyChance", 0.05D, 0.0D, 1.0D);
 
             permissionHandler = builder
                     .comment("The permission handler used by the server. Defaults to forge:default_handler if no such handler with that name is registered.")


### PR DESCRIPTION
While these options are fairly trivial to support, there are some benefits to removing it and having a separate mod offer them instead:
- A couple less patches to maintain
- Better support for the speed running community, as it's less things to verify haven't been tampered with for an unfair advantage
- No risk of being different from Vanilla behaviour when porting (e.g. Vanilla changes the default chance and Forge forgets to update the config defaults accordingly, or a user updates from an older MC version and unintentionally has different chance values than the new Vanilla default)