### PR TITLE
[1.21.1] Add optional fix of use item duration, disabled by default

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -515,14 +515,12 @@
              this.completeUsingItem();
          }
      }
-@@ -3029,8 +_,12 @@
+@@ -3029,8 +_,10 @@
      public void startUsingItem(InteractionHand p_21159_) {
          ItemStack itemstack = this.getItemInHand(p_21159_);
          if (!itemstack.isEmpty() && !this.isUsingItem()) {
 +            int duration = net.minecraftforge.event.ForgeEventFactory.onItemUseStart(this, itemstack, itemstack.getUseDuration(this));
-+            if (duration <= 0) {
-+                return;
-+            }
++            if (duration < 0) return;
              this.useItem = itemstack;
 -            this.useItemRemaining = itemstack.getUseDuration(this);
 +            this.useItemRemaining = duration;

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -520,7 +520,7 @@
          ItemStack itemstack = this.getItemInHand(p_21159_);
          if (!itemstack.isEmpty() && !this.isUsingItem()) {
 +            int duration = net.minecraftforge.event.ForgeEventFactory.onItemUseStart(this, itemstack, itemstack.getUseDuration(this));
-+            if (duration < 0) return;
++            if (duration < net.minecraftforge.common.ForgeConfig.SERVER.getUseItemDuration()) return;
              this.useItem = itemstack;
 -            this.useItemRemaining = itemstack.getUseDuration(this);
 +            this.useItemRemaining = duration;

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -29,6 +29,8 @@ public class ForgeConfig {
 
         public final BooleanValue advertiseDedicatedServerToLan;
 
+        public final BooleanValue useItemWithDurationZero;
+
         Server(ForgeConfigSpec.Builder builder) {
             builder.comment("Server configuration settings")
                    .push("server");
@@ -61,7 +63,16 @@ public class ForgeConfig {
                     .translation("forge.configgui.advertiseDedicatedServerToLan")
                     .define("advertiseDedicatedServerToLan", true);
 
+            useItemWithDurationZero = builder
+                    .comment("Set this to true to enable living entities to use items with durations of 0. Fixes being able to use Eyes of Ender repeatedly by holding down the use button. Disabled by default as it could change interactions with items of existing mods.")
+                    .translation("forge.configgui.useItemWithDurationZero")
+                    .define("useItemWithDurationZero", false);
+
             builder.pop();
+        }
+
+        public final int getUseItemDuration() {
+            return useItemWithDurationZero.get() ? 0 : 1;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -46,7 +46,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      *   Drinking Potions/Milk
      *   Guarding with a sword
      *
-     * Cancel the event, or set the duration or {@literal <=} 0 to prevent it from processing.
+     * Cancel the event, or set the duration or {@literal <} 0 to prevent it from processing.
      *
      */
     @Cancelable

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -170,6 +170,8 @@
   "forge.configgui.skipEmptyShapelessCheck":  "Skip checking for empty ingredients in Shapeless Recipe Deserialization",
   "forge.configgui.forceSystemNanoTime.tooltip": "Force the use of System.nanoTime instead of glfwGetTime as the main client Time provider.",
   "forge.configgui.forceSystemNanoTime": "Force System.nanoTime",
+  "forge.configgui.useItemWithDurationZero": "Allow Use Item with Duration of 0",
+  "forge.configgui.useItemWithDurationZero.tooltip": "Set this to true to enable living entities to use items with durations of 0. Fixes being able to use Eyes of Ender repeatedly by holding down the use button. Disabled by default as it could change interactions with items of existing mods.",
 
   "forge.configgui.zoomInMissingModelTextInGui.tooltip": "Toggle off to make missing model text in the gui fit inside the slot.",
   "forge.configgui.zoomInMissingModelTextInGui": "Zoom in Missing model text in the GUI",


### PR DESCRIPTION
Fixes #10150 for 1.21.1. This fix is disabled by default and can only be enabled through the server config.