### PR TITLE
[1.20.6] Fix JOpt Simple needing a strict version requirement declaration

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -117,7 +117,7 @@ dependencies {
     bootstrap(libs.unsafe)        // Needed by securemodules
     bootstrap(libs.bundles.asm)   // Needed by securemodules
     
-    implementation(libs.jopt.simple) { version { strictly '5.0.4' } }
+    implementation(libs.jopt.simple)
     
     installer(libs.bootstrap)
     installer(libs.bootstrap.api) // Needed by securemodules

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -141,9 +141,6 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    
-    // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transitive dependencies request 6.0+ 
-    implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
             library('modlauncher', 'net.minecraftforge:modlauncher:10.2.1') // Needs securemodules
             library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
-            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.0')
+            library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.4')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
             library('eventbus', 'net.minecraftforge:eventbus:6.2.8')


### PR DESCRIPTION
- Backport of #10311 to 1.20.6.