### PR TITLE
[1.21.4] Simplify Title Screen Brandings

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -353,6 +353,7 @@ public class ForgeHooksClient {
     }
 
     // NO-OP method, kept for bin-compat. Used in TitleScreen.java
+    @Deprecated(forRemoval = true, since = "1.21.4")
     public static void renderMainMenu(TitleScreen gui, GuiGraphics graphics, Font font, int width, int height, int alpha) {
         /*
         VersionChecker.Status status = getForgeVersionStatus();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -352,7 +352,9 @@ public class ForgeHooksClient {
         return LazyInit.INSTANCE;
     }
 
+    // NO-OP method, kept for bin-compat. Used in TitleScreen.java
     public static void renderMainMenu(TitleScreen gui, GuiGraphics graphics, Font font, int width, int height, int alpha) {
+        /*
         VersionChecker.Status status = getForgeVersionStatus();
 
         if (status == VersionChecker.Status.BETA || status == VersionChecker.Status.BETA_OUTDATED) {
@@ -362,6 +364,7 @@ public class ForgeHooksClient {
             line = Component.translatable("forge.update.beta.2");
             graphics.drawCenteredString(font, line, width / 2, 4 + (font.lineHeight + 1), 0xFFFFFF | alpha);
         }
+         */
     }
 
     public static String forgeStatusLine;

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -8,6 +8,7 @@ package net.minecraftforge.common;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
+import net.minecraftforge.fml.loading.FMLLoader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
@@ -122,7 +123,7 @@ public class ForgeConfig {
                 .define("allowMipmapLowering", false);
 
             debugBrandingVersions = builder
-                .comment("When enabled, Forge will show additional versions on the main menu (such as MCP).")
+                .comment("When enabled, Forge will show additional versions on the main menu (such as MCP). In ForgeDev, this is always enabled regardless of the config value.")
                 .translation("forge.configgui.debugBrandingVersions")
                 .define("debugBrandingVersions", false);
 
@@ -137,6 +138,13 @@ public class ForgeConfig {
 
         public final boolean allowMipmapLowering() {
             return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
+        }
+
+        public final boolean showDebugBrandingVersions() {
+            // if we're in ForgeDev, we always want these, so always show them regardless of config
+            if (FMLLoader.launcherHandlerName().startsWith("forge_dev")) return true;
+
+            return clientSpec.isLoaded() ? debugBrandingVersions.get() : debugBrandingVersions.getDefault();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -8,7 +8,6 @@ package net.minecraftforge.common;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
-import net.minecraftforge.fml.loading.FMLLoader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -101,8 +101,6 @@ public class ForgeConfig {
 
         public final BooleanValue allowMipmapLowering;
 
-        public final BooleanValue debugBrandingVersions;
-
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -122,11 +120,6 @@ public class ForgeConfig {
                 .translation("forge.configgui.allowMipmapLowering")
                 .define("allowMipmapLowering", false);
 
-            debugBrandingVersions = builder
-                .comment("When enabled, Forge will show additional versions on the main menu (such as MCP). In ForgeDev, this is always enabled regardless of the config value.")
-                .translation("forge.configgui.debugBrandingVersions")
-                .define("debugBrandingVersions", false);
-
             builder.pop();
         }
 
@@ -138,13 +131,6 @@ public class ForgeConfig {
 
         public final boolean allowMipmapLowering() {
             return clientSpec.isLoaded() ? allowMipmapLowering.get() : allowMipmapLowering.getDefault();
-        }
-
-        public final boolean showDebugBrandingVersions() {
-            // if we're in ForgeDev, we always want these, so always show them regardless of config
-            if (FMLLoader.launcherHandlerName().startsWith("forge_dev")) return true;
-
-            return clientSpec.isLoaded() ? debugBrandingVersions.get() : debugBrandingVersions.getDefault();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -100,6 +100,8 @@ public class ForgeConfig {
 
         public final BooleanValue allowMipmapLowering;
 
+        public final BooleanValue debugBrandingVersions;
+
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                    .push("client");
@@ -118,6 +120,11 @@ public class ForgeConfig {
                 .comment("When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.")
                 .translation("forge.configgui.allowMipmapLowering")
                 .define("allowMipmapLowering", false);
+
+            debugBrandingVersions = builder
+                .comment("When enabled, Forge will show additional versions on the main menu (such as MCP).")
+                .translation("forge.configgui.debugBrandingVersions")
+                .define("debugBrandingVersions", false);
 
             builder.pop();
         }

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -16,6 +16,7 @@ import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.versions.mcp.MCPVersion;
 
@@ -32,18 +33,28 @@ public final class BrandingControl {
         if (brandings == null) {
             var list = new ArrayList<String>();
 
-            // always show these ones
-            list.add("Minecraft " + MCPVersion.getMCVersion());
-            list.add("Forge " + ForgeVersion.getVersion() + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
+            // Forge
+            // TODO Red text for beta version. This will probably change some semantics.
+            var forge = ForgeVersion.getVersion().split("-", 2);
 
-            // additional debug versions
-            if (ForgeConfig.CLIENT.showDebugBrandingVersions()) {
-                // TODO [Forge][FML] When FML is rewritten, add its version here.
-                list.add("MCP " + MCPVersion.getMCPVersion());
-            }
+            // I don't want to use VersionChecker to check for this, so I'm just going to use the version string.
+            // We only have Forge Betas on the "XX.0.XX" versions anyways.
+            boolean beta = "0".equals(forge[0].split("\\.")[1]);
+            var name = beta ? "§cForge Beta§f " : "§cForge§f ";
+            list.add(name + forge[0] + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
+
+            // Extra forge version info (like branch)
+            if (forge.length > 1) list.add("Forge Branch " + forge[1]);
+
+            // TODO [Forge][FML] When FML is rewritten, add its version here behind a config value to show it (debugBrandingVersions)
+            // this is how to check if we are in ForgeDev:
+            // (FMLLoader.launcherHandlerName().startsWith("forge_dev"));
+
+            // Minecraft
+            list.add("Minecraft " + MCPVersion.getMCVersion());
 
             brandings = List.copyOf(list);
-            brandingsNoMC = brandings.subList(1, brandings.size());
+            brandingsNoMC = brandings.subList(0, brandings.size() - 1);
         }
     }
 

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -28,13 +28,12 @@ public final class BrandingControl {
 
     private static void computeBranding() {
         if (brandings == null) {
-            brandings = List.of(
-                    "Forge " + ForgeVersion.getVersion(),
-                    "Minecraft " + MCPVersion.getMCVersion(),
-                    "MCP " + MCPVersion.getMCPVersion(),
-                    ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size())
-            );
-            brandingsNoMC = brandings.subList(1, brandings.size());
+            var forge = "Forge " + ForgeVersion.getVersion();
+            var mc = "Minecraft " + MCPVersion.getMCVersion();
+            var mcp = "MCP " + MCPVersion.getMCPVersion();
+            var modCount = ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size());
+            brandings = List.of(forge, mc, mcp, modCount);
+            brandingsNoMC = List.of(forge, mcp, modCount);
         }
     }
 

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -34,13 +34,12 @@ public final class BrandingControl {
             var list = new ArrayList<String>();
 
             // Forge
-            // TODO Red text for beta version. This will probably change some semantics.
             var forge = ForgeVersion.getVersion().split("-", 2);
 
             // I don't want to use VersionChecker to check for this, so I'm just going to use the version string.
             // We only have Forge Betas on the "XX.0.XX" versions anyways.
             boolean beta = "0".equals(forge[0].split("\\.")[1]);
-            var name = beta ? "§cForge Beta§f " : "§cForge§f ";
+            var name = beta ? "§eForge Beta§f " : "Forge ";
             list.add(name + forge[0] + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
 
             // Extra forge version info (like branch)

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -13,6 +13,7 @@ import java.util.function.ObjIntConsumer;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.versions.forge.ForgeVersion;
@@ -36,8 +37,10 @@ public final class BrandingControl {
             list.add("Forge " + ForgeVersion.getVersion() + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
 
             // additional debug versions
-            // TODO [Forge][FML] When FML is rewritten, add its version here.
-            list.add("MCP " + MCPVersion.getMCPVersion());
+            if (ForgeConfig.CLIENT.debugBrandingVersions.get()) {
+                // TODO [Forge][FML] When FML is rewritten, add its version here.
+                list.add("MCP " + MCPVersion.getMCPVersion());
+            }
 
             brandings = List.copyOf(list);
             brandingsNoMC = brandings.subList(1, brandings.size());

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -13,10 +13,8 @@ import java.util.function.ObjIntConsumer;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraftforge.client.ForgeHooksClient;
-import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.versions.mcp.MCPVersion;
 

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.internal;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.ObjIntConsumer;
@@ -28,12 +29,18 @@ public final class BrandingControl {
 
     private static void computeBranding() {
         if (brandings == null) {
-            var forge = "Forge " + ForgeVersion.getVersion();
-            var mc = "Minecraft " + MCPVersion.getMCVersion();
-            var mcp = "MCP " + MCPVersion.getMCPVersion();
-            var modCount = ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size());
-            brandings = List.of(forge, mc, mcp, modCount);
-            brandingsNoMC = List.of(forge, mcp, modCount);
+            var list = new ArrayList<String>();
+
+            // always show these ones
+            list.add("Minecraft " + MCPVersion.getMCVersion());
+            list.add("Forge " + ForgeVersion.getVersion() + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
+
+            // additional debug versions
+            // TODO [Forge][FML] When FML is rewritten, add its version here.
+            list.add("MCP " + MCPVersion.getMCPVersion());
+
+            brandings = List.copyOf(list);
+            brandingsNoMC = brandings.subList(1, brandings.size());
         }
     }
 

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -37,7 +37,7 @@ public final class BrandingControl {
             list.add("Forge " + ForgeVersion.getVersion() + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
 
             // additional debug versions
-            if (ForgeConfig.CLIENT.debugBrandingVersions.get()) {
+            if (ForgeConfig.CLIENT.showDebugBrandingVersions()) {
                 // TODO [Forge][FML] When FML is rewritten, add its version here.
                 list.add("MCP " + MCPVersion.getMCPVersion());
             }

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -17,6 +17,9 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.versions.mcp.MCPVersion;
 
+/**
+ * Controls the title screen brandings for the game.
+ */
 public final class BrandingControl {
     private BrandingControl() {}
 
@@ -43,6 +46,11 @@ public final class BrandingControl {
             return reverse ? brandingsNoMC.reversed() : brandingsNoMC;
     }
 
+    /**
+     * Gets the branding lines to display over the copyright line. This is usually a message when Forge has an update.
+     *
+     * @return The branding lines to display
+     */
     public static List<String> getOverCopyrightBrandings() {
         final class LazyInit {
             private static final List<String> INSTANCE = ForgeHooksClient.forgeStatusLine == null
@@ -55,22 +63,46 @@ public final class BrandingControl {
         return LazyInit.INSTANCE;
     }
 
+    /**
+     * Iterates over each branding line, passing the line and its index to the consumer.
+     *
+     * @param includeMC    Whether to include the Minecraft version line
+     * @param reverse      Whether to iterate in reverse order
+     * @param lineConsumer The consumer to accept each line and its index
+     */
     public static void forEachLine(boolean includeMC, boolean reverse, ObjIntConsumer<String> lineConsumer) {
         var brandings = getBrandings(includeMC, reverse);
         for (int idx = 0; idx < brandings.size(); idx++)
             lineConsumer.accept(brandings.get(idx), idx);
     }
 
+    /**
+     * Iterates over each branding line that should be displayed above the copyright line, passing the line and its
+     * index to the consumer.
+     *
+     * @param lineConsumer The consumer to accept each line and its index
+     */
     public static void forEachAboveCopyrightLine(ObjIntConsumer<String> lineConsumer) {
         var overCopyrightBrandings = getOverCopyrightBrandings();
         for (int idx = 0; idx < overCopyrightBrandings.size(); idx++)
             lineConsumer.accept(overCopyrightBrandings.get(idx), idx);
     }
 
+    /**
+     * Gets the branding to use in place of the default {@code "vanilla"} branding.
+     *
+     * @return The branding to use
+     */
     public static String getBranding() {
         return "forge";
     }
 
+    /**
+     * The reload listener for the branding control. On reload, the brandings are recomputed in
+     * {@link #computeBranding()}.
+     *
+     * @return The reload listener
+     */
     public static ResourceManagerReloadListener resourceManagerReloadListener() {
         return BrandingControl::onResourceManagerReload;
     }

--- a/src/main/java/net/minecraftforge/internal/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/internal/BrandingControl.java
@@ -41,11 +41,11 @@ public final class BrandingControl {
             list.add(name + forge[0] + " (" + ForgeI18n.parseMessage("fml.menu.loadingmods", ModList.get().size()) + ")");
 
             // Extra forge version info (like branch)
-            if (forge.length > 1) list.add("Forge Branch " + forge[1]);
+            if (forge.length > 1) list.add("Branch " + forge[1]);
 
             // TODO [Forge][FML] When FML is rewritten, add its version here behind a config value to show it (debugBrandingVersions)
             // this is how to check if we are in ForgeDev:
-            // (FMLLoader.launcherHandlerName().startsWith("forge_dev"));
+            // FMLLoader.launcherHandlerName().startsWith("forge_dev")
 
             // Minecraft
             list.add("Minecraft " + MCPVersion.getMCVersion());

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -36,7 +36,7 @@
   "fml.menu.multiplayer.modsincompatible":"Server mod list is not compatible",
   "fml.menu.multiplayer.networkincompatible":"Server network message list is not compatible",
   "fml.menu.multiplayer.missingdatapackregistries":"Missing required datapack registries: {0}",
-  "fml.menu.loadingmods": "{0,choice,0#No mods|1#1 mod|1<{0} mods}",
+  "fml.menu.loadingmods": "{0,choice,0#No mods|1#1 mod|1<{0} mods} loaded",
   "fml.menu.notification.title": "Startup Notification",
   "fml.menu.accessdenied.title": "Server Access Denied",
   "fml.menu.accessdenied.message": "Forge Mod Loader could not connect to this server\nThe server {0} has forbidden modded access",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -187,6 +187,8 @@
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
   "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
   "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
+  "forge.configgui.debugBrandingVersions.tooltip": "When enabled, Forge will show additional versions on the main menu (such as MCP).",
+  "forge.configgui.debugBrandingVersions": "Show debug brandings in Title Screen",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -36,7 +36,7 @@
   "fml.menu.multiplayer.modsincompatible":"Server mod list is not compatible",
   "fml.menu.multiplayer.networkincompatible":"Server network message list is not compatible",
   "fml.menu.multiplayer.missingdatapackregistries":"Missing required datapack registries: {0}",
-  "fml.menu.loadingmods": "{0,choice,0#No mods|1#1 mod|1<{0} mods} loaded",
+  "fml.menu.loadingmods": "{0,choice,0#No mods|1#1 mod|1<{0} mods}",
   "fml.menu.notification.title": "Startup Notification",
   "fml.menu.accessdenied.title": "Server Access Denied",
   "fml.menu.accessdenied.message": "Forge Mod Loader could not connect to this server\nThe server {0} has forbidden modded access",
@@ -187,8 +187,6 @@
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
   "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
   "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
-  "forge.configgui.debugBrandingVersions.tooltip": "When enabled, Forge will show additional versions on the main menu (such as MCP). In ForgeDev, this is always enabled regardless of the config value.",
-  "forge.configgui.debugBrandingVersions": "Show debug brandings in Title Screen",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -187,7 +187,7 @@
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
   "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
   "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
-  "forge.configgui.debugBrandingVersions.tooltip": "When enabled, Forge will show additional versions on the main menu (such as MCP).",
+  "forge.configgui.debugBrandingVersions.tooltip": "When enabled, Forge will show additional versions on the main menu (such as MCP). In ForgeDev, this is always enabled regardless of the config value.",
   "forge.configgui.debugBrandingVersions": "Show debug brandings in Title Screen",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -141,8 +141,6 @@
   "commands.config.getwithtype": "Config for %s of type %s found at %s",
   "commands.config.noconfig": "Config for %s of type %s not found",
 
-  "forge.update.beta.1": "%sWARNING: %sForge Beta",
-  "forge.update.beta.2": "Major issues may arise, verify before reporting.",
   "forge.update.newversion": "New Forge version available: %s",
   "forge.menu.updatescreen.title": "Mod Update",
 


### PR DESCRIPTION
This is an opinionated PR that simplifies how the Forge version brandings are displayed on the title screen.

**BEFORE:**
![Screenshot_20241231_173646](https://github.com/user-attachments/assets/34cd9d9e-6c53-43c9-b489-12148e640599)

**AFTER:**
![Screenshot_20241231_182814](https://github.com/user-attachments/assets/1eb42151-5ab0-448e-9e3f-1954cc1166da)

## Version Ordering

The versions used to be listed in this order from top-to-bottom: Forge, Minecraft, MCP, and the number of mods loaded. Not only was this order a little bit nonsensical, it also caused an issue where `BrandingControl.brandingsNoMC` would incorrectly hold the MC version but not the Forge version.

I've instead ordered the versions like this from top-to-bottom: Forge (mods loaded), Forge Branch (if any), and Minecraft. That way, the Minecraft version is displayed in the same position as in vanilla and the field from earlier is correctly set. Additionally, this assists with separate branches in Forge by moving the version-ified branch name to its own line. If there is no branch name to display, this line is never added.

## Debug Version Brandings

When I originally made this PR, I made a config value to show debug versions such as the MCP timestamp. Since we've agreed to no longer show the MCP version, I've since removed it. But it would be useful to consider once we rewrite FML to show the FML version as a debug branding (the user does not need to know the FML version).

## Mod Count after Forge Version

I've moved the mod count from the bottom of the brandings to directly after the Forge version. This removes the clutter of having an extra line specifically for the number of mods listed, which was not that long anyway.