### PR TITLE
[1.21.1] Deprecate `@ObjectHolder`, add a couple of fast-paths

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ObjectHolder.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolder.java
@@ -16,7 +16,19 @@ import java.lang.annotation.Target;
 /**
  * ObjectHolder can be used to automatically populate public static final fields with entries
  * from the registry. These values can then be referred within mod code directly.
+ * @deprecated Use {@link DeferredRegister} or {@link RegistryObject} instead. Refer to the MDK for more detailed examples.
+ * <br>
+ * Example usage of alternatives:
+ * <pre>{@code
+ * // To register something
+ * public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+ * public static final RegistryObject<Item> EXAMPLE_ITEM = ITEMS.register("example_item", () -> new Item(new Item.Properties()));
+ *
+ * // To get a RegistryObject that you didn't register yourself:
+ * public static final RegistryObject<Block> DIRT = RegistryObject.create(ResourceLocation.withDefaultNamespace("dirt"), ForgeRegistries.BLOCKS);
+ * }</pre>
  */
+@Deprecated(since = "1.21.4", forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ObjectHolder

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
@@ -89,6 +89,9 @@ public class ObjectHolderRegistry
             .filter(a -> OBJECT_HOLDER.equals(a.annotationType()) || MOD.equals(a.annotationType()))
             .toList();
 
+        if (annotations.stream().noneMatch(a -> OBJECT_HOLDER.equals(a.annotationType())))
+             return; // No object holders found, skip the rest of the processing
+
         Map<Type, String> classModIds = Maps.newHashMap();
         Map<Type, Class<?>> classCache = Maps.newHashMap();
 


### PR DESCRIPTION
- Backport of #10195 to Minecraft 1.21.1.