### PR TITLE
[1.21.4] Fix JOpt Simple for real this time

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
             plugin('apt', 'com.diffplug.eclipse.apt').version('4.2.0')
 
             library('forgespi', 'net.minecraftforge:forgespi:7.1.5') // Needs modlauncher
-            library('modlauncher', 'net.minecraftforge:modlauncher:10.2.3') // Needs securemodules
+            library('modlauncher', 'net.minecraftforge:modlauncher:10.2.4') // Needs securemodules
             library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')


### PR DESCRIPTION
I forgot that ModLauncher also had JOpt Simple 6. ffs we need a dependendabot of some kind. Anyways this should do it. MDK changes were in the other PR.

I did full dependency scans of 1.21.4 down to 1.20.6 and it's just ModLauncher this time.

![Screenshot_20250127_112516](https://github.com/user-attachments/assets/5637c40e-6749-4a38-8d70-1b6b1d18062d)

- Follows up on #10311.
