### PR TITLE
[1.20.6] Cleanup FML Bindings

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/Bindings.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/Bindings.java
@@ -27,7 +27,7 @@ public class Bindings {
             .findFirst().orElseThrow(() -> new IllegalStateException("Could not find bindings provider"));
 
     /**
-     * @see net.minecraftforge.common.MinecraftForge#EVENT_BUS
+     * @return A supplier of net.minecraftforge.common.MinecraftForge#EVENT_BUS
      */
     public static Supplier<IEventBus> getForgeBus() {
         return PROVIDER.getForgeBusSupplier();


### PR DESCRIPTION
A small PR that cleans up the FML Bindings, removes one level of indirection, fixes some minor bugs and adds documentation.

This class is internally used by FML to access some stuff from the GAME layer.

The old code had a couple of bugs which I fixed:
1) If two providers somehow existed, it would claim none were found
2) It replaced the ServiceConfigurationError with an IllegalStateException that showed an empty list. While it did print out the stacktrace of the former, I figured allowing the former to actually throw would be better for attaching a debugger to troubleshoot the issue