### PR TITLE
[1.19.4] Remove unneeded boat patch

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -63,20 +63,3 @@
     }
  
     protected int m_213801_() {
-@@ -858,6 +_,16 @@
- 
-    public boolean m_5842_() {
-       return this.f_38279_ == Boat.Status.UNDER_WATER || this.f_38279_ == Boat.Status.UNDER_FLOWING_WATER;
-+   }
-+
-+   // Forge: Fix MC-119811 by instantly completing lerp on board
-+   @Override
-+   protected void m_20348_(Entity passenger) {
-+      super.m_20348_(passenger);
-+      if (this.m_6109_() && this.f_38267_ > 0) {
-+         this.f_38267_ = 0;
-+         this.m_19890_(this.f_38268_, this.f_38269_, this.f_38270_, (float)this.f_38271_, (float)this.f_38272_);
-+      }
-    }
- 
-    public ItemStack m_142340_() {


### PR DESCRIPTION
Backport of https://github.com/MinecraftForge/MinecraftForge/pull/10061 to 1.19.4