### PR TITLE
[1.20.4] Bump dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.14')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,7 @@ dependencyResolutionManagement {
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
             bundle('jimfs', ['guava', 'failureaccess'])
             
-            version('bootstrap', '2.1.0')
+            version('bootstrap', '2.1.8')
             library('bootstrap',      'net.minecraftforge', 'bootstrap'     ).versionRef('bootstrap') // Needs modlauncher
             library('bootstrap-api',  'net.minecraftforge', 'bootstrap-api' ).versionRef('bootstrap')
             library('bootstrap-dev',  'net.minecraftforge', 'bootstrap-dev' ).versionRef('bootstrap')

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.14')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.15')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 


### PR DESCRIPTION
- Bumped EventBus to 6.2.15
- Bumped Bootstrap to 2.1.8
- Did not bump SecureModules since the version is too old
- Did not bump AccessTransformers since the version is too old
- Did not bump ModLauncher since the version is too old