### PR TITLE
[1.20.6] Add ModelLayers patch back

### DIFF
--- a/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/client/model/geom/ModelLayers.java
++++ b/net/minecraft/client/model/geom/ModelLayers.java
+@@ -228,11 +_,13 @@
+     }
+ 
+     public static ModelLayerLocation createSignModelName(WoodType p_171292_) {
+-        return createLocation("sign/" + p_171292_.name(), "main");
++        ResourceLocation location = new ResourceLocation(p_171292_.name());
++        return new ModelLayerLocation(new ResourceLocation(location.getNamespace(), "sign/" + location.getPath()), "main");
+     }
+ 
+     public static ModelLayerLocation createHangingSignModelName(WoodType p_252225_) {
+-        return createLocation("hanging_sign/" + p_252225_.name(), "main");
++        ResourceLocation location = new ResourceLocation(p_252225_.name());
++        return new ModelLayerLocation(new ResourceLocation(location.getNamespace(), "hanging_sign/" + location.getPath()), "main");
+     }
+ 
+     public static Stream<ModelLayerLocation> getKnownLocations() {


### PR DESCRIPTION
Seems to be missed when porting to 1.20.6