### PR TITLE
[1.21.1] Fix incorrect method reference in TntBlock.explode()

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/TntBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/TntBlock.java.patch
@@ -31,12 +31,12 @@
          }
      }
  
-+    @Deprecated //Forge: Prefer using IForgeBlock#catchFire
++    @Deprecated //Forge: Prefer using IForgeBlock#onCaughtFire
      public static void explode(Level p_57434_, BlockPos p_57435_) {
          explode(p_57434_, p_57435_, null);
      }
  
-+    @Deprecated //Forge: Prefer using IForgeBlock#catchFire
++    @Deprecated //Forge: Prefer using IForgeBlock#onCaughtFire
      private static void explode(Level p_57437_, BlockPos p_57438_, @Nullable LivingEntity p_57439_) {
          if (!p_57437_.isClientSide) {
              PrimedTnt primedtnt = new PrimedTnt(


### PR DESCRIPTION
- Backport of #10326 for 1.21.1. 
- Fixes #10054 for 1.21.1.