### PR TITLE
[1.20.4] Bump CoreMods to 5.2

### DIFF
--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -74,3 +74,11 @@ eclipse {
     // Run when importing the project
     synchronizationTasks generateResources, copyEclipseSettings, eclipseClasspath, eclipseProject
 }
+
+idea {
+    module {
+        // IntelliJ IDEA does not do this by itself anymore...
+        downloadJavadoc = true
+        downloadSources = true
+    }
+}

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -57,6 +57,9 @@ public class FMLLoader {
         LOGGER.debug(CORE, "Detected version data : {}", versionInfo);
         LOGGER.debug(CORE, "FML {} loading", LauncherVersion.getVersion());
 
+        // Allows us to communicate properties with other services through ModLauncher
+        setupBlackboardKeys();
+
         checkPackage(ITransformationService.class, "4.0", "ModLauncher");
         accessTransformer  = getPlugin(env, "accesstransformer",  "1.0", "AccessTransformer");
         /*eventBus       =*/ getPlugin(env, "eventbus",           "1.0", "EventBus");
@@ -118,6 +121,12 @@ public class FMLLoader {
           }
 
           return providers.get(0);
+    }
+
+    private static void setupBlackboardKeys() {
+        LOGGER.debug(CORE, "Requesting CoreMods to not apply the fix for ASMAPI.findFirstInstructionBefore by default");
+        var blackboardKey = TypesafeMap.Key.getOrCreate(Launcher.INSTANCE.blackboard(), "coremods.use_old_findFirstInstructionBefore", Boolean.class);
+        Launcher.INSTANCE.blackboard().<Boolean>computeIfAbsent(blackboardKey, k -> true);
     }
 
     static void setupLaunchHandler(final IEnvironment environment, final Map<String, Object> arguments) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
-            library('coremods', 'net.minecraftforge:coremods:5.2.0')
+            library('coremods', 'net.minecraftforge:coremods:5.2.1')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,8 +29,8 @@ dependencyResolutionManagement {
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
-            library('coremods', 'net.minecraftforge:coremods:5.1.0')
-            library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.3') // Needed by coremods, because the JRE no longer ships JS
+            library('coremods', 'net.minecraftforge:coremods:5.2.0')
+            library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
@@ -51,7 +51,7 @@ dependencyResolutionManagement {
             library('bootstrap-shim', 'net.minecraftforge', 'bootstrap-shim').versionRef('bootstrap')
 
             // ASM it's used for so many of our hacks
-            version('asm', '9.7')
+            version('asm', '9.7.1')
             library('asm',          'org.ow2.asm', 'asm'         ).versionRef('asm')
             library('asm-tree',     'org.ow2.asm', 'asm-tree'    ).versionRef('asm')
             library('asm-util',     'org.ow2.asm', 'asm-util'    ).versionRef('asm')


### PR DESCRIPTION
This PR bumps CoreMods to 5.2.

- Backport of #10156 to 1.20.4.
- Includes disabling the fix for `ASMAPI.findFirstInstructionBefore`.

Related dependency bumps:
- Updated ASM to 9.7.1
- Updated Nashorn to 15.4