### PR TITLE
[1.20.6] Bump CoreMods to 5.2

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -57,6 +57,9 @@ public class FMLLoader {
         LOGGER.debug(CORE, "Detected version data : {}", versionInfo);
         LOGGER.debug(CORE, "FML {} loading", LauncherVersion.getVersion());
 
+        // Allows us to communicate properties with other services through ModLauncher
+        setupBlackboardKeys();
+
         checkPackage(ITransformationService.class, "4.0", "ModLauncher");
         accessTransformer  = getPlugin(env, "accesstransformer",  "1.0", "AccessTransformer");
         /*eventBus       =*/ getPlugin(env, "eventbus",           "1.0", "EventBus");
@@ -118,6 +121,12 @@ public class FMLLoader {
           }
 
           return providers.get(0);
+    }
+
+    private static void setupBlackboardKeys() {
+        LOGGER.debug(CORE, "Requesting CoreMods to not apply the fix for ASMAPI.findFirstInstructionBefore by default");
+        var blackboardKey = TypesafeMap.Key.getOrCreate(Launcher.INSTANCE.blackboard(), "coremods.use_old_findFirstInstructionBefore", Boolean.class);
+        Launcher.INSTANCE.blackboard().<Boolean>computeIfAbsent(blackboardKey, k -> true);
     }
 
     static void setupLaunchHandler(final IEnvironment environment, final Map<String, Object> arguments) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
-            library('coremods', 'net.minecraftforge:coremods:5.1.13')
+            library('coremods', 'net.minecraftforge:coremods:5.2.0')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
-            library('coremods', 'net.minecraftforge:coremods:5.2.0')
+            library('coremods', 'net.minecraftforge:coremods:5.2.1')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas


### PR DESCRIPTION
This PR bumps CoreMods to 5.2.

- Backport of #10156 to 1.20.6.
- Includes disabling the fix for `ASMAPI.findFirstInstructionBefore`.