### PR TITLE
[1.19.2] Backport some Vanilla 1.21 `ResourceLocation` methods

### DIFF
--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -1,5 +1,18 @@
 --- a/net/minecraft/resources/ResourceLocation.java
 +++ b/net/minecraft/resources/ResourceLocation.java
+@@ -38,10 +_,12 @@
+       }
+    }
+ 
++   /** Forge: Consider using {@link #parse(String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
+    public ResourceLocation(String p_135809_) {
+       this(m_135832_(p_135809_, ':'));
+    }
+ 
++   /** Forge: Consider using {@link #fromNamespaceAndPath(String, String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
+    public ResourceLocation(String p_135811_, String p_135812_) {
+       this(new String[]{p_135811_, p_135812_});
+    }
 @@ -125,6 +_,12 @@
        return i;
     }
@@ -13,3 +26,19 @@
     public String m_179910_() {
        return this.toString().replace('/', '_').replace(':', '_');
     }
+@@ -203,5 +_,15 @@
+       public JsonElement serialize(ResourceLocation p_135855_, Type p_135856_, JsonSerializationContext p_135857_) {
+          return new JsonPrimitive(p_135855_.toString());
+       }
++   }
++
++   /** Forge: Backport of Vanilla 1.21 method */
++   public static ResourceLocation fromNamespaceAndPath(String namespace, String path) {
++      return new ResourceLocation(namespace, path);
++   }
++
++   /** Forge: Backport of Vanilla 1.21 method */
++   public static ResourceLocation parse(String location) {
++      return new ResourceLocation(location);
+    }
+ }


### PR DESCRIPTION
- Backport of #10084 to Minecraft 1.19.2.