### PR TITLE
[1.21.3] Bump CoreMods to 5.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.20') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
-            library('coremods', 'net.minecraftforge:coremods:5.1.13')
+            library('coremods', 'net.minecraftforge:coremods:5.2.0')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.20') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
-            library('coremods', 'net.minecraftforge:coremods:5.2.0')
+            library('coremods', 'net.minecraftforge:coremods:5.2.1')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas


### PR DESCRIPTION
This PR bumps CoreMods to 5.2.

Full Changelog:
https://gist.github.com/Jonathing/c3ad28b2a048ac839a7baba5417ee870

The key features are:
- ES6 language support
- Thoroughly updated ASMAPI, with full documentation
- Bug fixes (some optional for backwards-compatibility)
- Partial internal code cleanup