### PR TITLE
[1.19.2] Gate non-passenger entity ticking behind canUpdate()

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -84,6 +84,14 @@
        }
  
     }
+@@ -646,6 +_,7 @@
+          return Registry.f_122826_.m_7981_(p_8648_.m_6095_()).toString();
+       });
+       profilerfiller.m_6174_("tickNonPassenger");
++      if (p_8648_.canUpdate())
+       p_8648_.m_8119_();
+       this.m_46473_().m_7238_();
+ 
 @@ -665,6 +_,7 @@
                 return Registry.f_122826_.m_7981_(p_8664_.m_6095_()).toString();
              });


### PR DESCRIPTION
- Backport of #10303 to 1.19.2.
- Partial backport of 59a7bbd to 1.19.2.