### PR TITLE
[1.21.4] Allow mipmap lowering to be disabled

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
@@ -5,7 +5,7 @@
          int k1 = Mth.log2(j1);
          int l1;
 -        if (k1 < p_261919_) {
-+        if (net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering() && k1 < p_261919_) { // Forge: Do not lower the mipmap level
++        if (k1 < p_261919_ && net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering()) { // Forge: Do not lower the mipmap level
              LOGGER.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.location, p_261919_, k1, j1);
              l1 = k1;
          } else {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
@@ -5,7 +5,7 @@
          int k1 = Mth.log2(j1);
          int l1;
 -        if (k1 < p_261919_) {
-+        if (false) { // Forge: Do not lower the mipmap level
++        if (net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering() && k1 < p_261919_) { // Forge: Do not lower the mipmap level
              LOGGER.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.location, p_261919_, k1, j1);
              l1 = k1;
          } else {

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -98,6 +98,8 @@ public class ForgeConfig {
 
         public final BooleanValue showLoadWarnings;
 
+        public final BooleanValue allowMipmapLowering;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -112,6 +114,11 @@ public class ForgeConfig {
                 .translation("forge.configgui.showLoadWarnings")
                 .define("showLoadWarnings", true);
 
+            allowMipmapLowering = builder
+                .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. Use this if you experience issues with resource packs that use textures lower than 8x8.")
+                .translation("forge.configgui.allowMipmapLowering")
+                .define("allowMipmapLowering", false);
+
             builder.pop();
         }
 
@@ -119,6 +126,10 @@ public class ForgeConfig {
         // Prevents a ton of spam when an error screen is displayed.
         public final boolean showLoadWarnings() {
             return clientSpec.isLoaded() ? showLoadWarnings.get() : showLoadWarnings.getDefault();
+        }
+
+        public final boolean allowMipmapLowering() {
+            return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -115,7 +115,7 @@ public class ForgeConfig {
                 .define("showLoadWarnings", true);
 
             allowMipmapLowering = builder
-                .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. Use this if you experience issues with resource packs that use textures lower than 8x8.")
+                .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.")
                 .translation("forge.configgui.allowMipmapLowering")
                 .define("allowMipmapLowering", false);
 

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -185,7 +185,7 @@
   "forge.configgui.selectiveResourceReloadEnabled": "Enable Selective Resource Loading",
   "forge.configgui.showLoadWarnings.tooltip": "When enabled, Forge will show any warnings that occurred during loading.",
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
-  "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. Use this if you experience issues with resource packs that use textures lower than 8x8.",
+  "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
   "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -185,6 +185,8 @@
   "forge.configgui.selectiveResourceReloadEnabled": "Enable Selective Resource Loading",
   "forge.configgui.showLoadWarnings.tooltip": "When enabled, Forge will show any warnings that occurred during loading.",
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
+  "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. Use this if you experience issues with resource packs that use textures lower than 8x8.",
+  "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",


### PR DESCRIPTION
This PR allows mipmaps to be lowered in real-time, which Forge disables. This is done with a new flag in the Forge client config, and it is set to `false` by default.

- Fixes #10155.
- Follows up on #8622.