### PR TITLE
Removed unneeded boat patch (Fix MC-119811)

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -63,20 +63,3 @@
      }
  
      protected int getMaxPassengers() {
-@@ -904,6 +_,16 @@
-     @Override
-     public ItemStack getPickResult() {
-         return new ItemStack(this.getDropItem());
-+    }
-+
-+    // Forge: Fix MC-119811 by instantly completing lerp on board
-+    @Override
-+    protected void addPassenger(Entity passenger) {
-+        super.addPassenger(passenger);
-+        if (this.isControlledByLocalInstance() && this.lerpSteps > 0) {
-+            this.lerpSteps = 0;
-+            this.absMoveTo(this.lerpX, this.lerpY, this.lerpZ, (float)this.lerpYRot, (float)this.lerpXRot);
-+        }
-     }
- 
-     public static enum Status {


### PR DESCRIPTION
 Forge has a [fix](https://github.com/MinecraftForge/MinecraftForge/blob/4995902bc016d06f2b91e58cc99a50c6131d6ea6/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch#L72) for a clientside boat lerp glitch (MC-119811) since 1.11. The glitch was fixed in vanilla since 1.15 (19w38a), but the patch was kept and updated by Forge. The forge patch which overrides `addPassenger()` in the boat class is now just adding an unnecessary condition and extra function call.
 Here is a [duplicate](https://bugs.mojang.com/browse/MC-103672) of the ticket which also confirms it was fixed since.