### PR TITLE
fix(network): stop disconnect when adding custom recipe book types and connecting to vanilla servers

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -9,6 +9,15 @@
      static Minecraft instance;
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final boolean ON_OSX = Util.getPlatform() == Util.OS.OSX;
+@@ -348,7 +_,7 @@
+     @Nullable
+     private IntegratedServer singleplayerServer;
+     @Nullable
+-    private Connection pendingConnection;
++    public Connection pendingConnection;
+     private boolean isLocalServer;
+     @Nullable
+     public Entity cameraEntity;
 @@ -438,7 +_,6 @@
              }
          }, Util.nonCriticalIoPool());

--- a/patches/minecraft/net/minecraft/stats/RecipeBookSettings.java.patch
+++ b/patches/minecraft/net/minecraft/stats/RecipeBookSettings.java.patch
@@ -1,7 +1,14 @@
 --- a/net/minecraft/stats/RecipeBookSettings.java
 +++ b/net/minecraft/stats/RecipeBookSettings.java
-@@ -11,7 +_,7 @@
+@@ -6,12 +_,14 @@
+ import java.util.EnumMap;
+ import java.util.Map;
+ import net.minecraft.Util;
++import net.minecraft.client.Minecraft;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.network.FriendlyByteBuf;
  import net.minecraft.world.inventory.RecipeBookType;
++import net.minecraftforge.network.ConnectionType;
  
  public final class RecipeBookSettings {
 -    private static final Map<RecipeBookType, Pair<String, String>> TAG_FIELDS = ImmutableMap.of(
@@ -18,6 +25,29 @@
      private final Map<RecipeBookType, RecipeBookSettings.TypeSettings> states;
  
      private RecipeBookSettings(Map<RecipeBookType, RecipeBookSettings.TypeSettings> p_12730_) {
+@@ -53,8 +_,14 @@
+ 
+     public static RecipeBookSettings read(FriendlyByteBuf p_12753_) {
+         Map<RecipeBookType, RecipeBookSettings.TypeSettings> map = Maps.newEnumMap(RecipeBookType.class);
++        var connection = Minecraft.getInstance().getConnection() == null ? Minecraft.getInstance().pendingConnection : Minecraft.getInstance().getConnection().getConnection();
++        var connectionType = connection == null ? ConnectionType.VANILLA : net.minecraftforge.network.NetworkContext.get(connection).getType();
+ 
+         for (RecipeBookType recipebooktype : RecipeBookType.values()) {
++            if (connectionType == ConnectionType.VANILLA && recipebooktype.isModded()) {
++                continue;
++            }
++
+             boolean flag = p_12753_.readBoolean();
+             boolean flag1 = p_12753_.readBoolean();
+             map.put(recipebooktype, new RecipeBookSettings.TypeSettings(flag, flag1));
+@@ -110,6 +_,7 @@
+ 
+         for (RecipeBookType recipebooktype : RecipeBookType.values()) {
+             RecipeBookSettings.TypeSettings recipebooksettings$typesettings = p_12733_.states.get(recipebooktype);
++            if (recipebooksettings$typesettings == null) continue;
+             this.states.put(recipebooktype, recipebooksettings$typesettings.copy());
+         }
+     }
 @@ -158,5 +_,10 @@
          public String toString() {
              return "[open=" + this.open + ", filtering=" + this.filtering + "]";

--- a/patches/minecraft/net/minecraft/world/inventory/RecipeBookType.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/RecipeBookType.java.patch
@@ -1,9 +1,11 @@
 --- a/net/minecraft/world/inventory/RecipeBookType.java
 +++ b/net/minecraft/world/inventory/RecipeBookType.java
-@@ -1,8 +_,18 @@
+@@ -1,8 +_,24 @@
  package net.minecraft.world.inventory;
  
 -public enum RecipeBookType {
++import net.minecraft.network.protocol.Packet;
++
 +public enum RecipeBookType implements net.minecraftforge.common.IExtensibleEnum {
      CRAFTING,
      FURNACE,
@@ -18,5 +20,9 @@
 +   public void init() {
 +       String name = this.name().toLowerCase(java.util.Locale.ROOT).replace("_","");
 +       net.minecraft.stats.RecipeBookSettings.addTagsForType(this, "is" + name + "GuiOpen", "is" + name + "FilteringCraftable");
++   }
++
++   public boolean isModded() {
++       return this != CRAFTING && this != FURNACE && this != BLAST_FURNACE && this != SMOKER;
 +   }
  }


### PR DESCRIPTION
The reason I made this is because when a mod adds a custom RecipeBookType, and then attempts to connect to a vanilla server they get disconnected as it's attempting to read more from the buffer than is being sent by the server.

Again, not sure if this solution is perfect but I have also tested this with a mixin and it works. I'm specifically uncertain about getting the connection like I have? I'm not sure where you're supposed to access the connection from at that point of the process (decoding a packet)

Depends on https://github.com/MinecraftForge/MinecraftForge/pull/9993