### PR TITLE
[1.21.4] Bump dependencies, most notably EventBus

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,16 +30,16 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
-            library('coremods', 'net.minecraftforge:coremods:5.2.4')
+            library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.15')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
             library('mixin', 'org.spongepowered:mixin:0.8.7')
             library('nulls', 'org.jetbrains:annotations:24.1.0') // Got to have our null annotations!
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')
-            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.5')
+            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.8')
 
             // Google's InMemory File System. Used by ForgeDev Tests for now, but could be useful for a lot of things.
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
@@ -69,7 +69,7 @@ dependencyResolutionManagement {
             bundle('terminalconsoleappender', ['terminalconsoleappender', 'jline-reader', 'jline-terminal', 'jline-terminal-jna'])
 
             // The core of our configuration system, it has many flaws, but it works for the most part
-            version('night-config', '3.7.3')
+            version('night-config', '3.7.4')
             library('night-config-toml', 'com.electronwill.night-config', 'toml').versionRef('night-config')
             library('night-config-core', 'com.electronwill.night-config', 'core').versionRef('night-config')
             bundle('night-config', ['night-config-toml', 'night-config-core'])


### PR DESCRIPTION
Name entails. Bump to EventBus includes memory savings and bug fixes.

@PaintNinja should elaborate further what he wants in the commit message before this gets pulled.