### PR TITLE
[1.21.4] Simplify memory usage display on loading screen

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -13,10 +13,10 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 
 public class PerformanceInfo {
+    private static final MemoryMXBean MEMORY_BEAN = ManagementFactory.getMemoryMXBean();
 
     private final boolean showCPUUsage;
     private final OperatingSystemMXBean osBean;
-    private final MemoryMXBean memoryBean;
 
     private float memory;
     private String text;
@@ -24,11 +24,10 @@ public class PerformanceInfo {
     PerformanceInfo() {
         showCPUUsage = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_CPU);
         osBean = showCPUUsage ? ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class) : null;
-        memoryBean = ManagementFactory.getMemoryMXBean();
     }
 
     void update() {
-        final MemoryUsage heapusage = memoryBean.getHeapMemoryUsage();
+        final MemoryUsage heapusage = MEMORY_BEAN.getHeapMemoryUsage();
         memory = (float) heapusage.getUsed() / heapusage.getMax();
 
         if (!showCPUUsage) {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -31,7 +31,7 @@ public class PerformanceInfo {
         memory = (float) heapusage.getUsed() / heapusage.getMax();
 
         if (!showCPUUsage) {
-            text = "Memory: %d/%d MB (%.1f%%)".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0);
+            text = "Memory: %d/%dMB (%.1f%%)".formatted(heapusage.getUsed() >>> 20, heapusage.getMax() >>> 20, memory * 100f);
             return;
         }
 
@@ -43,7 +43,7 @@ public class PerformanceInfo {
             cpuText = "CPU: %.1f%%".formatted(cpuLoad * 100f);
         }
 
-        text = "Memory: %d/%d MB (%.1f%%)  %s".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
+        text = "Memory: %d/%dMB (%.1f%%)  %s".formatted(heapusage.getUsed() >>> 20, heapusage.getMax() >>> 20, memory * 100f, cpuText);
     }
 
     String text() {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -32,7 +32,7 @@ public class PerformanceInfo {
         memory = (float) heapusage.getUsed() / heapusage.getMax();
 
         if (!showCPUUsage) {
-            text = "Heap: %d/%d MB (%.1f%%) OffHeap: %d MB".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20);
+            text = "Memory: %d/%d MB (%.1f%%)".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0);
             return;
         }
 
@@ -44,7 +44,7 @@ public class PerformanceInfo {
             cpuText = "CPU: %.1f%%".formatted(cpuLoad * 100f);
         }
 
-        text = "Heap: %d/%d MB (%.1f%%) OffHeap: %d MB  %s".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
+        text = "Memory: %d/%d MB (%.1f%%)  %s".formatted(heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
     }
 
     String text() {


### PR DESCRIPTION
Simplifies the memory usage display to be easier for novice users to understand:

<img width="429" alt="image" src="https://github.com/user-attachments/assets/5d3b3bae-d892-4eda-8df9-35d6afa6b312">