### PR TITLE
[1.20.4] Bump CoreMods to 5.2.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
-            library('coremods', 'net.minecraftforge:coremods:5.2.1')
+            library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas


### PR DESCRIPTION
- Backport of #10262 to Minecraft 1.20.4.