### PR TITLE
[1.21.3] Skip Vanilla classes for the `CapabilityTokenSubclass` transformer

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
@@ -50,7 +50,14 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
 
     @Override
     public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
-        return isEmpty ? NAY : YAY;
+        if (isEmpty)
+            return NAY;
+
+        String internalName = classType.getInternalName();
+        if (internalName.startsWith("net/minecraft/") || internalName.startsWith("com/mojang/"))
+            return NAY;
+        
+        return YAY;
     }
 
     @Override


### PR DESCRIPTION
- Backport of #10196 for Minecraft 1.21.3.