### PR TITLE
[1.20.4] Cache this.useItem before running item break logic

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,15 +135,21 @@
           if (!this.level().isClientSide) {
              this.awardStat(Stats.ITEM_USED.get(this.useItem.getItem()));
           }
-@@ -864,6 +_,8 @@
+@@ -862,10 +_,13 @@
+          if (p_36383_ >= 3.0F) {
+             int i = 1 + Mth.floor(p_36383_);
              InteractionHand interactionhand = this.getUsedItemHand();
++            ItemStack currentItem = this.useItem;
              this.useItem.hurtAndBreak(i, this, (p_219739_) -> {
                 p_219739_.broadcastBreakEvent(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.useItem, interactionhand);
 +               stopUsingItem(); // Forge: fix MC-168573
              });
-             if (this.useItem.isEmpty()) {
+-            if (this.useItem.isEmpty()) {
++            if (currentItem.isEmpty()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {
+                   this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                } else {
 @@ -882,10 +_,13 @@
  
     protected void actuallyHurt(DamageSource p_36312_, float p_36313_) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,10 +135,11 @@
           if (!this.level().isClientSide) {
              this.awardStat(Stats.ITEM_USED.get(this.useItem.getItem()));
           }
-@@ -862,10 +_,13 @@
+@@ -862,10 +_,15 @@
           if (p_36383_ >= 3.0F) {
              int i = 1 + Mth.floor(p_36383_);
              InteractionHand interactionhand = this.getUsedItemHand();
++            // FORGE: cache this.useItem -- if this.stopUsingItem() is called, it will be set to ItemStack.EMPTY
 +            ItemStack currentItem = this.useItem;
              this.useItem.hurtAndBreak(i, this, (p_219739_) -> {
                 p_219739_.broadcastBreakEvent(interactionhand);
@@ -146,6 +147,7 @@
 +               stopUsingItem(); // Forge: fix MC-168573
              });
 -            if (this.useItem.isEmpty()) {
++            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY
 +            if (currentItem.isEmpty()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {
                    this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -144,7 +144,7 @@
              this.useItem.hurtAndBreak(i, this, (p_219739_) -> {
                 p_219739_.broadcastBreakEvent(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.useItem, interactionhand);
-+               stopUsingItem(); // Forge: fix MC-168573
++               if (this.useItem == currentItem) stopUsingItem(); // Forge: fix MC-168573
              });
 -            if (this.useItem.isEmpty()) {
 +            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -62,7 +63,25 @@ public interface IForgeGameTestHelper {
             throw new GameTestAssertException(message.get());
     }
 
-    /** Backported from 1.20.6 */
+    default <N> void assertValueEqual(N expected, N actual, String name, String message) {
+        this.assertValueEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueEqual(N expected, N actual, String name, Supplier<String> message) {
+        if (!Objects.equals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, expected, actual));
+    }
+
+    default <N> void assertValueEqual(N[] expected, N[] actual, String name, String message) {
+        this.assertValueEqual(expected, actual, name, () -> message);
+    }
+
+    default <N> void assertValueEqual(N[] expected, N[] actual, String name, Supplier<String> message) {
+        if (!Objects.deepEquals(expected, actual))
+            throw new GameTestAssertException("%s -- Expected %s to be %s, but was %s".formatted(message.get(), name, Arrays.toString(expected), Arrays.toString(actual)));
+    }
+
+    // Backported from 1.20.6
     default <N> void assertValueEqual(N expected, N actual, String name) {
         if (!Objects.equals(expected, actual)) {
             throw new GameTestAssertException("Expected " + name + " to be " + expected + ", but was " + actual);
@@ -185,19 +204,49 @@ public interface IForgeGameTestHelper {
         }
 
         public void assertUnset() {
-            if (this.value != null)
-                throw new GameTestAssertException("Expected " + name + " to be null, but was " + this.value);
+            this.assertUnset((Supplier<String>) null);
+        }
+
+        public void assertUnset(String message) {
+            this.assertUnset(message != null ? () -> message : null);
+        }
+
+        public void assertUnset(Supplier<String> message) {
+            if (this.value != null) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Expected " + name + " to be null, but was " + this.value);
+            }
         }
 
         public void assertSet() {
-            if (this.value == null)
-                throw new GameTestAssertException("Flag " + name + " was never set");
+            this.assertSet((Supplier<String>) null);
+        }
+
+        public void assertSet(String message) {
+            this.assertSet(message != null ? () -> message : null);
+        }
+
+        public void assertSet(Supplier<String> message) {
+            if (this.value == null) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Flag " + name + " was never set");
+            }
         }
 
         public void assertEquals(T expected) {
-            assertSet();
-            if (expected != null && !expected.equals(this.value))
-                throw new GameTestAssertException("Expected " + name + " to be " + expected + ", but was " + this.value);
+            this.assertEquals(expected, (Supplier<String>) null);
+        }
+
+        public void assertEquals(T expected, String message) {
+            this.assertEquals(expected, message != null ? () -> message : null);
+        }
+
+        public void assertEquals(T expected, Supplier<String> message) {
+            assertSet(message);
+            if (expected != null && !expected.equals(this.value)) {
+                String s = message != null ? message.get() + " -- " : "";
+                throw new GameTestAssertException(s + "Expected " + name + " to be " + expected + ", but was " + this.value);
+            }
         }
     }
 
@@ -222,8 +271,28 @@ public interface IForgeGameTestHelper {
             return this.value == null ? -1 : this.value.longValue();
         }
 
+        public void assertEquals(int expected) {
+            super.assertEquals((long) expected);
+        }
+
         public void assertEquals(long expected) {
             super.assertEquals(expected);
+        }
+
+        public void assertEquals(int expected, String message) {
+            super.assertEquals((long) expected, message);
+        }
+
+        public void assertEquals(long expected, String message) {
+            super.assertEquals(expected, message);
+        }
+
+        public void assertEquals(int expected, Supplier<String> message) {
+            super.assertEquals((long) expected, message);
+        }
+
+        public void assertEquals(long expected, Supplier<String> message) {
+            super.assertEquals(expected, message);
         }
     }
 
@@ -242,6 +311,14 @@ public interface IForgeGameTestHelper {
 
         public void assertEquals(boolean expected) {
             super.assertEquals(expected);
+        }
+
+        public void assertEquals(boolean expected, String message) {
+            super.assertEquals(expected, message);
+        }
+
+        public void assertEquals(boolean expected, Supplier<String> message) {
+            super.assertEquals(expected, message);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.Nullable;
@@ -106,6 +109,10 @@ public interface IForgeGameTestHelper {
                 return true;
             }
         };
+    }
+
+    default <E> HolderLookup.RegistryLookup<E> registryLookup(ResourceKey<? extends Registry<? extends E>> registryKey) {
+        return this.self().getLevel().registryAccess().lookupOrThrow(registryKey);
     }
 
     default ServerPlayer makeMockServerPlayer() {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -1,0 +1,79 @@
+package net.minecraftforge.debug.gameplay.item;
+
+import net.minecraft.commands.arguments.EntityAnchorArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ShieldItem;
+import net.minecraft.world.level.GameType;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.test.BaseTestMod;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+@Mod(PreventItemDamageTest.MOD_ID)
+@GameTestHolder("forge." + PreventItemDamageTest.MOD_ID)
+public class PreventItemDamageTest extends BaseTestMod {
+    static final String MOD_ID = "prevent_item_damage";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().setId(ITEMS.key("fake_shield")).durability(10)) {
+        @Override
+        public int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
+            onBroken.accept(this);
+            return 0;
+        }
+    });
+
+    public PreventItemDamageTest(FMLJavaModLoadingContext context) {
+        super(context);
+        this.testItem(lookup -> new ItemStack(FAKE_SHIELD.get()));
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void player_fake_shield_took_no_damage(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup player
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        helper.<LivingEntityUseItemEvent.Start>addEventListener(event -> {
+            // Artificially pass 5 seconds from start of the shield
+            // This is because the first 5 ticks, the player is still vulnerable
+            if (event.getEntity() == player) {
+                event.setDuration(event.getDuration() - 100);
+            }
+        });
+
+        // start using shield
+        var shield = FAKE_SHIELD.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shield);
+        player.startUsingItem(InteractionHand.MAIN_HAND);
+        int initialDamage = shield.getDamageValue();
+
+        // setup enemy
+        var enemy = helper.spawnWithNoFreeWill(EntityType.HUSK, new BlockPos(2, 0, 2));
+        player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
+
+        // hit the player
+        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+
+        // shield on cooldown?
+        helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());
+        helper.succeed();
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -32,17 +32,16 @@ public class PreventItemDamageTest extends BaseTestMod {
     static final String MOD_ID = "prevent_item_damage";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
-    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().setId(ITEMS.key("fake_shield")).durability(10)) {
+    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().durability(10)) {
         @Override
-        public int damageItem(ItemStack stack, int damage, ServerLevel level, @Nullable ServerPlayer player, Consumer<Item> onBroken) {
-            onBroken.accept(this);
+        public <T extends LivingEntity> int damageItem(ItemStack stack, int amount, T entity, Consumer<T> onBroken) {
+            onBroken.accept(entity);
             return 0;
         }
     });
 
-    public PreventItemDamageTest(FMLJavaModLoadingContext context) {
-        super(context);
-        this.testItem(lookup -> new ItemStack(FAKE_SHIELD.get()));
+    public PreventItemDamageTest() {
+        this.testItem(() -> new ItemStack(FAKE_SHIELD.get()));
     }
 
     @GameTest(template = "forge:empty3x3x3")
@@ -70,7 +69,7 @@ public class PreventItemDamageTest extends BaseTestMod {
         player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
 
         // hit the player
-        player.hurtServer(helper.getLevel(), enemy.damageSources().mobAttack(enemy), 5.0F);
+        player.hurt(enemy.damageSources().mobAttack(enemy), 5.0F);
 
         // shield on cooldown?
         helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -7,10 +7,13 @@ package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
@@ -83,7 +86,14 @@ public class PreventItemDamageTest extends BaseTestMod {
         player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
 
         // hit the player
-        player.hurt(enemy.damageSources().mobAttack(enemy), 5.0F);
+        var attack = helper.registryLookup(Registries.DAMAGE_TYPE).getOrThrow(DamageTypes.MOB_ATTACK);
+        var damage = new DamageSource(attack, enemy) {
+            @Override
+            public boolean scalesWithDifficulty() {
+                return false;
+            }
+        };
+        player.hurt(damage, 5.0F);
 
         // ok, run the tests
         firedLivingEntityUseItem.assertEquals(true);

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -1,28 +1,30 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -32,34 +34,46 @@ public class PreventItemDamageTest extends BaseTestMod {
     static final String MOD_ID = "prevent_item_damage";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
-    private static final RegistryObject<Item> FAKE_SHIELD = ITEMS.register("fake_shield", () -> new ShieldItem(new Item.Properties().durability(10)) {
-        @Override
-        public <T extends LivingEntity> int damageItem(ItemStack stack, int amount, T entity, Consumer<T> onBroken) {
-            onBroken.accept(entity);
-            return 0;
-        }
-    });
+    private static final RegistryObject<FakeShieldItem> FAKE_SHIELD = ITEMS.register("fake_shield", FakeShieldItem::new);
 
     public PreventItemDamageTest() {
-        this.testItem(() -> new ItemStack(FAKE_SHIELD.get()));
+        this.testItem(() -> FAKE_SHIELD.get().getDefaultInstance());
     }
 
     @GameTest(template = "forge:empty3x3x3")
-    public static void player_fake_shield_took_no_damage(GameTestHelper helper) {
+    public static void player_fake_shield_took_modified_damage(GameTestHelper helper) {
         helper.makeFloor();
 
         // setup player
         var player = helper.makeMockPlayer(GameType.SURVIVAL);
+
+        // setup shield
+        var shield = FAKE_SHIELD.get().getDefaultInstance();
+
+        // setup events
+        var firedLivingEntityUseItem = helper.boolFlag("fired LivingEntityUseItemEvent");
+        var firedPlayerDestroyItem = helper.boolFlag("fired PlayerDestroyItemEvent");
         helper.<LivingEntityUseItemEvent.Start>addEventListener(event -> {
+            if (event.getEntity() != player) return;
+
+            if (event.getItem() != shield)
+                helper.fail("Player is using an item, but it's not the fake shield! Check the game test impl.");
+
             // Artificially pass 5 seconds from start of the shield
             // This is because the first 5 ticks, the player is still vulnerable
-            if (event.getEntity() == player) {
-                event.setDuration(event.getDuration() - 100);
-            }
+            firedLivingEntityUseItem.set(true);
+            event.setDuration(event.getDuration() - 100);
+        });
+        helper.<PlayerDestroyItemEvent>addEventListener(event -> {
+            if (event.getEntity() != player) return;
+
+            if (event.getOriginal() != shield)
+                helper.fail("Player destroyed an item, but it's not the fake shield! Check the game test impl.");
+
+            firedPlayerDestroyItem.set(true);
         });
 
         // start using shield
-        var shield = FAKE_SHIELD.get().getDefaultInstance();
         player.setItemInHand(InteractionHand.MAIN_HAND, shield);
         player.startUsingItem(InteractionHand.MAIN_HAND);
         int initialDamage = shield.getDamageValue();
@@ -71,8 +85,52 @@ public class PreventItemDamageTest extends BaseTestMod {
         // hit the player
         player.hurt(enemy.damageSources().mobAttack(enemy), 5.0F);
 
-        // shield on cooldown?
-        helper.assertTrue(initialDamage == shield.getDamageValue(), "Fake shield took damage! Expected: " + initialDamage + ", Actual: " + shield.getDamageValue());
+        // ok, run the tests
+        firedLivingEntityUseItem.assertEquals(true);
+        firedPlayerDestroyItem.assertEquals(true);
+        helper.assertValueEqual(initialDamage + 1, shield.getDamageValue(), "shield damage value", "Fake shield did not take precisely 1 damage! Check IForgeItem#damageItem.");
+        helper.assertValueEqual(player.getItemInHand(InteractionHand.MAIN_HAND), shield, "player shield", "Fake shield was removed from player's hand! Check Player#hurtCurrentlyUsedShield.");
         helper.succeed();
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void fake_shield_damage_item_impl(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup player
+        var player = helper.makeMockServerPlayer();
+
+        // setup shield
+        var shield = FAKE_SHIELD.get().getDefaultInstance();
+        int initialDamage = shield.getDamageValue();
+
+        // test hurt and break
+        var damaged = helper.<ServerPlayer>flag("damaged shield");
+        shield.hurtAndBreak(1, player, damaged::set);
+        damaged.assertEquals(player, "Fake shield was not damaged! Check IForgeItem#damageItem.");
+        helper.assertValueEqual(initialDamage + 1, shield.getDamageValue(), "shield damage value", "Fake shield did not take precisely 1 damage! Check IForgeItem#damageItem.");
+
+        // HURT WITHOUT BREAK WAS ADDED IN 1.21.3
+        /*
+        // test hurt without breaking
+        initialDamage = shield.getDamageValue();
+        shield.hurtWithoutBreaking(1, player);
+        helper.assertValueEqual(initialDamage, shield.getDamageValue(), "shield damage value", "Fake shield took damage even though hurtWithoutBreak test should set damage taken to 0! Check FakeShieldItem or IForgeItem#damageItem.");
+        */
+
+        // finished
+        helper.succeed();
+    }
+
+    private static final class FakeShieldItem extends ShieldItem {
+        public FakeShieldItem() {
+            super(new Item.Properties().durability(10));
+        }
+
+        @Override
+        public <T extends LivingEntity> int damageItem(ItemStack stack, int amount, T entity, Consumer<T> onBroken) {
+            onBroken.accept(entity);
+            return 1;
+        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
@@ -8,9 +8,12 @@ package net.minecraftforge.debug.gameplay.item;
 import net.minecraft.Util;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -67,7 +70,14 @@ public final class ShieldDisablingTest extends BaseTestMod {
         player.lookAt(EntityAnchorArgument.Anchor.EYES, enemy.position());
 
         // hit the player
-        player.hurt(enemy.damageSources().mobAttack(enemy), 5.0F);
+        var attack = helper.registryLookup(Registries.DAMAGE_TYPE).getOrThrow(DamageTypes.MOB_ATTACK);
+        var damage = new DamageSource(attack, enemy) {
+            @Override
+            public boolean scalesWithDifficulty() {
+                return false;
+            }
+        };
+        player.hurt(damage, 5.0F);
 
         // shield on cooldown?
         helper.assertTrue(player.getCooldowns().isOnCooldown(shield.getItem()), "shield should be on cooldown");

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShieldDisablingTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.Util;


### PR DESCRIPTION
Name entails. Since modders might want to apply custom logic when an item could be broken, this patch ensures that the item itself was set to empty before attempting to run any logic that could actually delete it from the player's hand.

- Partial backport of #10371 to 1.20.4
- Fixes #10344 for 1.20.4