### PR TITLE
[1.21.3] Remove redundant rendering options

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
@@ -11,18 +11,13 @@
              }
  
              this.setFilterMode(9728, true);
-@@ -106,8 +_,13 @@
-             GlStateManager._texImage2D(3553, 0, 32856, this.width, this.height, 0, 6408, 5121, null);
+@@ -107,7 +_,8 @@
              GlStateManager._glBindFramebuffer(36160, this.frameBufferId);
              GlStateManager._glFramebufferTexture2D(36160, 36064, 3553, this.colorTextureId, 0);
--            if (this.useDepth) {
-+            if (this.useDepth && !stencilEnabled) {
-                 GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0);
-+            } else if(this.useDepth && net.minecraftforge.common.ForgeConfig.CLIENT.useCombinedDepthStencilAttachment.get()) {
-+                GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_DEPTH_STENCIL_ATTACHMENT, 3553, this.depthBufferId, 0);
-+            } else if (this.useDepth) {
-+                GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_DEPTH_ATTACHMENT, 3553, this.depthBufferId, 0);
-+                GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_STENCIL_ATTACHMENT, 3553, this.depthBufferId, 0);
+             if (this.useDepth) {
+-                GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0);
++                if (stencilEnabled) GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_DEPTH_STENCIL_ATTACHMENT, 3553, this.depthBufferId, 0);
++                else GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0); // GL_DEPTH_ATTACHMENT
              }
  
              this.checkStatus();

--- a/patches/minecraft/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
@@ -11,13 +11,11 @@
              }
  
              this.setFilterMode(9728, true);
-@@ -107,7 +_,8 @@
-             GlStateManager._glBindFramebuffer(36160, this.frameBufferId);
+@@ -108,6 +_,7 @@
              GlStateManager._glFramebufferTexture2D(36160, 36064, 3553, this.colorTextureId, 0);
              if (this.useDepth) {
--                GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0);
-+                if (stencilEnabled) GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_DEPTH_STENCIL_ATTACHMENT, 3553, this.depthBufferId, 0);
-+                else GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0); // GL_DEPTH_ATTACHMENT
+                 GlStateManager._glFramebufferTexture2D(36160, 36096, 3553, this.depthBufferId, 0);
++                if (stencilEnabled) GlStateManager._glFramebufferTexture2D(org.lwjgl.opengl.GL30.GL_FRAMEBUFFER, org.lwjgl.opengl.GL30.GL_STENCIL_ATTACHMENT, 3553, this.depthBufferId, 0);
              }
  
              this.checkStatus();

--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -177,15 +177,6 @@
          }
      }
  
