### PR TITLE
[1.20.6] Make Rarity Extensible once again

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/Gui.java.patch
@@ -35,7 +35,7 @@
                      TextureAtlasSprite textureatlassprite = mobeffecttexturemanager.get(holder);
                      int l1 = i;
                      int i1 = j;
-@@ -635,6 +_,10 @@
+@@ -635,16 +_,21 @@
      }
  
      private void renderSelectedItemName(GuiGraphics p_283501_) {
@@ -45,8 +45,9 @@
 +    public void renderSelectedItemName(GuiGraphics p_283501_, int yShift) {
          this.minecraft.getProfiler().push("selectedItemName");
          if (this.toolHighlightTimer > 0 && !this.lastToolHighlight.isEmpty()) {
-             MutableComponent mutablecomponent = Component.empty().append(this.lastToolHighlight.getHoverName()).withStyle(this.lastToolHighlight.getRarity().color());
-@@ -642,9 +_,10 @@
+-            MutableComponent mutablecomponent = Component.empty().append(this.lastToolHighlight.getHoverName()).withStyle(this.lastToolHighlight.getRarity().color());
++            MutableComponent mutablecomponent = Component.empty().append(this.lastToolHighlight.getHoverName()).withStyle(this.lastToolHighlight.getForgeRarity().color());
+             if (this.lastToolHighlight.has(DataComponents.CUSTOM_NAME)) {
                  mutablecomponent.withStyle(ChatFormatting.ITALIC);
              }
  

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -72,11 +72,10 @@
      public int getEnchantmentValue() {
          return 0;
      }
-@@ -332,6 +_,30 @@
-     public FeatureFlagSet requiredFeatures() {
+@@ -333,6 +_,30 @@
          return this.requiredFeatures;
      }
-+
+ 
 +    private Object renderProperties;
 +
 +    /*
@@ -100,6 +99,21 @@
 +    }
 +
 +    public void initializeClient(java.util.function.Consumer<net.minecraftforge.client.extensions.common.IClientItemExtensions> consumer) { }
- 
++
      public static class Properties {
          private static final Interner<DataComponentMap> COMPONENT_INTERNER = Interners.newStrongInterner();
+         @Nullable
+@@ -361,8 +_,11 @@
+             return this;
+         }
+ 
+-        public Item.Properties rarity(Rarity p_41498_) {
+-            return this.component(DataComponents.RARITY, p_41498_);
++        public Item.Properties rarity(net.minecraftforge.items.IForgeRarity p_41498_) {
++            if (p_41498_.isModded())
++                return this.component(net.minecraftforge.common.ForgeMod.FORGE_RARITY_COMPONENT.get(), (net.minecraftforge.items.ForgeRarity) p_41498_);
++            else
++                return this.component(DataComponents.RARITY, (Rarity) p_41498_);
+         }
+ 
+         public Item.Properties fireResistant() {

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -103,17 +103,16 @@
      public static class Properties {
          private static final Interner<DataComponentMap> COMPONENT_INTERNER = Interners.newStrongInterner();
          @Nullable
-@@ -361,8 +_,11 @@
-             return this;
+@@ -362,7 +_,11 @@
          }
  
--        public Item.Properties rarity(Rarity p_41498_) {
+         public Item.Properties rarity(Rarity p_41498_) {
 -            return this.component(DataComponents.RARITY, p_41498_);
-+        public Item.Properties rarity(net.minecraftforge.items.IForgeRarity p_41498_) {
-+            if (p_41498_.isModded())
-+                return this.component(net.minecraftforge.common.ForgeMod.FORGE_RARITY_COMPONENT.get(), (net.minecraftforge.items.ForgeRarity) p_41498_);
-+            else
-+                return this.component(DataComponents.RARITY, (Rarity) p_41498_);
++            return this.component(DataComponents.RARITY, (Rarity) p_41498_);
++        }
++
++        public Item.Properties rarity(java.util.function.Supplier<net.minecraftforge.items.ForgeRarity> forgeRaritySupplier) {
++            return this.component(net.minecraftforge.common.ForgeMod.FORGE_RARITY_COMPONENT.get(), forgeRaritySupplier.get());
          }
  
          public Item.Properties fireResistant() {

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -103,16 +103,14 @@
      public static class Properties {
          private static final Interner<DataComponentMap> COMPONENT_INTERNER = Interners.newStrongInterner();
          @Nullable
-@@ -362,7 +_,11 @@
-         }
+@@ -363,6 +_,10 @@
  
          public Item.Properties rarity(Rarity p_41498_) {
--            return this.component(DataComponents.RARITY, p_41498_);
-+            return this.component(DataComponents.RARITY, (Rarity) p_41498_);
+             return this.component(DataComponents.RARITY, p_41498_);
 +        }
 +
-+        public Item.Properties rarity(java.util.function.Supplier<net.minecraftforge.items.ForgeRarity> forgeRaritySupplier) {
-+            return this.component(net.minecraftforge.common.ForgeMod.FORGE_RARITY_COMPONENT.get(), forgeRaritySupplier.get());
++        public Item.Properties rarity(java.util.function.Supplier<net.minecraftforge.items.IForgeRarity> forgeRaritySupplier) {
++            return this.component(net.minecraftforge.common.ForgeMod.FORGE_RARITY_COMPONENT.get(), net.minecraftforge.items.IForgeRarity.wrapper(forgeRaritySupplier));
          }
  
          public Item.Properties fireResistant() {

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -44,6 +44,15 @@
                  p_41624_.broadcastBreakEvent(p_335324_);
                  Item item = this.getItem();
                  this.shrink(1);
+@@ -702,7 +_,7 @@
+             return List.of();
+         } else {
+             List<Component> list = Lists.newArrayList();
+-            MutableComponent mutablecomponent = Component.empty().append(this.getHoverName()).withStyle(this.getRarity().color());
++            MutableComponent mutablecomponent = Component.empty().append(this.getHoverName()).withStyle(this.getForgeRarity().color());
+             if (this.has(DataComponents.CUSTOM_NAME)) {
+                 mutablecomponent.withStyle(ChatFormatting.ITALIC);
+             }
 @@ -757,6 +_,8 @@
                  list.add(DISABLED_ITEM_TOOLTIP);
              }
@@ -53,6 +62,15 @@
              return list;
          }
      }
+@@ -913,7 +_,7 @@
+ 
+         MutableComponent mutablecomponent1 = ComponentUtils.wrapInSquareBrackets(mutablecomponent);
+         if (!this.isEmpty()) {
+-            mutablecomponent1.withStyle(this.getRarity().color())
++            mutablecomponent1.withStyle(this.getForgeRarity().color())
+                 .withStyle(p_220170_ -> p_220170_.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_ITEM, new HoverEvent.ItemStackInfo(this))));
+         }
+ 
 @@ -970,6 +_,7 @@
          this.getItem().onUseTick(p_41732_, p_41733_, this, p_41734_);
      }

--- a/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
@@ -1,0 +1,46 @@
+--- a/net/minecraft/world/item/Rarity.java
++++ b/net/minecraft/world/item/Rarity.java
+@@ -9,15 +_,16 @@
+ import net.minecraft.util.ByIdMap;
+ import net.minecraft.util.StringRepresentable;
+ 
+-public enum Rarity implements StringRepresentable {
++public enum Rarity implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
+     COMMON(0, "common", ChatFormatting.WHITE),
+     UNCOMMON(1, "uncommon", ChatFormatting.YELLOW),
+     RARE(2, "rare", ChatFormatting.AQUA),
+     EPIC(3, "epic", ChatFormatting.LIGHT_PURPLE);
+ 
+-    public static final Codec<Rarity> CODEC = StringRepresentable.fromValues(Rarity::values);
++    public static final Codec<Rarity> CODEC = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(Rarity::values, Rarity::byName);
+     public static final IntFunction<Rarity> BY_ID = ByIdMap.continuous(p_328775_ -> p_328775_.id, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
+-    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, p_330010_ -> p_330010_.id);
++    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = net.minecraftforge.common.IExtensibleEnum.createStreamCodecForExtensibleEnum(Rarity::values);
++    private static final java.util.Map<String, Rarity> BY_NAME = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(Rarity::getName, rarity -> rarity));
+     private final int id;
+     private final String name;
+     private final ChatFormatting color;
+@@ -35,5 +_,23 @@
+     @Override
+     public String getSerializedName() {
+         return this.name;
++    }
++
++    public static Rarity create(final String EnumName, final int id, final String name, final ChatFormatting chatFormatting) {
++        throw new IllegalStateException("Enum not extended");
++    }
++
++    public String getName() {
++        return name;
++    }
++
++    @Override
++    @Deprecated
++    public void init() {
++        BY_NAME.put(this.getName(), this);
++    }
++
++    public static Rarity byName(String name) {
++        return BY_NAME.get(name);
+     }
+ }

--- a/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/Rarity.java
 +++ b/net/minecraft/world/item/Rarity.java
-@@ -9,15 +_,16 @@
+@@ -9,15 +_,19 @@
  import net.minecraft.util.ByIdMap;
  import net.minecraft.util.StringRepresentable;
  
@@ -12,32 +12,36 @@
      EPIC(3, "epic", ChatFormatting.LIGHT_PURPLE);
  
 -    public static final Codec<Rarity> CODEC = StringRepresentable.fromValues(Rarity::values);
++    private static final java.util.Map<String, Rarity> BY_NAME = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(rarity -> rarity.name, rarity -> rarity));
++    private static final java.util.Map<Rarity, String> BY_RARITY = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(rarity -> rarity, rarity -> rarity.name));
++
 +    public static final Codec<Rarity> CODEC = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(Rarity::values, Rarity::byName);
      public static final IntFunction<Rarity> BY_ID = ByIdMap.continuous(p_328775_ -> p_328775_.id, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
 -    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, p_330010_ -> p_330010_.id);
-+    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = net.minecraftforge.common.IExtensibleEnum.createStreamCodecForExtensibleEnum(Rarity::values);
-+    private static final java.util.Map<String, Rarity> BY_NAME = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(Rarity::getName, rarity -> rarity));
++    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = net.minecraftforge.common.IExtensibleEnum.createStreamCodecForExtensibleEnum(BY_NAME, BY_RARITY);
++
      private final int id;
      private final String name;
      private final ChatFormatting color;
-@@ -35,5 +_,23 @@
+@@ -35,5 +_,24 @@
      @Override
      public String getSerializedName() {
          return this.name;
 +    }
 +
-+    public static Rarity create(final String EnumName, final int id, final String name, final ChatFormatting chatFormatting) {
-+        throw new IllegalStateException("Enum not extended");
++    public static Rarity createRarity(final String name, final int id, final ChatFormatting chatFormatting) {
++        return create(name.toUpperCase(), id, name.toLowerCase(), chatFormatting);
 +    }
 +
-+    public String getName() {
-+        return name;
++    public static Rarity create(final String name, final int id, String lowerCaseNName, final ChatFormatting chatFormatting) {
++        throw new IllegalStateException("Enum not extended");
 +    }
 +
 +    @Override
 +    @Deprecated
 +    public void init() {
-+        BY_NAME.put(this.getName(), this);
++        BY_NAME.put(getSerializedName(), this);
++        BY_RARITY.put(this, getSerializedName());
 +    }
 +
 +    public static Rarity byName(String name) {

--- a/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Rarity.java.patch
@@ -1,50 +1,11 @@
 --- a/net/minecraft/world/item/Rarity.java
 +++ b/net/minecraft/world/item/Rarity.java
-@@ -9,15 +_,19 @@
+@@ -9,7 +_,7 @@
  import net.minecraft.util.ByIdMap;
  import net.minecraft.util.StringRepresentable;
  
 -public enum Rarity implements StringRepresentable {
-+public enum Rarity implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
++public enum Rarity implements StringRepresentable, net.minecraftforge.items.IForgeRarity {
      COMMON(0, "common", ChatFormatting.WHITE),
      UNCOMMON(1, "uncommon", ChatFormatting.YELLOW),
      RARE(2, "rare", ChatFormatting.AQUA),
-     EPIC(3, "epic", ChatFormatting.LIGHT_PURPLE);
- 
--    public static final Codec<Rarity> CODEC = StringRepresentable.fromValues(Rarity::values);
-+    private static final java.util.Map<String, Rarity> BY_NAME = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(rarity -> rarity.name, rarity -> rarity));
-+    private static final java.util.Map<Rarity, String> BY_RARITY = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(rarity -> rarity, rarity -> rarity.name));
-+
-+    public static final Codec<Rarity> CODEC = net.minecraftforge.common.IExtensibleEnum.createCodecForExtensibleEnum(Rarity::values, Rarity::byName);
-     public static final IntFunction<Rarity> BY_ID = ByIdMap.continuous(p_328775_ -> p_328775_.id, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
--    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, p_330010_ -> p_330010_.id);
-+    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = net.minecraftforge.common.IExtensibleEnum.createStreamCodecForExtensibleEnum(BY_NAME, BY_RARITY);
-+
-     private final int id;
-     private final String name;
-     private final ChatFormatting color;
-@@ -35,5 +_,24 @@
-     @Override
-     public String getSerializedName() {
-         return this.name;
-+    }
-+
-+    public static Rarity createRarity(final String name, final int id, final ChatFormatting chatFormatting) {
-+        return create(name.toUpperCase(), id, name.toLowerCase(), chatFormatting);
-+    }
-+
-+    public static Rarity create(final String name, final int id, String lowerCaseNName, final ChatFormatting chatFormatting) {
-+        throw new IllegalStateException("Enum not extended");
-+    }
-+
-+    @Override
-+    @Deprecated
-+    public void init() {
-+        BY_NAME.put(getSerializedName(), this);
-+        BY_RARITY.put(this, getSerializedName());
-+    }
-+
-+    public static Rarity byName(String name) {
-+        return BY_NAME.get(name);
-     }
- }

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -362,13 +362,13 @@ public class ForgeMod {
     public static final RegistryObject<Fluid> FLOWING_MILK = RegistryObject.create(new ResourceLocation("flowing_milk"), ForgeRegistries.FLUIDS);
 
     public static DeferredRegister<DataComponentType<?>> component() {
-        var a = DeferredRegister.create(ForgeRegistries.DATA_COMPONENT_TYPES.get(), "forge");
+        var a = DeferredRegister.create(ForgeRegistries.DATA_COMPONENT_TYPES, "forge");
         registries.add(a);
         return a;
     }
     public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = component();
 
-    public static final RegistryObject<DataComponentType<IForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("rarity", () -> {
+    public static final RegistryObject<DataComponentType<IForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("forge_rarity", () -> {
         return DataComponentType.<IForgeRarity>builder().persistent(ForgeRarity.RARITY_CODEC).networkSynchronized(ForgeRarity.STREAM_CODEC).build();
     });
 

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -70,6 +70,7 @@ import net.minecraftforge.fml.*;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.*;
 import net.minecraftforge.items.ForgeRarity;
+import net.minecraftforge.items.IForgeRarity;
 import net.minecraftforge.registries.*;
 import net.minecraftforge.registries.holdersets.AndHolderSet;
 import net.minecraftforge.registries.holdersets.AnyHolderSet;
@@ -361,8 +362,8 @@ public class ForgeMod {
     public static final RegistryObject<Fluid> FLOWING_MILK = RegistryObject.create(new ResourceLocation("flowing_milk"), ForgeRegistries.FLUIDS);
 
     public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = deferred(Registries.DATA_COMPONENT_TYPE);
-    public static final RegistryObject<DataComponentType<ForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("forge_rarity", () -> {
-        return DataComponentType.<ForgeRarity>builder().persistent(ForgeRarity.RARITY_CODEC).networkSynchronized(ForgeRarity.STREAM_CODEC).build();
+    public static final RegistryObject<DataComponentType<IForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("forge_rarity", () -> {
+        return DataComponentType.<IForgeRarity>builder().persistent(ForgeRarity.RARITY_CODEC).networkSynchronized(ForgeRarity.STREAM_CODEC).build();
     });
 
     /*

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -14,6 +14,9 @@ import net.minecraft.commands.synchronization.SingletonArgumentInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
@@ -66,6 +69,7 @@ import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.*;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.*;
+import net.minecraftforge.items.ForgeRarity;
 import net.minecraftforge.registries.*;
 import net.minecraftforge.registries.holdersets.AndHolderSet;
 import net.minecraftforge.registries.holdersets.AnyHolderSet;
@@ -355,6 +359,11 @@ public class ForgeMod {
     public static final RegistryObject<FluidType> MILK_TYPE = RegistryObject.createOptional(new ResourceLocation("milk"), ForgeRegistries.Keys.FLUID_TYPES.location(), "minecraft");
     public static final RegistryObject<Fluid> MILK = RegistryObject.create(new ResourceLocation("milk"), ForgeRegistries.FLUIDS);
     public static final RegistryObject<Fluid> FLOWING_MILK = RegistryObject.create(new ResourceLocation("flowing_milk"), ForgeRegistries.FLUIDS);
+
+    public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = deferred(Registries.DATA_COMPONENT_TYPE);
+    public static final RegistryObject<DataComponentType<ForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("forge_rarity", () -> {
+        return DataComponentType.<ForgeRarity>builder().persistent(ForgeRarity.RARITY_CODEC).networkSynchronized(ForgeRarity.STREAM_CODEC).build();
+    });
 
     /*
     private static final ChatTypeDecoration SYSTEM_CHAT_TYPE_DECORATION = new ChatTypeDecoration("forge.chatType.system", List.of(ChatTypeDecoration.Parameter.CONTENT), Style.EMPTY);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -361,8 +361,14 @@ public class ForgeMod {
     public static final RegistryObject<Fluid> MILK = RegistryObject.create(new ResourceLocation("milk"), ForgeRegistries.FLUIDS);
     public static final RegistryObject<Fluid> FLOWING_MILK = RegistryObject.create(new ResourceLocation("flowing_milk"), ForgeRegistries.FLUIDS);
 
-    public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = deferred(Registries.DATA_COMPONENT_TYPE);
-    public static final RegistryObject<DataComponentType<IForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("forge_rarity", () -> {
+    public static DeferredRegister<DataComponentType<?>> component() {
+        var a = DeferredRegister.create(ForgeRegistries.DATA_COMPONENT_TYPES.get(), "forge");
+        registries.add(a);
+        return a;
+    }
+    public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = component();
+
+    public static final RegistryObject<DataComponentType<IForgeRarity>> FORGE_RARITY_COMPONENT = DATA_COMPONENT_TYPES.register("rarity", () -> {
         return DataComponentType.<IForgeRarity>builder().persistent(ForgeRarity.RARITY_CODEC).networkSynchronized(ForgeRarity.STREAM_CODEC).build();
     });
 

--- a/src/main/java/net/minecraftforge/common/ForgeTier.java
+++ b/src/main/java/net/minecraftforge/common/ForgeTier.java
@@ -18,42 +18,6 @@ import java.util.function.Supplier;
  */
 @SuppressWarnings("ClassCanBeRecord") // can't make it a record because the method names will be obfuscated
 public final class ForgeTier implements Tier {
-
-    public static Tier createTier(TagKey<Block> incorrectBlocks, int uses, int speed, float attackDamageBonus, int enchantmentValue, Supplier<Ingredient> repairIngredient) {
-        return new Tier() {
-            @Override
-            public int getUses() {
-                return uses;
-            }
-
-            @Override
-            public float getSpeed() {
-                return speed;
-            }
-
-            @Override
-            public float getAttackDamageBonus() {
-                return attackDamageBonus;
-            }
-
-            @Override
-            public TagKey<Block> getIncorrectBlocksForDrops() {
-                return incorrectBlocks;
-            }
-
-            @Override
-            public int getEnchantmentValue() {
-                return enchantmentValue;
-            }
-
-            @Override
-            public Ingredient getRepairIngredient() {
-                return repairIngredient.get();
-            }
-        };
-    }
-
-
     private final int uses;
     private final float speed;
     private final float attackDamageBonus;

--- a/src/main/java/net/minecraftforge/common/ForgeTier.java
+++ b/src/main/java/net/minecraftforge/common/ForgeTier.java
@@ -18,6 +18,42 @@ import java.util.function.Supplier;
  */
 @SuppressWarnings("ClassCanBeRecord") // can't make it a record because the method names will be obfuscated
 public final class ForgeTier implements Tier {
+
+    public static Tier createTier(TagKey<Block> incorrectBlocks, int uses, int speed, float attackDamageBonus, int enchantmentValue, Supplier<Ingredient> repairIngredient) {
+        return new Tier() {
+            @Override
+            public int getUses() {
+                return uses;
+            }
+
+            @Override
+            public float getSpeed() {
+                return speed;
+            }
+
+            @Override
+            public float getAttackDamageBonus() {
+                return attackDamageBonus;
+            }
+
+            @Override
+            public TagKey<Block> getIncorrectBlocksForDrops() {
+                return incorrectBlocks;
+            }
+
+            @Override
+            public int getEnchantmentValue() {
+                return enchantmentValue;
+            }
+
+            @Override
+            public Ingredient getRepairIngredient() {
+                return repairIngredient.get();
+            }
+        };
+    }
+
+
     private final int uses;
     private final float speed;
     private final float attackDamageBonus;

--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -8,10 +8,15 @@ package net.minecraftforge.common;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.StringRepresentable;
 
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 /**
  * To be implemented on vanilla enums that should be enhanced with ASM to be
@@ -58,5 +63,13 @@ public interface IExtensibleEnum {
                 ),
                 value -> Either.left(value.getSerializedName())
         );
+    }
+
+    /**
+     * Use this instead of {@link ByteBufCodecs#idMapper(IntFunction, ToIntFunction)} for extensible enums
+     * because this will not cache the enum values on construction
+     */
+    static <E extends Enum<E> & StringRepresentable> StreamCodec<ByteBuf, E> createStreamCodecForExtensibleEnum(Supplier<E[]> valuesSupplier) {
+        return ByteBufCodecs.VAR_INT.map(i -> valuesSupplier.get()[i], Enum::ordinal);
     }
 }

--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -12,7 +12,9 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.item.Rarity;
 
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
@@ -69,7 +71,8 @@ public interface IExtensibleEnum {
      * Use this instead of {@link ByteBufCodecs#idMapper(IntFunction, ToIntFunction)} for extensible enums
      * because this will not cache the enum values on construction
      */
-    static <E extends Enum<E> & StringRepresentable> StreamCodec<ByteBuf, E> createStreamCodecForExtensibleEnum(Supplier<E[]> valuesSupplier) {
-        return ByteBufCodecs.VAR_INT.map(i -> valuesSupplier.get()[i], Enum::ordinal);
+    static <E extends Enum<E> & StringRepresentable> StreamCodec<ByteBuf, E> createStreamCodecForExtensibleEnum(Map<String, E> BY_NAME, Map<E, String> BY_RARITY) {
+        return ByteBufCodecs.STRING_UTF8.map(BY_NAME::get, BY_RARITY::get);
+        //return ByteBufCodecs.VAR_INT.map(i -> valuesSupplier.get()[i], Enum::ordinal);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -26,8 +26,10 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.items.IForgeRarity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -426,5 +428,12 @@ public interface IForgeItemStack {
      */
     default boolean canGrindstoneRepair() {
         return self().getItem().canGrindstoneRepair(self());
+    }
+
+    default IForgeRarity getForgeRarity() {
+        var forgeRarity = self().get(ForgeMod.FORGE_RARITY_COMPONENT.get());
+        if (forgeRarity != null)
+            return forgeRarity;
+        return self().getRarity();
     }
 }

--- a/src/main/java/net/minecraftforge/items/ForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/ForgeRarity.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.items;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public record ForgeRarity(ChatFormatting color) implements IForgeRarity {
+    public static final StreamCodec<RegistryFriendlyByteBuf, ForgeRarity> STREAM_CODEC = ByteBufCodecs.registry(ForgeRegistries.Keys.FORGE_RARITY);
+    public static final Codec<ForgeRarity> RARITY_CODEC = ForgeRegistries.FORGE_RARITY.get().getCodec();
+}

--- a/src/main/java/net/minecraftforge/items/ForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/ForgeRarity.java
@@ -5,9 +5,17 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Rarity;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public record ForgeRarity(ChatFormatting color) implements IForgeRarity {
     public static final Codec<IForgeRarity> RARITY_CODEC = ForgeRegistries.FORGE_RARITY.get().getCodec();
     public static final StreamCodec<RegistryFriendlyByteBuf, IForgeRarity> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(RARITY_CODEC);
+
+    static {
+        for (Rarity rarity : Rarity.values()) {
+            ForgeRegistries.FORGE_RARITY.get().register(new ResourceLocation("minecraft", rarity.getSerializedName()), rarity);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/items/ForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/ForgeRarity.java
@@ -8,6 +8,6 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public record ForgeRarity(ChatFormatting color) implements IForgeRarity {
-    public static final Codec<ForgeRarity> RARITY_CODEC = ForgeRegistries.FORGE_RARITY.get().getCodec();
-    public static final StreamCodec<RegistryFriendlyByteBuf, ForgeRarity> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(RARITY_CODEC);
+    public static final Codec<IForgeRarity> RARITY_CODEC = ForgeRegistries.FORGE_RARITY.get().getCodec();
+    public static final StreamCodec<RegistryFriendlyByteBuf, IForgeRarity> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(RARITY_CODEC);
 }

--- a/src/main/java/net/minecraftforge/items/ForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/ForgeRarity.java
@@ -8,6 +8,6 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public record ForgeRarity(ChatFormatting color) implements IForgeRarity {
-    public static final StreamCodec<RegistryFriendlyByteBuf, ForgeRarity> STREAM_CODEC = ByteBufCodecs.registry(ForgeRegistries.Keys.FORGE_RARITY);
     public static final Codec<ForgeRarity> RARITY_CODEC = ForgeRegistries.FORGE_RARITY.get().getCodec();
+    public static final StreamCodec<RegistryFriendlyByteBuf, ForgeRarity> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(RARITY_CODEC);
 }

--- a/src/main/java/net/minecraftforge/items/IForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/IForgeRarity.java
@@ -4,9 +4,25 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.Rarity;
 import org.jetbrains.annotations.ApiStatus;
 
-public interface IForgeRarity {
-    ChatFormatting color();
+import java.util.function.Supplier;
 
+public interface IForgeRarity {
+
+    static IForgeRarity wrapper(Supplier<IForgeRarity> forgeRaritySupplier) {
+        return new IForgeRarity() {
+            @Override
+            public ChatFormatting color() {
+                return forgeRaritySupplier.get().color();
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return forgeRaritySupplier.get().equals(obj);
+            }
+        };
+    }
+
+    ChatFormatting color();
 
     @ApiStatus.Internal
     default boolean isModded() {

--- a/src/main/java/net/minecraftforge/items/IForgeRarity.java
+++ b/src/main/java/net/minecraftforge/items/IForgeRarity.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.items;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.item.Rarity;
+import org.jetbrains.annotations.ApiStatus;
+
+public interface IForgeRarity {
+    ChatFormatting color();
+
+
+    @ApiStatus.Internal
+    default boolean isModded() {
+        return getClass() != Rarity.class;
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -9,6 +9,7 @@ import com.mojang.serialization.MapCodec;
 
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import net.minecraft.world.item.ItemDisplayContext;
@@ -78,7 +79,7 @@ public class ForgeRegistries {
     // Game objects
     public static final IForgeRegistry<Block> BLOCKS = active(Keys.BLOCKS);
     public static final IForgeRegistry<Fluid> FLUIDS = active(Keys.FLUIDS);
-    public static final Supplier<IForgeRegistry<DataComponentType<?>>> DATA_COMPONENT_TYPES = registry(Keys.DATA_COMPONENT_TYPE, () -> RegistryBuilder.<DataComponentType<?>>of().hasWrapper());
+    public static final IForgeRegistry<DataComponentType<?>> DATA_COMPONENT_TYPES = active(Keys.DATA_COMPONENT_TYPE);
     public static final IForgeRegistry<Item> ITEMS = active(Keys.ITEMS);
     public static final IForgeRegistry<MobEffect> MOB_EFFECTS = active(Keys.MOB_EFFECTS);
     public static final IForgeRegistry<SoundEvent> SOUND_EVENTS = active(Keys.SOUND_EVENTS);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -50,6 +50,8 @@ import net.minecraftforge.common.crafting.ingredients.IIngredientSerializer;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.world.BiomeModifier;
 import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.items.ForgeRarity;
+import net.minecraftforge.items.IForgeRarity;
 import net.minecraftforge.registries.holdersets.HolderSetType;
 
 import java.util.ArrayList;
@@ -122,6 +124,7 @@ public class ForgeRegistries {
     public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = registry(Keys.DISPLAY_CONTEXTS, GameData::getItemDisplayContextRegistryBuilder);
     public static final Supplier<IForgeRegistry<MapCodec<? extends ICondition>>> CONDITION_SERIALIZERS = registry(Keys.CONDITION_SERIALIZERS, GameData::makeUnsavedAndUnsynced);
     public static final Supplier<IForgeRegistry<IIngredientSerializer<?>>> INGREDIENT_SERIALIZERS = registry(Keys.INGREDIENT_SERIALIZERS, GameData::makeUnsavedAndUnsynced);
+    public static final Supplier<IForgeRegistry<ForgeRarity>> FORGE_RARITY = registry(Keys.FORGE_RARITY, GameData::makeUnsavedAndUnsynced);
 
     public static final class Keys {
         //Vanilla
@@ -168,6 +171,7 @@ public class ForgeRegistries {
         public static final ResourceKey<Registry<ItemDisplayContext>> DISPLAY_CONTEXTS = key("forge:display_contexts");
         public static final ResourceKey<Registry<MapCodec<? extends ICondition>>> CONDITION_SERIALIZERS = key("forge:condition_codecs");
         public static final ResourceKey<Registry<IIngredientSerializer<?>>> INGREDIENT_SERIALIZERS = key("forge:ingredient_serializers");
+        public static final ResourceKey<Registry<ForgeRarity>> FORGE_RARITY = key("forge:rarity_type");
 
         // Forge Dynamic
         public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIERS = key("forge:biome_modifier");

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -124,7 +124,7 @@ public class ForgeRegistries {
     public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = registry(Keys.DISPLAY_CONTEXTS, GameData::getItemDisplayContextRegistryBuilder);
     public static final Supplier<IForgeRegistry<MapCodec<? extends ICondition>>> CONDITION_SERIALIZERS = registry(Keys.CONDITION_SERIALIZERS, GameData::makeUnsavedAndUnsynced);
     public static final Supplier<IForgeRegistry<IIngredientSerializer<?>>> INGREDIENT_SERIALIZERS = registry(Keys.INGREDIENT_SERIALIZERS, GameData::makeUnsavedAndUnsynced);
-    public static final Supplier<IForgeRegistry<ForgeRarity>> FORGE_RARITY = registry(Keys.FORGE_RARITY, GameData::makeUnsavedAndUnsynced);
+    public static final Supplier<IForgeRegistry<IForgeRarity>> FORGE_RARITY = registry(Keys.FORGE_RARITY, GameData::makeUnsavedAndUnsynced);
 
     public static final class Keys {
         //Vanilla
@@ -171,7 +171,7 @@ public class ForgeRegistries {
         public static final ResourceKey<Registry<ItemDisplayContext>> DISPLAY_CONTEXTS = key("forge:display_contexts");
         public static final ResourceKey<Registry<MapCodec<? extends ICondition>>> CONDITION_SERIALIZERS = key("forge:condition_codecs");
         public static final ResourceKey<Registry<IIngredientSerializer<?>>> INGREDIENT_SERIALIZERS = key("forge:ingredient_serializers");
-        public static final ResourceKey<Registry<ForgeRarity>> FORGE_RARITY = key("forge:rarity_type");
+        public static final ResourceKey<Registry<IForgeRarity>> FORGE_RARITY = key("forge:rarity_type");
 
         // Forge Dynamic
         public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIERS = key("forge:biome_modifier");

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -5,10 +5,10 @@
 
 package net.minecraftforge.registries;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import net.minecraft.world.item.ItemDisplayContext;
@@ -50,7 +50,6 @@ import net.minecraftforge.common.crafting.ingredients.IIngredientSerializer;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.world.BiomeModifier;
 import net.minecraftforge.fluids.FluidType;
-import net.minecraftforge.items.ForgeRarity;
 import net.minecraftforge.items.IForgeRarity;
 import net.minecraftforge.registries.holdersets.HolderSetType;
 
@@ -79,6 +78,7 @@ public class ForgeRegistries {
     // Game objects
     public static final IForgeRegistry<Block> BLOCKS = active(Keys.BLOCKS);
     public static final IForgeRegistry<Fluid> FLUIDS = active(Keys.FLUIDS);
+    public static final Supplier<IForgeRegistry<DataComponentType<?>>> DATA_COMPONENT_TYPES = registry(Keys.DATA_COMPONENT_TYPE, () -> RegistryBuilder.<DataComponentType<?>>of().hasWrapper());
     public static final IForgeRegistry<Item> ITEMS = active(Keys.ITEMS);
     public static final IForgeRegistry<MobEffect> MOB_EFFECTS = active(Keys.MOB_EFFECTS);
     public static final IForgeRegistry<SoundEvent> SOUND_EVENTS = active(Keys.SOUND_EVENTS);
@@ -131,6 +131,7 @@ public class ForgeRegistries {
         public static final ResourceKey<Registry<Block>>  BLOCKS  = key("block");
         public static final ResourceKey<Registry<Fluid>>  FLUIDS  = key("fluid");
         public static final ResourceKey<Registry<Item>>   ITEMS   = key("item");
+        public static final ResourceKey<Registry<DataComponentType<?>>> DATA_COMPONENT_TYPE = key("data_component_type");
         public static final ResourceKey<Registry<MobEffect>> MOB_EFFECTS = key("mob_effect");
         public static final ResourceKey<Registry<Potion>> POTIONS = key("potion");
         public static final ResourceKey<Registry<Attribute>> ATTRIBUTES = key("attribute");

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -32,7 +32,9 @@ import net.minecraft.core.IdMapper;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.core.WritableRegistry;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -109,6 +111,7 @@ public class GameData {
 
         // Game objects
         makeRegistry(Keys.BLOCKS, "air").addCallback(BlockCallbacks.INSTANCE).legacyName("blocks").intrusiveHolderCallback(Block::builtInRegistryHolder).create();
+        makeRegistry(Keys.DATA_COMPONENT_TYPE).create();
         makeRegistry(Keys.FLUIDS, "empty").intrusiveHolderCallback(Fluid::builtInRegistryHolder).create();
         makeRegistry(Keys.ITEMS, "air").addCallback(ItemCallbacks.INSTANCE).legacyName("items").intrusiveHolderCallback(Item::builtInRegistryHolder).create();
         makeRegistry(Keys.MOB_EFFECTS).create();
@@ -167,6 +170,10 @@ public class GameData {
             .setMaxID(128 * 2) /* 0 -> 127 gets positive ID, 128 -> 256 gets negative ID */.disableOverrides().disableSaving()
             .setDefaultKey(new ResourceLocation("minecraft:none"))
             .onAdd(ItemDisplayContext.ADD_CALLBACK);
+    }
+
+    static RegistryBuilder<DataComponentType<?>> getDataComponentRegistryBuilder() {
+        return makeRegistry(Registries.DATA_COMPONENT_TYPE);
     }
 
     private static <T> RegistryBuilder<T> makeRegistry(ResourceKey<? extends Registry<T>> key) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -4,6 +4,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Rarity;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.items.ForgeRarity;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -14,8 +15,9 @@ public class RarityTest extends BaseTestMod {
     static final String MOD_ID = "raritytest";
 
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+    public static final DeferredRegister<ForgeRarity> RARITIES = DeferredRegister.create(ForgeRegistries.FORGE_RARITY, MOD_ID);
 
-    public static final Rarity CUSTOM = Rarity.createRarity("LEGENDARY", 4, ChatFormatting.GOLD);
+    public static final RegistryObject<ForgeRarity> LEGENDARY = RARITIES.register("legendary", () -> new ForgeRarity(ChatFormatting.GOLD));
 
-    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().rarity(CUSTOM)));
+    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().rarity(LEGENDARY.get())));
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -3,6 +3,7 @@ package net.minecraftforge.debug.gameplay.item;
 import net.minecraft.ChatFormatting;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.fml.common.Mod;
@@ -22,7 +23,8 @@ public class RarityTest extends BaseTestMod {
 
     public static final RegistryObject<ForgeRarity> LEGENDARY = RARITIES.register("legendary", () -> new ForgeRarity(ChatFormatting.GOLD));
 
-    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new TestItem(new Item.Properties().rarity(() -> LEGENDARY.get())));
+    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new TestItem(new Item.Properties().rarity(LEGENDARY::get)));
+    public static final RegistryObject<Item> TEST_ITEM_2 = ITEMS.register("test2", () -> new Item(new Item.Properties().rarity(() -> Rarity.UNCOMMON)));
 
 
     public static class TestItem extends Item {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -1,14 +1,15 @@
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.Registry;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ForgeRarity;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.GameData;
-import net.minecraftforge.registries.IForgeRegistry;
-import net.minecraftforge.registries.RegistryBuilder;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;
 
@@ -23,5 +24,22 @@ public class RarityTest extends BaseTestMod {
 
     public static final RegistryObject<ForgeRarity> LEGENDARY = RARITIES.register("legendary", () -> new ForgeRarity(ChatFormatting.GOLD));
 
-    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().rarity(LEGENDARY.get())));
+    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new TestItem(new Item.Properties()));
+
+
+    public static class TestItem extends Item {
+
+        public TestItem(Properties p_41383_) {
+            super(p_41383_);
+        }
+
+        @Override
+        public InteractionResult useOn(UseOnContext p_41427_) {
+            var lvl = p_41427_.getLevel();
+            if (!lvl.isClientSide()) {
+                p_41427_.getItemInHand().set(ForgeMod.FORGE_RARITY_COMPONENT.get(), LEGENDARY.get());
+            }
+            return super.useOn(p_41427_);
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -2,13 +2,17 @@ package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.Rarity;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ForgeRarity;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.GameData;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryBuilder;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;
+
+import java.util.function.Supplier;
 
 @Mod(RarityTest.MOD_ID)
 public class RarityTest extends BaseTestMod {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -1,30 +1,28 @@
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.Registry;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ForgeRarity;
+import net.minecraftforge.items.IForgeRarity;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;
-
-import java.util.function.Supplier;
 
 @Mod(RarityTest.MOD_ID)
 public class RarityTest extends BaseTestMod {
     static final String MOD_ID = "raritytest";
 
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
-    public static final DeferredRegister<ForgeRarity> RARITIES = DeferredRegister.create(ForgeRegistries.FORGE_RARITY, MOD_ID);
+    public static final DeferredRegister<IForgeRarity> RARITIES = DeferredRegister.create(ForgeRegistries.FORGE_RARITY, MOD_ID);
 
     public static final RegistryObject<ForgeRarity> LEGENDARY = RARITIES.register("legendary", () -> new ForgeRarity(ChatFormatting.GOLD));
 
-    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new TestItem(new Item.Properties()));
+    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new TestItem(new Item.Properties().rarity(() -> LEGENDARY.get())));
 
 
     public static class TestItem extends Item {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.debug.gameplay.item;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.test.BaseTestMod;
+
+@Mod(RarityTest.MOD_ID)
+public class RarityTest extends BaseTestMod {
+    static final String MOD_ID = "raritytest";
+
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+
+    public static final Rarity CUSTOM = Rarity.create("LEGENDARY", 4, "legendary", ChatFormatting.GOLD);
+
+    public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().rarity(CUSTOM)));
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/RarityTest.java
@@ -15,7 +15,7 @@ public class RarityTest extends BaseTestMod {
 
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
 
-    public static final Rarity CUSTOM = Rarity.create("LEGENDARY", 4, "legendary", ChatFormatting.GOLD);
+    public static final Rarity CUSTOM = Rarity.createRarity("LEGENDARY", 4, ChatFormatting.GOLD);
 
     public static final RegistryObject<Item> TEST_ITEM = ITEMS.register("test", () -> new Item(new Item.Properties().rarity(CUSTOM)));
 }


### PR DESCRIPTION
This will allow Rarity to be extensible once again. 

Will do seperate PR for 1.21.

Does not appear to be needed to be added back for older versions.

We make it extensible by having our own DataComponentType and custom Registries.