### PR TITLE
Fix RenderHandEvent firing with incorrect InteractionHand

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
@@ -11,7 +11,7 @@
          if (iteminhandrenderer$handrenderselection.renderOffHand) {
              float f6 = interactionhand == InteractionHand.OFF_HAND ? f : 0.0F;
              float f7 = 1.0F - Mth.lerp(p_109315_, this.oOffHandHeight, this.offHandHeight);
-+            if (!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonHand(InteractionHand.OFF_HAND, p_109316_, p_109317_, p_109319_, p_109315_, f1, f6, f7, this.mainHandItem))
++            if (!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonHand(InteractionHand.OFF_HAND, p_109316_, p_109317_, p_109319_, p_109315_, f1, f6, f7, this.offHandItem))
              this.renderArmWithItem(p_109318_, p_109315_, f1, InteractionHand.OFF_HAND, f6, this.offHandItem, f7, p_109316_, p_109317_, p_109319_);
          }
  

--- a/patches/minecraft/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
@@ -11,7 +11,7 @@
          if (iteminhandrenderer$handrenderselection.renderOffHand) {
              float f6 = interactionhand == InteractionHand.OFF_HAND ? f : 0.0F;
              float f7 = 1.0F - Mth.lerp(p_109315_, this.oOffHandHeight, this.offHandHeight);
-+            if (!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonHand(InteractionHand.MAIN_HAND, p_109316_, p_109317_, p_109319_, p_109315_, f1, f6, f7, this.mainHandItem))
++            if (!net.minecraftforge.client.ForgeHooksClient.renderSpecificFirstPersonHand(InteractionHand.OFF_HAND, p_109316_, p_109317_, p_109319_, p_109315_, f1, f6, f7, this.mainHandItem))
              this.renderArmWithItem(p_109318_, p_109315_, f1, InteractionHand.OFF_HAND, f6, this.offHandItem, f7, p_109316_, p_109317_, p_109319_);
          }
  


### PR DESCRIPTION
It appears that this was a mistake made when porting to 1.20.6