### PR TITLE
Retain game event identifier in Forge event

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -1012,7 +1012,7 @@ public final class ForgeEventFactory {
     }
 
     public static boolean onVanillaGameEvent(Level level, Holder<GameEvent> vanillaEvent, Vec3 pos, GameEvent.Context context) {
-        return post(new VanillaGameEvent(level, vanillaEvent.get(), pos, context));
+        return post(new VanillaGameEvent(level, vanillaEvent, pos, context));
     }
 
     public static boolean onLivingEffectExpire(LivingEntity entity, MobEffectInstance effect) {

--- a/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
+++ b/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
@@ -59,8 +59,19 @@ public class VanillaGameEvent extends Event
 
     /**
      * @return The Vanilla event.
+     * 
+     * @deprecated Use {@link #getVanillaEventHolder()}
      */
-    public Holder<GameEvent> getVanillaEvent()
+    @Deprecated
+    public GameEvent getVanillaEvent()
+    {
+        return vanillaEvent.get();
+    }
+
+    /**
+     * @return The Vanilla event.
+     */
+    public Holder<GameEvent> getVanillaEventHolder()
     {
         return vanillaEvent;
     }

--- a/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
+++ b/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.event;
 
+import net.minecraft.core.Holder;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -27,11 +28,11 @@ import org.jetbrains.annotations.Nullable;
 public class VanillaGameEvent extends Event
 {
     private final Level level;
-    private final GameEvent vanillaEvent;
+    private final Holder<GameEvent> vanillaEvent;
     private final Vec3 position;
     private final GameEvent.Context context;
 
-    public VanillaGameEvent(Level level, GameEvent vanillaEvent, Vec3 position, GameEvent.Context context)
+    public VanillaGameEvent(Level level, Holder<GameEvent> vanillaEvent, Vec3 position, GameEvent.Context context)
     {
         this.level = level;
         this.vanillaEvent = vanillaEvent;
@@ -59,7 +60,7 @@ public class VanillaGameEvent extends Event
     /**
      * @return The Vanilla event.
      */
-    public GameEvent getVanillaEvent()
+    public Holder<GameEvent> getVanillaEvent()
     {
         return vanillaEvent;
     }

--- a/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
@@ -1,12 +1,14 @@
 package net.minecraftforge.debug.event;
 
+import java.util.function.Consumer;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.VanillaGameEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
@@ -23,26 +25,30 @@ public class VanillaGameEventTest extends BaseTestMod {
 
     @GameTest(template = "forge:empty3x3x3")
     public static void game_event_matches(GameTestHelper helper) {
-        // Place a button in the test area
-        var pos = new BlockPos(1, 1, 1);
-        helper.setBlock(pos, Blocks.STONE_BUTTON);
-        
-        // Press the button, which is supposed to trigger the BLOCK_ACTIVATE game event
-        helper.pressButton(pos);
-        
-        // Confirm that the button has been replaced by a diamond block
-        helper.assertBlockPresent(Blocks.DIAMOND_BLOCK, pos);
-        helper.succeed();
-    }
-
-    @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-    public static class Listener {
-        @SubscribeEvent
-        public static void vanillaEvent(VanillaGameEvent event) {
+        // Create and register the event listener
+        Consumer<VanillaGameEvent> listener = event -> {
             // Replace any activated block with a diamond block
             if (GameEvent.BLOCK_ACTIVATE.is(event.getVanillaEventHolder())) {
                 event.getLevel().setBlock(BlockPos.containing(event.getEventPosition()), Blocks.DIAMOND_BLOCK.defaultBlockState(), 3);
             }
+        };
+        MinecraftForge.EVENT_BUS.addListener(listener);
+        
+        try {
+            // Place a button in the test area
+            var pos = new BlockPos(1, 1, 1);
+            helper.setBlock(pos, Blocks.STONE_BUTTON);
+            
+            // Press the button, which is supposed to trigger the BLOCK_ACTIVATE game event
+            helper.pressButton(pos);
+            
+            // Confirm that the button has been replaced by a diamond block
+            helper.assertBlockPresent(Blocks.DIAMOND_BLOCK, pos);
+            helper.succeed();
+        }
+        finally {
+            // Unregister the listener when no longer needed
+            MinecraftForge.EVENT_BUS.unregister(listener);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
@@ -40,7 +40,7 @@ public class VanillaGameEventTest extends BaseTestMod {
         @SubscribeEvent
         public static void vanillaEvent(VanillaGameEvent event) {
             // Replace any activated block with a diamond block
-            if (GameEvent.BLOCK_ACTIVATE.is(event.getVanillaEvent())) {
+            if (GameEvent.BLOCK_ACTIVATE.is(event.getVanillaEventHolder())) {
                 event.getLevel().setBlock(BlockPos.containing(event.getEventPosition()), Blocks.DIAMOND_BLOCK.defaultBlockState(), 3);
             }
         }

--- a/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/event/VanillaGameEventTest.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.debug.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraftforge.event.VanillaGameEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.test.BaseTestMod;
+
+@GameTestHolder("forge." + VanillaGameEventTest.MODID)
+@Mod(VanillaGameEventTest.MODID)
+public class VanillaGameEventTest extends BaseTestMod {
+    static final String MODID = "vanilla_game_event";
+
+    public VanillaGameEventTest(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void game_event_matches(GameTestHelper helper) {
+        // Place a button in the test area
+        var pos = new BlockPos(1, 1, 1);
+        helper.setBlock(pos, Blocks.STONE_BUTTON);
+        
+        // Press the button, which is supposed to trigger the BLOCK_ACTIVATE game event
+        helper.pressButton(pos);
+        
+        // Confirm that the button has been replaced by a diamond block
+        helper.assertBlockPresent(Blocks.DIAMOND_BLOCK, pos);
+        helper.succeed();
+    }
+
+    @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+    public static class Listener {
+        @SubscribeEvent
+        public static void vanillaEvent(VanillaGameEvent event) {
+            // Replace any activated block with a diamond block
+            if (GameEvent.BLOCK_ACTIVATE.is(event.getVanillaEvent())) {
+                event.getLevel().setBlock(BlockPos.containing(event.getEventPosition()), Blocks.DIAMOND_BLOCK.defaultBlockState(), 3);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As currently implemented in 1.21, Forge strips out the identifying information from the game event holder when creating a VanillaGameEvent object. This makes it impossible to tell which game event was fired. This change causes the VanillaGameEvent object to transmit the fully identified holder so that it can be properly handled by listeners.