### PR TITLE
[1.20.6] Use the new `fire()` and Result#isAllowed/isDenied/isDefault methods from EventBus

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -7,7 +7,7 @@
 -        if (this.shouldShowName(p_114485_)) {
 -            this.renderNameTag(p_114485_, p_114485_.getDisplayName(), p_114488_, p_114489_, p_114490_, p_114487_);
 +        var event = net.minecraftforge.client.event.ForgeEventFactoryClient.fireRenderNameTagEvent(p_114485_, p_114485_.getDisplayName(), this, p_114488_, p_114489_, p_114490_, p_114487_);
-+        if (event.getResult() != net.minecraftforge.eventbus.api.Event.Result.DENY && (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || this.shouldShowName(p_114485_))) {
++        if (!event.getResult().isDenied() && (event.getResult().isAllowed() || this.shouldShowName(p_114485_))) {
 +           this.renderNameTag(p_114485_, event.getContent(), p_114488_, p_114489_, p_114490_, p_114487_);
          }
      }

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -5,7 +5,7 @@
  
      public void handleBlockBreakAction(BlockPos p_215120_, ServerboundPlayerActionPacket.Action p_215121_, Direction p_215122_, int p_215123_, int p_215124_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLeftClickBlock(player, p_215120_, p_215122_, p_215121_);
-+        if (event.isCanceled() || (!this.isCreative() && event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY)) {
++        if (event.isCanceled() || (!this.isCreative() && event.getResult().isDenied())) {
 +           return;
 +        }
          if (!this.player.canInteractWithBlock(p_215120_, 1.0)) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -129,9 +129,9 @@
      }
  
      public boolean canBeAffected(MobEffectInstance p_21197_) {
-+        var event = net.minecraftforge.event.ForgeEventFactory.onLivingEffectCanApply(this, p_21197_);
-+        if (event.getResult() != net.minecraftforge.eventbus.api.Event.Result.DEFAULT) {
-+            return event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
++        var eventResult = net.minecraftforge.event.ForgeEventFactory.onLivingEffectCanApply(this, p_21197_).getResult();
++        if (!eventResult.isDefault()) {
++            return eventResult.isAllowed();
 +        }
          if (this.getType().is(EntityTypeTags.IMMUNE_TO_INFESTED)) {
              return !p_21197_.is(MobEffects.INFESTED);

--- a/patches/minecraft/net/minecraft/world/entity/monster/Spider.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Spider.java.patch
@@ -1,14 +1,12 @@
 --- a/net/minecraft/world/entity/monster/Spider.java
 +++ b/net/minecraft/world/entity/monster/Spider.java
-@@ -121,7 +_,12 @@
+@@ -121,7 +_,10 @@
  
      @Override
      public boolean canBeAffected(MobEffectInstance p_33809_) {
 -        return p_33809_.is(MobEffects.POISON) ? false : super.canBeAffected(p_33809_);
 +        if (p_33809_.getEffect() == MobEffects.POISON) {
-+            net.minecraftforge.event.entity.living.MobEffectEvent.Applicable event = new net.minecraftforge.event.entity.living.MobEffectEvent.Applicable(this, p_33809_);
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+            return event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
++            return net.minecraftforge.event.ForgeEventFactory.onLivingEffectCanApply(this, p_33809_).getResult().isAllowed();
 +        }
 +        return super.canBeAffected(p_33809_);
      }

--- a/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -36,9 +36,9 @@
 +            var event = net.minecraftforge.event.ForgeEventFactory.fireZombieSummonAid(this, level(), i, j, k, livingentity, this.getAttributeValue(Attributes.SPAWN_REINFORCEMENTS_CHANCE));
 +
 +            Zombie zombie = null;
-+            if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW) {
++            if (event.getResult().isAllowed()) {
 +                zombie = event.getCustomSummonedAid() != null ? event.getCustomSummonedAid() : EntityType.ZOMBIE.create(this.level());
-+            } else if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DEFAULT && vanilla) {
++            } else if (vanilla && event.getResult().isDefault()) {
 +                zombie = EntityType.ZOMBIE.create(this.level());
 +            }
 +

--- a/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
@@ -7,7 +7,7 @@
 -        this.getFeature(p_221243_).ifPresent(p_256352_ -> p_256352_.value().place(p_221243_, p_221243_.getChunkSource().getGenerator(), p_221244_, p_221245_));
 +        this.getFeature(p_221243_).ifPresent(p_256352_ -> {
 +            var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_221243_, p_221244_, p_221245_, p_256352_);
-+            if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY)) return;
++            if (event.getResult().isDenied()) return;
 +            event.getFeature().value().place(p_221243_, p_221243_.getChunkSource().getGenerator(), p_221244_, p_221245_);
 +        });
      }

