### PR TITLE
[1.20.6]: Fixes screen layering and re-add the test. 

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -31,13 +31,13 @@
                      0.0F,
                      1000.0F,
 -                    21000.0F
-+                    21000.0f
++                    net.minecraftforge.client.ForgeHooksClient.getGuiFarPlane()
                  );
              RenderSystem.setProjectionMatrix(matrix4f, VertexSorting.ORTHOGRAPHIC_Z);
              Matrix4fStack matrix4fstack = RenderSystem.getModelViewStack();
              matrix4fstack.pushMatrix();
 -            matrix4fstack.translation(0.0F, 0.0F, -11000.0F);
-+            matrix4fstack.translation(0.0F, 0.0F, 1000F - net.minecraftforge.client.ForgeHooksClient.getGuiFarPlane());
++            matrix4fstack.translation(0.0F, 0.0F, 10000F - net.minecraftforge.client.ForgeHooksClient.getGuiFarPlane());
              RenderSystem.applyModelViewMatrix();
              Lighting.setupFor3DItems();
              GuiGraphics guigraphics = new GuiGraphics(this.minecraft, this.renderBuffers.bufferSource());

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -247,10 +247,10 @@ public class ForgeHooksClient {
     }
 
     public static float getGuiFarPlane() {
-        // 1000 units for the overlay background,
+        // 11000 units for the overlay background,
         // and 10000 units for each layered Screen,
 
-        return 1000.0F + 10000.0F * (1 + guiLayers.size());
+        return 11000.0F + 10000.0F * (1 + guiLayers.size());
     }
 
     public static boolean onClientPauseChangePre(boolean pause) {
@@ -383,7 +383,7 @@ public class ForgeHooksClient {
         guiLayers.forEach(layer -> {
             // Prevent the background layers from thinking the mouse is over their controls and showing them as highlighted.
             drawScreenInternal(layer, guiGraphics, Integer.MAX_VALUE, Integer.MAX_VALUE, partialTick);
-            guiGraphics.pose().translate(0,0,2000);
+            guiGraphics.pose().translate(0, 0, 10000);
         });
         drawScreenInternal(screen, guiGraphics, mouseX, mouseY, partialTick);
         guiGraphics.pose().popPose();

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -23,7 +23,7 @@ import java.util.Random;
 
 @Mod(GuiLayeringTest.MODID)
 public class GuiLayeringTest {
-    private static final boolean ENABLED = false;
+    private static final boolean ENABLED = true;
 
     private static final Random RANDOM = new Random();
     public static final String MODID = "gui_layer_test";
@@ -52,8 +52,8 @@ public class GuiLayeringTest {
             @Override
             public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
                 this.renderBackground(graphics, mouseX, mouseY, partialTicks);
-                graphics.drawString(this.font, this.title, this.width / 2, 15, 0xFFFFFF);
                 super.render(graphics, mouseX, mouseY, partialTicks);
+                graphics.drawString(this.font, this.title, this.width / 2, 15, 0xFFFFFF);
             }
 
             @Override

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -23,7 +23,7 @@ import java.util.Random;
 
 @Mod(GuiLayeringTest.MODID)
 public class GuiLayeringTest {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
 
     private static final Random RANDOM = new Random();
     public static final String MODID = "gui_layer_test";
@@ -52,8 +52,8 @@ public class GuiLayeringTest {
             @Override
             public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
                 this.renderBackground(graphics, mouseX, mouseY, partialTicks);
-                super.render(graphics, mouseX, mouseY, partialTicks);
                 graphics.drawString(this.font, this.title, this.width / 2, 15, 0xFFFFFF);
+                super.render(graphics, mouseX, mouseY, partialTicks);
             }
 
             @Override


### PR DESCRIPTION
The z distance between screens needs to be increased with 1.20.6. 
Currently, adding a second layer makes other layers disappear. This can be observed by adding the test back in the the test package and running it before these changes.
This PR fixes that. 
I also re-added the the test back into the main test package 