### PR TITLE
[1.19.4] Fix finalizeSpawn's return value not being used correctly

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -230,10 +230,10 @@ public class ForgeEventFactory
 
         if (!cancel)
         {
-            mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData(), event.getSpawnTag());
+            return mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData(), event.getSpawnTag());
         }
 
-        return cancel ? null : event.getSpawnData();
+        return null;
     }
 
     /**


### PR DESCRIPTION
- Backport of #10302.
- Partial backport of 59a7bbd for 1.19.4.
- Fixes #9964 for 1.19.4.