### PR TITLE
feat(event): add Pre/Post for PlayerEvent.PlayerLoggedOutEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -36,10 +36,18 @@
      }
  
      public void remove(ServerPlayer p_11287_) {
-+        net.minecraftforge.event.ForgeEventFactory.firePlayerLoggedOut(p_11287_);
++        net.minecraftforge.event.ForgeEventFactory.firePrePlayerLoggedOut(p_11287_);
          ServerLevel serverlevel = p_11287_.serverLevel();
          p_11287_.awardStat(Stats.LEAVE_GAME);
          this.save(p_11287_);
+@@ -379,6 +_,7 @@
+         }
+ 
+         this.broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(p_11287_.getUUID())));
++        net.minecraftforge.event.ForgeEventFactory.firePostPlayerLoggedOut(p_11287_);
+     }
+ 
+     @Nullable
 @@ -497,6 +_,7 @@
          this.playersByUUID.put(serverplayer.getUUID(), serverplayer);
          serverplayer.initInventoryMenu();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -778,8 +778,11 @@ public final class ForgeEventFactory {
         post(new PlayerEvent.PlayerLoggedInEvent(player));
     }
 
-    public static void firePlayerLoggedOut(Player player) {
-        post(new PlayerEvent.PlayerLoggedOutEvent(player));
+    public static void firePrePlayerLoggedOut(Player player) {
+        post(new PlayerEvent.PlayerLoggedOutEvent.Pre(player));
+    }
+    public static void firePostPlayerLoggedOut(Player player) {
+        post(new PlayerEvent.PlayerLoggedOutEvent.Post(player));
     }
 
     public static void firePlayerRespawnEvent(Player player, boolean endConquered) {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -458,9 +458,20 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class PlayerLoggedOutEvent extends PlayerEvent {
-        public PlayerLoggedOutEvent(Player player)
-        {
+        protected PlayerLoggedOutEvent(Player player) {
             super(player);
+        }
+
+        public static class Pre extends PlayerLoggedOutEvent {
+            public Pre(Player player) {
+                super(player);
+            }
+        }
+
+        public static class Post extends PlayerLoggedOutEvent {
+            public Post(Player player) {
+                super(player);
+            }
         }
     }
 


### PR DESCRIPTION
I added the post event because when listening to the current PlayerLoggedOutEvent you will find that the PlayerTickEvent still fires after it because it is called before the player is removed from the server's playerlist. 

This can be problematic (a solveable problem of course, but one nonetheless) because if you have something that saves/removes your player data from a cache and also something that accesses that data during the player tick event it may attempt to load the player-data a new thinking that the player is still online. Thus causing an offline player to be stored in the cache. 

Therefore, I thought it would make sense to add the ability to hook in after the player has been removed from the server's list of online players to easily avoid this situation.