### PR TITLE
[1.21.4] Deprecate `@ObjectHolder`, add a couple of fast-paths

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
@@ -8,6 +8,7 @@ package net.minecraftforge.fml.common.asm;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -35,6 +36,9 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
             new VanillaObjectHolderData("net.minecraft.core.particles.ParticleTypes", "particle_type", "net.minecraft.core.particles.ParticleType"),
             new VanillaObjectHolderData("net.minecraft.sounds.SoundEvents", "sound_event", "net.minecraft.sounds.SoundEvent")
     ).collect(Collectors.toUnmodifiableMap(VanillaObjectHolderData::holderClass, Function.identity()));
+    private static final Set<String> VANILLA_OBJECT_HOLDER_CLASSES = VANILLA_OBJECT_HOLDERS.keySet().stream()
+            .map(it -> it.replace('.', '/'))
+            .collect(Collectors.toUnmodifiableSet());
     private static final String OBJECT_HOLDER = "Lnet/minecraftforge/registries/ObjectHolder;"; //Don't directly reference this to prevent class loading.
     private static final int PUBLIC_STATIC_FINAL_FLAGS = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
 
@@ -47,9 +51,25 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
     private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
 
     @Override
-    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty)
-    {
-        return isEmpty ? NAY : YAY;
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
+        if (isEmpty)
+            return NAY;
+
+        // Let's skip processing classes that definitely don't have object holders
+        String internalName = classType.getInternalName();
+
+        // Forge classes that aren't in the debug package (that package is used for tests)
+        if (internalName.startsWith("net/minecraftforge/") && !internalName.substring(18).contains("debug"))
+            return NAY;
+
+        // Vanilla classes that don't have object holders
+        if (internalName.startsWith("com/mojang"))
+            return NAY;
+
+        if (internalName.startsWith("net/minecraft/") && !VANILLA_OBJECT_HOLDER_CLASSES.contains(internalName))
+            return NAY;
+
+        return YAY;
     }
 
     private static boolean hasHolder(List<AnnotationNode> lst) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
@@ -63,7 +63,7 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
             return NAY;
 
         // Vanilla classes that don't have object holders
-        if (internalName.startsWith("com/mojang"))
+        if (internalName.startsWith("com/mojang/"))
             return NAY;
 
         // ...except specific ones we added to the VANILLA_OBJECT_HOLDERS map

--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/ObjectHolderDefinalize.java
@@ -66,6 +66,7 @@ public class ObjectHolderDefinalize implements ILaunchPluginService {
         if (internalName.startsWith("com/mojang"))
             return NAY;
 
+        // ...except specific ones we added to the VANILLA_OBJECT_HOLDERS map
         if (internalName.startsWith("net/minecraft/") && !VANILLA_OBJECT_HOLDER_CLASSES.contains(internalName))
             return NAY;
 

--- a/src/main/java/net/minecraftforge/registries/ObjectHolder.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolder.java
@@ -16,7 +16,17 @@ import java.lang.annotation.Target;
 /**
  * ObjectHolder can be used to automatically populate public static final fields with entries
  * from the registry. These values can then be referred within mod code directly.
- * @deprecated Use {@link DeferredRegister} instead.
+ * @deprecated Use {@link DeferredRegister} or {@link RegistryObject} instead. Refer to the MDK for more detailed examples.
+ * <br>
+ * Example usage of alternatives:
+ * <pre>{@code
+ * // To register something
+ * public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+ * public static final RegistryObject<Item> EXAMPLE_ITEM = ITEMS.register("example_item", () -> new Item(new Item.Properties()));
+ *
+ * // To get a RegistryObject that you didn't register yourself:
+ * public static final RegistryObject<Block> DIRT = RegistryObject.create(ResourceLocation.withDefaultNamespace("dirt"), ForgeRegistries.BLOCKS);
+ * }</pre>
  */
 @Deprecated(since = "1.21.4", forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/net/minecraftforge/registries/ObjectHolder.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolder.java
@@ -16,7 +16,9 @@ import java.lang.annotation.Target;
 /**
  * ObjectHolder can be used to automatically populate public static final fields with entries
  * from the registry. These values can then be referred within mod code directly.
+ * @deprecated Use {@link DeferredRegister} instead.
  */
+@Deprecated(since = "1.21.4", forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ObjectHolder

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
@@ -89,6 +89,9 @@ public class ObjectHolderRegistry
             .filter(a -> OBJECT_HOLDER.equals(a.annotationType()) || MOD.equals(a.annotationType()))
             .toList();
 
+        if (annotations.stream().noneMatch(a -> OBJECT_HOLDER.equals(a.annotationType())))
+             return; // No object holders found, skip the rest of the processing
+
         Map<Type, String> classModIds = Maps.newHashMap();
         Map<Type, Class<?>> classCache = Maps.newHashMap();
 


### PR DESCRIPTION
As the title says - this PR deprecates the `@ObjectHolder` annotation and adds a fast-path to skip some unnecessary processing when no `@ObjectHolder`s are found.

As discussed on Discord https://discord.com/channels/1129059589325852724/1129095235889270844/1314380503486566440