### PR TITLE
[1.20.6] Backport some Vanilla 1.21 `ResourceLocation` methods

### DIFF
--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -1,20 +1,18 @@
 --- a/net/minecraft/resources/ResourceLocation.java
 +++ b/net/minecraft/resources/ResourceLocation.java
-@@ -38,6 +_,8 @@
+@@ -38,6 +_,7 @@
          this.path = p_249394_;
      }
  
-+    /** @deprecated Forge: Use {@link #fromNamespaceAndPath(String, String)} instead */
-+    @Deprecated(forRemoval = true, since = "1.21")
++    /** Forge: Consider using {@link #fromNamespaceAndPath(String, String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
      public ResourceLocation(String p_135811_, String p_135812_) {
          this(assertValidNamespace(p_135811_, p_135812_), assertValidPath(p_135811_, p_135812_), null);
      }
-@@ -46,6 +_,8 @@
+@@ -46,6 +_,7 @@
          this(p_135814_[0], p_135814_[1]);
      }
  
-+    /** @deprecated Forge: Use {@link #parse(String)} instead */
-+    @Deprecated(forRemoval = true, since = "1.21")
++    /** Forge: Consider using {@link #parse(String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
      public ResourceLocation(String p_135809_) {
          this(decompose(p_135809_, ':'));
      }

--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -1,5 +1,23 @@
 --- a/net/minecraft/resources/ResourceLocation.java
 +++ b/net/minecraft/resources/ResourceLocation.java
+@@ -38,6 +_,8 @@
+         this.path = p_249394_;
+     }
+ 
++    /** @deprecated Forge: Use {@link #fromNamespaceAndPath(String, String)} instead */
++    @Deprecated(forRemoval = true, since = "1.21")
+     public ResourceLocation(String p_135811_, String p_135812_) {
+         this(assertValidNamespace(p_135811_, p_135812_), assertValidPath(p_135811_, p_135812_), null);
+     }
+@@ -46,6 +_,8 @@
+         this(p_135814_[0], p_135814_[1]);
+     }
+ 
++    /** @deprecated Forge: Use {@link #parse(String)} instead */
++    @Deprecated(forRemoval = true, since = "1.21")
+     public ResourceLocation(String p_135809_) {
+         this(decompose(p_135809_, ':'));
+     }
 @@ -147,6 +_,12 @@
          return i;
      }
@@ -13,3 +31,19 @@
      public String toDebugFileName() {
          return this.toString().replace('/', '_').replace(':', '_');
      }
+@@ -279,5 +_,15 @@
+         public JsonElement serialize(ResourceLocation p_135855_, Type p_135856_, JsonSerializationContext p_135857_) {
+             return new JsonPrimitive(p_135855_.toString());
+         }
++    }
++
++    /** Forge: Backport of Vanilla 1.21 method */
++    public static ResourceLocation fromNamespaceAndPath(String namespace, String path) {
++        return new ResourceLocation(namespace, path);
++    }
++
++    /** Forge: Backport of Vanilla 1.21 method */
++    public static ResourceLocation parse(String location) {
++        return new ResourceLocation(location);
+     }
+ }


### PR DESCRIPTION
Vanilla 1.21 removed these public constructors and instead required devs to use the newly added static methods.

This PR backports those static method signatures to 1.20.6 and adds comments mentioning them to the constructors, allowing mod devs to adopt this breaking change early to ease porting to 1.21.1. It also allows more simple mods to work on both 1.20.6 and 1.21.1 with the same jar.