### PR TITLE
Fix inverted logic in TagEmptyCondition

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -194,6 +194,7 @@ patcher {
 
         forge_server_gametest {
             args '--launchTarget', 'forge_dev_server_gametest'
+            args '--uniqueWorld' // Unique world is used so that the world regenerates, as well as the world config isn't influenced by other runs
         }
 
         forge_server_gametest_test {

--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
@@ -5,7 +5,7 @@
              p_206609_.reload();
              WorldDataConfiguration worlddataconfiguration = new WorldDataConfiguration(
 -                new DataPackConfig(new ArrayList<>(p_206609_.getAvailableIds()), List.of()), FeatureFlags.REGISTRY.allFlags()
-+                new DataPackConfig(new ArrayList<>(p_206609_.getSelectedIds()), List.of()), FeatureFlags.REGISTRY.allFlags()
++                new DataPackConfig(new ArrayList<>(p_206609_.getSelectedIds()), List.of()), FeatureFlags.REGISTRY.allFlags() // Forge: Use the selected datapacks as this takes sorting into account.
              );
              LevelSettings levelsettings = new LevelSettings("Test Level", GameType.CREATIVE, false, Difficulty.NORMAL, true, TEST_GAME_RULES, worlddataconfiguration);
              WorldLoader.PackConfig worldloader$packconfig = new WorldLoader.PackConfig(p_206609_, worlddataconfiguration, false, true);

--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/gametest/framework/GameTestServer.java
++++ b/net/minecraft/gametest/framework/GameTestServer.java
+@@ -79,7 +_,7 @@
+         } else {
+             p_206609_.reload();
+             WorldDataConfiguration worlddataconfiguration = new WorldDataConfiguration(
+-                new DataPackConfig(new ArrayList<>(p_206609_.getAvailableIds()), List.of()), FeatureFlags.REGISTRY.allFlags()
++                new DataPackConfig(new ArrayList<>(p_206609_.getSelectedIds()), List.of()), FeatureFlags.REGISTRY.allFlags()
+             );
+             LevelSettings levelsettings = new LevelSettings("Test Level", GameType.CREATIVE, false, Difficulty.NORMAL, true, TEST_GAME_RULES, worlddataconfiguration);
+             WorldLoader.PackConfig worldloader$packconfig = new WorldLoader.PackConfig(p_206609_, worlddataconfiguration, false, true);

--- a/patches/minecraft/net/minecraft/server/Main.java.patch
+++ b/patches/minecraft/net/minecraft/server/Main.java.patch
@@ -1,15 +1,17 @@
 --- a/net/minecraft/server/Main.java
 +++ b/net/minecraft/server/Main.java
-@@ -83,6 +_,15 @@
+@@ -83,6 +_,17 @@
          OptionSpec<Void> optionspec13 = optionparser.accepts("jfrProfile");
          OptionSpec<Path> optionspec14 = optionparser.accepts("pidFile").withRequiredArg().withValuesConvertedBy(new PathConverter());
          OptionSpec<String> optionspec15 = optionparser.nonOptions();
 +        optionparser.accepts("allowUpdates").withRequiredArg().ofType(Boolean.class).defaultsTo(Boolean.TRUE); // Forge: allow mod updates to proceed
 +        optionparser.accepts("gameDir").withRequiredArg().ofType(File.class).defaultsTo(new File(".")); //Forge: Consume this argument, we use it in the launcher, and the client side.
 +        final OptionSpec<net.minecraft.core.BlockPos> spawnPosOpt;
++        OptionSpec<Void> uniqueWorld = null;
 +        boolean gametestEnabled = Boolean.getBoolean("forge.gameTestServer");
 +        if (gametestEnabled) {
 +            spawnPosOpt = optionparser.accepts("spawnPos").withRequiredArg().withValuesConvertedBy(new net.minecraftforge.gametest.BlockPosValueConverter()).defaultsTo(new net.minecraft.core.BlockPos(0, 60, 0));
++            uniqueWorld = optionparser.accepts("uniqueWorld");
 +        } else {
 +            spawnPosOpt = null;
 +        }
@@ -31,7 +33,7 @@
              Path path = optionset.valueOf(optionspec14);
              if (path != null) {
                  writePidFile(path);
-@@ -105,24 +_,26 @@
+@@ -105,24 +_,29 @@
              Bootstrap.validate();
              Util.startTimerHackThread();
              Path path1 = Paths.get("server.properties");
@@ -58,6 +60,9 @@
              File file1 = new File(optionset.valueOf(optionspec9));
              Services services = Services.create(new YggdrasilAuthenticationService(Proxy.NO_PROXY), file1);
              String s = Optional.ofNullable(optionset.valueOf(optionspec10)).orElse(dedicatedserversettings.getProperties().levelName);
++            // Forge: make each gametest use a timestamped world name
++            if (uniqueWorld != null && optionset.has(uniqueWorld))
++                s = "gametest_world\\" + java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss.SSS").format(java.time.LocalDateTime.now());
 +            if (s == null || s.isEmpty() || new File(file1, s).getAbsolutePath().equals(new File(s).getAbsolutePath())) {
 +                LOGGER.error("Invalid world directory specified, must not be null, empty or the same directory as your universe! " + s);
 +                return;

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
@@ -32,7 +32,7 @@ public record TagEmptyCondition(TagKey<Item> tag) implements ICondition {
             Optional<HolderGetter<Item>> items = reg.getter(Registries.ITEM);
             if (items.isPresent()) {
                 var optional = items.get().get(this.tag);
-                return optional.isPresent();
+                return optional.isEmpty() || optional.get().size() == 0;
             }
         }
         return context.getTag(tag).isEmpty();

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
@@ -5,19 +5,14 @@
 
 package net.minecraftforge.common.crafting.conditions;
 
-import java.util.Optional;
-
 import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
-import net.minecraft.core.HolderGetter;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
-import net.minecraft.resources.RegistryOps;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 
 public record TagEmptyCondition(TagKey<Item> tag) implements ICondition {
     public static final MapCodec<TagEmptyCondition> CODEC = RecordCodecBuilder.mapCodec(b -> b.group(
@@ -27,14 +22,6 @@ public record TagEmptyCondition(TagKey<Item> tag) implements ICondition {
 
     @Override
     public boolean test(ICondition.IContext context, DynamicOps<?> ops) {
-        // Check the actual deserialization context if possible
-        if (ops instanceof RegistryOps<?> reg) {
-            Optional<HolderGetter<Item>> items = reg.getter(Registries.ITEM);
-            if (items.isPresent()) {
-                var optional = items.get().get(this.tag);
-                return optional.isEmpty() || optional.get().size() == 0;
-            }
-        }
         return context.getTag(tag).isEmpty();
     }
 

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_doesnt_load.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_doesnt_load.json
@@ -1,0 +1,40 @@
+{
+  "advancements": [
+    {
+      "parent": "minecraft:recipes/root",
+      "criteria": {
+        "has_iron_ore": {
+          "conditions": {
+            "items": [
+              {
+                "items": "minecraft:iron_ore"
+              }
+            ]
+          },
+          "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+          "conditions": {
+            "recipe": "minecraft:diamond_block"
+          },
+          "trigger": "minecraft:recipe_unlocked"
+        }
+      },
+      "forge:condition": {
+        "type": "forge:tag_empty",
+        "tag": "minecraft:dirt"
+      },
+      "requirements": [
+        [
+          "has_the_recipe",
+          "has_iron_ore"
+        ]
+      ],
+      "rewards": {
+        "recipes": [
+          "minecraft:diamond_block"
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_loads.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_loads.json
@@ -1,0 +1,40 @@
+{
+  "advancements": [
+    {
+      "parent": "minecraft:recipes/root",
+      "criteria": {
+        "has_gold_ore": {
+          "conditions": {
+            "items": [
+              {
+                "items": "minecraft:gold_ore"
+              }
+            ]
+          },
+          "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+          "conditions": {
+            "recipe": "minecraft:diamond_block"
+          },
+          "trigger": "minecraft:recipe_unlocked"
+        }
+      },
+      "forge:condition": {
+        "type": "forge:tag_empty",
+        "tag": "forge:empty"
+      },
+      "requirements": [
+        [
+          "has_the_recipe",
+          "has_gold_ore"
+        ]
+      ],
+      "rewards": {
+        "recipes": [
+          "minecraft:diamond_block"
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_loads.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/advancement/recipes/tag_empty_condition_loads.json
@@ -22,7 +22,7 @@
       },
       "forge:condition": {
         "type": "forge:tag_empty",
-        "tag": "forge:empty"
+        "tag": "forge:eggs"
       },
       "requirements": [
         [

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_doesnt_load.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_doesnt_load.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "forge:condition": {
+    "type": "forge:tag_empty",
+    "tag": "minecraft:dirt"
+  },
+  "recipes": [
+    {
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "category": "misc",
+        "ingredients": [
+          {
+            "item": "minecraft:iron_ore"
+          },
+          {
+            "item": "minecraft:iron_ore"
+          },
+          {
+            "item": "minecraft:iron_ore"
+          }
+        ],
+        "result": {
+          "count": 1,
+          "id": "minecraft:diamond_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_loads.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_loads.json
@@ -2,7 +2,7 @@
   "type": "forge:conditional",
   "forge:condition": {
     "type": "forge:tag_empty",
-    "tag": "forge:empty"
+    "tag": "forge:eggs"
   },
   "recipes": [
     {

--- a/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_loads.json
+++ b/src/test/generated/conditional_recipe/data/conditional_recipe/recipe/tag_empty_condition_loads.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "forge:condition": {
+    "type": "forge:tag_empty",
+    "tag": "forge:empty"
+  },
+  "recipes": [
+    {
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "category": "misc",
+        "ingredients": [
+          {
+            "item": "minecraft:gold_ore"
+          },
+          {
+            "item": "minecraft:gold_ore"
+          },
+          {
+            "item": "minecraft:gold_ore"
+          }
+        ],
+        "result": {
+          "count": 1,
+          "id": "minecraft:diamond_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/generated/conditional_recipe/data/forge/tags/item/eggs.json
+++ b/src/test/generated/conditional_recipe/data/forge/tags/item/eggs.json
@@ -1,0 +1,6 @@
+{
+  "remove": [
+    "minecraft:egg"
+  ],
+  "values": []
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
@@ -21,8 +21,6 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -41,7 +39,6 @@ import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.test.BaseTestMod;
@@ -51,8 +48,6 @@ import net.minecraftforge.test.BaseTestMod;
 public class ConditionalRecipeTest extends BaseTestMod {
     static final String MODID = "conditional_recipe";
     
-    private static final TagKey<Item> EMPTY = ItemTags.create(ResourceLocation.fromNamespaceAndPath("forge", "empty"));
-
     public ConditionalRecipeTest(FMLJavaModLoadingContext context) {
         super(context);
     }

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
@@ -20,6 +20,8 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
@@ -42,6 +44,8 @@ import net.minecraftforge.test.BaseTestMod;
 @Mod(ConditionalRecipeTest.MODID)
 public class ConditionalRecipeTest extends BaseTestMod {
     static final String MODID = "conditional_recipe";
+    
+    private static final TagKey<Item> EMPTY = ItemTags.create(ResourceLocation.fromNamespaceAndPath("forge", "empty"));
 
     public ConditionalRecipeTest(FMLJavaModLoadingContext context) {
         super(context);
@@ -146,6 +150,24 @@ public class ConditionalRecipeTest extends BaseTestMod {
             .pattern("XXX")
             .pattern("XX ")
             .define('X', Blocks.OAK_LOG)
+            .build()
+        );
+    }
+    
+    @GameTest(template = "forge:empty3x3x3")
+    public static void tag_empty_condition_with_populated_tag(GameTestHelper helper) {
+        assertFalse(helper, RecipeType.CRAFTING, SimpleCraftingContainer.builder()
+            .pattern("XXX")
+            .define('X', Blocks.IRON_ORE)
+            .build()
+        );
+    }
+    
+    @GameTest(template = "forge:empty3x3x3")
+    public static void tag_empty_condition_with_empty_tag(GameTestHelper helper) {
+        assertTrue(helper, RecipeType.CRAFTING, SimpleCraftingContainer.builder()
+            .pattern("XXX")
+            .define('X', Blocks.GOLD_ORE)
             .build()
         );
     }
@@ -302,6 +324,30 @@ public class ConditionalRecipeTest extends BaseTestMod {
                         ::save
                 )
                 .save(out, rl("conditional_doesnt_load_empty"));
+
+            ConditionalRecipe.builder()
+                .condition(tagEmpty(ItemTags.DIRT))
+                .recipe(
+                    ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Blocks.DIAMOND_BLOCK)
+                        .requires(Blocks.IRON_ORE)
+                        .requires(Blocks.IRON_ORE)
+                        .requires(Blocks.IRON_ORE)
+                        .unlockedBy(getHasName(Blocks.IRON_ORE), has(Blocks.IRON_ORE))
+                        ::save
+                )
+                .save(out, rl("tag_empty_condition_doesnt_load"));
+
+            ConditionalRecipe.builder()
+                .condition(tagEmpty(EMPTY))
+                .recipe(
+                    ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Blocks.DIAMOND_BLOCK)
+                        .requires(Blocks.GOLD_ORE)
+                        .requires(Blocks.GOLD_ORE)
+                        .requires(Blocks.GOLD_ORE)
+                        .unlockedBy(getHasName(Blocks.GOLD_ORE), has(Blocks.GOLD_ORE))
+                        ::save
+                )
+                .save(out, rl("tag_empty_condition_loads"));
         }
     }
 

--- a/src/test/resources/conditional_recipe/META-INF/mods.toml
+++ b/src/test/resources/conditional_recipe/META-INF/mods.toml
@@ -1,0 +1,6 @@
+[[dependencies.conditional_recipe]]
+    modId="forge"
+    mandatory=true
+    versionRange="[0,]"
+    ordering="AFTER"
+    side="BOTH"


### PR DESCRIPTION
The tag-empty condition was previously evaluating as true for populated tags instead of empty ones, causing incorrect loading of dependent recipes. This change implements a fix and adds a pair of tests to prevent regressions.