### PR TITLE
Update vulnerable `eclipse` dependency

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     implementation 'net.minecraftforge:srgutils:0.5.10'
     implementation 'commons-io:commons-io:2.13.0'
     implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r'
 }


### PR DESCRIPTION
See [CVE-2023-4759](https://nvd.nist.gov/vuln/detail/CVE-2023-4759) for full description