### PR TITLE
[1.18.2] Allow mipmap lowering to be disabled

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlas.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlas.java.patch
@@ -22,7 +22,7 @@
        int j1 = Mth.m_14173_(i1);
 -      int k1;
 +      int k1 = p_118311_;
-+      if (false) // FORGE: do not lower the mipmap level
++      if (net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering()) // FORGE: do not lower the mipmap level
        if (j1 < p_118311_) {
           f_118261_.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.f_118265_, p_118311_, j1, i1);
           k1 = j1;

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -130,6 +130,8 @@ public class ForgeConfig {
 
         public final BooleanValue compressLanIPv6Addresses;
 
+        public final BooleanValue allowMipmapLowering;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -166,7 +168,16 @@ public class ForgeConfig {
                     .translation("forge.configgui.compressLanIPv6Addresses")
                     .define("compressLanIPv6Addresses", true);
 
+            allowMipmapLowering = builder
+                    .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.")
+                    .translation("forge.configgui.allowMipmapLowering")
+                    .define("allowMipmapLowering", false);
+
             builder.pop();
+        }
+
+        public final boolean allowMipmapLowering() {
+            return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -177,7 +177,7 @@ public class ForgeConfig {
         }
 
         public final boolean allowMipmapLowering() {
-            return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
+            return clientSpec.isLoaded() && allowMipmapLowering.get();
         }
     }
 

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -184,6 +184,8 @@
   "forge.configgui.selectiveResourceReloadEnabled": "Enable Selective Resource Loading",
   "forge.configgui.showLoadWarnings.tooltip": "When enabled, Forge will show any warnings that occurred during loading.",
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
+  "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
+  "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",


### PR DESCRIPTION
- Backport of #10242 for Minecraft 1.18.2.