### PR TITLE
[1.18.2] Debump Log4J to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,9 +280,6 @@ def sharedDeps = {
     installer 'org.openjdk.nashorn:nashorn-core:15.4'
     installer "net.minecraftforge:JarJarSelector:${JARJAR_VERSION}"
     installer "net.minecraftforge:JarJarMetadata:${JARJAR_VERSION}"
-    installer "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0" // Bumped for CoreMods
-    installer "org.apache.logging.log4j:log4j-api:2.19.0" // Bumped for CoreMods
-    installer "org.apache.logging.log4j:log4j-core:2.19.0" // Bumped for CoreMods
     installer 'net.java.dev.jna:jna:5.12.1'
     installer 'net.java.dev.jna:jna-platform:5.12.1'
 

--- a/fmlloader/build.gradle
+++ b/fmlloader/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api("org.ow2.asm:asm-tree:${ASM_VERSION}")
     api("org.ow2.asm:asm-commons:${ASM_VERSION}")
     api("net.minecraftforge:forgespi:${SPI_VERSION}")
-    api('org.apache.logging.log4j:log4j-api:2.19.0')
+    api('org.apache.logging.log4j:log4j-api:2.17.0')
     api('org.slf4j:slf4j-api:1.8.0-beta4')
     api('com.google.guava:guava:21.0')
     api('com.google.code.gson:gson:2.8.9')
@@ -31,8 +31,8 @@ dependencies {
     api "net.minecraftforge:JarJarMetadata:${JARJAR_VERSION}"
 
     implementation("cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}")
-    implementation('org.apache.logging.log4j:log4j-core:2.19.0')
-    annotationProcessor('org.apache.logging.log4j:log4j-core:2.19.0')
+    implementation('org.apache.logging.log4j:log4j-core:2.17.0')
+    annotationProcessor('org.apache.logging.log4j:log4j-core:2.17.0')
     implementation('net.minecraftforge:accesstransformers:8.0.4')
     implementation('net.minecrell:terminalconsoleappender:1.2.0')
 //    implementation('org.jline:jline:3.12.+')


### PR DESCRIPTION
Bumping Log4J in #10133 brought about an unintended bug on dedicated servers where non of vanilla Minecraft's logs would ever make it to the console. This PR fixes that issue.