### PR TITLE
[1.21.3] Re-introduce ModelEvent.RegisterAdditional (as used in 1.21.1)

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/ModelDiscovery.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelDiscovery.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/resources/model/ModelDiscovery.java
++++ b/net/minecraft/client/resources/model/ModelDiscovery.java
+@@ -60,6 +_,7 @@
+         this.referencedModels.put(SpecialModels.BUILTIN_GENERATED, SpecialModels.GENERATED_MARKER);
+         this.referencedModels.put(SpecialModels.BUILTIN_BLOCK_ENTITY, SpecialModels.BLOCK_ENTITY_MARKER);
+         Set<ModelResourceLocation> set = listMandatoryModels();
++        net.minecraftforge.client.ForgeHooksClient.onRegisterAdditionalModels(set);
+         p_361458_.models().forEach((p_366538_, p_363254_) -> {
+             this.registerTopModel(p_366538_, p_363254_.model());
+             set.remove(p_366538_);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -174,6 +174,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -730,6 +731,12 @@ public class ForgeHooksClient {
 
     public static void onRegisterKeyMappings(Options options) {
         ModLoader.get().postEvent(new RegisterKeyMappingsEvent(options));
+    }
+
+    public static void onRegisterAdditionalModels(Set<ModelResourceLocation> existingModels) {
+        Set<ModelResourceLocation> additionalModels = new HashSet<>();
+        ModLoader.get().postEvent(new ModelEvent.RegisterAdditional(additionalModels));
+        existingModels.addAll(additionalModels);
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -734,9 +734,7 @@ public class ForgeHooksClient {
     }
 
     public static void onRegisterAdditionalModels(Set<ModelResourceLocation> existingModels) {
-        Set<ModelResourceLocation> additionalModels = new HashSet<>();
-        ModLoader.get().postEvent(new ModelEvent.RegisterAdditional(additionalModels));
-        existingModels.addAll(additionalModels);
+        ModLoader.get().postEvent(new ModelEvent.RegisterAdditional(existingModels));
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -21,6 +21,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Houses events related to models.
@@ -112,6 +113,31 @@ public abstract class ModelEvent extends Event {
          */
         public ModelBakery getModelBakery() {
             return modelBakery;
+        }
+    }
+
+    /**
+     * Fired when the {@link net.minecraft.client.resources.model.ModelDiscovery} is notified of the resource manager reloading.
+     * Allows developers to register models to be loaded, along with their dependencies.
+     *
+     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+     *
+     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
+     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     */
+    public static class RegisterAdditional extends ModelEvent implements IModBusEvent {
+        private final Set<ModelResourceLocation> models;
+
+        @ApiStatus.Internal
+        public RegisterAdditional(Set<ModelResourceLocation> models) {
+            this.models = models;
+        }
+
+        /**
+         * Registers a model to be loaded, along with its dependencies.
+         */
+        public void register(ModelResourceLocation model) {
+            models.add(model);
         }
     }
 


### PR DESCRIPTION
This PR re-introduces `ModelEvent.RegisterAdditional`, which allowed modders in 1.21.1 and lower to add models through the event without needing to tinker much with the model bakery or discoverer. In 1.21.3, the process of model loading was moved from `ModelBakery` to `ModelDiscovery`, and the way it is done is largely the same as it was in 1.21.1.

**Quick disclaimer:** I don't think this can be applicable to 1.21.4 with the sheer amount of changes due to item models. Even model discovery itself has been changed, and I'm still unable to find how I would apply this to 1.21.4