### PR TITLE
[1.20.6] Fire `OnDatapackSyncEvent` when a player joins a server

### DIFF
--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -8,6 +8,14 @@
  
      public PlayerList(MinecraftServer p_203842_, LayeredRegistryAccess<RegistryLayer> p_251844_, PlayerDataStorage p_203844_, int p_203845_) {
          this.server = p_203842_;
+@@ -199,6 +_,7 @@
+         servergamepacketlistenerimpl.send(new ClientboundChangeDifficultyPacket(leveldata.getDifficulty(), leveldata.isDifficultyLocked()));
+         servergamepacketlistenerimpl.send(new ClientboundPlayerAbilitiesPacket(p_11263_.getAbilities()));
+         servergamepacketlistenerimpl.send(new ClientboundSetCarriedItemPacket(p_11263_.getInventory().selected));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, null));
+         servergamepacketlistenerimpl.send(new ClientboundUpdateRecipesPacket(this.server.getRecipeManager().getOrderedRecipes()));
+         this.sendPlayerPermissionLevel(p_11263_);
+         p_11263_.getStats().markAllDirty();
 @@ -267,6 +_,7 @@
          }
  


### PR DESCRIPTION
This PR matches #10076, but targeted for 1.20.6.

This fixes #10075 by re-adding the line which fires the `OnDatapackSyncEvent` event in `PlayerList#placeNewPlayer`.
This matches the behaviour as it was in 1.20.4.
The 1.20.4 `PlayerList` patch for reference:
https://github.com/MinecraftForge/MinecraftForge/blob/54f5e1213afb4ec87a3fe51f6530201d5767e9e1/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch#L11-L19.