### PR TITLE
[1.21.4] Manage FileWatcher instance per ConfigFileTypeHandler

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -95,7 +95,7 @@ public class ConfigFileTypeHandler {
                     onFileNotFound((newfile, configFormat)-> setupConfigFile(c, newfile, configFormat)).
                     writingMode(WritingMode.REPLACE).
                     build();
-            LOGGER.debug(CONFIG, "Built TOML config for {}", configPath.toString());
+            LOGGER.debug(CONFIG, "Built TOML config for {}", configPath);
             try
             {
                 configData.load();
@@ -104,9 +104,9 @@ public class ConfigFileTypeHandler {
             {
                 throw new ConfigLoadingException(c, ex);
             }
-            LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath.toString());
+            LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath);
             this.getWatcher().addWatch(configPath, new ConfigWatcher(c, configData, Thread.currentThread().getContextClassLoader()));
-            LOGGER.debug(CONFIG, "Watching TOML config file {} for changes", configPath.toString());
+            LOGGER.debug(CONFIG, "Watching TOML config file {} for changes", configPath);
             return configData;
         };
     }
@@ -114,9 +114,9 @@ public class ConfigFileTypeHandler {
     public void unload(Path configBasePath, ModConfig config) {
         Path configPath = configBasePath.resolve(config.getFileName());
         try {
-            this.getWatcher().removeWatch(configBasePath.resolve(config.getFileName()));
+            this.getWatcher().removeWatch(configPath);
         } catch (RuntimeException e) {
-            LOGGER.error("Failed to remove config {} from tracker!", configPath.toString(), e);
+            LOGGER.error("Failed to remove config {} from tracker!", configPath, e);
         }
     }
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -14,6 +14,7 @@ import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.loading.FMLConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -25,8 +26,65 @@ import static net.minecraftforge.fml.config.ConfigTracker.CONFIG;
 
 public class ConfigFileTypeHandler {
     private static final Logger LOGGER = LogUtils.getLogger();
-    static final ConfigFileTypeHandler TOML = new ConfigFileTypeHandler();
     private static final Path defaultConfigPath = FMLPaths.GAMEDIR.get().resolve(FMLConfig.getConfigValue(FMLConfig.ConfigValue.DEFAULT_CONFIG_PATH));
+
+    private static final ConfigFileTypeHandler CLIENT = new ConfigFileTypeHandler(ModConfig.Type.CLIENT);
+    private static final ConfigFileTypeHandler COMMON = new ConfigFileTypeHandler(ModConfig.Type.COMMON);
+    private static final ConfigFileTypeHandler SERVER = new ConfigFileTypeHandler(ModConfig.Type.SERVER);
+
+    private final @Nullable ModConfig.Type type;
+    private @Nullable FileWatcher watcher;
+
+    // exists for bin compat
+    public ConfigFileTypeHandler() {
+        this(null);
+    }
+
+    private ConfigFileTypeHandler(@Nullable ModConfig.Type type) {
+        this.type = type;
+    }
+
+    /**
+     * Gets the handler for the given {@link ModConfig.Type}.
+     *
+     * @param type The type to get the handler for
+     * @return The handler
+     */
+    static ConfigFileTypeHandler get(ModConfig.Type type) {
+        return switch (type) {
+            case CLIENT -> CLIENT;
+            case COMMON -> COMMON;
+            case SERVER -> SERVER;
+        };
+    }
+
+    /**
+     * Gets the {@link FileWatcher} for this handler, creating it if it doesn't exist and/or has been stopped.
+     *
+     * @return The watcher
+     *
+     * @apiNote This is package-private so modders can't just call {@link FileWatcher#stop()} and fuck up everything.
+     */
+    FileWatcher getWatcher() {
+        if (this.watcher == null) {
+            LOGGER.debug(CONFIG, "Starting watcher for handler: {}", this);
+            this.watcher = new FileWatcher();
+        }
+
+        return this.watcher;
+    }
+
+    /**
+     * Stops the {@link FileWatcher} for this handler, and sets it to null afterward. Use this instead of
+     * {@link FileWatcher#stop()}.
+     */
+    void stopWatcher() {
+        if (this.watcher == null) return;
+
+        LOGGER.debug(CONFIG, "Stopping watcher for hander: {}", this);
+        this.watcher.stop();
+        this.watcher = null;
+    }
 
     public Function<ModConfig, CommentedFileConfig> reader(Path configBasePath) {
         return (c) -> {
@@ -47,7 +105,7 @@ public class ConfigFileTypeHandler {
                 throw new ConfigLoadingException(c, ex);
             }
             LOGGER.debug(CONFIG, "Loaded TOML config file {}", configPath.toString());
-            FileWatcher.defaultInstance().addWatch(configPath, new ConfigWatcher(c, configData, Thread.currentThread().getContextClassLoader()));
+            this.getWatcher().addWatch(configPath, new ConfigWatcher(c, configData, Thread.currentThread().getContextClassLoader()));
             LOGGER.debug(CONFIG, "Watching TOML config file {} for changes", configPath.toString());
             return configData;
         };
@@ -56,7 +114,7 @@ public class ConfigFileTypeHandler {
     public void unload(Path configBasePath, ModConfig config) {
         Path configPath = configBasePath.resolve(config.getFileName());
         try {
-            FileWatcher.defaultInstance().removeWatch(configBasePath.resolve(config.getFileName()));
+            this.getWatcher().removeWatch(configBasePath.resolve(config.getFileName()));
         } catch (RuntimeException e) {
             LOGGER.error("Failed to remove config {} from tracker!", configPath.toString(), e);
         }
@@ -107,6 +165,11 @@ public class ConfigFileTypeHandler {
         {
             LOGGER.warn(CONFIG, "Failed to back up config file {}", commentedFileConfig.getNioPath(), exception);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigFileTypeHandler[" + (type != null ? type : "UNKNOWN") + "]";
     }
 
     private record ConfigWatcher(

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -55,6 +55,8 @@ public class ConfigTracker {
         }
     }
 
+    // TODO: [FML] This is only called for the server (outside of forceUnload)
+    // rethink config implementation for eventual FML rewrite
     public void unloadConfigs(ModConfig.Type type, Path configBasePath) {
         LOGGER.debug(CONFIG, "Unloading configs type {}", type);
         for (ModConfig config : this.configSets.get(type)) {
@@ -66,8 +68,8 @@ public class ConfigTracker {
     // If there is a better way to do this, please tell me. Because this is FUCKED
     public void forceUnload() {
         // This is how ModStateProvider handles loading configs. So we're doing the same but with unloadConfigs instead
-        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get()));
-        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> this.unloadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get()));
+        this.unloadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
     }
 
     private static void openConfig(final ModConfig config, final Path configBasePath) {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -8,6 +8,9 @@ package net.minecraftforge.fml.config;
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.mojang.logging.LogUtils;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLPaths;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
@@ -58,6 +61,13 @@ public class ConfigTracker {
             closeConfig(config, configBasePath);
         }
         ConfigFileTypeHandler.get(type).stopWatcher();
+    }
+
+    // If there is a better way to do this, please tell me. Because this is FUCKED
+    public void forceUnload() {
+        // This is how ModStateProvider handles loading configs. So we're doing the same but with unloadConfigs instead
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get()));
+        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
     }
 
     private static void openConfig(final ModConfig config, final Path configBasePath) {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -70,6 +70,9 @@ public class ConfigTracker {
         // This is how ModStateProvider handles loading configs. So we're doing the same but with unloadConfigs instead
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> this.unloadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get()));
         this.unloadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
+
+        // just in case server watcher is still alive somehow...
+        ConfigFileTypeHandler.get(ModConfig.Type.SERVER).stopWatcher();
     }
 
     private static void openConfig(final ModConfig config, final Path configBasePath) {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -57,6 +57,7 @@ public class ConfigTracker {
         for (ModConfig config : this.configSets.get(type)) {
             closeConfig(config, configBasePath);
         }
+        ConfigFileTypeHandler.get(type).stopWatcher();
     }
 
     private static void openConfig(final ModConfig config, final Path configBasePath) {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -30,7 +30,7 @@ public class ModConfig
         this.spec = spec;
         this.fileName = fileName;
         this.container = container;
-        this.configHandler = ConfigFileTypeHandler.TOML;
+        this.configHandler = ConfigFileTypeHandler.get(type);
         ConfigTracker.INSTANCE.trackConfig(this);
     }
 

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -145,6 +145,14 @@
              this.screen = p_91153_;
              if (this.screen != null) {
                  this.screen.added();
+@@ -1146,6 +_,7 @@
+ 
+             FreeTypeUtil.destroy();
+             Util.shutdownExecutors();
++            net.minecraftforge.fml.config.ConfigTracker.INSTANCE.forceUnload();
+         } catch (Throwable throwable) {
+             LOGGER.error("Shutdown failure!", throwable);
+             throw throwable;
 @@ -1215,9 +_,11 @@
          this.mouseHandler.handleAccumulatedMovement();
          profilerfiller.pop();

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -45,7 +45,7 @@
          }
      }
  
-@@ -275,6 +_,11 @@
+@@ -275,6 +_,13 @@
          if (this.queryThreadGs4 != null) {
              this.queryThreadGs4.stop();
          }
@@ -54,6 +54,8 @@
 +            this.dediLanPinger.interrupt();
 +            this.dediLanPinger = null;
 +        }
++
++        net.minecraftforge.fml.config.ConfigTracker.INSTANCE.forceUnload();
      }
  
      @Override


