### PR TITLE
[1.20.4] Add missed @user_jvm_args.txt to run.bat

### DIFF
--- a/server_files/run.bat
+++ b/server_files/run.bat
@@ -9,7 +9,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 REM Add custom program arguments (such as nogui) to the next line before the %* or pass them to this script directly
-java @libraries/@MAVEN_PATH@/win_args.txt %*
+java @user_jvm_args.txt @libraries/@MAVEN_PATH@/win_args.txt %*
 
 :exit
 pause


### PR DESCRIPTION
Backport of [40a0a16](https://github.com/MinecraftForge/MinecraftForge/commit/40a0a16db0dbbdc226ddc8a089ee2e798d4fe6df) to 1.20.4