### PR TITLE
fix(registry): change conditional checking so that errors in the original codec are respected

### DIFF
--- a/patches/minecraft/net/minecraft/resources/RegistryDataLoader.java.patch
+++ b/patches/minecraft/net/minecraft/resources/RegistryDataLoader.java.patch
@@ -46,17 +46,26 @@
          RegistryOps<JsonElement> p_332135_,
          ResourceKey<E> p_332850_,
          Resource p_335244_,
-@@ -197,7 +_,14 @@
+@@ -197,7 +_,23 @@
      ) throws IOException {
          try (Reader reader = p_335244_.openAsReader()) {
              JsonElement jsonelement = JsonParser.parseReader(reader);
 -            DataResult<E> dataresult = p_333909_.parse(p_332135_, jsonelement);
 +
 +            var result = p_333909_.decode(p_332135_, jsonelement);
-+            if (result.result().map(p -> p.getFirst()).isEmpty()) {
-+               LOGGER.debug("Skipping {} conditions not met", p_332850_);
-+               return;
++
++            if (result.isError()) {
++                LOGGER.error("Couldn't parse data file {}: {}", p_332850_, result.error().get().message());
++                throw new IllegalStateException("Couldn't parse data file " + p_332850_ + ": " + result.error().get().message());
 +            }
++
++            var mappedResult = result.result().map(a -> a.getFirst());
++
++            if (mappedResult.get().isEmpty()) {
++                LOGGER.debug("Skipping {} conditions not met", p_332850_);
++                return;
++            }
++
 +            DataResult<E> dataresult = result.map(p -> p.mapFirst(Optional::get)).map(p -> p.getFirst());
 +
              E e = dataresult.getOrThrow();


### PR DESCRIPTION
This fixes an issue where if a mod creates a custom registry, and then subsequently an invalid JSON ends up in a datapack for that custom reigstry then the error was being swallowed by Forge and making debugging JSONs effectively impossible.

https://github.com/EnvyWare/ExampleForgeMod - This is an example mod with a mixin version of this fix both demonstrating the issue (if you disable the mixin), and also the fix working.