### PR TITLE
[1.20.1] Allow mipmap lowering to be disabled

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
@@ -5,7 +5,7 @@
        int k1 = Mth.m_14173_(j1);
        int l1;
 -      if (k1 < p_261919_) {
-+      if (net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering() && k1 < p_261919_) { // Forge: Do not lower the mipmap level
++      if (k1 < p_261919_ && net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering()) { // Forge: Do not lower the mipmap level
           f_244357_.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.f_244500_, p_261919_, k1, j1);
           l1 = k1;
        } else {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
@@ -5,7 +5,7 @@
        int k1 = Mth.m_14173_(j1);
        int l1;
 -      if (k1 < p_261919_) {
-+      if (false) { // Forge: Do not lower the mipmap level
++      if (net.minecraftforge.common.ForgeConfig.CLIENT.allowMipmapLowering() && k1 < p_261919_) { // Forge: Do not lower the mipmap level
           f_244357_.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.f_244500_, p_261919_, k1, j1);
           l1 = k1;
        } else {

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -110,6 +110,8 @@ public class ForgeConfig {
 
         public final BooleanValue stabilizeDirectionGetNearest;
 
+        public final BooleanValue allowMipmapLowering;
+
 
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
@@ -156,6 +158,11 @@ public class ForgeConfig {
                     .translation("forge.configgui.stabilizeDirectionGetNearest")
                     .define("stabilizeDirectionGetNearest", true);
 
+            allowMipmapLowering = builder
+                .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.")
+                .translation("forge.configgui.allowMipmapLowering")
+                .define("allowMipmapLowering", false);
+
             builder.pop();
         }
 
@@ -167,6 +174,10 @@ public class ForgeConfig {
 
         public final boolean showLoadWarnings() {
             return clientSpec.isLoaded() ? showLoadWarnings.get() : showLoadWarnings.getDefault();
+        }
+
+        public final boolean allowMipmapLowering() {
+            return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
         }
     }
 

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -185,6 +185,8 @@
   "forge.configgui.selectiveResourceReloadEnabled": "Enable Selective Resource Loading",
   "forge.configgui.showLoadWarnings.tooltip": "When enabled, Forge will show any warnings that occurred during loading.",
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
+  "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
+  "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",


### PR DESCRIPTION
- Backport of #10242 for Minecraft 1.20.1.