### PR TITLE
bump JNA to 5.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -447,7 +447,7 @@ def sharedFmlonlyForge = { Project prj ->
         // SecureJarHandler bootstrap values.
         run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,lowcodelanguage,mclanguage,${prj.name}-"
         // FIXME: Without this jna doesn't work at runtime. Someone figure out why please?
-        run.property 'mergeModules', 'jna-5.10.0.jar,jna-platform-5.10.0.jar'
+        run.property 'mergeModules', 'jna-5.12.1.jar,jna-platform-5.12.1.jar'
         if (userdevRuns.contains(run)) {
             run.property 'legacyClassPath.file', '{minecraft_classpath_file}'
             run.jvmArgs '-p', '{modules}'


### PR DESCRIPTION
bumped JNA to 5.12.1 .

this fixes the mod 'WATERMeDIA' and 'WATERFrAMES' on mac on 1.19.2. on the previous version of JNA the mod couldn't hook into VLC and play videos