### PR TITLE
[1.20.1] Add a way to render tooltips from Formatted text and TooltipComponents elements

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiGraphics.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiGraphics.java.patch
@@ -92,7 +92,7 @@
        this.m_280497_(p_283128_, list, p_283678_, p_281696_, DefaultTooltipPositioner.f_262752_);
     }
  
-@@ -544,7 +_,15 @@
+@@ -544,7 +_,22 @@
     }
  
     public void m_280666_(Font p_282739_, List<Component> p_281832_, int p_282191_, int p_282446_) {
@@ -104,6 +104,13 @@
 +   public void renderComponentTooltip(Font font, List<? extends net.minecraft.network.chat.FormattedText> tooltips, int mouseX, int mouseY, ItemStack stack) {
 +      this.tooltipStack = stack;
 +      List<ClientTooltipComponent> components = net.minecraftforge.client.ForgeHooksClient.gatherTooltipComponents(stack, tooltips, mouseX, m_280182_(), m_280206_(), font);
++      this.m_280497_(font, components, mouseX, mouseY, DefaultTooltipPositioner.f_262752_);
++      this.tooltipStack = ItemStack.f_41583_;
++   }
++
++   public void renderComponentTooltipFromElements(Font font, List<com.mojang.datafixers.util.Either<FormattedText, TooltipComponent>> elements, int mouseX, int mouseY, ItemStack stack) {
++      this.tooltipStack = stack;
++      List<ClientTooltipComponent> components = net.minecraftforge.client.ForgeHooksClient.gatherTooltipComponentsFromElements(stack, elements, mouseX, m_280182_(), m_280206_(), font);
 +      this.m_280497_(font, components, mouseX, mouseY, DefaultTooltipPositioner.f_262752_);
 +      this.tooltipStack = ItemStack.f_41583_;
     }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1049,11 +1049,16 @@ public class ForgeHooksClient
 
     public static List<ClientTooltipComponent> gatherTooltipComponents(ItemStack stack, List<? extends FormattedText> textElements, Optional<TooltipComponent> itemComponent, int mouseX, int screenWidth, int screenHeight, Font fallbackFont)
     {
-        Font font = getTooltipFont(stack, fallbackFont);
         List<Either<FormattedText, TooltipComponent>> elements = textElements.stream()
                 .map((Function<FormattedText, Either<FormattedText, TooltipComponent>>) Either::left)
                 .collect(Collectors.toCollection(ArrayList::new));
         itemComponent.ifPresent(c -> elements.add(1, Either.right(c)));
+        return gatherTooltipComponentsFromElements(stack, elements, mouseX, screenWidth, screenHeight, fallbackFont);
+    }
+
+    public static List<ClientTooltipComponent> gatherTooltipComponentsFromElements(ItemStack stack, List<Either<FormattedText, TooltipComponent>> elements, int mouseX, int screenWidth, int screenHeight, Font fallbackFont)
+    {
+        Font font = getTooltipFont(stack, fallbackFont);
 
         var event = new RenderTooltipEvent.GatherComponents(stack, screenWidth, screenHeight, elements, -1);
         MinecraftForge.EVENT_BUS.post(event);


### PR DESCRIPTION
1.20.1 version of 
* https://github.com/MinecraftForge/MinecraftForge/pull/10056

I want to render a mix of `FormattedText` and `TooltipComponent`, with more control than the current methods offer.
Currently I can render tooltips, but it's not correctly integrated with Forge's events and tooltip wrapping, and this PR will let me do it properly.