### PR TITLE
[1.20.1] GameTestHelper extensions and additions

### DIFF
--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestHelper.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestHelper.java.patch
@@ -1,0 +1,36 @@
+--- a/net/minecraft/gametest/framework/GameTestHelper.java
++++ b/net/minecraft/gametest/framework/GameTestHelper.java
+@@ -49,7 +_,7 @@
+ import net.minecraft.world.phys.BlockHitResult;
+ import net.minecraft.world.phys.Vec3;
+ 
+-public class GameTestHelper {
++public class GameTestHelper implements net.minecraftforge.common.extensions.IForgeGameTestHelper {
+    private final GameTestInfo f_127595_;
+    private boolean f_177099_;
+ 
+@@ -796,5 +_,24 @@
+       BlockHitResult blockhitresult = new BlockHitResult(Vec3.m_82512_(blockpos), p_262008_, blockpos, false);
+       UseOnContext useoncontext = new UseOnContext(p_261595_, InteractionHand.MAIN_HAND, blockhitresult);
+       p_262007_.m_41661_(useoncontext);
++   }
++
++   /**
++    * Adds a cleanup handler that will be called when the test is done, pass or fail.
++    */
++   public void addCleanup(Consumer<Boolean> handler) {
++      this.f_127595_.m_127624_(new GameTestListener() {
++         @Override
++         public void m_142378_(GameTestInfo info) {
++            handler.accept(true);
++         }
++
++         @Override
++         public void m_8066_(GameTestInfo info) {
++            handler.accept(false);
++         }
++
++         @Override public void m_8073_(GameTestInfo info) { }
++      });
+    }
+ }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.extensions;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.mojang.authlib.GameProfile;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.common.ForgeI18n;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
+
+public interface IForgeGameTestHelper {
+    private GameTestHelper self() {
+        return (GameTestHelper) this;
+    }
+
+    default void say(String message) {
+        this.say(message, Style.EMPTY);
+    }
+
+    default void say(String message, Style style) {
+        var component = ForgeI18n.getPattern(message) != null ? Component.translatable(message) : Component.literal(message);
+        this.say(component.withStyle(style));
+    }
+
+    default void say(Component component) {
+        this.self().getLevel().players().forEach(p -> p.sendSystemMessage(component));
+    }
+
+    default void assertTrue(boolean value, Supplier<String> message) {
+        if (!value)
+            throw new GameTestAssertException(message.get());
+    }
+
+    default void assertFalse(boolean value, Supplier<String> message) {
+        if (value)
+            throw new GameTestAssertException(message.get());
+    }
+
+    default ServerPlayer makeMockServerPlayer() {
+        var level = self().getLevel();
+        var player = new ServerPlayer(level.getServer(), level, new GameProfile(UUID.randomUUID(), "test-mock-player")) {
+            public boolean isSpectator() {
+                return false;
+            }
+
+            public boolean isCreative() {
+                return true;
+            }
+        };
+        var connection = new Connection(PacketFlow.SERVERBOUND);
+        @SuppressWarnings("unused") // The constructor has side effects
+        var channel = new EmbeddedChannel(connection);
+        var server = level.getServer();
+
+        var listener = new ServerGamePacketListenerImpl(server, connection, player);
+        connection.setListener(listener);
+        return player;
+    }
+
+    /**
+     * Registers an event listener that will be unregistered when the test is finished running.
+     */
+    default <E extends Event> void addEventListener(Consumer<E> consumer) {
+        MinecraftForge.EVENT_BUS.addListener(consumer);
+        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(consumer));
+    }
+
+    /**
+     * Registers an event listener that will be unregistered when the test is finished running.
+     */
+    default void registerEventListener(Object handler) {
+        MinecraftForge.EVENT_BUS.register(handler);
+        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(handler));
+    }
+
+    /**
+     * Creates a floor of stone blocks at the bottom of the test area.
+     */
+    default void makeFloor() {
+        makeFloor(Blocks.STONE);
+    }
+
+    /**
+     * Creates a floor of the specified block under the test area.
+     */
+    default void makeFloor(Block block) {
+        makeFloor(block, -1);
+    }
+
+    /**
+     * Creates a floor of the specified block at the specified height.
+     */
+    default void makeFloor(Block block, int height) {
+//        var bounds = self().getBounds();
+//        var pos = new BlockPos.MutableBlockPos();
+//        for (int x = 0; x < (int) bounds.getXsize(); x++) {
+//            for (int y = 0; y < (int) bounds.getZsize(); y++) {
+//                pos.set(x, height, y);
+//                if (self().getBlockState(pos).is(Blocks.AIR))
+//                    self().setBlock(pos, block);
+//            }
+//        }
+    }
+
+    default <T> Flag<T> flag(String name) {
+        return new Flag<>(name);
+    }
+
+    default IntFlag intFlag(String name) {
+        return new IntFlag(name);
+    }
+
+    default BoolFlag boolFlag(String name) {
+        return new BoolFlag(name);
+    }
+
+    public static class Flag<T> {
+        private final String name;
+        @Nullable
+        protected T value = null;
+
+        public Flag(String name) {
+            this.name = name;
+        }
+
+        public void set(T value) {
+            this.value = value;
+        }
+
+        @Nullable
+        public T get() {
+            return this.value;
+        }
+
+        public void assertUnset() {
+            if (this.value != null)
+                throw new GameTestAssertException("Expected " + name + " to be null, but was " + this.value);
+        }
+
+        public void assertSet() {
+            if (this.value == null)
+                throw new GameTestAssertException("Flag " + name + " was never set");
+        }
+
+        public void assertEquals(T expected) {
+            assertSet();
+            if (expected != null && !expected.equals(this.value))
+                throw new GameTestAssertException("Expected " + name + " to be " + expected + ", but was " + this.value);
+        }
+    }
+
+    public static class IntFlag extends Flag<Long> {
+        public IntFlag(String name) {
+            super(name);
+        }
+
+        public void set(long value) {
+            super.set(value);
+        }
+
+        public byte getByte() {
+            return this.value == null ? -1 : this.value.byteValue();
+        }
+
+        public int getInt() {
+            return this.value == null ? -1 : this.value.intValue();
+        }
+
+        public long getLong() {
+            return this.value == null ? -1 : this.value.longValue();
+        }
+
+        public void assertEquals(long expected) {
+            super.assertEquals(expected);
+        }
+    }
+
+    public static class BoolFlag extends Flag<Boolean> {
+        public BoolFlag(String name) {
+            super(name);
+        }
+
+        public void set(boolean value) {
+            super.set(value);
+        }
+
+        public boolean getBool() {
+            return this.value != null && this.value;
+        }
+
+        public void assertEquals(boolean expected) {
+            super.assertEquals(expected);
+        }
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -201,6 +201,7 @@ public net.minecraft.data.tags.IntrinsicHolderTagsProvider$IntrinsicTagAppender
 protected net.minecraft.data.tags.TagsProvider f_126543_ # builders
 public-f net.minecraft.data.tags.TagsProvider m_6055_()Ljava/lang/String; # getName
 public net.minecraft.data.tags.TagsProvider$TagAppender
+public net.minecraft.gametest.framework.GameTestHelper m_177448_()Lnet/minecraft/world/phys/AABB; # getBounds
 public net.minecraft.gametest.framework.GameTestServer <init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/util/Collection;Lnet/minecraft/core/BlockPos;)V # constructor
 public net.minecraft.resources.ResourceLocation m_135835_(C)Z # validNamespaceChar
 public net.minecraft.resources.ResourceLocation m_135841_(Ljava/lang/String;)Z # isValidPath


### PR DESCRIPTION
Introduces extensions made to GameTestHelper in 1.20.6 and later.

- Includes backport of #10338 for 1.20.1.