### PR TITLE
[1.20.6] Bump dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.1')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.14')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.15')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.14')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
             bundle('jimfs', ['guava', 'failureaccess'])
             
-            version('bootstrap', '2.1.3')
+            version('bootstrap', '2.1.8')
             library('bootstrap',      'net.minecraftforge', 'bootstrap'     ).versionRef('bootstrap') // Needs modlauncher
             library('bootstrap-api',  'net.minecraftforge', 'bootstrap-api' ).versionRef('bootstrap')
             library('bootstrap-dev',  'net.minecraftforge', 'bootstrap-dev' ).versionRef('bootstrap')

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
         libs {
             library('forgespi', 'net.minecraftforge:forgespi:7.1.4') // Needs modlauncher
             library('modlauncher', 'net.minecraftforge:modlauncher:10.2.1') // Needs securemodules
-            library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
+            library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
             library('modlauncher', 'net.minecraftforge:modlauncher:10.2.1') // Needs securemodules
             library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
-            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
+            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.1')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.14')


### PR DESCRIPTION
- Bumped EventBus to 6.2.15
- Bumped Bootstrap to 2.1.8
- Bumped SecureModules to 2.2.21
- Bumped AccessTransformers to 8.2.1
- Did not bump ModLauncher due to breaking change in 10.2.2