### PR TITLE
[1.21.3] Further ForgeConfigSpec cleanup

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -707,15 +707,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public boolean hasComment() { return !this.comment.isEmpty(); }
         public String buildComment() { return buildComment(List.of("unknown", "unknown")); }
         public String buildComment(final List<String> path) {
-            if (comment.stream().allMatch(String::isBlank)) {
-                if (FMLEnvironment.production)
-                    LOGGER.warn(Logging.CORE, "Detected a comment that is all whitespace for config option {}, which causes obscure bugs in Forge's config system and will cause a crash in the future. Please report this to the mod author.",
-                            DOT_JOINER.join(path));
-                else
-                    throw new IllegalStateException("Can not build comment for config option " + DOT_JOINER.join(path) + " as it comprises entirely of blank lines/whitespace. This is not allowed as it causes a \"constantly correcting config\" bug with NightConfig in Forge's config system.");
-
-                return "A developer of this mod has defined this config option with a blank comment, which causes obscure bugs in Forge's config system and will cause a crash in the future. Please report this to the mod author.";
-            }
+            if (comment.stream().allMatch(String::isBlank))
+                throw new IllegalStateException("Can not build comment for config option " + DOT_JOINER.join(path) + " as it comprises entirely of blank lines/whitespace. This is not allowed as it causes a \"constantly correcting config\" bug with NightConfig in Forge's config system.");
 
             return LINE_JOINER.join(comment);
         }

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.config.IConfigSpec;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
@@ -37,7 +36,6 @@ import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import com.electronwill.nightconfig.core.file.FileConfig;
 import com.electronwill.nightconfig.core.utils.UnmodifiableConfigWrapper;
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,7 +57,6 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
     private static final Pattern WINDOWS_NEWLINE = Pattern.compile("\r\n");
     private static final Joiner LINE_JOINER = Joiner.on("\n");
     private static final Joiner DOT_JOINER = Joiner.on(".");
-    private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
     private ForgeConfigSpec(UnmodifiableConfig storage, UnmodifiableConfig values, Map<List<String>, String> levelComments, Map<List<String>, String> levelTranslationKeys) {
         super(storage);

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -245,7 +245,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         return count;
     }
 
-    private boolean stringsMatchIgnoringNewlines(@Nullable String string1, @Nullable String string2) {
+    private static boolean stringsMatchIgnoringNewlines(@Nullable String string1, @Nullable String string2) {
         if (string1 != null && string2 != null) {
             if (!string1.isEmpty() && !string2.isEmpty()) {
                 return WINDOWS_NEWLINE.matcher(string1).replaceAll("\n")
@@ -346,13 +346,13 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 @Override
                 public Object correct(Object value) {
                     if (!(value instanceof List<?> list) || list.isEmpty()) {
-                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It is null, not a list, or an empty list. Modders, consider defineListAllowEmpty?", path.get(path.size() - 1));
+                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It is null, not a list, or an empty list. Modders, consider defineListAllowEmpty?", path.getLast());
                         return getDefault();
                     }
                     final List<?> copy = new ArrayList<>(list);
                     copy.removeIf(elementValidator.negate());
                     if (copy.isEmpty()) {
-                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It failed validation.", path.get(path.size() - 1));
+                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It failed validation.", path.getLast());
                         return getDefault();
                     }
                     return copy;
@@ -374,13 +374,13 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
                 @Override
                 public Object correct(Object value) {
                     if (!(value instanceof List<?> list)) {
-                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction, as it is null or not a list.", path.get(path.size() - 1));
+                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction, as it is null or not a list.", path.getLast());
                         return getDefault();
                     }
                     final List<?> copy = new ArrayList<>(list);
                     copy.removeIf(elementValidator.negate());
                     if (copy.isEmpty()) {
-                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It failed validation.", path.get(path.size() - 1));
+                        LOGGER.debug(Logging.CORE, "List on key {} is deemed to need correction. It failed validation.", path.getLast());
                         return getDefault();
                     }
                     return copy;

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -1119,6 +1119,9 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
     }
 
     private static List<String> split(String path) {
-        return DOT_SPLITTER.splitToStream(path).toList();
+        if (path.contains("."))
+            throw new IllegalArgumentException("Path cannot contain '.' - use nested push/pop calls or List.of() instead");
+
+        return Collections.singletonList(path);
     }
 }


### PR DESCRIPTION
- Promote 1.19.x deprecations to finally always throw exceptions
    - Mod devs have had years to fix their mods at this point, with it logging a warning in production and crashing in userdev
- Avoid allocating suppliers internally, add more overloads that accept `defaultValue`
    - Reduces memory usage
- Remove support for implicit paths
    - Mod devs are encouraged to use push()/pop() or List.of() instead