### PR TITLE
[1.19.4] Bump JNA to 5.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,8 @@ def sharedDeps = {
     installer 'org.openjdk.nashorn:nashorn-core:15.4'
     installer "net.minecraftforge:JarJarSelector:${JARJAR_VERSION}"
     installer "net.minecraftforge:JarJarMetadata:${JARJAR_VERSION}"
+    installer 'net.java.dev.jna:jna:5.12.1'
+    installer 'net.java.dev.jna:jna-platform:5.12.1'
 
     /*
     installer 'org.lwjgl:lwjgl:3.2.2'
@@ -455,7 +457,7 @@ def sharedFmlonlyForge = { Project prj ->
         // SecureJarHandler bootstrap values.
         run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,lowcodelanguage,mclanguage,${prj.name}-"
         // FIXME: Without this jna doesn't work at runtime. Someone figure out why please?
-        run.property 'mergeModules', 'jna-5.10.0.jar,jna-platform-5.10.0.jar'
+        run.property 'mergeModules', 'jna-5.12.1.jar,jna-platform-5.12.1.jar'
         if (userdevRuns.contains(run)) {
             run.property 'legacyClassPath.file', '{minecraft_classpath_file}'
             run.jvmArgs '-p', '{modules}'


### PR DESCRIPTION
Bumps JNA to 5.12.1 to fix issues with JNA 5.10 on macOS.

- Ports #10186 to Minecraft 1.19.4.
- Supercedes #10122 for Minecraft 1.19.4.