### PR TITLE
[1.21.4] Add an option to hide the memory usage bar, cleanup

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -149,7 +149,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         }
         this.maximized = parsed.has(maximizedopt) || FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_MAXIMIZED);
 
-        StartupNotificationManager.modLoaderConsumer().ifPresent(c->c.accept("Forge loading " + forgeVersion));
+        StartupNotificationManager.modLoaderConsumer().ifPresent(c->c.accept("Forge loading " + FMLLoader.versionInfo().forgeVersion()));
         performanceInfo = new PerformanceInfo();
         return start(mcVersion, forgeVersion);
     }
@@ -238,7 +238,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
 
         var date = Calendar.getInstance();
         if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SQUIR) || (date.get(Calendar.MONTH) == Calendar.APRIL && date.get(Calendar.DAY_OF_MONTH) == 1))
-            this.elements.add(0, RenderElement.squir());
+            this.elements.addFirst(RenderElement.squir());
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -304,7 +304,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         return this.glVersion;
     }
 
-    private void crashElegantly(String errorDetails) {
+    private static void crashElegantly(String errorDetails) {
         StringBuilder msgBuilder = new StringBuilder(2000);
         msgBuilder.append("Failed to initialize graphics window with current settings.\n");
         msgBuilder.append("\n\n");
@@ -512,7 +512,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
             this.winY = y;
         }
     }
-    private void handleLastGLFWError(BiConsumer<Integer, String> handler) {
+    private static void handleLastGLFWError(BiConsumer<Integer, String> handler) {
         try (MemoryStack memorystack = MemoryStack.stackPush()) {
             PointerBuffer pointerbuffer = memorystack.mallocPointer(1);
             int error = glfwGetError(pointerbuffer);
@@ -640,7 +640,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
     }
 
     public void addMojangTexture(final int textureId) {
-        this.elements.add(0, RenderElement.mojang(textureId, framecount));
+        this.elements.addFirst(RenderElement.mojang(textureId, framecount));
     }
 
     public void close() {

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/PerformanceInfo.java
@@ -14,6 +14,7 @@ import java.lang.management.MemoryUsage;
 
 public class PerformanceInfo {
 
+    private final boolean showMemoryUsageBar;
     private final boolean showCPUUsage;
     private final OperatingSystemMXBean osBean;
     private final MemoryMXBean memoryBean;
@@ -22,6 +23,7 @@ public class PerformanceInfo {
     private String text;
 
     PerformanceInfo() {
+        showMemoryUsageBar = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_MEM_BAR);
         showCPUUsage = FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SHOW_CPU);
         osBean = showCPUUsage ? ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class) : null;
         memoryBean = ManagementFactory.getMemoryMXBean();
@@ -53,5 +55,9 @@ public class PerformanceInfo {
 
     float memory() {
         return memory;
+    }
+
+    boolean showMemoryBar() {
+        return showMemoryUsageBar;
     }
 }

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
@@ -195,13 +195,22 @@ public class RenderElement {
     }
 
     private static void memoryInfo(SimpleFont font, final SimpleBufferBuilder buffer, final DisplayContext context, final int frameNumber) {
-        var y = 10 * context.scale();
+        int barY = 10 * context.scale();
+        int textY = barY;
         PerformanceInfo pi = context.performance();
-        final int colour = hsvToRGB((1.0f - (float)Math.pow(pi.memory(), 1.5f)) / 3f, 1.0f, 0.5f);
-        var bar = progressBar(ctx -> new int[]{(ctx.scaledWidth() - BAR_WIDTH * ctx.scale()) / 2, y, BAR_WIDTH * ctx.scale()}, f -> colour, f -> new float[]{0f, pi.memory()});
-        var width = font.stringWidth(pi.text());
-        Renderer label = (bb, ctx, frame) -> renderText(font, text(ctx.scaledWidth() / 2 - width / 2, y + 18, pi.text(), context.colourScheme.foreground().packedint(globalAlpha)), bb, ctx);
-        bar.then(label).accept(buffer, context, frameNumber);
+
+        int textX = context.scaledWidth() / 2 - font.stringWidth(pi.text()) / 2;
+        if (pi.showMemoryBar()) {
+            float memory = pi.memory();
+            var bar = progressBar(
+                    ctx -> new int[]{ (ctx.scaledWidth() - BAR_WIDTH * ctx.scale()) / 2, barY, BAR_WIDTH * ctx.scale() },
+                    f -> hsvToRGB((1.0f - (float) Math.pow(memory, 1.5f)) / 3f, 1.0f, 0.5f),
+                    f -> new float[] { 0f, memory }
+            );
+            bar.accept(buffer, context, frameNumber);
+            textY += 18;
+        }
+        renderText(font, text(textX, textY, pi.text(), context.colourScheme.foreground().packedint(globalAlpha)), buffer, context);
     }
 
     @FunctionalInterface

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/RenderElement.java
@@ -75,7 +75,7 @@ public class RenderElement {
         List<SimpleFont.DisplayText> texts = new ArrayList<>();
         for (int i = messages.size() - 1; i >= 0; i--) {
             final StartupNotificationManager.AgeMessage pair = messages.get(i);
-            final float fade = clamp((4000.0f - (float) pair.age() - ( i - 4 ) * 1000.0f) / 5000.0f, 0.0f, 1.0f);
+            final float fade = Math.clamp((4000.0f - (float) pair.age() - ( i - 4 ) * 1000.0f) / 5000.0f, 0.0f, 1.0f);
             if (fade <0.01f) continue;
             Message msg = pair.message();
             int colour = Math.min((int)(fade * 255f), globalAlpha) << 24 | 0xFFFFFF;
@@ -187,10 +187,10 @@ public class RenderElement {
     }
     private static float[] indeterminateBar(int frame, boolean isActive) {
         if (RenderElement.globalAlpha != 0xFF || !isActive) {
-            return new float[] {0f,1f};
+            return new float[] { 0f, 1f };
         } else {
             var progress = frame % 100;
-            return new float[]{clamp((progress - 2) / 100f, 0f, 1f), clamp((progress + 2) / 100f, 0f, 1f)};
+            return new float[] { Math.clamp((progress - 2) / 100f, 0f, 1f), Math.clamp((progress + 2) / 100f, 0f, 1f) };
         }
     }
 
@@ -291,12 +291,9 @@ public class RenderElement {
     }
 
 
+    @Deprecated(since = "1.21.4", forRemoval = true)
     public static float clamp(float num, float min, float max) {
-        if (num < min) {
-            return min;
-        } else {
-            return Math.min(num, max);
-        }
+        return Math.clamp(num, min, max);
     }
 
     public static int clamp(int num, int min, int max) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -38,6 +38,7 @@ public class FMLConfig
         EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers"),
         EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?"),
         EARLY_WINDOW_SHOW_CPU("earlyWindowShowCPU", Boolean.FALSE, "Whether to show CPU usage stats in early window"),
+        EARLY_WINDOW_SHOW_MEM_BAR("earlyWindowShowMemoryBar", Boolean.TRUE, "Whether to show the memory usage bar in early window"),
         EARLY_WINDOW_LOG_HELP_MSG("earlyWindowLogHelpMessage", Boolean.TRUE, "Whether to log a help message on first attempt, to aid troubleshooting. This setting should automatically disable itself after a successful launch"),
         ;
 


### PR DESCRIPTION
This is what it looks like with the memory bar disabled:
<img width="429" alt="image" src="https://github.com/user-attachments/assets/aea35f9f-630b-4d54-8cbd-693f171590aa">

By default, the memory bar is still enabled. Do we want to default to hiding the memory bar?

Related PR: #10193 