### PR TITLE
[1.20.4] Use the new fire() and Result#isAllowed/isDenied/isDefault methods from EventBus

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -8,7 +8,7 @@
 -         this.renderNameTag(p_114485_, p_114485_.getDisplayName(), p_114488_, p_114489_, p_114490_);
 +      var renderNameTagEvent = new net.minecraftforge.client.event.RenderNameTagEvent(p_114485_, p_114485_.getDisplayName(), this, p_114488_, p_114489_, p_114490_, p_114487_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(renderNameTagEvent);
-+      if (renderNameTagEvent.getResult() != net.minecraftforge.eventbus.api.Event.Result.DENY && (renderNameTagEvent.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || this.shouldShowName(p_114485_))) {
++      if (!renderNameTagEvent.getResult().isDenied() && (renderNameTagEvent.getResult().isAllowed() || this.shouldShowName(p_114485_))) {
 +         this.renderNameTag(p_114485_, renderNameTagEvent.getContent(), p_114488_, p_114489_, p_114490_);
        }
     }

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -17,7 +17,7 @@
              float f = 1.0F;
              BlockState blockstate = this.level.getBlockState(p_215120_);
              if (!blockstate.isAir()) {
-+               if (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY)
++               if (!event.getUseBlock().isDenied())
                 blockstate.attack(this.level, p_215120_, this.player);
                 f = blockstate.getDestroyProgress(this.player, this.player.level(), p_215120_);
              }
@@ -103,12 +103,12 @@
           MenuProvider menuprovider = blockstate.getMenuProvider(p_9267_, blockpos);
           if (menuprovider != null) {
              p_9266_.openMenu(menuprovider);
-@@ -308,10 +_,15 @@
+@@ -308,10 +_,16 @@
              return InteractionResult.PASS;
           }
        } else {
 +         UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+         if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++         if (!event.getUseItem().isDenied()) {
 +            InteractionResult result = p_9268_.onItemUseFirst(useoncontext);
 +            if (result != InteractionResult.PASS) return result;
 +         }
@@ -117,7 +117,8 @@
 +         boolean flag1 = (p_9266_.isSecondaryUseActive() && flag) && !(p_9266_.getMainHandItem().doesSneakBypassUse(p_9267_, blockpos, p_9266_) && p_9266_.getOffhandItem().doesSneakBypassUse(p_9267_, blockpos, p_9266_));
           ItemStack itemstack = p_9268_.copy();
 -         if (!flag1) {
-+         if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1)) {
++         var useBlockResult = event.getUseBlock();
++         if (useBlockResult.isAllowed() || (!flag1 && !useBlockResult.isDenied())) {
              InteractionResult interactionresult = blockstate.use(p_9267_, p_9266_, p_9269_, p_9270_);
              if (interactionresult.consumesAction()) {
                 CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(p_9266_, blockpos, itemstack);
@@ -127,8 +128,8 @@
  
 -         if (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_.getItem())) {
 -            UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+         if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_.getItem()))) {
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return InteractionResult.PASS;
++         if (event.getUseItem().isAllowed() || (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_.getItem()))) {
++            if (event.getUseItem().isDenied()) return InteractionResult.PASS;
              InteractionResult interactionresult1;
              if (this.isCreative()) {
                 int i = p_9268_.getCount();

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -131,13 +131,12 @@
           if (mobeffectinstance == null) {
              this.activeEffects.put(p_147208_.getEffect(), p_147208_);
              this.onEffectAdded(p_147208_, p_147209_);
-@@ -928,6 +_,9 @@
+@@ -928,6 +_,8 @@
     }
  
     public boolean canBeAffected(MobEffectInstance p_21197_) {
-+      var event = new net.minecraftforge.event.entity.living.MobEffectEvent.Applicable(this, p_21197_);
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+      if (event.getResult() != net.minecraftforge.eventbus.api.Event.Result.DEFAULT) return event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
++      var eventResult = net.minecraftforge.event.ForgeEventFactory.onLivingEffectCanApply(this, p_21197_).getResult();
++      if (!eventResult.isDefault()) return eventResult.isAllowed();
        if (this.getMobType() == MobType.UNDEAD) {
           MobEffect mobeffect = p_21197_.getEffect();
           if (mobeffect == MobEffects.REGENERATION || mobeffect == MobEffects.POISON) {

--- a/patches/minecraft/net/minecraft/world/entity/monster/Spider.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Spider.java.patch
@@ -1,14 +1,12 @@
 --- a/net/minecraft/world/entity/monster/Spider.java
 +++ b/net/minecraft/world/entity/monster/Spider.java
-@@ -121,7 +_,12 @@
+@@ -121,7 +_,10 @@
     }
  
     public boolean canBeAffected(MobEffectInstance p_33809_) {
 -      return p_33809_.getEffect() == MobEffects.POISON ? false : super.canBeAffected(p_33809_);
 +      if (p_33809_.getEffect() == MobEffects.POISON) {
-+         net.minecraftforge.event.entity.living.MobEffectEvent.Applicable event = new net.minecraftforge.event.entity.living.MobEffectEvent.Applicable(this, p_33809_);
-+         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+         return event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW;
++         return net.minecraftforge.event.ForgeEventFactory.onLivingEffectCanApply(this, p_33809_).getResult().isAllowed();
 +      }
 +      return super.canBeAffected(p_33809_);
     }

--- a/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -16,7 +16,7 @@
        }
  
     }
-@@ -275,11 +_,15 @@
+@@ -275,11 +_,16 @@
              livingentity = (LivingEntity)p_34288_.getEntity();
           }
  
@@ -25,12 +25,13 @@
              int j = Mth.floor(this.getY());
              int k = Mth.floor(this.getZ());
 -            Zombie zombie = new Zombie(this.level());
-+         net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent event = net.minecraftforge.event.ForgeEventFactory.fireZombieSummonAid(this, level(), i, j, k, livingentity, this.getAttribute(Attributes.SPAWN_REINFORCEMENTS_CHANCE).getValue());
-+         if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) return true;
-+         if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW  ||
++         var event = net.minecraftforge.event.ForgeEventFactory.fireZombieSummonAid(this, level(), i, j, k, livingentity, this.getAttribute(Attributes.SPAWN_REINFORCEMENTS_CHANCE).getValue());
++         var eventResult = event.getResult();
++         if (eventResult.isDenied()) return true;
++         if (eventResult.isAllowed() ||
 +            livingentity != null && this.level().getDifficulty() == Difficulty.HARD && (double)this.random.nextFloat() < this.getAttribute(Attributes.SPAWN_REINFORCEMENTS_CHANCE).getValue() && this.level()
 +                    .getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING)) {
-+            Zombie zombie = event.getCustomSummonedAid() != null && event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW ? event.getCustomSummonedAid() : EntityType.ZOMBIE.create(this.level());
++            Zombie zombie = event.getCustomSummonedAid() != null && eventResult.isAllowed() ? event.getCustomSummonedAid() : EntityType.ZOMBIE.create(this.level());
  
              for(int l = 0; l < 50; ++l) {
                 int i1 = i + Mth.nextInt(this.random, 7, 40) * Mth.nextInt(this.random, -1, 1);

--- a/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FungusBlock.java.patch
@@ -6,7 +6,7 @@
        this.getFeature(p_221243_).ifPresent((p_256352_) -> {
 -         p_256352_.value().place(p_221243_, p_221243_.getChunkSource().getGenerator(), p_221244_, p_221245_);
 +         var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_221243_, p_221244_, p_221245_, p_256352_);
-+         if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY)) return;
++         if (event.getResult().isDenied()) return;
 +         event.getFeature().value().place(p_221243_, p_221243_.getChunkSource().getGenerator(), p_221244_, p_221245_);
        });
     }

