### PR TITLE
Add `c:flowers`, `c:flowers/tall`, and `c:flowers/small` block and item tags

### DIFF
--- a/src/main/generated/data/c/tags/block/flowers.json
+++ b/src/main/generated/data/c/tags/block/flowers.json
@@ -1,0 +1,16 @@
+{
+  "values": [
+    "minecraft:flowering_azalea_leaves",
+    "minecraft:flowering_azalea",
+    "minecraft:mangrove_propagule",
+    "minecraft:pink_petals",
+    "minecraft:chorus_flower",
+    "minecraft:spore_blossom",
+    "#c:flowers/small",
+    "#c:flowers/tall",
+    {
+      "id": "#minecraft:flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/c/tags/block/flowers/small.json
+++ b/src/main/generated/data/c/tags/block/flowers/small.json
@@ -1,0 +1,24 @@
+{
+  "values": [
+    "minecraft:dandelion",
+    "minecraft:poppy",
+    "minecraft:blue_orchid",
+    "minecraft:allium",
+    "minecraft:azure_bluet",
+    "minecraft:red_tulip",
+    "minecraft:orange_tulip",
+    "minecraft:white_tulip",
+    "minecraft:pink_tulip",
+    "minecraft:oxeye_daisy",
+    "minecraft:cornflower",
+    "minecraft:lily_of_the_valley",
+    "minecraft:wither_rose",
+    "minecraft:torchflower",
+    "minecraft:open_eyeblossom",
+    "minecraft:closed_eyeblossom",
+    {
+      "id": "#minecraft:small_flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/c/tags/block/flowers/tall.json
+++ b/src/main/generated/data/c/tags/block/flowers/tall.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "minecraft:sunflower",
+    "minecraft:lilac",
+    "minecraft:peony",
+    "minecraft:rose_bush",
+    "minecraft:pitcher_plant",
+    {
+      "id": "minecraft:tall_flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/c/tags/item/flowers.json
+++ b/src/main/generated/data/c/tags/item/flowers.json
@@ -1,0 +1,16 @@
+{
+  "values": [
+    "minecraft:flowering_azalea_leaves",
+    "minecraft:flowering_azalea",
+    "minecraft:mangrove_propagule",
+    "minecraft:pink_petals",
+    "minecraft:chorus_flower",
+    "minecraft:spore_blossom",
+    "#c:flowers/small",
+    "#c:flowers/tall",
+    {
+      "id": "#minecraft:flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/c/tags/item/flowers/small.json
+++ b/src/main/generated/data/c/tags/item/flowers/small.json
@@ -1,0 +1,24 @@
+{
+  "values": [
+    "minecraft:dandelion",
+    "minecraft:poppy",
+    "minecraft:blue_orchid",
+    "minecraft:allium",
+    "minecraft:azure_bluet",
+    "minecraft:red_tulip",
+    "minecraft:orange_tulip",
+    "minecraft:white_tulip",
+    "minecraft:pink_tulip",
+    "minecraft:oxeye_daisy",
+    "minecraft:cornflower",
+    "minecraft:lily_of_the_valley",
+    "minecraft:wither_rose",
+    "minecraft:torchflower",
+    "minecraft:open_eyeblossom",
+    "minecraft:closed_eyeblossom",
+    {
+      "id": "#minecraft:small_flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/c/tags/item/flowers/tall.json
+++ b/src/main/generated/data/c/tags/item/flowers/tall.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "minecraft:sunflower",
+    "minecraft:lilac",
+    "minecraft:peony",
+    "minecraft:rose_bush",
+    "minecraft:pitcher_plant",
+    {
+      "id": "minecraft:tall_flowers",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -164,6 +164,22 @@ public class Tags {
         public static final TagKey<Block> DYED_WHITE = cTag("dyed/white");
         public static final TagKey<Block> DYED_YELLOW = cTag("dyed/yellow");
 
+        /**
+         * Contains living ground-based flowers that are 1 block tall such as Dandelions or Poppy.
+         * Equivalent to the {@code minecraft:small_flowers} block tag.
+         */
+        public static final TagKey<Block> FLOWERS_SMALL = cTag("flowers/small");
+        /**
+         * Contains living ground-based flowers that are 2 block tall such as Rose Bush or Peony.
+         * Equivalent to the {@code minecraft:tall_flowers} block tag in past Minecraft versions.
+         */
+        public static final TagKey<Block> FLOWERS_TALL = cTag("flowers/tall");
+        /**
+         * Contains any living plant block that contains flowers or is a flower itself.
+         * Equivalent to the {@code minecraft:flowers} block tag.
+         */
+        public static final TagKey<Block> FLOWERS = cTag("flowers");
+
         public static final TagKey<Block> GLASS_BLOCKS = cTag("glass_blocks");
         public static final TagKey<Block> GLASS_BLOCKS_COLORLESS = cTag("glass_blocks/colorless");
         /**
@@ -615,6 +631,21 @@ public class Tags {
          * For bonemeal-like items that can grow plants.
          */
         public static final TagKey<Item> FERTILIZERS = cTag("fertilizers");
+        /**
+         * Contains living ground-based flowers that are 1 block tall such as Dandelions or Poppy.
+         * Equivalent to the {@code minecraft:small_flowers} item tag.
+         */
+        public static final TagKey<Item> FLOWERS_SMALL = cTag("flowers/small");
+        /**
+         * Contains living ground-based flowers that are 2 block tall such as Rose Bush or Peony.
+         * Equivalent to the {@code minecraft:tall_flowers} item tag in past Minecraft versions.
+         */
+        public static final TagKey<Item> FLOWERS_TALL = cTag("flowers/tall");
+        /**
+         * Contains any living plant block that contains flowers or is a flower itself.
+         * Equivalent to the {@code minecraft:flowers} item tag in past Minecraft versions.
+         */
+        public static final TagKey<Item> FLOWERS = cTag("flowers");
         public static final TagKey<Item> FOODS = cTag("foods");
         /**
          * Apples and other foods that are considered fruits in the culinary field belong in this tag.

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -85,6 +85,16 @@ public final class ForgeBlockTagsProvider extends BlockTagsProvider {
         tag(FENCES).addTags(FENCES_NETHER_BRICK, FENCES_WOODEN); // forge:fences
         tag(FENCES_NETHER_BRICK).add(Blocks.NETHER_BRICK_FENCE); // forge:fences/nether_brick
         tag(FENCES_WOODEN).addTag(BlockTags.WOODEN_FENCES); // forge:fences/wooden
+        tag(Tags.Blocks.FLOWERS_SMALL)
+                .add(Blocks.DANDELION, Blocks.POPPY, Blocks.BLUE_ORCHID, Blocks.ALLIUM, Blocks.AZURE_BLUET, Blocks.RED_TULIP, Blocks.ORANGE_TULIP, Blocks.WHITE_TULIP, Blocks.PINK_TULIP, Blocks.OXEYE_DAISY, Blocks.CORNFLOWER, Blocks.LILY_OF_THE_VALLEY, Blocks.WITHER_ROSE, Blocks.TORCHFLOWER, Blocks.OPEN_EYEBLOSSOM, Blocks.CLOSED_EYEBLOSSOM)
+                .addOptionalTag(BlockTags.SMALL_FLOWERS);
+        tag(Tags.Blocks.FLOWERS_TALL)
+                .add(Blocks.SUNFLOWER, Blocks.LILAC, Blocks.PEONY, Blocks.ROSE_BUSH, Blocks.PITCHER_PLANT)
+                .addOptional(ResourceLocation.withDefaultNamespace("tall_flowers"));
+        tag(Tags.Blocks.FLOWERS)
+                .add(Blocks.FLOWERING_AZALEA_LEAVES, Blocks.FLOWERING_AZALEA, Blocks.MANGROVE_PROPAGULE, Blocks.PINK_PETALS, Blocks.CHORUS_FLOWER, Blocks.SPORE_BLOSSOM)
+                .addTags(Tags.Blocks.FLOWERS_SMALL, Tags.Blocks.FLOWERS_TALL)
+                .addOptionalTag(BlockTags.FLOWERS);
         tag(GLASS_BLOCKS)
                 .addTags(GLASS_BLOCKS_COLORLESS, GLASS_BLOCKS_CHEAP, GLASS_BLOCKS_TINTED)
                 .addOptionalTag(forgeTagKey("glass"));

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -132,6 +132,9 @@ public final class ForgeItemTagsProvider extends ItemTagsProvider {
         copy(Tags.Blocks.FENCES_NETHER_BRICK, Tags.Items.FENCES_NETHER_BRICK);
         copy(Tags.Blocks.FENCES_WOODEN, Tags.Items.FENCES_WOODEN);
         tag(Tags.Items.FERTILIZERS).add(Items.BONE_MEAL);
+        copy(Tags.Blocks.FLOWERS_SMALL, Tags.Items.FLOWERS_SMALL);
+        copy(Tags.Blocks.FLOWERS_TALL, Tags.Items.FLOWERS_TALL);
+        copy(Tags.Blocks.FLOWERS, Tags.Items.FLOWERS);
         tag(Tags.Items.FOODS_FRUIT).add(Items.APPLE, Items.GOLDEN_APPLE, Items.ENCHANTED_GOLDEN_APPLE, Items.CHORUS_FRUIT, Items.MELON_SLICE);
         tag(Tags.Items.FOODS_VEGETABLE).add(Items.CARROT, Items.GOLDEN_CARROT, Items.POTATO, Items.BEETROOT);
         tag(Tags.Items.FOODS_BERRY).add(Items.SWEET_BERRIES, Items.GLOW_BERRIES);


### PR DESCRIPTION
Forge port of https://github.com/neoforged/NeoForge/pull/1825 and https://github.com/FabricMC/fabric/pull/4352.

This PR adds the following new tags to Forge 1.21.4, listed are their names and contents (click a category to expand):
<details>
<summary>Blocks</summary>

- `c:flowers`
    - `minecraft:allium`
    - `minecraft:azure_bluet`
    - `minecraft:blue_orchid`
    - `minecraft:cherry_leaves`
    - `minecraft:chorus_flower`
    - `minecraft:closed_eyeblossom`
    - `minecraft:cornflower`
    - `minecraft:dandelion`
    - `minecraft:flowering_azalea`
    - `minecraft:flowering_azalea_leaves`
    - `minecraft:lilac`
    - `minecraft:lily_of_the_valley`
    - `minecraft:mangrove_propagule`
    - `minecraft:open_eyeblossom`
    - `minecraft:orange_tulip`
    - `minecraft:oxeye_daisy`
    - `minecraft:peony`
    - `minecraft:pink_petals`
    - `minecraft:pink_tulip`
    - `minecraft:pitcher_plant`
    - `minecraft:poppy`
    - `minecraft:red_tulip`
    - `minecraft:rose_bush`
    - `minecraft:spore_blossom`
    - `minecraft:sunflower`
    - `minecraft:torchflower`
    - `minecraft:white_tulip`
    - `minecraft:wither_rose`
- `c:flowers/small`
    - `minecraft:allium`
    - `minecraft:azure_bluet`
    - `minecraft:blue_orchid`
    - `minecraft:closed_eyeblossom`
    - `minecraft:cornflower`
    - `minecraft:dandelion`
    - `minecraft:lily_of_the_valley`
    - `minecraft:open_eyeblossom`
    - `minecraft:orange_tulip`
    - `minecraft:oxeye_daisy`
    - `minecraft:pink_tulip`
    - `minecraft:poppy`
    - `minecraft:red_tulip`
    - `minecraft:torchflower`
    - `minecraft:white_tulip`
    - `minecraft:wither_rose`
- `c:flowers/tall`
    - `minecraft:lilac`
    - `minecraft:peony`
    - `minecraft:pitcher_plant`
    - `minecraft:rose_bush`
    - `minecraft:sunflower`
</details>

<details>
<summary>Items</summary>

- `c:flowers`
    - `minecraft:allium`
    - `minecraft:azure_bluet`
    - `minecraft:blue_orchid`
    - `minecraft:chorus_flower`
    - `minecraft:closed_eyeblossom`
    - `minecraft:cornflower`
    - `minecraft:dandelion`
    - `minecraft:flowering_azalea`
    - `minecraft:flowering_azalea_leaves`
    - `minecraft:lilac`
    - `minecraft:lily_of_the_valley`
    - `minecraft:mangrove_propagule`
    - `minecraft:open_eyeblossom`
    - `minecraft:orange_tulip`
    - `minecraft:oxeye_daisy`
    - `minecraft:peony`
    - `minecraft:pink_petals`
    - `minecraft:pink_tulip`
    - `minecraft:pitcher_plant`
    - `minecraft:poppy`
    - `minecraft:red_tulip`
    - `minecraft:rose_bush`
    - `minecraft:spore_blossom`
    - `minecraft:sunflower`
    - `minecraft:torchflower`
    - `minecraft:white_tulip`
    - `minecraft:wither_rose`
- `c:flowers/small`
    - `minecraft:allium`
    - `minecraft:azure_bluet`
    - `minecraft:blue_orchid`
    - `minecraft:closed_eyeblossom`
    - `minecraft:cornflower`
    - `minecraft:dandelion`
    - `minecraft:lily_of_the_valley`
    - `minecraft:open_eyeblossom`
    - `minecraft:orange_tulip`
    - `minecraft:oxeye_daisy`
    - `minecraft:pink_tulip`
    - `minecraft:poppy`
    - `minecraft:red_tulip`
    - `minecraft:torchflower`
    - `minecraft:white_tulip`
    - `minecraft:wither_rose`
- `c:flowers/tall`
    - `minecraft:lilac`
    - `minecraft:peony`
    - `minecraft:pitcher_plant`
    - `minecraft:rose_bush`
    - `minecraft:sunflower`
</details>

There is one caveat: Neo's implementation contains an additional entry in the `c:flowers` block tag that Fabric lacks. I've opted to include it to match Vanilla behaviour, however multiloader mod devs should be aware of this discrepancy. There are of course merits to excluding it as well, which are documented in the javadocs of Fabric's impl.
<details>
<summary>CommonTagsDumper diff</summary>

![image](https://github.com/user-attachments/assets/626c7fc7-f590-45ec-a6b3-b2854ab66b4a)
</details>