### PR TITLE
[1.19.2] Honor attacker shield disabling status

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
@@ -15,7 +15,7 @@
        ItemStack itemstack = p_40529_.m_43722_();
        Optional<BlockState> optional3 = Optional.empty();
        if (optional.isPresent()) {
-@@ -71,9 +_,20 @@
+@@ -71,9 +_,25 @@
        }
     }
  
@@ -34,5 +34,10 @@
 +   @Override
 +   public boolean canPerformAction(ItemStack stack, net.minecraftforge.common.ToolAction toolAction) {
 +      return net.minecraftforge.common.ToolActions.DEFAULT_AXE_ACTIONS.contains(toolAction);
++   }
++
++   @Override
++   public boolean canDisableShield(ItemStack stack, ItemStack shield, net.minecraft.world.entity.LivingEntity entity, net.minecraft.world.entity.LivingEntity attacker) {
++      return true;
     }
  }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -671,7 +671,7 @@ public interface IForgeItem
      */
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {
-        return this instanceof AxeItem;
+        return attacker.canDisableShield();
     }
 
     /**


### PR DESCRIPTION
- Backport of #10318 to 1.19.2.
- Fixes #8809 for 1.19.2.