### PR TITLE
[1.21.4] Fix shield disabling being completely ignored

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -129,7 +129,7 @@
          super.blockUsingShield(p_36295_);
          ItemStack itemstack = this.getItemBlockingWith();
 -        if (p_36295_.canDisableShield() && itemstack != null) {
-+        if (itemstack != null && itemstack.canDisableShield(this.useItem, this, p_36295_)) {
++        if (itemstack != null && p_36295_.getWeaponItem().canDisableShield(itemstack, this, p_36295_)) {
              this.disableShield(itemstack);
          }
      }

--- a/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
@@ -10,7 +10,7 @@
              if (optional.isEmpty()) {
                  return InteractionResult.PASS;
              } else {
-@@ -115,5 +_,16 @@
+@@ -115,5 +_,21 @@
      private Optional<BlockState> getStripped(BlockState p_150691_) {
          return Optional.ofNullable(STRIPPABLES.get(p_150691_.getBlock()))
              .map(p_359378_ -> p_359378_.defaultBlockState().setValue(RotatedPillarBlock.AXIS, p_150691_.getValue(RotatedPillarBlock.AXIS)));
@@ -25,5 +25,10 @@
 +    public static BlockState getAxeStrippingState(BlockState originalState) {
 +        Block block = STRIPPABLES.get(originalState.getBlock());
 +        return block != null ? block.defaultBlockState().setValue(RotatedPillarBlock.AXIS, originalState.getValue(RotatedPillarBlock.AXIS)) : null;
++    }
++
++    @Override
++    public boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker) {
++        return true;
      }
  }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -459,7 +459,7 @@ public interface IForgeItem {
      * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker) {
-        return attacker.canDisableShield() || this instanceof AxeItem;
+        return attacker.canDisableShield();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -459,7 +459,7 @@ public interface IForgeItem {
      * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker) {
-        return this instanceof AxeItem;
+        return attacker.canDisableShield() || this instanceof AxeItem;
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.debug.gameplay.item;
+
+import net.minecraft.Util;
+import net.minecraft.commands.arguments.EntityAnchorArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.test.BaseTestMod;
+
+import java.util.function.Function;
+
+@Mod(ShieldDisablingTest.MOD_ID)
+@GameTestHolder("forge." + ShieldDisablingTest.MOD_ID)
+public final class ShieldDisablingTest extends BaseTestMod {
+    public static final String MOD_ID = "shield_disabling";
+
+    public ShieldDisablingTest(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void player_shield_disabled_by_axe(GameTestHelper helper) {
+        player_shield_disabled_common(helper, h -> Util.make(
+            h.spawnWithNoFreeWill(EntityType.HUSK, new BlockPos(2, 0, 2)),
+            enemy -> enemy.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.IRON_AXE))
+        ));
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void player_shield_disabled_by_warden(GameTestHelper helper) {
+        player_shield_disabled_common(helper, h -> h.spawnWithNoFreeWill(EntityType.WARDEN, new BlockPos(2, 0, 2)));
+    }
+
+    private static void player_shield_disabled_common(GameTestHelper helper, Function<GameTestHelper, LivingEntity> enemyGetter) {
+        helper.makeFloor();
+
+        // setup player
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        helper.<LivingEntityUseItemEvent.Start>addEventListener(event -> {
+            // Artificially pass 5 seconds from start of the shield
+            // This is because the first 5 ticks, the player is still vulnerable
+            if (event.getEntity() == player) {
+                event.setDuration(event.getDuration() - 100);
+            }
+        });
+
+        // start using shield
+        var shield = Items.SHIELD.getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shield);
+        player.startUsingItem(InteractionHand.MAIN_HAND);
+
+        // setup enemy
+        var enemy = enemyGetter.apply(helper);
+        player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
+
+        // hit the player
+        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+
+        // shield on cooldown?
+        helper.assertTrue(player.getCooldowns().isOnCooldown(shield), "shield should be on cooldown");
+        helper.succeed();
+    }
+}


### PR DESCRIPTION
As of right now, shields are not disabled *at all* if a player is attacked in a context where they should be. They are never put in cooldown for any reason, whether the player is attacked with an axe or by a Warden. Also, the invocation of `canDisableShield()` is called on the shield... for some fucking reason?????

This PR fixes this by modifying the Player patch to use the attacker's weapon for any item-specific shield disabling checks. The check in question has been modified to no longer check if it is an Axe, but instead check if the attacker can destroy shields. The relevant method in IForgeItem has been overriden via a patch in AxeItem which skips the instanceof check that would've originally taken place.

- Fixes #8809 for 1.21.4.
- Supersedes #9031.
- Requires #10309.