### PR TITLE
[1.21] Fixed falling block entities not rendering as moving blocks

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/FallingBlockRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/FallingBlockRenderer.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/client/renderer/entity/FallingBlockRenderer.java
 +++ b/net/minecraft/client/renderer/entity/FallingBlockRenderer.java
-@@ -34,20 +_,25 @@
+@@ -34,20 +_,26 @@
                  p_114637_.pushPose();
                  BlockPos blockpos = BlockPos.containing(p_114634_.getX(), p_114634_.getBoundingBox().maxY, p_114634_.getZ());
                  p_114637_.translate(-0.5, 0.0, -0.5);
 +                var model = this.dispatcher.getBlockModel(blockstate);
 +                for (var renderType : model.getRenderTypes(blockstate, RandomSource.create(blockstate.getSeed(p_114634_.getStartPos())), net.minecraftforge.client.model.data.ModelData.EMPTY)) {
++                renderType = net.minecraftforge.client.RenderTypeHelper.getMovingBlockRenderType(renderType);
                  this.dispatcher
                      .getModelRenderer()
                      .tesselateBlock(


### PR DESCRIPTION
Corrects an oversight in the falling block entity renderer not converting the block render types into moving block render types, as is done in vanilla.

This fixes the issue of translucent blocks not rendering at all when rendering with the 'Fabulous!' graphics option, alongside other translucent blocks not rendering behind translucent falling blocks.

Closes: #9927 