### PR TITLE
[1.21.3] Pass player argument when firing `OnDatapackSyncEvent`

### DIFF
--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -12,7 +12,7 @@
          servergamepacketlistenerimpl.send(new ClientboundPlayerAbilitiesPacket(p_11263_.getAbilities()));
          servergamepacketlistenerimpl.send(new ClientboundSetHeldSlotPacket(p_11263_.getInventory().selected));
          RecipeManager recipemanager = this.server.getRecipeManager();
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, null));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, p_11263_));
          servergamepacketlistenerimpl.send(new ClientboundUpdateRecipesPacket(recipemanager.getSynchronizedItemProperties(), recipemanager.getSynchronizedStonecutterRecipes()));
          this.sendPlayerPermissionLevel(p_11263_);
          p_11263_.getStats().markAllDirty();


### PR DESCRIPTION
A while ago I submitted a pull request to add back the patch to fire the `OnDatapackSyncEvent` event in `PlayerList#placeNewPlayer`, #10076. This was supposed to be a straight copy from the patch in 1.20.4 ([PlayerList.java.patch](https://github.com/MinecraftForge/MinecraftForge/blob/1.20.4/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch)), however it seems I made a mistake and somehow managed to put `null` for the player argument rather than passing the player object.

This PR simply passes the player object to the event rather than `null`.