### PR TITLE
[1.19.x] Unlock wrapped registries when firing register events.

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -790,11 +790,17 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
     public void freeze()
     {
         this.isFrozen = true;
+        var wrapper = this.getWrapper();
+        if (wrapper != null)
+            wrapper.locked = true;
     }
 
     public void unfreeze()
     {
         this.isFrozen = false;
+        var wrapper = this.getWrapper();
+        if (wrapper != null)
+            wrapper.locked = false;
     }
 
     void dump(ResourceLocation name)


### PR DESCRIPTION
Backport of f22894c for 1.19.x