### PR TITLE
[1.18.2] Use the correct Forge version in the MDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1580,7 +1580,7 @@ project(':forge') {
                     exclude it
             }
             filter(ReplaceTokens, tokens: [
-                FORGE_VERSION: project.version,
+                FORGE_VERSION: FORGE_VERSION,
                 FORGE_GROUP: project.group,
                 FORGE_NAME: project.name,
                 MC_VERSION: MC_VERSION,


### PR DESCRIPTION
Due to an oversight in #10285, the `FORGE_VERSION` variable also included the Minecraft version. This PR fixes that.

- Follows up on, and fixes an oversight in, #10285.