### PR TITLE
[1.21.4] Fix JOpt Simple needing a strict version requirement declaration

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -118,7 +118,7 @@ dependencies {
     bootstrap(libs.unsafe)        // Needed by securemodules
     bootstrap(libs.bundles.asm)   // Needed by securemodules
 
-    implementation(libs.jopt.simple) { version { strictly '5.0.4' } }
+    implementation(libs.jopt.simple)
 
     installer(libs.bootstrap)
     installer(libs.bootstrap.api) // Needed by securemodules

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -141,9 +141,6 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    
-    // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transitive dependencies request 6.0+ 
-    implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
             library('modlauncher', 'net.minecraftforge:modlauncher:10.2.3') // Needs securemodules
             library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
-            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.1')
+            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.15')


### PR DESCRIPTION
This PR fixes needing additional bloat in the MDK by declaring a strict version of JOpt Simple. AccessTransformers was the culprit, and I've fixed that there. Forge now uses updated AT, so the MDK issue is resolved.

- Bumps AccessTransformers to 8.2.2.
- Follows up on MinecraftForge/AccessTransformers#22.