### PR TITLE
[1.21.4] Fix forced chunks never being ticked by the server

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -24,7 +24,7 @@
                  this.write(chunkpos, completablefuture::join).handle((p_358676_, p_358677_) -> {
                      if (p_358677_ != null) {
                          this.level.getServer().reportChunkSaveFailure(p_358677_, this.storageInfo(), chunkpos);
-@@ -934,15 +_,32 @@
+@@ -934,10 +_,27 @@
      void forEachSpawnCandidateChunk(Consumer<ChunkHolder> p_364582_) {
          LongIterator longiterator = this.distanceManager.getSpawnCandidateChunks();
  
@@ -38,6 +38,11 @@
 +        this.forEachChunk(longiterator, pos -> true, callback);
 +    }
 +
++    /** FORGE: check if there are any forced chunks */
++    boolean hasForcedChunks() {
++        return !this.distanceManager.forcedTickets.isEmpty();
++    }
++
 +    /** FORGE: commonize logic between forEachSpawnCandidateChunk and forEachForcedChunk */
 +    private void forEachChunk(LongIterator longiterator, java.util.function.Predicate<ChunkPos> filter, Consumer<ChunkHolder> p_364582_) {
          while (longiterator.hasNext()) {
@@ -48,16 +53,6 @@
                  p_364582_.accept(chunkholder);
              }
          }
-     }
- 
-+    /** FORGE: check if there are any forced chunks */
-+    boolean hasForcedChunks() {
-+        return !this.distanceManager.forcedTickets.isEmpty();
-+    }
-+
-     boolean anyPlayerCloseEnoughForSpawning(ChunkPos p_183880_) {
-         return !this.distanceManager.hasPlayersNearby(p_183880_.toLong()) ? false : this.anyPlayerCloseEnoughForSpawningInternal(p_183880_);
-     }
 @@ -1102,7 +_,7 @@
      }
  

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -24,6 +24,30 @@
                  this.write(chunkpos, completablefuture::join).handle((p_358676_, p_358677_) -> {
                      if (p_358677_ != null) {
                          this.level.getServer().reportChunkSaveFailure(p_358677_, this.storageInfo(), chunkpos);
+@@ -934,10 +_,22 @@
+     void forEachSpawnCandidateChunk(Consumer<ChunkHolder> p_364582_) {
+         LongIterator longiterator = this.distanceManager.getSpawnCandidateChunks();
+ 
++        // FORGE: separated forEach logic into its own method
++        this.forEachChunk(longiterator, this::anyPlayerCloseEnoughForSpawningInternal, p_364582_);
++    }
++
++    /** FORGE: grab forced chunks, use forEachChunk to avoid duplicate logic */
++    void forEachForcedChunk(Consumer<ChunkHolder> callback) {
++        LongIterator longiterator = this.distanceManager.forcedTickets.keySet().iterator();
++        this.forEachChunk(longiterator, pos -> true, callback);
++    }
++
++    /** FORGE: commonize logic between forEachSpawnCandidateChunk and forEachForcedChunk */
++    private void forEachChunk(LongIterator longiterator, java.util.function.Predicate<ChunkPos> filter, Consumer<ChunkHolder> p_364582_) {
+         while (longiterator.hasNext()) {
+             long i = longiterator.nextLong();
+             ChunkHolder chunkholder = this.visibleChunkMap.get(i);
+-            if (chunkholder != null && this.anyPlayerCloseEnoughForSpawningInternal(chunkholder.getPos())) {
++            if (chunkholder != null && filter.test(chunkholder.getPos())) {
+                 p_364582_.accept(chunkholder);
+             }
+         }
 @@ -1102,7 +_,7 @@
      }
  
@@ -33,23 +57,3 @@
              EntityType<?> entitytype = p_140200_.getType();
              int i = entitytype.clientTrackingRange() * 16;
              if (i != 0) {
-@@ -1344,6 +_,19 @@
-         public void updatePlayers(List<ServerPlayer> p_140488_) {
-             for (ServerPlayer serverplayer : p_140488_) {
-                 this.updatePlayer(serverplayer);
-+            }
-+        }
-+    }
-+
-+    // Copy of forEachSpawnCandidateChunk, but with forced chunks
-+    void forEachForcedChunk(Consumer<ChunkHolder> p_364582_) {
-+        LongIterator longiterator = this.distanceManager.forcedTickets.keySet().iterator();
-+
-+        while (longiterator.hasNext()) {
-+            long i = longiterator.nextLong();
-+            ChunkHolder chunkholder = this.visibleChunkMap.get(i);
-+            if (chunkholder != null) {
-+                p_364582_.accept(chunkholder);
-             }
-         }
-     }

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -24,7 +24,7 @@
                  this.write(chunkpos, completablefuture::join).handle((p_358676_, p_358677_) -> {
                      if (p_358677_ != null) {
                          this.level.getServer().reportChunkSaveFailure(p_358677_, this.storageInfo(), chunkpos);
-@@ -934,10 +_,22 @@
+@@ -934,15 +_,32 @@
      void forEachSpawnCandidateChunk(Consumer<ChunkHolder> p_364582_) {
          LongIterator longiterator = this.distanceManager.getSpawnCandidateChunks();
  
@@ -48,6 +48,16 @@
                  p_364582_.accept(chunkholder);
              }
          }
+     }
+ 
++    /** FORGE: check if there are any forced chunks */
++    boolean hasForcedChunks() {
++        return !this.distanceManager.forcedTickets.isEmpty();
++    }
++
+     boolean anyPlayerCloseEnoughForSpawning(ChunkPos p_183880_) {
+         return !this.distanceManager.hasPlayersNearby(p_183880_.toLong()) ? false : this.anyPlayerCloseEnoughForSpawningInternal(p_183880_);
+     }
 @@ -1102,7 +_,7 @@
      }
  

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -33,3 +33,23 @@
              EntityType<?> entitytype = p_140200_.getType();
              int i = entitytype.clientTrackingRange() * 16;
              if (i != 0) {
+@@ -1344,6 +_,19 @@
+         public void updatePlayers(List<ServerPlayer> p_140488_) {
+             for (ServerPlayer serverplayer : p_140488_) {
+                 this.updatePlayer(serverplayer);
++            }
++        }
++    }
++
++    // Copy of forEachSpawnCandidateChunk, but with forced chunks
++    void forEachForcedChunk(Consumer<ChunkHolder> p_364582_) {
++        LongIterator longiterator = this.distanceManager.forcedTickets.keySet().iterator();
++
++        while (longiterator.hasNext()) {
++            long i = longiterator.nextLong();
++            ChunkHolder chunkholder = this.visibleChunkMap.get(i);
++            if (chunkholder != null) {
++                p_364582_.accept(chunkholder);
+             }
+         }
+     }

--- a/patches/minecraft/net/minecraft/server/level/DistanceManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/DistanceManager.java.patch
@@ -4,7 +4,7 @@
      final Executor mainThreadExecutor;
      private long ticketTickCounter;
      private int simulationDistance = 10;
-+    private final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> forcedTickets = new Long2ObjectOpenHashMap<>();
++    final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> forcedTickets = new Long2ObjectOpenHashMap<>();
  
      protected DistanceManager(Executor p_140774_, Executor p_140775_) {
          TaskScheduler<Runnable> taskscheduler = TaskScheduler.wrapExecutor("player ticket throttler", p_140775_);
@@ -44,7 +44,7 @@
 +    }
 +
 +    public <T> void addRegionTicket(TicketType<T> p_140841_, ChunkPos p_140842_, int p_140843_, T p_140844_, boolean forceTicks) {
-+       Ticket<T> ticket = new Ticket<>(p_140841_, ChunkLevel.byStatus(FullChunkStatus.FULL) - p_140843_, p_140844_, forceTicks);
++        Ticket<T> ticket = new Ticket<>(p_140841_, ChunkLevel.byStatus(FullChunkStatus.FULL) - p_140843_, p_140844_, forceTicks);
          long i = p_140842_.toLong();
          this.addTicket(i, ticket);
          this.tickingTicketsTracker.addTicket(i, ticket);

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -11,12 +11,18 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -368,9 +_,19 @@
+@@ -368,9 +_,25 @@
      }
  
      private void collectTickingChunks(List<LevelChunk> p_368970_) {
 -        this.chunkMap.forEachSpawnCandidateChunk(p_358696_ -> {
-+        // FORGE: Use a LinkedHashSet to preserve order
++        // FORGE: If there are no forced chunks, just do the vanilla logic
++        if (!this.chunkMap.hasForcedChunks()) {
++            this.chunkMap.forEachSpawnCandidateChunk(this.getChunkCollector(p_368970_, chunk -> this.level.isNaturalSpawningAllowed(chunk.getPos())));
++            return;
++        }
++
++        // FORGE: We have forced chunks? Ok, use a linked hash set to preserve order
 +        Set<LevelChunk> set = new java.util.LinkedHashSet<>();
 +        this.chunkMap.forEachSpawnCandidateChunk(this.getChunkCollector(set, chunk -> this.level.isNaturalSpawningAllowed(chunk.getPos())));
 +        this.chunkMap.forEachForcedChunk(this.getChunkCollector(set, chunk -> true));

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -11,23 +11,25 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -368,9 +_,17 @@
+@@ -368,9 +_,19 @@
      }
  
      private void collectTickingChunks(List<LevelChunk> p_368970_) {
 -        this.chunkMap.forEachSpawnCandidateChunk(p_358696_ -> {
-+        this.chunkMap.forEachSpawnCandidateChunk(this.getChunkCollector(p_368970_, chunk -> this.level.isNaturalSpawningAllowed(chunk.getPos())));
-+        this.chunkMap.forEachForcedChunk(this.getChunkCollector(p_368970_, chunk -> true));
++        // FORGE: Use a LinkedHashSet to preserve order
++        Set<LevelChunk> set = new java.util.LinkedHashSet<>();
++        this.chunkMap.forEachSpawnCandidateChunk(this.getChunkCollector(set, chunk -> this.level.isNaturalSpawningAllowed(chunk.getPos())));
++        this.chunkMap.forEachForcedChunk(this.getChunkCollector(set, chunk -> true));
++        p_368970_.addAll(set);
 +    }
 +
 +    /** FORGE: Isolate chunk collection callback */
-+    private Consumer<ChunkHolder> getChunkCollector(List<LevelChunk> p_368970_, java.util.function.Predicate<LevelChunk> predicate) {
++    private Consumer<ChunkHolder> getChunkCollector(java.util.Collection<LevelChunk> p_368970_, java.util.function.Predicate<LevelChunk> predicate) {
 +        return (p_358696_ -> {
              LevelChunk levelchunk = p_358696_.getTickingChunk();
 -            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_358696_.getPos())) {
++            // FORGE: Use custom predicate instead of only checking isNaturalSpawningAllowed
 +            if (levelchunk != null && predicate.test(levelchunk)) {
-+                // FORGE: Do not add duplicate chunks to list
-+                if (!p_368970_.contains(levelchunk))
                  p_368970_.add(levelchunk);
              }
          });

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -11,6 +11,19 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
+@@ -374,6 +_,12 @@
+                 p_368970_.add(levelchunk);
+             }
+         });
++        this.chunkMap.forEachForcedChunk(holder -> {
++            LevelChunk levelchunk = holder.getTickingChunk();
++            if (levelchunk != null) {
++                p_368970_.add(levelchunk);
++            }
++        });
+     }
+ 
+     private void tickChunks(ProfilerFiller p_368327_, long p_362313_, List<LevelChunk> p_366274_) {
 @@ -466,11 +_,19 @@
      }
  

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -20,7 +20,7 @@
 +        this.chunkMap.forEachForcedChunk(this.getChunkCollector(p_368970_, chunk -> true));
 +    }
 +
-+    // FORGE: isolate chunk collection callback
++    /** FORGE: Isolate chunk collection callback */
 +    private Consumer<ChunkHolder> getChunkCollector(List<LevelChunk> p_368970_, java.util.function.Predicate<LevelChunk> predicate) {
 +        return (p_358696_ -> {
              LevelChunk levelchunk = p_358696_.getTickingChunk();

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -11,25 +11,26 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -368,12 +_,17 @@
+@@ -368,9 +_,17 @@
      }
  
      private void collectTickingChunks(List<LevelChunk> p_368970_) {
 -        this.chunkMap.forEachSpawnCandidateChunk(p_358696_ -> {
-+        // FORGE: isolate callback into its own variable for use in both forEachSpawnCandidateChunk and forEachForcedChunk
-+        Consumer<ChunkHolder> callback = (p_358696_ -> {
++        this.chunkMap.forEachSpawnCandidateChunk(this.getChunkCollector(p_368970_, chunk -> this.level.isNaturalSpawningAllowed(chunk.getPos())));
++        this.chunkMap.forEachForcedChunk(this.getChunkCollector(p_368970_, chunk -> true));
++    }
++
++    // FORGE: isolate chunk collection callback
++    private Consumer<ChunkHolder> getChunkCollector(List<LevelChunk> p_368970_, java.util.function.Predicate<LevelChunk> predicate) {
++        return (p_358696_ -> {
              LevelChunk levelchunk = p_358696_.getTickingChunk();
-             if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_358696_.getPos())) {
+-            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_358696_.getPos())) {
++            if (levelchunk != null && predicate.test(levelchunk)) {
 +                // FORGE: Do not add duplicate chunks to list
 +                if (!p_368970_.contains(levelchunk))
                  p_368970_.add(levelchunk);
              }
          });
-+        this.chunkMap.forEachSpawnCandidateChunk(callback);
-+        this.chunkMap.forEachForcedChunk(callback);
-     }
- 
-     private void tickChunks(ProfilerFiller p_368327_, long p_362313_, List<LevelChunk> p_366274_) {
 @@ -466,11 +_,19 @@
      }
  

--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -11,16 +11,22 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -374,6 +_,12 @@
+@@ -368,12 +_,17 @@
+     }
+ 
+     private void collectTickingChunks(List<LevelChunk> p_368970_) {
+-        this.chunkMap.forEachSpawnCandidateChunk(p_358696_ -> {
++        // FORGE: isolate callback into its own variable for use in both forEachSpawnCandidateChunk and forEachForcedChunk
++        Consumer<ChunkHolder> callback = (p_358696_ -> {
+             LevelChunk levelchunk = p_358696_.getTickingChunk();
+             if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_358696_.getPos())) {
++                // FORGE: Do not add duplicate chunks to list
++                if (!p_368970_.contains(levelchunk))
                  p_368970_.add(levelchunk);
              }
          });
-+        this.chunkMap.forEachForcedChunk(holder -> {
-+            LevelChunk levelchunk = holder.getTickingChunk();
-+            if (levelchunk != null) {
-+                p_368970_.add(levelchunk);
-+            }
-+        });
++        this.chunkMap.forEachSpawnCandidateChunk(callback);
++        this.chunkMap.forEachForcedChunk(callback);
      }
  
      private void tickChunks(ProfilerFiller p_368327_, long p_362313_, List<LevelChunk> p_366274_) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -13,6 +13,8 @@ import java.util.function.Supplier;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.MutableComponent;
 import org.jetbrains.annotations.Nullable;
 
 import com.mojang.authlib.GameProfile;
@@ -46,12 +48,23 @@ public interface IForgeGameTestHelper {
     }
 
     default void say(String message, Style style) {
-        var component = ForgeI18n.getPattern(message) != null ? Component.translatable(message) : Component.literal(message);
-        this.say(component.withStyle(style));
+        this.say(this.getMessage(message).withStyle(style));
+    }
+
+    default void say(String message, ChatFormatting style) {
+        this.say(this.getMessage(message).withStyle(style));
+    }
+
+    default void say(String message, int color) {
+        this.say(this.getMessage(message).withColor(color));
     }
 
     default void say(Component component) {
         this.self().getLevel().players().forEach(p -> p.sendSystemMessage(component));
+    }
+
+    private MutableComponent getMessage(String message) {
+        return ForgeI18n.getPattern(message) != null ? Component.translatable(message) : Component.literal(message);
     }
 
     default void assertTrue(boolean value, Supplier<String> message) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.ChatFormatting;
+import net.minecraft.Util;
 import net.minecraft.network.chat.MutableComponent;
 import org.jetbrains.annotations.Nullable;
 
@@ -193,6 +194,14 @@ public interface IForgeGameTestHelper {
         return new IntFlag(name);
     }
 
+    default IntFlag intFlag(String name, int value) {
+        return this.intFlag(name, (long) value);
+    }
+
+    default IntFlag intFlag(String name, long value) {
+        return Util.make(new IntFlag(name), flag -> flag.set(value));
+    }
+
     default BoolFlag boolFlag(String name) {
         return new BoolFlag(name);
     }
@@ -269,6 +278,32 @@ public interface IForgeGameTestHelper {
 
         public void set(long value) {
             super.set(value);
+        }
+
+        public void increment() {
+            this.decrement(1L);
+        }
+
+        public void increment(int amount) {
+            this.decrement((long) amount);
+        }
+
+        public void increment(long amount) {
+            if (this.value != null)
+                this.set(this.value + amount);
+        }
+
+        public void decrement() {
+            this.decrement(1L);
+        }
+
+        public void decrement(int amount) {
+            this.decrement((long) amount);
+        }
+
+        public void decrement(long amount) {
+            if (this.value != null)
+                this.set(this.value - amount);
         }
 
         public byte getByte() {

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -9,10 +9,11 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
-import net.minecraft.network.chat.Style;
 import net.minecraft.server.level.ChunkLevel;
 import net.minecraft.server.level.FullChunkStatus;
 import net.minecraft.server.level.TicketType;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
@@ -29,18 +30,34 @@ public class ForcedChunkLoadingTest extends BaseTestMod {
 
     @GameTest(template = "forge:empty3x3x3")
     public static void force_far_away_chunk(GameTestHelper helper) {
+        var random = RandomSource.create();
         var level = helper.getLevel();
         var chunkSource = level.getChunkSource();
 
-        var chunk = level.getChunk(new BlockPos(10000, 0, 10000));
+        var attempts = helper.intFlag("attempts", 0);
+        helper.addCleanup(passed -> {
+            if (!passed && attempts.getInt() > 0)
+                helper.say("Failed to find an unloaded far-away chunk after " + attempts.getInt() + " attempts", ChatFormatting.RED);
+        });
+
+        ChunkAccess chunk;
+        do {
+            attempts.increment();
+            int x = random.nextInt(1, 10) * 10000;
+            int z = random.nextInt(1, 10) * 10000;
+            chunk = level.getChunk(helper.absolutePos(BlockPos.ZERO).offset(x, 0, z));
+        } while (!chunkSource.isPositionTicking(chunk.getPos().toLong()));
+        attempts.set(0);
+
         var pos = chunk.getPos();
         helper.say("Attempting to force far away chunk: " + pos, ChatFormatting.YELLOW);
         chunkSource.chunkMap.getDistanceManager().addRegionTicket(TicketType.FORCED, pos, ChunkLevel.byStatus(FullChunkStatus.FULL), pos, true);
 
-        helper.runAfterDelay(90, () -> {
+        helper.runAfterDelay(20, () -> {
             helper.assertTrue(chunkSource.chunkMap.getDistanceManager().shouldForceTicks(pos.toLong()), "Chunk is not ticketed as a forced loaded chunk");
             helper.assertTrue(chunkSource.chunkMap.getDistanceManager().inEntityTickingRange(pos.toLong()), "Forced chunk cannot tick entities");
             helper.assertTrue(chunkSource.chunkMap.getDistanceManager().inBlockTickingRange(pos.toLong()), "Forced chunk cannot tick blocks");
+            helper.assertTrue(chunkSource.hasChunk(pos.x, pos.z), "Chunk is not loaded despite being ticketed as a force loaded chunk");
             helper.succeed();
         });
     }

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.level;
 
 import net.minecraft.ChatFormatting;

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.debug.gameplay.level;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.chat.Style;
+import net.minecraft.server.level.ChunkLevel;
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.server.level.TicketType;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.test.BaseTestMod;
+
+@GameTestHolder("forge." + ForcedChunkLoadingTest.MOD_ID)
+@Mod(ForcedChunkLoadingTest.MOD_ID)
+public class ForcedChunkLoadingTest extends BaseTestMod {
+    static final String MOD_ID = "forced_chunk_loading_test";
+
+    public ForcedChunkLoadingTest(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void force_far_away_chunk(GameTestHelper helper) {
+        var level = helper.getLevel();
+        var chunkSource = level.getChunkSource();
+
+        var chunk = level.getChunk(new BlockPos(10000, 0, 10000));
+        var pos = chunk.getPos();
+        helper.say("Attempting to force far away chunk: " + pos, ChatFormatting.YELLOW);
+        chunkSource.chunkMap.getDistanceManager().addRegionTicket(TicketType.FORCED, pos, ChunkLevel.byStatus(FullChunkStatus.FULL), pos, true);
+
+        helper.runAfterDelay(90, () -> {
+            helper.assertTrue(chunkSource.chunkMap.getDistanceManager().shouldForceTicks(pos.toLong()), "Chunk is not ticketed as a forced loaded chunk");
+            helper.assertTrue(chunkSource.chunkMap.getDistanceManager().inEntityTickingRange(pos.toLong()), "Forced chunk cannot tick entities");
+            helper.assertTrue(chunkSource.chunkMap.getDistanceManager().inBlockTickingRange(pos.toLong()), "Forced chunk cannot tick blocks");
+            helper.succeed();
+        });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -21,7 +21,7 @@ import net.minecraftforge.test.BaseTestMod;
 @GameTestHolder("forge." + ForcedChunkLoadingTest.MOD_ID)
 @Mod(ForcedChunkLoadingTest.MOD_ID)
 public class ForcedChunkLoadingTest extends BaseTestMod {
-    static final String MOD_ID = "forced_chunk_loading_test";
+    static final String MOD_ID = "forced_chunk_loading";
 
     public ForcedChunkLoadingTest(FMLJavaModLoadingContext context) {
         super(context);


### PR DESCRIPTION
In the update to 1.21.3, a patch was eaten that was responsible for adding forced chunk tickets to the iterator of ticking chunks. The functionality of collecting ticking chunks was moved elsewhere, so this PR compensates by patching the collection of chunks to include forced chunks.

- Fixes #10184 for 1.21.4.
- Backports will be made after this PR is approved.