### PR TITLE
[1.21.4] Re-introduce IForgeItem.damageItem when an item takes damage

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -142,6 +142,17 @@
              if (!this.level().isClientSide) {
                  this.awardStat(Stats.ITEM_USED.get(this.useItem.getItem()));
              }
+@@ -931,8 +_,9 @@
+             if (p_36383_ >= 3.0F) {
+                 int i = 1 + Mth.floor(p_36383_);
+                 InteractionHand interactionhand = this.getUsedItemHand();
++                ItemStack currentItem = this.useItem;
+                 this.useItem.hurtAndBreak(i, this, getSlotForHand(interactionhand));
+-                if (this.useItem.isEmpty()) {
++                if (currentItem.isEmpty()) {
+                     if (interactionhand == InteractionHand.MAIN_HAND) {
+                         this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                     } else {
 @@ -949,10 +_,13 @@
      @Override
      protected void actuallyHurt(ServerLevel p_365751_, DamageSource p_36312_, float p_36313_) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -142,13 +142,15 @@
              if (!this.level().isClientSide) {
                  this.awardStat(Stats.ITEM_USED.get(this.useItem.getItem()));
              }
-@@ -931,8 +_,9 @@
+@@ -931,8 +_,11 @@
              if (p_36383_ >= 3.0F) {
                  int i = 1 + Mth.floor(p_36383_);
                  InteractionHand interactionhand = this.getUsedItemHand();
++                // FORGE: cache this.useItem -- if this.stopUsingItem() is called, it will be set to ItemStack.EMPTY
 +                ItemStack currentItem = this.useItem;
                  this.useItem.hurtAndBreak(i, this, getSlotForHand(interactionhand));
 -                if (this.useItem.isEmpty()) {
++                // FORGE: use cached item since this.useItem could be ItemStack.EMPTY
 +                if (currentItem.isEmpty()) {
                      if (interactionhand == InteractionHand.MAIN_HAND) {
                          this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -57,6 +57,7 @@
          } else if (p_365570_ != null && p_365570_.hasInfiniteMaterials()) {
              return 0;
          } else {
++            // FORGE: modify the base damage based on the item's impl of IForgeItem.damageItem
 +            p_362423_ = this.damageItem(p_362423_, p_364910_, p_365570_, canBreak, onBreak);
              return p_362423_ > 0 ? EnchantmentHelper.processDurabilityChange(p_364910_, this, p_362423_) : p_362423_;
          }

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -45,9 +45,8 @@
          }
      }
  
-+    @Deprecated // use context-sensitive sister: processDurabilityChange(int, ServerLevel, ServerPlayer, boolean, Consumer<Item>)
      private int processDurabilityChange(int p_362423_, ServerLevel p_364910_, @Nullable ServerPlayer p_365570_) {
-+        return this.processDurabilityChange(p_362423_, p_364910_, p_365570_, false, item -> { });
++        return this.processDurabilityChange(p_362423_, p_364910_, p_365570_, false, p_359411_ -> { });
 +    }
 +
 +    /** FORGE: context-sensitive sister of processDurabilityChange that calls IForgeItem.damageItem */
@@ -62,27 +61,6 @@
              return p_362423_ > 0 ? EnchantmentHelper.processDurabilityChange(p_364910_, this, p_362423_) : p_362423_;
          }
      }
-@@ -499,14 +_,17 @@
- 
-     public void hurtWithoutBreaking(int p_363289_, Player p_369700_) {
-         if (p_369700_ instanceof ServerPlayer serverplayer) {
--            int i = this.processDurabilityChange(p_363289_, serverplayer.serverLevel(), serverplayer);
-+            // FORGE: move empty callback into its own variable so we don't have two of them
-+            Consumer<Item> onBreak = p_359411_ -> { };
-+            // FORGE: use context-sensitive sister of processDurabilityChange that calls IForgeItem.damageItem
-+            int i = this.processDurabilityChange(p_363289_, serverplayer.serverLevel(), serverplayer, false, onBreak);
-             if (i == 0) {
-                 return;
-             }
- 
-             int j = Math.min(this.getDamageValue() + i, this.getMaxDamage() - 1);
--            this.applyDamage(j, serverplayer, p_359411_ -> {
--            });
-+            // FORGE: use isolated empty callback
-+            this.applyDamage(j, serverplayer, onBreak);
-         }
-     }
- 
 @@ -516,7 +_,13 @@
                  p_41623_,
                  serverlevel,

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -69,7 +69,7 @@
 +                p_341563_ -> {
 +                    if (p_41624_ instanceof Player player) {
 +                        net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(player, this, p_335324_);
-+                        player.stopUsingItem(); // Forge: fix MC-168573
++                        if (player.getUseItem() == this) player.stopUsingItem(); // Forge: fix MC-168573
 +                    }
 +                    p_41624_.onEquippedItemBroken(p_341563_, p_335324_);
 +                }

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -33,14 +33,55 @@
              if (player != null && interactionresult instanceof InteractionResult.Success interactionresult$success && interactionresult$success.wasItemInteraction()) {
                  player.awardStat(Stats.ITEM_USED.get(item));
              }
-@@ -468,6 +_,7 @@
+@@ -468,18 +_,26 @@
      }
  
      public void hurtAndBreak(int p_220158_, ServerLevel p_342197_, @Nullable ServerPlayer p_220160_, Consumer<Item> p_343361_) {
-+        p_220158_ = this.damageItem(p_220158_, p_342197_, p_220160_, p_343361_);
-         int i = this.processDurabilityChange(p_220158_, p_342197_, p_220160_);
+-        int i = this.processDurabilityChange(p_220158_, p_342197_, p_220160_);
++        // FORGE: use context-sensitive sister of processDurabilityChange that calls IForgeItem.damageItem
++        int i = this.processDurabilityChange(p_220158_, p_342197_, p_220160_, true, p_343361_);
          if (i != 0) {
              this.applyDamage(this.getDamageValue() + i, p_220160_, p_343361_);
+         }
+     }
+ 
++    @Deprecated // use context-sensitive sister: processDurabilityChange(int, ServerLevel, ServerPlayer, boolean, Consumer<Item>)
+     private int processDurabilityChange(int p_362423_, ServerLevel p_364910_, @Nullable ServerPlayer p_365570_) {
++        return this.processDurabilityChange(p_362423_, p_364910_, p_365570_, false, item -> { });
++    }
++
++    /** FORGE: context-sensitive sister of processDurabilityChange that calls IForgeItem.damageItem */
++    private int processDurabilityChange(int p_362423_, ServerLevel p_364910_, @Nullable ServerPlayer p_365570_, boolean canBreak, Consumer<Item> onBreak) {
+         if (!this.isDamageableItem()) {
+             return 0;
+         } else if (p_365570_ != null && p_365570_.hasInfiniteMaterials()) {
+             return 0;
+         } else {
++            p_362423_ = this.damageItem(p_362423_, p_364910_, p_365570_, canBreak, onBreak);
+             return p_362423_ > 0 ? EnchantmentHelper.processDurabilityChange(p_364910_, this, p_362423_) : p_362423_;
+         }
+     }
+@@ -499,14 +_,17 @@
+ 
+     public void hurtWithoutBreaking(int p_363289_, Player p_369700_) {
+         if (p_369700_ instanceof ServerPlayer serverplayer) {
+-            int i = this.processDurabilityChange(p_363289_, serverplayer.serverLevel(), serverplayer);
++            // FORGE: move empty callback into its own variable so we don't have two of them
++            Consumer<Item> onBreak = p_359411_ -> { };
++            // FORGE: use context-sensitive sister of processDurabilityChange that calls IForgeItem.damageItem
++            int i = this.processDurabilityChange(p_363289_, serverplayer.serverLevel(), serverplayer, false, onBreak);
+             if (i == 0) {
+                 return;
+             }
+ 
+             int j = Math.min(this.getDamageValue() + i, this.getMaxDamage() - 1);
+-            this.applyDamage(j, serverplayer, p_359411_ -> {
+-            });
++            // FORGE: use isolated empty callback
++            this.applyDamage(j, serverplayer, onBreak);
+         }
+     }
+ 
 @@ -516,7 +_,13 @@
                  p_41623_,
                  serverlevel,

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -33,6 +33,14 @@
              if (player != null && interactionresult instanceof InteractionResult.Success interactionresult$success && interactionresult$success.wasItemInteraction()) {
                  player.awardStat(Stats.ITEM_USED.get(item));
              }
+@@ -468,6 +_,7 @@
+     }
+ 
+     public void hurtAndBreak(int p_220158_, ServerLevel p_342197_, @Nullable ServerPlayer p_220160_, Consumer<Item> p_343361_) {
++        p_220158_ = this.damageItem(p_220158_, p_342197_, p_220160_, p_343361_);
+         int i = this.processDurabilityChange(p_220158_, p_342197_, p_220160_);
+         if (i != 0) {
+             this.applyDamage(this.getDamageValue() + i, p_220160_, p_343361_);
 @@ -516,7 +_,13 @@
                  p_41623_,
                  serverlevel,

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -82,6 +82,24 @@ public interface IForgeGameTestHelper {
             throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, Arrays.toString(expected), Arrays.toString(actual)));
     }
 
+    default <N> void assertValueNotEqual(N expected, N actual, String name, String message) {
+        this.assertValueNotEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueNotEqual(N expected, N actual, String name, Supplier<String> message) {
+        if (Objects.equals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to NOT be %s, but was".formatted(message.get(), name, expected));
+    }
+
+    default <N> void assertValueNotEqual(N[] expected, N[] actual, String name, String message) {
+        this.assertValueNotEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueNotEqual(N[] expected, N[] actual, String name, Supplier<String> message) {
+        if (!Objects.deepEquals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to NOT be %s, but was".formatted(message.get(), name, Arrays.toString(expected)));
+    }
+
     default <E> Registry<E> registryLookup(ResourceKey<? extends Registry<? extends E>> registryKey) {
         return this.self().getLevel().registryAccess().lookupOrThrow(registryKey);
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -5,10 +5,13 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import net.minecraft.ChatFormatting;
 import org.jetbrains.annotations.Nullable;
 
 import com.mojang.authlib.GameProfile;
@@ -58,6 +61,24 @@ public interface IForgeGameTestHelper {
     default void assertFalse(boolean value, Supplier<String> message) {
         if (value)
             throw new GameTestAssertException(message.get());
+    }
+
+    default <N> void assertValueEqual(N expected, N actual, String name, String message) {
+        this.assertValueEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueEqual(N expected, N actual, String name, Supplier<String> message) {
+        if (!Objects.equals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, expected, actual));
+    }
+
+    default <N> void assertValueEqual(N[] expected, N[] actual, String name, String message) {
+        this.assertValueEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueEqual(N[] expected, N[] actual, String name, Supplier<String> message) {
+        if (!Objects.deepEquals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, Arrays.toString(expected), Arrays.toString(actual)));
     }
 
     default ServerPlayer makeMockServerPlayer() {
@@ -159,19 +180,49 @@ public interface IForgeGameTestHelper {
         }
 
         public void assertUnset() {
-            if (this.value != null)
-                throw new GameTestAssertException("Expected " + name + " to be null, but was " + this.value);
+            this.assertUnset((Supplier<String>) null);
+        }
+
+        public void assertUnset(String message) {
+            this.assertUnset(message != null ? () -> message : null);
+        }
+
+        public void assertUnset(Supplier<String> message) {
+            if (this.value != null) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Expected " + name + " to be null, but was " + this.value);
+            }
         }
 
         public void assertSet() {
-            if (this.value == null)
-                throw new GameTestAssertException("Flag " + name + " was never set");
+            this.assertSet((Supplier<String>) null);
+        }
+
+        public void assertSet(String message) {
+            this.assertSet(message != null ? () -> message : null);
+        }
+
+        public void assertSet(Supplier<String> message) {
+            if (this.value == null) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Flag " + name + " was never set");
+            }
         }
 
         public void assertEquals(T expected) {
-            assertSet();
-            if (expected != null && !expected.equals(this.value))
-                throw new GameTestAssertException("Expected " + name + " to be " + expected + ", but was " + this.value);
+            this.assertEquals(expected, (Supplier<String>) null);
+        }
+
+        public void assertEquals(T expected, String message) {
+            this.assertEquals(expected, message != null ? () -> message : null);
+        }
+
+        public void assertEquals(T expected, Supplier<String> message) {
+            assertSet(message);
+            if (expected != null && !expected.equals(this.value)) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Expected " + name + " to be " + expected + ", but was " + this.value);
+            }
         }
     }
 
@@ -196,8 +247,28 @@ public interface IForgeGameTestHelper {
             return this.value == null ? -1 : this.value.longValue();
         }
 
+        public void assertEquals(int expected) {
+            super.assertEquals((long) expected);
+        }
+
         public void assertEquals(long expected) {
             super.assertEquals(expected);
+        }
+
+        public void assertEquals(int expected, String message) {
+            super.assertEquals((long) expected, message);
+        }
+
+        public void assertEquals(long expected, String message) {
+            super.assertEquals(expected, message);
+        }
+
+        public void assertEquals(int expected, Supplier<String> message) {
+            super.assertEquals((long) expected, message);
+        }
+
+        public void assertEquals(long expected, Supplier<String> message) {
+            super.assertEquals(expected, message);
         }
     }
 
@@ -216,6 +287,14 @@ public interface IForgeGameTestHelper {
 
         public void assertEquals(boolean expected) {
             super.assertEquals(expected);
+        }
+
+        public void assertEquals(boolean expected, String message) {
+            super.assertEquals(expected, message);
+        }
+
+        public void assertEquals(boolean expected, Supplier<String> message) {
+            super.assertEquals(expected, message);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -11,7 +11,8 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import net.minecraft.ChatFormatting;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.Nullable;
 
 import com.mojang.authlib.GameProfile;
@@ -79,6 +80,10 @@ public interface IForgeGameTestHelper {
     default <N> void assertValueEqual(N[] expected, N[] actual, String name, Supplier<String> message) {
         if (!Objects.deepEquals(expected, actual))
             throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, Arrays.toString(expected), Arrays.toString(actual)));
+    }
+
+    default <E> Registry<E> registryLookup(ResourceKey<? extends Registry<? extends E>> registryKey) {
+        return this.self().getLevel().registryAccess().lookupOrThrow(registryKey);
     }
 
     default ServerPlayer makeMockServerPlayer() {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -484,18 +484,24 @@ public interface IForgeItem {
     default void onHorseArmorTick(ItemStack stack, Level level, Mob horse) { }
 
     /**
-     * Called from {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)} when an item is to be
-     * damaged.
+     * Called when this item is to be damaged, such as use a tool being used or a shield blocking damage. The damage
+     * parameter has not yet been processed, so enchantments are not taken into account.
      *
-     * @param stack    The stack of the item to be damaged
-     * @param damage   The amount of damage the item will take
+     * @param stack    The processed amount of damage the item will take
+     * @param damage   The amount of damage the item will take before processing
      * @param level    The level where the damage is taking place
      * @param player   The player holding the item
+     * @param canBreak If the item can break from this damage instance ({@code true} if this is called from
+     *                 {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)}, {@code false} if from
+     *                 {@link ItemStack#hurtWithoutBreaking(int, Player)})
      * @param onBroken The callback for when an item is broken (use this if you plan on cancelling damage that will
      *                 break an item)
-     * @return The amount of damage the item should take
+     * @return The amount of damage the item should take, after processing
+     *
+     * @apiNote If the item stack is not {@linkplain ItemStack#isDamageableItem() damageable} or the player
+     * {@linkplain Player#hasInfiniteMaterials() has infinite materials}, this method will not be called.
      */
-    default int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
+    default int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, boolean canBreak, Consumer<Item> onBroken) {
         return damage;
     }
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -7,6 +7,8 @@ package net.minecraftforge.common.extensions;
 
 import java.util.function.Consumer;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.*;
@@ -480,6 +482,22 @@ public interface IForgeItem {
      * @param horse the horse wearing this armor
      */
     default void onHorseArmorTick(ItemStack stack, Level level, Mob horse) { }
+
+    /**
+     * Called from {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)} when an item is to be
+     * damaged.
+     *
+     * @param stack    The stack of the item to be damaged
+     * @param damage   The amount of damage the item will take
+     * @param level    The level where the damage is taking place
+     * @param player   The player holding the item
+     * @param onBroken The callback for when an item is broken (use this if you plan on cancelling damage that will
+     *                 break an item)
+     * @return The amount of damage the item should take
+     */
+    default int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
+        return damage;
+    }
 
     /**
      * Called when an item entity for this stack is destroyed. Note: The {@link ItemStack} can be retrieved from the item entity.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -382,20 +382,25 @@ public interface IForgeItemStack {
     }
 
     /**
-     * Called from {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)} when an item is to be
-     * damaged.
+     * Called when this item is to be damaged, such as use a tool being used or a shield blocking damage. The damage
+     * parameter has not yet been processed, so enchantments are not taken into account.
      *
-     * @param damage   The amount of damage the item will take
+     * @param damage   The amount of damage the item will take before processing
      * @param level    The level where the damage is taking place
      * @param player   The player holding the item
+     * @param canBreak If the item can break from this damage instance ({@code true} if this is called from
+     *                 {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)}, {@code false} if from
+     *                 {@link ItemStack#hurtWithoutBreaking(int, Player)})
      * @param onBroken The callback for when an item is broken (use this if you plan on cancelling damage that will
      *                 break an item)
      * @return The amount of damage the item should take
      *
-     * @see IForgeItem#damageItem(ItemStack, int, ServerLevel, ServerPlayer, Consumer)
+     * @apiNote If the item stack is not {@linkplain ItemStack#isDamageableItem() damageable} or the player
+     * {@linkplain Player#hasInfiniteMaterials() has infinite materials}, this method will not be called.
+     * @see IForgeItem#damageItem(ItemStack, int, ServerLevel, ServerPlayer, boolean, Consumer)
      */
-    default int damageItem(int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
-        return self().getItem().damageItem(self(), damage, level, player, onBroken);
+    default int damageItem(int damage, ServerLevel level, @Nullable ServerPlayer player, boolean canBreak, Consumer<Item> onBroken) {
+        return self().getItem().damageItem(self(), damage, level, player, canBreak, onBroken);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.common.extensions;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.player.Inventory;
@@ -31,6 +33,8 @@ import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 /*
  * Extension added to ItemStack that bounces to ItemSack sensitive Item methods. Typically this is just for convince.
@@ -375,6 +379,23 @@ public interface IForgeItemStack {
     @NotNull
     default AABB getSweepHitBox(@NotNull Player player, @NotNull Entity target) {
         return self().getItem().getSweepHitBox(self(), player, target);
+    }
+
+    /**
+     * Called from {@link ItemStack#hurtAndBreak(int, ServerLevel, ServerPlayer, Consumer)} when an item is to be
+     * damaged.
+     *
+     * @param damage   The amount of damage the item will take
+     * @param level    The level where the damage is taking place
+     * @param player   The player holding the item
+     * @param onBroken The callback for when an item is broken (use this if you plan on cancelling damage that will
+     *                 break an item)
+     * @return The amount of damage the item should take
+     *
+     * @see IForgeItem#damageItem(ItemStack, int, ServerLevel, ServerPlayer, Consumer)
+     */
+    default int damageItem(int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
+        return self().getItem().damageItem(self(), damage, level, player, onBroken);
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.commands.arguments.EntityAnchorArgument;

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -103,6 +103,7 @@ public class PreventItemDamageTest extends BaseTestMod {
         firedPlayerDestroyItem.assertEquals(true);
         helper.assertValueEqual(initialDamage + 1, shield.getDamageValue(), "shield damage value", "Fake shield did not take precisely 1 damage! Check IForgeItem#damageItem.");
         helper.assertValueEqual(player.getItemInHand(InteractionHand.MAIN_HAND), shield, "player shield", "Fake shield was removed from player's hand! Check Player#hurtCurrentlyUsedShield.");
+        helper.assertValueNotEqual(player.getUseItem(), shield, "player use item", "Player should not be using the shield! The onBreak callback was never invoked. Check FakeShieldItem or IForgeItem#damageItem.");
         helper.succeed();
     }
 

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -7,11 +7,14 @@ package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -86,7 +89,14 @@ public class PreventItemDamageTest extends BaseTestMod {
         player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
 
         // hit the player
-        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+        var attack = helper.registryLookup(Registries.DAMAGE_TYPE).getOrThrow(DamageTypes.MOB_ATTACK);
+        var damage = new DamageSource(attack, enemy) {
+            @Override
+            public boolean scalesWithDifficulty() {
+                return false;
+            }
+        };
+        player.hurtServer(helper.getLevel(), damage, 5.0F);
 
         // ok, run the tests
         firedLivingEntityUseItem.assertEquals(true);

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -1,0 +1,79 @@
+package net.minecraftforge.debug.gameplay.item;
+
+import net.minecraft.commands.arguments.EntityAnchorArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ShieldItem;
+import net.minecraft.world.level.GameType;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.test.BaseTestMod;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+@Mod(PreventItemDamageTest.MOD_ID)
+@GameTestHolder("forge." + PreventItemDamageTest.MOD_ID)
+public class PreventItemDamageTest extends BaseTestMod {
+    static final String MOD_ID = "prevent_item_damage";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().setId(ITEMS.key("fake_shield")).durability(10)) {
+        @Override
+        public int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
+            onBroken.accept(this);
+            return 0;
+        }
+    });
+
+    public PreventItemDamageTest(FMLJavaModLoadingContext context) {
+        super(context);
+        this.testItem(lookup -> new ItemStack(FAKE_SHIELD.get()));
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void player_fake_shield_took_no_damage(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup player
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        helper.<LivingEntityUseItemEvent.Start>addEventListener(event -> {
+            // Artificially pass 5 seconds from start of the shield
+            // This is because the first 5 ticks, the player is still vulnerable
+            if (event.getEntity() == player) {
+                event.setDuration(event.getDuration() - 100);
+            }
+        });
+
+        // start using shield
+        var shield = FAKE_SHIELD.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shield);
+        player.startUsingItem(InteractionHand.MAIN_HAND);
+        int initialDamage = shield.getDamageValue();
+
+        // setup enemy
+        var enemy = helper.spawnWithNoFreeWill(EntityType.HUSK, new BlockPos(2, 0, 2));
+        player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
+
+        // hit the player
+        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+
+        // shield on cooldown?
+        helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());
+        helper.succeed();
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -13,13 +13,12 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
@@ -30,7 +29,6 @@ import net.minecraftforge.test.BaseTestMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
-import java.util.function.IntUnaryOperator;
 
 @Mod(PreventItemDamageTest.MOD_ID)
 @GameTestHolder("forge." + PreventItemDamageTest.MOD_ID)
@@ -38,17 +36,11 @@ public class PreventItemDamageTest extends BaseTestMod {
     static final String MOD_ID = "prevent_item_damage";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
-    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().setId(ITEMS.key("fake_shield")).durability(10)) {
-        @Override
-        public int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
-            onBroken.accept(this);
-            return 0;
-        }
-    });
+    private static final RegistryObject<FakeShieldItem> FAKE_SHIELD = ITEMS.register("fake_shield", FakeShieldItem::new);
 
     public PreventItemDamageTest(FMLJavaModLoadingContext context) {
         super(context);
-        this.testItem(lookup -> new ItemStack(FAKE_SHIELD.get()));
+        this.testItem(lookup -> FAKE_SHIELD.get().getDefaultInstance());
     }
 
     @GameTest(template = "forge:empty3x3x3")
@@ -57,16 +49,34 @@ public class PreventItemDamageTest extends BaseTestMod {
 
         // setup player
         var player = helper.makeMockPlayer(GameType.SURVIVAL);
+
+        // setup shield
+        var shield = FAKE_SHIELD.get().getDefaultInstance();
+
+        // setup events
+        var firedLivingEntityUseItem = helper.boolFlag("fired LivingEntityUseItemEvent");
+        var firedPlayerDestroyItem = helper.boolFlag("fired PlayerDestroyItemEvent");
         helper.<LivingEntityUseItemEvent.Start>addEventListener(event -> {
+            if (event.getEntity() != player) return;
+
+            if (event.getItem() != shield)
+                helper.fail("Player is using an item, but it's not the fake shield! Check the game test impl.");
+
             // Artificially pass 5 seconds from start of the shield
             // This is because the first 5 ticks, the player is still vulnerable
-            if (event.getEntity() == player) {
-                event.setDuration(event.getDuration() - 100);
-            }
+            firedLivingEntityUseItem.set(true);
+            event.setDuration(event.getDuration() - 100);
+        });
+        helper.<PlayerDestroyItemEvent>addEventListener(event -> {
+            if (event.getEntity() != player) return;
+
+            if (event.getOriginal() != shield)
+                helper.fail("Player destroyed an item, but it's not the fake shield! Check the game test impl.");
+
+            firedPlayerDestroyItem.set(true);
         });
 
         // start using shield
-        var shield = FAKE_SHIELD.get().getDefaultInstance();
         player.setItemInHand(InteractionHand.MAIN_HAND, shield);
         player.startUsingItem(InteractionHand.MAIN_HAND);
         int initialDamage = shield.getDamageValue();
@@ -78,8 +88,11 @@ public class PreventItemDamageTest extends BaseTestMod {
         // hit the player
         player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
 
-        // shield on cooldown?
-        helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());
+        // ok, run the tests
+        firedLivingEntityUseItem.assertEquals(true);
+        firedPlayerDestroyItem.assertEquals(true);
+        helper.assertValueEqual(initialDamage + 1, shield.getDamageValue(), "shield damage value", "Fake shield did not take precisely 1 damage! Check IForgeItem#damageItem.");
+        helper.assertValueEqual(player.getItemInHand(InteractionHand.MAIN_HAND), shield, "player shield", "Fake shield was removed from player's hand! Check Player#hurtCurrentlyUsedShield.");
         helper.succeed();
     }
 

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -30,6 +30,7 @@ import net.minecraftforge.test.BaseTestMod;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
+import java.util.function.IntUnaryOperator;
 
 @Mod(PreventItemDamageTest.MOD_ID)
 @GameTestHolder("forge." + PreventItemDamageTest.MOD_ID)
@@ -80,5 +81,17 @@ public class PreventItemDamageTest extends BaseTestMod {
         // shield on cooldown?
         helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());
         helper.succeed();
+    }
+
+    private static final class FakeShieldItem extends ShieldItem {
+        public FakeShieldItem() {
+            super(new Item.Properties().setId(ITEMS.key("fake_shield")).durability(10));
+        }
+
+        @Override
+        public int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, boolean canBreak, Consumer<Item> onBroken) {
+            onBroken.accept(this);
+            return 1;
+        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
@@ -8,9 +8,12 @@ package net.minecraftforge.debug.gameplay.item;
 import net.minecraft.Util;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -69,7 +72,14 @@ public final class ShieldDisablingTest extends BaseTestMod {
         player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
 
         // hit the player
-        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+        var attack = helper.registryLookup(Registries.DAMAGE_TYPE).getOrThrow(DamageTypes.MOB_ATTACK);
+        var damage = new DamageSource(attack, enemy) {
+            @Override
+            public boolean scalesWithDifficulty() {
+                return false;
+            }
+        };
+        player.hurtServer(helper.getLevel(), damage, 5.0F);
 
         // shield on cooldown?
         helper.assertTrue(player.getCooldowns().isOnCooldown(shield), "shield should be on cooldown");

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.Util;


### PR DESCRIPTION
`IForgeItem.damageItem()` allows the modder to override the amount of damage that would've been dealt to an item when it takes damage. This PR also fixes an issue where the player's `this.useItem` could be pre-emptively set to `ItemStack.EMPTY` and disallow any "broken item" variants.

- Fixes #10344 for 1.21.4