### PR TITLE
[1.20.1] Choose default JarJar mod file type based on parent JAR

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -34,6 +34,10 @@ public abstract class AbstractModProvider implements IModProvider
     protected static final String MANIFEST = "META-INF/MANIFEST.MF";
 
     protected IModLocator.ModFileOrException createMod(Path... path) {
+        return this.createMod(getDefaultJarModType(), path);
+    }
+
+    protected IModLocator.ModFileOrException createMod(String defaultType, Path... path) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(
                 Manifest::new,
@@ -45,7 +49,7 @@ public abstract class AbstractModProvider implements IModProvider
         IModFile mod;
         var type = sj.moduleDataProvider().getManifest().getMainAttributes().getValue(ModFile.TYPE);
         if (type == null) {
-            type = getDefaultJarModType();
+            type = defaultType;
         }
         if (sj.moduleDataProvider().findFile(MODS_TOML).isPresent()) {
             LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -37,6 +37,7 @@ public abstract class AbstractModProvider implements IModProvider
         return this.createMod(getDefaultJarModType(), path);
     }
 
+    // FORGE: Backporting artifact, the defaultType must be the first parameter since path is varargs
     protected IModLocator.ModFileOrException createMod(String defaultType, Path... path) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -81,7 +81,14 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
             final Map<String, ?> outerFsArgs = ImmutableMap.of("packagePath", pathInModFile);
             final FileSystem zipFS = FileSystems.newFileSystem(filePathUri, outerFsArgs);
             final Path pathInFS = zipFS.getPath("/");
-            return Optional.of(createMod(pathInFS).file());
+            final IModFile.Type parentType = file.getType();
+            final String modType;
+            if (parentType == IModFile.Type.LIBRARY || parentType == IModFile.Type.LANGPROVIDER) {
+                modType = IModFile.Type.LIBRARY.name();
+            } else {
+                modType = IModFile.Type.GAMELIBRARY.name();
+            }
+            return Optional.of(createMod(modType, pathInFS).file());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Implements #9939 and 06336a40d879d54e0646f97d8748acfc785ddcc6, which fixes #8878, on 1.20.1.