### PR DESCRIPTION
**This is an urgent fix that affects the dedicated server hanging on shutdown (through `/stop` or a single use of ^C).**

## Dedicated Server Hanging Issue

This PR fixes a little-known issue that has been present in Forge since Minecraft 1.21.4, exclusively affecting dedicated servers. On server creation, or if the config files don't exist at `config` or `world/serverconfig`, the server will hang after the server thread has stopped due to a zombie NightConfig file watcher thread. It looks like this issue has been present in NightConfig for a while, but why it only affects 1.21.1 and later I still do not know.

> [!NOTE]
> After some work tracking down the introduction of this bug, it is present only after when #10052 was merged, which is why Minecraft 1.20.6 and older are unaffected. So, this issue is a combination of a bug in NightConfig and the overall structure of FML.

## Solution & Implementation

My solution to this, with help from @LexManos, was to repurpose ConfigFileTypeHandler into three instances, one per `ModConfig.Type` enum, instead of a singleton instance. These handlers would then each have their own file watchers that ConfigTracker can then interact with. The server (both dedicated and integrated) will unload server configs as usual, with addition of also stopping the watcher after all configs have been saved.

> [!IMPORTANT]
> The placement of `FileWatcher.stop()` does not cause issues with saving configs, as the configs are saved before it is invoked. What happens immediately afterwards is that Forge will send "config changed" events even while the server is closing, but this has nothing to do with the file watchers so this is not a problem.

I understand that this is more of a band-aid solution than anything else, but it solves the immediate problem of zombie file watcher threads while not including any breaking changes. When eventually finding time to rewrite FML in the future, a pain point might include looking for a simpler replacement for NightConfig or rethinking how it is implemented in the first place.