### PR TITLE
Patch BlockEntity#isValidBlockState to use getType Method 

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -22,6 +22,15 @@
      }
  
      private void validateBlockState(BlockState p_345558_) {
+@@ -51,7 +_,7 @@
+     }
+ 
+     public boolean isValidBlockState(BlockState p_345570_) {
+-        return this.type.isValid(p_345570_);
++        return this.getType().isValid(p_345570_);
+     }
+ 
+     public static BlockPos getPosFromTag(CompoundTag p_187473_) {
 @@ -72,6 +_,7 @@
      }
  


### PR DESCRIPTION
Useful patch for subclasses of blockentities that don't allow passing the type into the constructor directly, if this is the case devs have to then override isValidBlockState to prevent a crash dude to the block entity type being hardcoded in some vanilla block entities