### PR TITLE
[1.20.6] Update Bootstrap to improve the Java version check error message

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -483,10 +483,10 @@ tasks.register('createServerShimClasspath', BundleList) {
 tasks.register('createServerShimConfig') {
     ext.output = file('build/libs/bootstrap-shim.properties')
     doLast {
-        def cfg = new CleanProperties()
-        cfg."Main-Class" = 'net.minecraftforge.bootstrap.ForgeBootstrap'
-        cfg."Java-Version" = '17'
-        cfg."Arguments" = "--launchTarget forge_server"
+        var cfg = new CleanProperties()
+        cfg['Main-Class'] = 'net.minecraftforge.bootstrap.ForgeBootstrap'
+        cfg['Java-Version'] = '21'
+        cfg['Arguments'] = '--launchTarget forge_server'
         cfg.store(output)
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.os.OperatingSystem
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -45,7 +43,7 @@ dependencyResolutionManagement {
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
             bundle('jimfs', ['guava', 'failureaccess'])
             
-            version('bootstrap', '2.1.1')
+            version('bootstrap', '2.1.3')
             library('bootstrap',      'net.minecraftforge', 'bootstrap'     ).versionRef('bootstrap') // Needs modlauncher
             library('bootstrap-api',  'net.minecraftforge', 'bootstrap-api' ).versionRef('bootstrap')
             library('bootstrap-dev',  'net.minecraftforge', 'bootstrap-dev' ).versionRef('bootstrap')


### PR DESCRIPTION
Needs https://github.com/MinecraftForge/Bootstrap/pull/4 merged first.

- Fix min Java version for 1.20.6
- Show Java 8 as "8" instead of "1.8.0_411" (from Bootstrap update)

Same as #9989 but on the right origin this time >.<