### PR TITLE
[1.18.2] Gate non-passenger entity ticking behind canUpdate()

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -84,6 +84,14 @@
        }
  
     }
+@@ -640,6 +_,7 @@
+          return Registry.f_122826_.m_7981_(p_8648_.m_6095_()).toString();
+       });
+       profilerfiller.m_6174_("tickNonPassenger");
++      if (p_8648_.canUpdate())
+       p_8648_.m_8119_();
+       this.m_46473_().m_7238_();
+ 
 @@ -656,9 +_,10 @@
              ++p_8664_.f_19797_;
              ProfilerFiller profilerfiller = this.m_46473_();


### PR DESCRIPTION
- Backport of #10303 to 1.18.2.
- Partial backport of 59a7bbd to 1.18.2.