--- a/patches/minecraft/net/minecraft/world/level/block/grower/TreeGrower.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/grower/TreeGrower.java.patch
@@ -6,7 +6,7 @@
           Holder<ConfiguredFeature<?, ?>> holder = p_309830_.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).getHolder(resourcekey).orElse((Holder.Reference<ConfiguredFeature<?, ?>>)null);
 +         var event = net.minecraftforge.event.ForgeEventFactory.blockGrowFeature(p_309830_, p_309951_, p_310327_, holder);
 +         holder = event.getFeature();
-+         if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) return false;
++         if (event.getResult().isDenied()) return false;
           if (holder != null) {
              for(int i = 0; i >= -1; --i) {
                 for(int j = 0; j >= -1; --j) {

--- a/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/levelgen/PhantomSpawner.java
 +++ b/net/minecraft/world/level/levelgen/PhantomSpawner.java
-@@ -42,19 +_,22 @@
+@@ -42,19 +_,23 @@
                 for(ServerPlayer serverplayer : p_64576_.players()) {
                    if (!serverplayer.isSpectator()) {
                       BlockPos blockpos = serverplayer.blockPosition();
@@ -9,14 +9,15 @@
 +                     DifficultyInstance difficultyinstance = p_64576_.getCurrentDifficultyAt(blockpos);
 +                     var event = new net.minecraftforge.event.entity.player.PlayerSpawnPhantomsEvent(serverplayer, 1 + randomsource.nextInt(difficultyinstance.getDifficulty().getId() + 1));
 +                     net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY) continue;
-+                     if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || !p_64576_.dimensionType().hasSkyLight() || blockpos.getY() >= p_64576_.getSeaLevel() && p_64576_.canSeeSky(blockpos)) {
++                     var eventResult = event.getResult();
++                     if (eventResult.isDenied()) continue;
++                     if (eventResult.isAllowed() || !p_64576_.dimensionType().hasSkyLight() || blockpos.getY() >= p_64576_.getSeaLevel() && p_64576_.canSeeSky(blockpos)) {
                          if (difficultyinstance.isHarderThan(randomsource.nextFloat() * 3.0F)) {
                             ServerStatsCounter serverstatscounter = serverplayer.getStats();
                             int j = Mth.clamp(serverstatscounter.getValue(Stats.CUSTOM.get(Stats.TIME_SINCE_REST)), 1, Integer.MAX_VALUE);
                             int k = 24000;
 -                           if (randomsource.nextInt(j) >= 72000) {
-+                           if (event.getResult() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || randomsource.nextInt(j) >= 72000) {
++                           if (eventResult.isAllowed() || randomsource.nextInt(j) >= 72000) {
                                BlockPos blockpos1 = blockpos.above(20 + randomsource.nextInt(15)).east(-10 + randomsource.nextInt(21)).south(-10 + randomsource.nextInt(21));
                                BlockState blockstate = p_64576_.getBlockState(blockpos1);
                                FluidState fluidstate = p_64576_.getFluidState(blockpos1);

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
             library('coremods', 'net.minecraftforge:coremods:5.1.0')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.3') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.0')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
@@ -51,7 +51,7 @@ dependencyResolutionManagement {
             library('bootstrap-shim', 'net.minecraftforge', 'bootstrap-shim').versionRef('bootstrap')
 
             // ASM it's used for so many of our hacks
-            version('asm', '9.6')
+            version('asm', '9.7')
             library('asm',          'org.ow2.asm', 'asm'         ).versionRef('asm')
             library('asm-tree',     'org.ow2.asm', 'asm-tree'    ).versionRef('asm')
             library('asm-util',     'org.ow2.asm', 'asm-util'    ).versionRef('asm')

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -757,9 +757,8 @@ public class ForgeHooks {
     }
 
     public static boolean onCropsGrowPre(Level level, BlockPos pos, BlockState state, boolean def) {
-        BlockEvent ev = new BlockEvent.CropGrowEvent.Pre(level,pos,state);
-        MinecraftForge.EVENT_BUS.post(ev);
-        return (ev.getResult() == Event.Result.ALLOW || (ev.getResult() == Event.Result.DEFAULT && def));
+        var result = MinecraftForge.EVENT_BUS.fire(new BlockEvent.CropGrowEvent.Pre(level,pos,state)).getResult();
+        return (result.isAllowed() || (def && result.isDefault()));
     }
 
     public static void onCropsGrowPost(Level level, BlockPos pos, BlockState state) {
@@ -768,9 +767,8 @@ public class ForgeHooks {
 
     @Nullable
     public static CriticalHitEvent getCriticalHit(Player player, Entity target, boolean vanillaCritical, float damageModifier) {
-        CriticalHitEvent hitResult = new CriticalHitEvent(player, target, damageModifier, vanillaCritical);
-        MinecraftForge.EVENT_BUS.post(hitResult);
-        if (hitResult.getResult() == Event.Result.ALLOW || (vanillaCritical && hitResult.getResult() == Event.Result.DEFAULT))
+        CriticalHitEvent hitResult = MinecraftForge.EVENT_BUS.fire(new CriticalHitEvent(player, target, damageModifier, vanillaCritical));
+        if (hitResult.getResult().isAllowed() || (vanillaCritical && hitResult.getResult().isDefault()))
             return hitResult;
         return null;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -29,6 +29,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.Container;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
@@ -104,17 +105,7 @@ import net.minecraftforge.event.entity.EntityTeleportEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
-import net.minecraftforge.event.entity.living.AnimalTameEvent;
-import net.minecraftforge.event.entity.living.LivingConversionEvent;
-import net.minecraftforge.event.entity.living.LivingDestroyBlockEvent;
-import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
-import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
-import net.minecraftforge.event.entity.living.LivingFallEvent;
-import net.minecraftforge.event.entity.living.LivingHealEvent;
-import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
-import net.minecraftforge.event.entity.living.LivingSwapItemsEvent;
-import net.minecraftforge.event.entity.living.MobSpawnEvent;
-import net.minecraftforge.event.entity.living.ShieldBlockEvent;
+import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.living.MobSpawnEvent.AllowDespawn;
 import net.minecraftforge.event.entity.living.MobSpawnEvent.PositionCheck;
 import net.minecraftforge.event.entity.living.MobSpawnEvent.SpawnPlacementCheck;
@@ -489,6 +480,10 @@ public class ForgeEventFactory {
     public static float onLivingHeal(LivingEntity entity, float amount) {
         var event = new LivingHealEvent(entity, amount);
         return (post(event) ? 0 : event.getAmount());
+    }
+
+    public static MobEffectEvent.Applicable onLivingEffectCanApply(LivingEntity entity, MobEffectInstance effect) {
+        return fire(new MobEffectEvent.Applicable(entity, effect));
     }
 
     public static boolean onPotionAttemptBrew(NonNullList<ItemStack> stacks) {


### PR DESCRIPTION
Backport of #10028 to 1.20.4.

Also bumps ASM to 9.7 in line with 1.20.6 and 1.20.1