### PR TITLE
chore(deps): update jline for better darwin/arm64 support

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -62,7 +62,7 @@ dependencyResolutionManagement {
 
             // Terminal Console Appender.. essentually make pretty colors in the console, but it's been a PITA
             library('terminalconsoleappender', 'net.minecrell:terminalconsoleappender:1.2.0')
-            version('jline', '3.12.1')
+            version('jline', '3.25.1')
             library('jline-reader',       'org.jline', 'jline-reader'      ).versionRef('jline')
             library('jline-terminal',     'org.jline', 'jline-terminal'    ).versionRef('jline')
             library('jline-terminal-jna', 'org.jline', 'jline-terminal-jna').versionRef('jline') // Colors and tab completeion


### PR DESCRIPTION
Fixes #10107

Verified locally on a mac and in docker linux environments

Build with the change available: [forge-1.21.4-54.0.12-installer.jar.zip](https://github.com/user-attachments/files/18268105/forge-1.21.4-54.0.12-installer.jar.zip)
