### PR TITLE
[1.20.4] Gate non-passenger entity ticking behind canUpdate()

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -82,6 +82,14 @@
        }
  
     }
+@@ -699,6 +_,7 @@
+          return BuiltInRegistries.ENTITY_TYPE.getKey(p_8648_.getType()).toString();
+       });
+       profilerfiller.incrementCounter("tickNonPassenger");
++      if (p_8648_.canUpdate())
+       p_8648_.tick();
+       this.getProfiler().pop();
+ 
 @@ -718,6 +_,7 @@
                 return BuiltInRegistries.ENTITY_TYPE.getKey(p_8664_.getType()).toString();
              });


### PR DESCRIPTION
This PR backports an additional change made in 59a7bbd where the ticking of non-passengers is gated behind `Entity.canUpdate()`.

- Partial backport of 59a7bbd for 1.20.4.

> [!CAUTION]
> This is technically a bug fix and not a breaking change, but could cause mods that relied on this behavior to behave unexpectedly.