### PR TITLE
[1.21.1] Skip processing Forge classes in `RuntimeDistCleaner`

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -40,6 +40,21 @@ public class RuntimeDistCleaner implements ILaunchPluginService {
         return "runtimedistcleaner";
     }
 
+    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
+    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
+
+    @Override
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
+        if (isEmpty)
+            return NAY;
+
+        String internalName = classType.getInternalName();
+        if (internalName.startsWith("net/minecraftforge/"))
+            return NAY;
+
+        return YAY;
+    }
+
     @Override
     public int processClassWithFlags(final Phase phase, final ClassNode classNode, final Type classType, final String reason) {
         var changed = false;
@@ -196,14 +211,6 @@ public class RuntimeDistCleaner implements ILaunchPluginService {
             DIST = s.name();
             LOGGER.debug(DISTXFORM, "Configuring for Dist {}", DIST);
         };
-    }
-
-    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
-    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
-
-    @Override
-    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
-        return isEmpty ? NAY : YAY;
     }
 
     private static class LambdaGatherer extends MethodVisitor {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -40,21 +40,6 @@ public class RuntimeDistCleaner implements ILaunchPluginService {
         return "runtimedistcleaner";
     }
 
-    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
-    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
-
-    @Override
-    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
-        if (isEmpty)
-            return NAY;
-
-        String internalName = classType.getInternalName();
-        if (internalName.startsWith("net/minecraftforge/"))
-            return NAY;
-
-        return YAY;
-    }
-
     @Override
     public int processClassWithFlags(final Phase phase, final ClassNode classNode, final Type classType, final String reason) {
         var changed = false;
@@ -211,6 +196,21 @@ public class RuntimeDistCleaner implements ILaunchPluginService {
             DIST = s.name();
             LOGGER.debug(DISTXFORM, "Configuring for Dist {}", DIST);
         };
+    }
+
+    private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
+    private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
+
+    @Override
+    public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
+        if (isEmpty)
+            return NAY;
+
+        String internalName = classType.getInternalName();
+        if (internalName.startsWith("net/minecraftforge/"))
+            return NAY;
+
+        return YAY;
     }
 
     private static class LambdaGatherer extends MethodVisitor {

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -10,8 +10,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
@@ -38,7 +36,6 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-@OnlyIn(Dist.CLIENT)
 public abstract class ScreenEvent extends Event {
     private final Screen screen;
 

--- a/src/main/java/net/minecraftforge/client/gui/TitleScreenModUpdateIndicator.java
+++ b/src/main/java/net/minecraftforge/client/gui/TitleScreenModUpdateIndicator.java
@@ -11,14 +11,11 @@ import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.loading.FMLConfig;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.client.loading.ClientModLoader;
-import net.minecraftforge.api.distmarker.Dist;
 
-@OnlyIn(Dist.CLIENT)
 public class TitleScreenModUpdateIndicator extends Screen {
 
     private static final ResourceLocation VERSION_CHECK_ICONS = ResourceLocation.fromNamespaceAndPath(ForgeVersion.MOD_ID, "textures/gui/version_check_icons.png");

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -25,15 +25,12 @@ import org.apache.logging.log4j.Logger;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.server.packs.PackType;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.client.gui.LoadingErrorScreen;
 import net.minecraftforge.resource.ResourcePackLoader;
 import net.minecraftforge.server.LanguageHook;
 
-@OnlyIn(Dist.CLIENT)
 public class ClientModLoader {
     private static final Logger LOGGER = LogManager.getLogger();
     private static boolean loading;


### PR DESCRIPTION
- Backport of #10199 to Minecraft 1.21.1.