### PR TITLE
[1.18.2] Choose default JarJar mod file type based on parent JAR

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
@@ -34,6 +34,7 @@ public abstract class AbstractModLocator implements IModLocator
         return this.createMod(getDefaultJarModType(), path);
     }
 
+    // FORGE: Backporting artifact, the defaultType must be the first parameter since path is varargs
     protected Optional<IModFile> createMod(String defaultType, Path... path) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModLocator.java
@@ -31,6 +31,10 @@ public abstract class AbstractModLocator implements IModLocator
     protected static final String MANIFEST = "META-INF/MANIFEST.MF";
 
     protected Optional<IModFile> createMod(Path... path) {
+        return this.createMod(getDefaultJarModType(), path);
+    }
+
+    protected Optional<IModFile> createMod(String defaultType, Path... path) {
         var mjm = new ModJarMetadata();
         var sj = SecureJar.from(
                 Manifest::new,
@@ -42,7 +46,7 @@ public abstract class AbstractModLocator implements IModLocator
         IModFile mod;
         var type = sj.getManifest().getMainAttributes().getValue(ModFile.TYPE);
         if (type == null) {
-            type = getDefaultJarModType();
+            type = defaultType;
         }
         if (sj.findFile(MODS_TOML).isPresent()) {
             LOGGER.debug(LogMarkers.SCAN, "Found {} mod of type {}: {}", MODS_TOML, type, path);

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -81,7 +81,14 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
             final Map<String, ?> outerFsArgs = ImmutableMap.of("packagePath", pathInModFile);
             final FileSystem zipFS = FileSystems.newFileSystem(filePathUri, outerFsArgs);
             final Path pathInFS = zipFS.getPath("/");
-            return createMod(pathInFS);
+            final IModFile.Type parentType = file.getType();
+            final String modType;
+            if (parentType == IModFile.Type.LIBRARY || parentType == IModFile.Type.LANGPROVIDER) {
+                modType = IModFile.Type.LIBRARY.name();
+            } else {
+                modType = IModFile.Type.GAMELIBRARY.name();
+            }
+            return createMod(modType, pathInFS);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Implements #9939 and 06336a40d879d54e0646f97d8748acfc785ddcc6, which fixes #8878, on 1.18.2.