### PR TITLE
Packet distributor test crash fix

### DIFF
--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestServer.java.patch
@@ -9,3 +9,11 @@
              );
              LevelSettings levelsettings = new LevelSettings("Test Level", GameType.CREATIVE, false, Difficulty.NORMAL, true, TEST_GAME_RULES, worlddataconfiguration);
              WorldLoader.PackConfig worldloader$packconfig = new WorldLoader.PackConfig(p_206609_, worlddataconfiguration, false, true);
+@@ -138,6 +_,7 @@
+ 
+     @Override
+     public boolean initServer() {
++        if (!net.minecraftforge.server.ServerLifecycleHooks.handleServerAboutToStart(this)) return false;
+         this.setPlayerList(new PlayerList(this, this.registries(), this.playerDataStorage, 1) {
+         });
+         this.loadLevel();

--- a/src/test/java/net/minecraftforge/debug/network/PacketTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/PacketTest.java
@@ -1,0 +1,124 @@
+package net.minecraftforge.debug.network;
+
+import org.slf4j.Logger;
+
+import com.mojang.logging.LogUtils;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.event.network.CustomPayloadEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.network.Channel.VersionTest;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.network.SimpleChannel;
+import net.minecraftforge.test.BaseTestMod;
+
+@GameTestHolder("forge." + PacketTest.MODID)
+@Mod(PacketTest.MODID)
+public class PacketTest extends BaseTestMod {
+    static final String MODID = "packet";
+    
+    protected static final Logger LOGGER = LogUtils.getLogger();
+
+    public PacketTest(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+    
+    @SubscribeEvent
+    public void commonSetup(final FMLCommonSetupEvent event) {
+        PacketHandler.registerMessages();
+    }
+    
+    @GameTest(template = "forge:empty3x3x3")
+    public static void send_to_player(GameTestHelper helper) {
+        // Send a test packet directly to a player
+        ServerPlayer player = helper.makeMockServerPlayer();
+        PacketHandler.sendToPlayer(new TestPacket("testing123"), player);
+        helper.succeed();
+    }
+    
+    @GameTest(template = "forge:empty3x3x3")
+    public static void send_to_nearby(GameTestHelper helper) {
+        // Send a test packet to all players near a target point
+        helper.makeMockPlayer(GameType.SURVIVAL);
+        PacketHandler.sendToAllAround(new TestPacket("testing123"), Level.OVERWORLD, BlockPos.ZERO, 5D);
+        helper.succeed();
+    }
+    
+    @GameTest(template = "forge:empty3x3x3")
+    public static void send_to_all(GameTestHelper helper) {
+        // Send a test packet to all players
+        helper.makeMockPlayer(GameType.SURVIVAL);
+        PacketHandler.sendToAll(new TestPacket("testing123"));
+        helper.succeed();
+    }
+    
+    public static class TestPacket {
+        public static final StreamCodec<RegistryFriendlyByteBuf, TestPacket> STREAM_CODEC = StreamCodec.ofMember(TestPacket::encode, TestPacket::decode);
+        protected final String msg;
+        
+        public TestPacket(String msg) {
+            this.msg = msg;
+        }
+        
+        public static void encode(TestPacket message, RegistryFriendlyByteBuf buf) {
+            buf.writeUtf(message.msg);
+        }
+        
+        public static TestPacket decode(RegistryFriendlyByteBuf buf) {
+            return new TestPacket(buf.readUtf());
+        }
+        
+        public static void onMessage(TestPacket message, CustomPayloadEvent.Context ctx) {
+            LOGGER.info("Received packet with message: {}", message.msg);
+        }
+    }
+    
+    public static class PacketHandler {
+        private static final ResourceLocation CHANNEL_NAME = rl(PacketTest.MODID, "main_channel");
+        private static final int PROTOCOL_VERSION = 1;
+
+        private static final SimpleChannel CHANNEL = ChannelBuilder
+                .named(CHANNEL_NAME)
+                .clientAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
+                .serverAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
+                .networkProtocolVersion(PROTOCOL_VERSION)
+                .simpleChannel()
+                    .play()
+                        .clientbound()
+                            .addMain(TestPacket.class, TestPacket.STREAM_CODEC, TestPacket::onMessage)
+                .build();
+
+        public static void registerMessages() {
+            LOGGER.debug("Registering network {} v{}", CHANNEL.getName(), CHANNEL.getProtocolVersion());
+        }
+        
+        public static void sendToPlayer(Object message, ServerPlayer player) {
+            // Send a message to a specific player
+            CHANNEL.send(message, PacketDistributor.PLAYER.with(player));
+        }
+        
+        public static void sendToAllAround(Object message, ResourceKey<Level> dimension, BlockPos center, double radius) {
+            // Send a message to the clients of all players within a given distance of the given world position
+            CHANNEL.send(message, PacketDistributor.NEAR.with(new PacketDistributor.TargetPoint(center.getX() + 0.5D, center.getY() + 0.5D, center.getZ() + 0.5D, radius, dimension)));
+        }
+        
+        public static void sendToAll(Object message) {
+            // Send a message to all connected clients
+            CHANNEL.send(message, PacketDistributor.ALL.noArg());
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/network/PacketTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/PacketTest.java
@@ -4,16 +4,16 @@ import org.slf4j.Logger;
 
 import com.mojang.logging.LogUtils;
 
-import net.minecraft.core.BlockPos;
+import io.netty.channel.embedded.EmbeddedChannel;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.resources.ResourceKey;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.GameType;
-import net.minecraft.world.level.Level;
+import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.network.CustomPayloadEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.network.Channel.VersionTest;
 import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.ForgePayload;
 import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.network.SimpleChannel;
 import net.minecraftforge.test.BaseTestMod;
@@ -30,95 +31,138 @@ import net.minecraftforge.test.BaseTestMod;
 @Mod(PacketTest.MODID)
 public class PacketTest extends BaseTestMod {
     static final String MODID = "packet";
-    
+
     protected static final Logger LOGGER = LogUtils.getLogger();
 
     public PacketTest(FMLJavaModLoadingContext context) {
         super(context);
     }
-    
+
     @SubscribeEvent
     public void commonSetup(final FMLCommonSetupEvent event) {
-        PacketHandler.registerMessages();
+        TestChannel.registerMessages();
     }
-    
+
     @GameTest(template = "forge:empty3x3x3")
     public static void send_to_player(GameTestHelper helper) {
         // Send a test packet directly to a player
-        ServerPlayer player = helper.makeMockServerPlayer();
-        PacketHandler.sendToPlayer(new TestPacket("testing123"), player);
-        helper.succeed();
+        ServerPlayer target = mockPlayer(helper);
+        ServerPlayer bystander = mockPlayer(helper);
+        try {
+            var distro = PacketDistributor.PLAYER.with(target);
+            TestChannel.CHANNEL.send(new TestPacket("player target"), distro);
+            helper.assertValueEqual(count(target), 1, "Target packet count");
+            helper.assertValueEqual(count(bystander), 0, "Bystander packet count");
+
+            helper.succeed();
+        } finally {
+            helper.getLevel().getServer().getPlayerList().remove(target);
+            helper.getLevel().getServer().getPlayerList().remove(bystander);
+        }
     }
-    
+
     @GameTest(template = "forge:empty3x3x3")
     public static void send_to_nearby(GameTestHelper helper) {
         // Send a test packet to all players near a target point
-        helper.makeMockPlayer(GameType.SURVIVAL);
-        PacketHandler.sendToAllAround(new TestPacket("testing123"), Level.OVERWORLD, BlockPos.ZERO, 5D);
-        helper.succeed();
+
+        ServerPlayer target = mockPlayer(helper);
+        ServerPlayer bystander = mockPlayer(helper);
+        try {
+            var center = helper.absoluteVec(Vec3.ZERO);
+            target.moveTo(center); // Move to center
+            bystander.moveTo(center.add(0, 10, 0)); // Move 10 blocks away
+            var point = new PacketDistributor.TargetPoint(center.x(), center.y(), center.z(), 1/* Only within 1 block */, helper.getLevel().dimension());
+            var distro = PacketDistributor.NEAR.with(point);
+
+            TestChannel.CHANNEL.send(new TestPacket("point target"), distro);
+            helper.assertValueEqual(count(target), 1, "Target packet count");
+            helper.assertValueEqual(count(bystander), 0, "Bystander packet count");
+
+            helper.succeed();
+        } finally {
+            helper.getLevel().getServer().getPlayerList().remove(target);
+            helper.getLevel().getServer().getPlayerList().remove(bystander);
+        }
     }
-    
+
     @GameTest(template = "forge:empty3x3x3")
     public static void send_to_all(GameTestHelper helper) {
         // Send a test packet to all players
-        helper.makeMockPlayer(GameType.SURVIVAL);
-        PacketHandler.sendToAll(new TestPacket("testing123"));
-        helper.succeed();
-    }
-    
-    public static class TestPacket {
-        public static final StreamCodec<RegistryFriendlyByteBuf, TestPacket> STREAM_CODEC = StreamCodec.ofMember(TestPacket::encode, TestPacket::decode);
-        protected final String msg;
-        
-        public TestPacket(String msg) {
-            this.msg = msg;
+        ServerPlayer target = mockPlayer(helper);
+        ServerPlayer bystander = mockPlayer(helper);
+        try {
+            var distro = PacketDistributor.ALL.noArg();
+
+            TestChannel.CHANNEL.send(new TestPacket("everyone!"), distro);
+            helper.assertValueEqual(count(target), 1, "Target packet count");
+            helper.assertValueEqual(count(bystander), 1, "Bystander packet count");
+
+            helper.succeed();
+        } finally {
+            helper.getLevel().getServer().getPlayerList().remove(target);
+            helper.getLevel().getServer().getPlayerList().remove(bystander);
         }
-        
+    }
+
+    private static ServerPlayer mockPlayer(GameTestHelper helper) {
+        ServerPlayer ret = helper.makeMockServerPlayer();
+        CommonListenerCookie cookie = new CommonListenerCookie(null, 0, null, false);
+
+        helper.getLevel().getServer().getPlayerList().placeNewPlayer(ret.connection.getConnection(), ret, cookie);
+        // Ignore all the packets sent during connection
+        count(ret);
+        return ret;
+    }
+
+    private static int count(ServerPlayer player) {
+        EmbeddedChannel ec = (EmbeddedChannel)player.connection.getConnection().channel();
+
+        int count = 0;
+        Object msg;
+        while ((msg = ec.readOutbound()) != null) {
+            if (msg instanceof ClientboundCustomPayloadPacket pkt &&
+                pkt.payload() instanceof ForgePayload pay &&
+                pay.id().equals(TestChannel.CHANNEL_NAME)
+            )
+                count++;
+        }
+        return count;
+    }
+
+    private record TestPacket(String msg) {
+        public static final StreamCodec<RegistryFriendlyByteBuf, TestPacket> STREAM_CODEC =
+            StreamCodec.ofMember(TestPacket::encode, TestPacket::decode);
+
         public static void encode(TestPacket message, RegistryFriendlyByteBuf buf) {
             buf.writeUtf(message.msg);
         }
-        
+
         public static TestPacket decode(RegistryFriendlyByteBuf buf) {
             return new TestPacket(buf.readUtf());
         }
-        
+
         public static void onMessage(TestPacket message, CustomPayloadEvent.Context ctx) {
             LOGGER.info("Received packet with message: {}", message.msg);
         }
     }
-    
-    public static class PacketHandler {
+
+    private static class TestChannel {
         private static final ResourceLocation CHANNEL_NAME = rl(PacketTest.MODID, "main_channel");
         private static final int PROTOCOL_VERSION = 1;
 
         private static final SimpleChannel CHANNEL = ChannelBuilder
-                .named(CHANNEL_NAME)
-                .clientAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
-                .serverAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
-                .networkProtocolVersion(PROTOCOL_VERSION)
-                .simpleChannel()
-                    .play()
-                        .clientbound()
-                            .addMain(TestPacket.class, TestPacket.STREAM_CODEC, TestPacket::onMessage)
-                .build();
+            .named(CHANNEL_NAME)
+            .clientAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
+            .serverAcceptedVersions(VersionTest.exact(PROTOCOL_VERSION))
+            .networkProtocolVersion(PROTOCOL_VERSION)
+            .simpleChannel()
+                .play()
+                    .clientbound()
+                        .addMain(TestPacket.class, TestPacket.STREAM_CODEC, TestPacket::onMessage)
+            .build();
 
         public static void registerMessages() {
             LOGGER.debug("Registering network {} v{}", CHANNEL.getName(), CHANNEL.getProtocolVersion());
-        }
-        
-        public static void sendToPlayer(Object message, ServerPlayer player) {
-            // Send a message to a specific player
-            CHANNEL.send(message, PacketDistributor.PLAYER.with(player));
-        }
-        
-        public static void sendToAllAround(Object message, ResourceKey<Level> dimension, BlockPos center, double radius) {
-            // Send a message to the clients of all players within a given distance of the given world position
-            CHANNEL.send(message, PacketDistributor.NEAR.with(new PacketDistributor.TargetPoint(center.getX() + 0.5D, center.getY() + 0.5D, center.getZ() + 0.5D, radius, dimension)));
-        }
-        
-        public static void sendToAll(Object message) {
-            // Send a message to all connected clients
-            CHANNEL.send(message, PacketDistributor.ALL.noArg());
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/network/PacketTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/PacketTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.network;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
This PR deploys a fix discussed with LexManos in issue #10066 for a problem causing game test failures and crashes in the event that the test, or code being exercised by the test, attempted to send a packet to multiple clients. I've included three tests to confirm the fix and help prevent regressions. The tests sending packets to all players or nearby players will fail without the change to GameTestServer; the test sending a packet to a specific player never failed and is included for completeness' sake.