### PR TITLE
[1.20.1] Skip processing Forge classes in `RuntimeDistCleaner`

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -147,7 +147,7 @@ public class RuntimeDistCleaner implements ILaunchPluginService
         return ret;
     }
 
-    private boolean remove(final List<AnnotationNode> anns, final String side)
+    private static boolean remove(final List<AnnotationNode> anns, final String side)
     {
         return unpack(anns).stream().
                 filter(ann->Objects.equals(ann.desc, ONLYIN)).

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -169,9 +169,15 @@ public class RuntimeDistCleaner implements ILaunchPluginService
     private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
 
     @Override
-    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty)
-    {
-        return isEmpty ? NAY : YAY;
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
+        if (isEmpty)
+            return NAY;
+
+        String internalName = classType.getInternalName();
+        if (internalName.startsWith("net/minecraftforge/"))
+            return NAY;
+
+        return YAY;
     }
 
     private static class LambdaGatherer extends MethodVisitor {

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -10,8 +10,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
@@ -38,7 +36,6 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-@OnlyIn(Dist.CLIENT)
 public abstract class ScreenEvent extends Event
 {
     private final Screen screen;

--- a/src/main/java/net/minecraftforge/client/gui/TitleScreenModUpdateIndicator.java
+++ b/src/main/java/net/minecraftforge/client/gui/TitleScreenModUpdateIndicator.java
@@ -11,14 +11,11 @@ import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.loading.FMLConfig;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.client.loading.ClientModLoader;
-import net.minecraftforge.api.distmarker.Dist;
 
-@OnlyIn(Dist.CLIENT)
 public class TitleScreenModUpdateIndicator extends Screen
 {
 

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -38,8 +38,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.client.gui.LoadingErrorScreen;
@@ -48,7 +46,6 @@ import net.minecraftforge.resource.ResourcePackLoader;
 import net.minecraftforge.server.LanguageHook;
 import net.minecraftforge.forgespi.language.IModInfo;
 
-@OnlyIn(Dist.CLIENT)
 public class ClientModLoader
 {
     private static final Logger LOGGER = LogManager.getLogger();


### PR DESCRIPTION
- Backport of #10199 to Minecraft 1.20.1.
- Includes a few cherry-picked optimizations from #10052.