### PR TITLE
[1.20.6] Fix `onPlaceItemIntoWorld` always resetting item stack when in creative mode

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -474,7 +474,7 @@ public final class ForgeHooks {
         level.captureBlockSnapshots = false;
 
         if (ret.consumesAction()) {
-            var postUse = itemstack.copy();
+            var postUse = player.getItemInHand(context.getHand());
 
             var blockSnapshots = new ArrayList<>(level.capturedBlockSnapshots);
             level.capturedBlockSnapshots.clear();
@@ -500,8 +500,7 @@ public final class ForgeHooks {
                 }
             } else {
                 // Change the stack to its new content
-                if (!player.isCreative())
-                    player.setItemInHand(context.getHand(), postUse);
+                player.setItemInHand(context.getHand(), postUse);
 
                 for (BlockSnapshot snap : blockSnapshots) {
                     int updateFlag = snap.getFlag();


### PR DESCRIPTION
This is the 1.20.6 version of #10047 fixing the issue described in #10046.

As `ServerPlayerGameMode` and `MultiPlayerGameMode` store a reference to the original stack and reset the size of that stack object afterwards, we need to make sure that we keep the original item stack object rather than a copy of it. This allows the creative mode check later on to be removed, thus resulting in only the stack's size being reset rather than the entire stack when in creative mode.
Again, this reverts the behaviour back to the pre-1.20.6 behaviour.