### PR TITLE
[1.21] Fix `onPlaceItemIntoWorld` always resetting item stack when in creative mode

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -491,8 +491,7 @@ public final class ForgeHooks {
                 }
             } else {
                 // Change the stack to its new content
-                if (!player.isCreative())
-                    player.setItemInHand(context.getHand(), postUse);
+                player.setItemInHand(context.getHand(), postUse);
 
                 for (BlockSnapshot snap : blockSnapshots) {
                     int updateFlag = snap.getFlag();


### PR DESCRIPTION
Currently, `ForgeHooks#onPlaceItemIntoWorld` always ignores changes made during `Item#useOn` when the player is in creative mode as described in #10046.
This PR fixes the issue by removing the creative mode check and always setting player's held item back to the stack modified by `Item#useOn`. This reverts the behaviour back to the pre-1.20.6 behaviour when the issue was introduced.