### PR TITLE
[1.20.1] Disable clean on TeamCity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,45 +227,47 @@ project(':mcp') {
     }
 }
 
-project(':clean') {
-    evaluationDependsOn(':mcp')
-    apply plugin: 'net.minecraftforge.gradle.patcher'
-    tasks.withType(AbstractPublishToMaven.class).forEach{tsk -> tsk.enabled = false } // We don't want to publish anything
+if (!System.env.TEAMCITY_VERSION) {
+    project(':clean') {
+        evaluationDependsOn(':mcp')
+        apply plugin: 'net.minecraftforge.gradle.patcher'
+        tasks.withType(AbstractPublishToMaven.class).forEach{tsk -> tsk.enabled = false } // We don't want to publish anything
 
-    dependencies {
-        implementation 'net.minecraftforge:forgespi:' + SPI_VERSION
-    }
+        dependencies {
+            implementation 'net.minecraftforge:forgespi:' + SPI_VERSION
+        }
 
-    patcher {
-        parent = project(':mcp')
-        mcVersion = MC_VERSION
-        patchedSrc = file('src/main/java')
+        patcher {
+            parent = project(':mcp')
+            mcVersion = MC_VERSION
+            patchedSrc = file('src/main/java')
 
-        mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
+            mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
 
-        runs {
-            clean_client {
-                client true
-                taskName 'clean_client'
-                ideaModule "${rootProject.name}.${project.name}.main"
+            runs {
+                clean_client {
+                    client true
+                    taskName 'clean_client'
+                    ideaModule "${rootProject.name}.${project.name}.main"
 
-                main 'net.minecraft.client.main.Main'
-                workingDirectory project.file('run')
+                    main 'net.minecraft.client.main.Main'
+                    workingDirectory project.file('run')
 
-                args '--gameDir', '.'
-                args '--version', MC_VERSION
-                args '--assetsDir', downloadAssets.output
-                args '--assetIndex', '{asset_index}'
-                args '--accessToken', '0'
-            }
+                    args '--gameDir', '.'
+                    args '--version', MC_VERSION
+                    args '--assetsDir', downloadAssets.output
+                    args '--assetIndex', '{asset_index}'
+                    args '--accessToken', '0'
+                }
 
-            clean_server {
-                client false
-                taskName 'clean_server'
-                ideaModule "${rootProject.name}.${project.name}.main"
+                clean_server {
+                    client false
+                    taskName 'clean_server'
+                    ideaModule "${rootProject.name}.${project.name}.main"
 
-                main 'net.minecraft.server.Main'
-                workingDirectory project.file('run')
+                    main 'net.minecraft.server.Main'
+                    workingDirectory project.file('run')
+                }
             }
         }
     }
@@ -888,7 +890,7 @@ project(':fmlonly') {
 }
 
 project(':forge') {
-    evaluationDependsOn(':clean')
+    evaluationDependsOn(System.env.TEAMCITY_VERSION ? ':mcp' : ':clean')
     apply plugin: 'java-library'
     apply plugin: 'net.minecraftforge.gradle.patcher'
     apply plugin: 'org.cadixdev.licenser'
@@ -968,12 +970,18 @@ project(':forge') {
 
     patcher {
         excs.from file("$rootDir/src/main/resources/forge.exc")
-        parent = project(':clean')
+        parent = project(System.env.TEAMCITY_VERSION ? ':mcp' : ':clean')
         patches = file("$rootDir/patches/minecraft")
         patchedSrc = file('src/main/java')
         srgPatches = true
         accessTransformers.from file("$rootDir/src/main/resources/META-INF/accesstransformer.cfg")
         sideAnnotationStrippers.from file("$rootDir/src/main/resources/forge.sas")
+
+        // the clean project provides these. if we're not using it, we need to provide them ourselves
+        if (System.env.TEAMCITY_VERSION) {
+            mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
+            mcVersion = MC_VERSION
+        }
 
         runs {
             forge_client {
@@ -1795,7 +1803,8 @@ project(':forge') {
 
 //evaluationDependsOnChildren()
 task setup() {  //These must be strings so that we can do lazy resolution. Else we need evaluationDependsOnChildren above
-    dependsOn ':clean:extractMapped'
+    if (!System.env.TEAMCITY_VERSION)
+        dependsOn ':clean:extractMapped'
     if (symlinkValid)
         dependsOn ':fmlonly:extractMapped'
     dependsOn ':forge:extractMapped'
@@ -1808,7 +1817,9 @@ task doChecks {
 
 if (symlinkValid)
     project.gradle.startParameter.excludedTaskNames.add(':fmlonly:genPatches')
-project.gradle.startParameter.excludedTaskNames.add(':clean:genPatches')
+
+if (!System.env.TEAMCITY_VERSION)
+    project.gradle.startParameter.excludedTaskNames.add(':clean:genPatches')
 
 //Also output FMLOnly when building a version.
 if (System.env.TEAMCITY_VERSION) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,11 +30,14 @@ include 'lowcodelanguage'
 include 'fmlearlydisplay'
 
 include ':mcp'
-include ':clean'
 include ':fmlonly'
 include ':forge'
 
 project(":mcp").projectDir = file("projects/mcp")
-project(":clean").projectDir = file("projects/clean")
 project(":fmlonly").projectDir = file("projects/fmlonly")
 project(":forge").projectDir = file("projects/forge")
+
+if (!System.env.TEAMCITY_VERSION) {
+    include ':clean'
+    project(":clean").projectDir = file("projects/clean")
+}


### PR DESCRIPTION
This PR disables the clean project on TeamCity, so I don't have to go play a run of Spelunky 2 just to wait for it to build one commit.

- Partial backport of https://github.com/MinecraftForge/MinecraftForge/commit/2332ecf984babeaca5dd98432bea33b00c3aec16 to Minecraft 1.20.1.