### PR TITLE
[1.21] Fix compile errors in MDK

### DIFF
--- a/mdk/src/main/java/com/example/examplemod/Config.java
+++ b/mdk/src/main/java/com/example/examplemod/Config.java
@@ -46,7 +46,7 @@ public class Config
 
     private static boolean validateItemName(final Object obj)
     {
-        return obj instanceof final String itemName && ForgeRegistries.ITEMS.containsKey(new ResourceLocation(itemName));
+        return obj instanceof final String itemName && ForgeRegistries.ITEMS.containsKey(ResourceLocation.tryParse(itemName));
     }
 
     @SubscribeEvent
@@ -58,7 +58,7 @@ public class Config
 
         // convert the list of strings into a set of items
         items = ITEM_STRINGS.get().stream()
-                .map(itemName -> ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName)))
+                .map(itemName -> ForgeRegistries.ITEMS.getValue(ResourceLocation.tryParse(itemName)))
                 .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
MDK was using `new ResourceLocation(...)` which is now private. Replaced with `ResourceLocation.tryParse(...)`.