-@@ -1112,7 +_,7 @@
-                 boolean flag = false;
-                 if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.NEARBY) {
-                     BlockPos blockpos1 = sectionrenderdispatcher$rendersection.getOrigin().offset(8, 8, 8);
--                    flag = blockpos1.distSqr(blockpos) < 768.0 || sectionrenderdispatcher$rendersection.isDirtyFromPlayer();
-+                    flag = !net.minecraftforge.common.ForgeConfig.CLIENT.alwaysSetupTerrainOffThread.get() && (blockpos1.distSqr(blockpos) < 768.0D || sectionrenderdispatcher$rendersection.isDirtyFromPlayer()); // the target is the else block below, so invert the forge addition to get there early
-                 } else if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
-                     flag = sectionrenderdispatcher$rendersection.isDirtyFromPlayer();
-                 }
 @@ -1391,7 +_,7 @@
          } else {
              int i = p_109538_.getBrightness(LightLayer.SKY, p_109540_);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -447,7 +447,7 @@ public class ForgeHooksClient {
     // TODO Do we need this?
     public static void fillNormal(int[] faceData, Direction facing, boolean calculateNormals) {
         Vector3f v2;
-        if (calculateNormals || ForgeConfig.CLIENT.calculateAllNormals()) {
+        if (calculateNormals) {
             Vector3f v1 = getVertexPos(faceData, 3);
             Vector3f t1 = getVertexPos(faceData, 1);
             v2 = getVertexPos(faceData, 2);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -100,8 +100,6 @@ public class ForgeConfig {
 
         public final BooleanValue useCombinedDepthStencilAttachment;
 
-        public final BooleanValue calculateAllNormals;
-
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -121,24 +119,11 @@ public class ForgeConfig {
                     .translation("forge.configgui.useCombinedDepthStencilAttachment")
                     .define("useCombinedDepthStencilAttachment", false);
 
-            calculateAllNormals = builder
-                    .comment("During block model baking, manually calculates the normal for all faces.",
-                            "This was the default behavior of forge between versions 31.0 and 47.1.",
-                            "May result in differences between vanilla rendering and forge rendering.",
-                            "Will only produce differences for blocks that contain non-axis aligned faces.",
-                            "You will need to reload your resources to see results.")
-                    .translation("forge.configgui.calculateAllNormals")
-                    .define("calculateAllNormals", false);
-
             builder.pop();
         }
 
         // Allow these to be called before the config is loaded because its used before loading the error screens.
         // Prevents a ton of spam when an error screen is displayed.
-        public final boolean calculateAllNormals() {
-            return clientSpec.isLoaded() ? calculateAllNormals.get() : calculateAllNormals.getDefault();
-        }
-
         public final boolean showLoadWarnings() {
             return clientSpec.isLoaded() ? showLoadWarnings.get() : showLoadWarnings.getDefault();
         }

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -98,8 +98,6 @@ public class ForgeConfig {
 
         public final BooleanValue showLoadWarnings;
 
-        public final BooleanValue useCombinedDepthStencilAttachment;
-
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -113,11 +111,6 @@ public class ForgeConfig {
                 .comment("When enabled, Forge will show any warnings that occurred during loading.")
                 .translation("forge.configgui.showLoadWarnings")
                 .define("showLoadWarnings", true);
-
-            useCombinedDepthStencilAttachment = builder
-                    .comment("Set to true to use a combined DEPTH_STENCIL attachment instead of two separate ones.")
-                    .translation("forge.configgui.useCombinedDepthStencilAttachment")
-                    .define("useCombinedDepthStencilAttachment", false);
 
             builder.pop();
         }

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -94,8 +94,6 @@ public class ForgeConfig {
      * Client specific configuration - only loaded clientside from forge-client.toml
      */
     public static class Client {
-        public final BooleanValue alwaysSetupTerrainOffThread;
-
         public final BooleanValue experimentalForgeLightPipelineEnabled;
 
         public final BooleanValue showLoadWarnings;
@@ -107,13 +105,6 @@ public class ForgeConfig {
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
-
-            alwaysSetupTerrainOffThread = builder
-                .comment("Enable Forge to queue all chunk updates to the Chunk Update thread.",
-                        "May increase FPS significantly, but may also cause weird rendering lag.",
-                        "Not recommended for computers without a significant number of cores available.")
-                .translation("forge.configgui.alwaysSetupTerrainOffThread")
-                .define("alwaysSetupTerrainOffThread", false);
 
             experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.")


### PR DESCRIPTION
This PR removes rendering options that Forge added which are now deemed redundant.

- `alwaysSetupTerrainOffThread`
    - This has been in Vanilla since 1.18, so this is no longer needed and may have been hurting Forge performance over Vanilla by making it off by default.
- `calculateAllNormals`
    - Differs from Vanilla behaviour, been off by default since 47.1.0 and not aware of any major mods needing this on
    - Currently has no effect in 1.21.3 build 53.0.0
- `useCombinedDepthStencilAttachment`
    - Forge adds a `RenderTarget.enableStencil()` method which when called, enables a stencil attachment on the buffer. The config option switches from calling `GL_DEPTH_ATTACHMENT` and `GL_STENCIL_ATTACHMENT` on the same buffer separately to calling `GL_DEPTH_STENCIL_ATTACHMENT` once
    - My limited understanding is that these are equivalent and that it defaulted to the two separate calls to workaround a bug in very old Nvidia graphics drivers many years ago.
    - The option has been removed and has the same behaviour as the default