### PR TITLE
[1.18.2] Bump JNA to 5.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,6 +283,8 @@ def sharedDeps = {
     installer "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0" // Bumped for CoreMods
     installer "org.apache.logging.log4j:log4j-api:2.19.0" // Bumped for CoreMods
     installer "org.apache.logging.log4j:log4j-core:2.19.0" // Bumped for CoreMods
+    installer 'net.java.dev.jna:jna:5.12.1'
+    installer 'net.java.dev.jna:jna-platform:5.12.1'
 
     /*
     installer 'org.lwjgl:lwjgl:3.2.2'
@@ -440,7 +442,7 @@ def sharedFmlonlyForge = { Project prj ->
         // SecureJarHandler bootstrap values.
         run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,lowcodelanguage,mclanguage,${prj.name}-"
         // FIXME: Without this jna doesn't work at runtime. Someone figure out why please?
-        run.property 'mergeModules', 'jna-5.10.0.jar,jna-platform-5.10.0.jar,java-objc-bridge-1.0.0.jar'
+        run.property 'mergeModules', 'jna-5.12.1.jar,jna-platform-5.12.1.jar,java-objc-bridge-1.0.0.jar'
         if (userdevRuns.contains(run)) {
             run.property 'legacyClassPath.file', '{minecraft_classpath_file}'
             run.jvmArgs '-p', '{modules}'


### PR DESCRIPTION
Bumps JNA to 5.12.1 to fix issues with JNA 5.10 on macOS.

- Backports #10186 to Minecraft 1.18.2.
- Supercedes #10122 for Minecraft 1.18.2.