### PR TITLE
Extensible HangingSignBlockEntity for 1.20.1

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
-@@ -10,6 +_,7 @@
+@@ -10,6 +_,10 @@
     public HangingSignBlockEntity(BlockPos p_250603_, BlockState p_251674_) {
        super(BlockEntityType.f_244529_, p_250603_, p_251674_);
     }
-+   public HangingSignBlockEntity(BlockEntityType type, BlockPos pos, BlockState state) {super(type, pos, state);}
++   
++   public HangingSignBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
++      super(type, pos, state);
++   }
  
     public int m_245065_() {
        return 9;

--- a/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
@@ -1,0 +1,8 @@
+--- a/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
+@@ -13,1 +_,5 @@
+    
++    public HangingSignBlockEntity(BlockEntityType type, BlockPos pos, BlockState state) {
++        super(type, pos, state);
++    }
++

--- a/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java.patch
@@ -1,8 +1,10 @@
 --- a/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HangingSignBlockEntity.java
-@@ -13,1 +_,5 @@
-    
-+    public HangingSignBlockEntity(BlockEntityType type, BlockPos pos, BlockState state) {
-+        super(type, pos, state);
-+    }
-+
+@@ -10,6 +_,7 @@
+    public HangingSignBlockEntity(BlockPos p_250603_, BlockState p_251674_) {
+       super(BlockEntityType.f_244529_, p_250603_, p_251674_);
+    }
++   public HangingSignBlockEntity(BlockEntityType type, BlockPos pos, BlockState state) {super(type, pos, state);}
+ 
+    public int m_245065_() {
+       return 9;


### PR DESCRIPTION
\[duplicate of previous closed pull request [here](https://github.com/MinecraftForge/MinecraftForge/pull/10037), after reviewing the guidelines and following the proper procedure to the best of my knowledge\]
### Description
In the process of developing a mod for Minecraft 1.20.1, I encountered an issue when attempting to add a custom hanging sign type for a wood set. The `HangingSignBlockEntity` class currently hardcodes the `BlockEntityType` in its constructor. To work around this, I extended the `SignBlockEntity` class for my hanging sign block entities. However, this caused issues with GUI rendering, as the rendering code (`LocalPlayer$openTextEdit`) relies on whether the block entity extends `HangingSignBlockEntity` to determine the correct texture to use.

### Proposed Changes
To address this limitation and facilitate easier extension of the `HangingSignBlockEntity` class for future modders, I propose adding a secondary constructor to `HangingSignBlockEntity`. This approach follows the precedent set by the patch to TntBlock.java, which similarly provides methods to enable more natural access to vanilla behaviors. I have also confirmed that adding this constructor should not affect vanilla behavior when no mods are present.

### Notes
This is my first pull request, and I have made every effort to correctly interpret the procedure. I welcome any feedback on errors or areas for improvement.
