### PR TITLE
Add AT for BlockEntityType constructor.

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -352,6 +352,7 @@ public net.minecraft.world.level.block.Block m_49805_(Lnet/minecraft/server/leve
 public net.minecraft.world.level.block.FireBlock m_221164_(Lnet/minecraft/world/level/block/state/BlockState;)I # getBurnOdds
 public net.minecraft.world.level.block.FireBlock m_221166_(Lnet/minecraft/world/level/block/state/BlockState;)I # getIgniteOdds
 public net.minecraft.world.level.block.entity.BlockEntityType$BlockEntitySupplier
+public net.minecraft.world.level.block.entity.BlockEntityType <init>(Lnet/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier;Ljava/util/Set;)V # <init>
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59395_(I)V # setCooldown
 public net.minecraft.world.level.block.entity.HopperBlockEntity m_59409_()Z # isOnCustomCooldown
 public net.minecraft.world.level.block.state.properties.BlockSetType m_272115_(Lnet/minecraft/world/level/block/state/properties/BlockSetType;)Lnet/minecraft/world/level/block/state/properties/BlockSetType; # register


### PR DESCRIPTION
1.21.3 has removed the builder for BlockEntityType. The constructor, however, is private. This would make it simpler for registration.