### PR TITLE
[1.20.4] Fix finalizeSpawn's return value not being used correctly

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -268,9 +268,9 @@ public class ForgeEventFactory {
         boolean cancel = post(event);
 
         if (!cancel)
-            mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData(), event.getSpawnTag());
+            return mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData(), event.getSpawnTag());
 
-        return cancel ? null : event.getSpawnData();
+        return null;
     }
 
     /**


### PR DESCRIPTION
- Partial Backport of 59a7bbd for 1.20.4.
- Fixes #9964 for 1.20.4.