--- a/patches/minecraft/net/minecraft/world/level/block/MushroomBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/MushroomBlock.java.patch
@@ -14,7 +14,7 @@
              return false;
          } else {
 +            var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_221774_, p_221777_, p_221775_, optional.get());
-+            if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY)) return false;
++            if (event.getResult().isDenied()) return false;
              p_221774_.removeBlock(p_221775_, false);
 -            if (optional.get().value().place(p_221774_, p_221774_.getChunkSource().getGenerator(), p_221777_, p_221775_)) {
 +            if (event.getFeature().value().place(p_221774_, p_221774_.getChunkSource().getGenerator(), p_221777_, p_221775_)) {

--- a/patches/minecraft/net/minecraft/world/level/block/grower/TreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/TreeGrower.java.patch
@@ -6,7 +6,7 @@
              Holder<ConfiguredFeature<?, ?>> holder = p_309830_.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).getHolder(resourcekey).orElse(null);
 +            var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_309830_, p_309951_, p_310327_, holder);
 +            holder = event.getFeature();
-+            if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) return false;
++            if (event.getResult().isDenied()) return false;
              if (holder != null) {
                  for (int i = 0; i >= -1; i--) {
                      for (int j = 0; j >= -1; j--) {

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
 +++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
-@@ -42,13 +_,17 @@
+@@ -42,13 +_,18 @@
                      for (ServerPlayer serverplayer : p_64576_.players()) {
                          if (!serverplayer.isSpectator()) {
                              BlockPos blockpos = serverplayer.blockPosition();
@@ -9,8 +9,9 @@
 +                            var vanillaPosition = (!p_64576_.dimensionType().hasSkyLight() || blockpos.getY() >= p_64576_.getSeaLevel() && p_64576_.canSeeSky(blockpos));
 +                            var count = 1 + randomsource.nextInt(difficultyinstance.getDifficulty().getId() + 1);
 +                            var event = net.minecraftforge.event.ForgeEventFactory.onPlayerSpawnPhantom(serverplayer, count);
-+                            if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) continue;
-+                            if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || vanillaPosition) {
++                            var eventResult = event.getResult();
++                            if (eventResult.isDenied()) continue;
++                            if (vanillaPosition || eventResult.isAllowed()) {
                                  if (difficultyinstance.isHarderThan(randomsource.nextFloat() * 3.0F)) {
                                      ServerStatsCounter serverstatscounter = serverplayer.getStats();
                                      int j = Mth.clamp(serverstatscounter.getValue(Stats.CUSTOM.get(Stats.TIME_SINCE_REST)), 1, Integer.MAX_VALUE);

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
             library('coremods', 'net.minecraftforge:coremods:5.1.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.6')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -647,9 +647,8 @@ public final class ForgeHooks {
     }
 
     public static boolean onCropsGrowPre(Level level, BlockPos pos, BlockState state, boolean def) {
-        BlockEvent ev = new BlockEvent.CropGrowEvent.Pre(level,pos,state);
-        MinecraftForge.EVENT_BUS.post(ev);
-        return (ev.getResult() == Event.Result.ALLOW || (ev.getResult() == Event.Result.DEFAULT && def));
+        var result = MinecraftForge.EVENT_BUS.fire(new BlockEvent.CropGrowEvent.Pre(level,pos,state)).getResult();
+        return (result.isAllowed() || (def && result.isDefault()));
     }
 
     public static void onCropsGrowPost(Level level, BlockPos pos, BlockState state) {


### PR DESCRIPTION
Backport of #10028 to 1.20.6