### PR TITLE
[1.20.6] Switch to Forge's fork of Fabric Mixin

### DIFF
--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -13,9 +13,6 @@ repositories {
     maven gradleutils.forgeMaven
     maven gradleutils.minecraftLibsMaven
     //mavenLocal()
-    maven { // temporary measure until Fabric Mixin is mirrored on Forge's maven
-        url = 'https://maven.fabricmc.net/'
-    }
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -13,6 +13,9 @@ repositories {
     maven gradleutils.forgeMaven
     maven gradleutils.minecraftLibsMaven
     //mavenLocal()
+    maven { // temporary measure until Fabric Mixin is mirrored on Forge's maven
+        url = 'https://maven.fabricmc.net/'
+    }
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
-            library('mixin', 'org.spongepowered:mixin:0.8.5')
+            library('mixin', 'net.fabricmc:sponge-mixin:0.13.4+mixin.0.8.5')
             library('nulls', 'org.jetbrains:annotations:24.1.0') // Got to have our null annotations!
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')
             library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.5')

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
-            library('mixin', 'net.fabricmc:sponge-mixin:0.13.4+mixin.0.8.5')
+            library('mixin', 'net.minecraftforge:mixins:0.8.5-fabric.0.13.4-forge.0.0.1')
             library('nulls', 'org.jetbrains:annotations:24.1.0') // Got to have our null annotations!
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')
             library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.5')


### PR DESCRIPTION
This PR switches Forge from Sponge's Mixin to a fork of Fabric's, which offers various benefits, such as:
- Support for `"compatibilityLevel": "JAVA_21"` in mixin json files
    - Internally this maps to `JAVA_13`, same as Forge does for `"compatibilityLevel": "JAVA_17"`
    - This just removes a hurdle some devs have when porting their Forge mods to 1.20.6, rather than crashing with an error saying 21 isn't supported
    - <img width="1060" alt="image" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/b06bddd0-1027-4ecb-942d-838a1d5c5f7b">

- Support for interface mixins (FabricMC Mixin PR 51)
- Improved performance/efficiency/memory usage due to avoiding allocations of unused `CallbackInfo` objects (FabricMC Mixin PR 52)
    - <img width="1242" alt="image" src="https://github.com/MinecraftForge/MinecraftForge/assets/3158390/07ff5db9-f344-485d-a94d-427fb79ba094">

Known limitations:
- Logs will say "from mod (unknown)" as we currently don't decorate Mixin config objects with their associated mod ID (a Fabric Mixin feature). I'm still looking into this and will consider fixing in a future PR, but it's not trivial to support amongst ModLauncher's and FML's complexity - especially without a dev experience regression where we would require mod devs to explicitly list all mixin configs in their mods.toml. Once I've figured out something nice for this, I'll do it later.

## Quick Q&A

- Q: Why not wait for Mumfrey to finish Sponge Mixin 0.8.6?

A: We've given him ample time to do this - much longer than downstream did, but we understand life can get busy and don't want to rush him. To avoid stagnation and help mod devs, this PR was made as a stop-gap solution. Once upstream Mixin catches up, we can switch back.

- Q: What about safety?

A: We'll host our own fork that of Fabric Mixin that we'll keep up to date, so any concerns about that (however valid or paranoid they may be) are avoided.

- Q: How do I test this?

A: You can either use this installer made for your convenience or do the usual testing process of cloning the PR branch, running the `setup` gradle task and `publish`: [forge-1.20.6-50.0.7-1.20.6-fabric-mixin-installer.zip](https://github.com/MinecraftForge/MinecraftForge/files/15267821/forge-1.20.6-50.0.7-1.20.6-fabric-mixin-installer.zip)

- Q: Are there any breaking changes?

A: Not to my knowledge - it should be a drop-in replacement. Did some testing and didn't run into any problems myself. The only change for Forge mod devs writing mixins from 1.20.4 is about no longer needing the MixinGradle plugin or refmaps, as 1.20.6 uses MojMap/official runtime mappings.