### PR TITLE
[1.21.3] Fix pause menu having a black background

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/platform/GlStateManager.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/platform/GlStateManager.java.patch
@@ -1,5 +1,17 @@
 --- a/com/mojang/blaze3d/platform/GlStateManager.java
 +++ b/com/mojang/blaze3d/platform/GlStateManager.java
+@@ -94,6 +_,11 @@
+         }
+     }
+ 
++    public static boolean _isBlendEnabled() {
++        RenderSystem.assertOnRenderThread();
++        return BLEND.mode.enabled;
++    }
++
+     public static void _disableBlend() {
+         RenderSystem.assertOnRenderThread();
+         BLEND.mode.disable();
 @@ -519,9 +_,17 @@
          }
      }

--- a/patches/minecraft/com/mojang/blaze3d/systems/RenderSystem.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/systems/RenderSystem.java.patch
@@ -1,0 +1,14 @@
+--- a/com/mojang/blaze3d/systems/RenderSystem.java
++++ b/com/mojang/blaze3d/systems/RenderSystem.java
+@@ -196,6 +_,11 @@
+         GlStateManager._depthMask(p_69459_);
+     }
+ 
++    public static boolean isBlendEnabled() {
++        assertOnRenderThread();
++        return GlStateManager._isBlendEnabled();
++    }
++
+     public static void enableBlend() {
+         assertOnRenderThread();
+         GlStateManager._enableBlend();

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -11,15 +11,17 @@
          }
      }
  
-@@ -171,8 +_,11 @@
+@@ -171,8 +_,13 @@
          if (!(f < 1.0F)) {
              PostChain postchain = this.minecraft.getShaderManager().getPostChain(BLUR_POST_CHAIN_ID, LevelTargetBundle.MAIN_TARGETS);
              if (postchain != null) {
-+                // FORGE: Blending the blur was removed in 1.21. This is necessary for screen layering to work properly. https://github.com/MinecraftForge/MinecraftForge/issues/10114
-+                RenderSystem.enableBlend();
++                boolean wasBlendEnabled = RenderSystem.isBlendEnabled();
++                if (wasBlendEnabled)
++                    RenderSystem.disableBlend();
                  postchain.setUniform("Radius", f);
                  postchain.process(this.minecraft.getMainRenderTarget(), this.resourcePool);
-+                RenderSystem.disableBlend();
++                if (wasBlendEnabled)
++                    RenderSystem.enableBlend();
              }
          }
      }


### PR DESCRIPTION
The new render layers require that the container blur be rendered with blending disabled, as the blending itself will also (sadly) blend the alpha channel of the image.

This will, unfortunately, undo: https://github.com/MinecraftForge/MinecraftForge/pull/10115 for the time being.