### PR TITLE
[1.20.6] Fix matrix stack translations for `RenderHighlightEvent`

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -123,13 +123,13 @@
              profilerfiller.popPush("outline");
              BlockPos blockpos1 = ((BlockHitResult)hitresult).getBlockPos();
              BlockState blockstate = this.level.getBlockState(blockpos1);
-+            if (!net.minecraftforge.client.ForgeHooksClient.onDrawHighlight(this, p_109604_, hitresult, p_109601_, p_254120_, multibuffersource$buffersource))
++            if (!net.minecraftforge.client.ForgeHooksClient.onDrawHighlight(this, p_109604_, hitresult, p_109601_, posestack, multibuffersource$buffersource))
              if (!blockstate.isAir() && this.level.getWorldBorder().isWithinBounds(blockpos1)) {
                  VertexConsumer vertexconsumer2 = multibuffersource$buffersource.getBuffer(RenderType.lines());
                  this.renderHitOutline(posestack, vertexconsumer2, p_109604_.getEntity(), d0, d1, d2, blockpos1, blockstate);
              }
 +        } else if (hitresult != null && hitresult.getType() == HitResult.Type.ENTITY) {
-+            net.minecraftforge.client.ForgeHooksClient.onDrawHighlight(this, p_109604_, hitresult, p_109601_, p_254120_, multibuffersource$buffersource);
++            net.minecraftforge.client.ForgeHooksClient.onDrawHighlight(this, p_109604_, hitresult, p_109601_, posestack, multibuffersource$buffersource);
          }
  
          this.minecraft.debugRenderer.render(posestack, multibuffersource$buffersource, d0, d1, d2);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -267,16 +267,6 @@ public class ForgeHooksClient {
         return result != null ? result : layer.texture(inner);
     }
 
-    /**
-     * @deprecated Use the version taking a {@code PoseStack} instead, {@link #onDrawHighlight(LevelRenderer, Camera, HitResult, float, PoseStack, MultiBufferSource)}.
-     */
-    @Deprecated
-    public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, Matrix4f ctxPos, MultiBufferSource bufferSource) {
-        var poseStack = new PoseStack();
-        poseStack.mulPose(ctxPos);
-        return onDrawHighlight(context, camera, target, partialTick, poseStack, bufferSource);
-    }
-
     public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {
         switch (target.getType()) {
             case BLOCK:

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -267,9 +267,17 @@ public class ForgeHooksClient {
         return result != null ? result : layer.texture(inner);
     }
 
+    /**
+     * @deprecated Use the version taking a {@code PoseStack} instead, {@link #onDrawHighlight(LevelRenderer, Camera, HitResult, float, PoseStack, MultiBufferSource)}.
+     */
+    @Deprecated
     public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, Matrix4f ctxPos, MultiBufferSource bufferSource) {
         var poseStack = new PoseStack();
         poseStack.mulPose(ctxPos);
+        return onDrawHighlight(context, camera, target, partialTick, poseStack, bufferSource);
+    }
+
+    public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {
         switch (target.getType()) {
             case BLOCK:
                 if (!(target instanceof BlockHitResult blockTarget)) return false;


### PR DESCRIPTION
This is the 1.20.6 version of #10050.
As described in #10049, the `RenderHighlightEvent`s currently receive a `PoseStack` with the transformations from the model view matrix, rather than the `PoseStack` used for vanilla's highlighting.

This PR changes `ForgeHooksClient#onDrawHighlight` to take a `PoseStack` directly, rather than a `Matrix4f`. The calls to the method have been updated to pass the matrix stack used by vanilla's rendering.
To avoid breaking changes, the old method signature is simply marked as deprecated and redirects to the new method.