### PR TITLE
[1.19.4] Cache this.useItem before running item break logic

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,15 +135,23 @@
           if (!this.f_19853_.f_46443_) {
              this.m_36246_(Stats.f_12982_.m_12902_(this.f_20935_.m_41720_()));
           }
-@@ -864,6 +_,8 @@
+@@ -862,10 +_,15 @@
+          if (p_36383_ >= 3.0F) {
+             int i = 1 + Mth.m_14143_(p_36383_);
              InteractionHand interactionhand = this.m_7655_();
++            // FORGE: cache this.useItem -- if this.stopUsingItem() is called, it will be set to ItemStack.EMPTY
++            ItemStack currentItem = this.f_20935_;
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
 +               m_5810_(); // Forge: fix MC-168573
              });
-             if (this.f_20935_.m_41619_()) {
+-            if (this.f_20935_.m_41619_()) {
++            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY
++            if (currentItem.m_41619_()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {
+                   this.m_8061_(EquipmentSlot.MAINHAND, ItemStack.f_41583_);
+                } else {
 @@ -882,10 +_,13 @@
  
     protected void m_6475_(DamageSource p_36312_, float p_36313_) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -144,7 +144,7 @@
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
-+               m_5810_(); // Forge: fix MC-168573
++               if (this.f_20935_ == currentItem) m_5810_(); // Forge: fix MC-168573
              });
 -            if (this.f_20935_.m_41619_()) {
 +            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY


### PR DESCRIPTION
- Backport of #10375 to 1.19.4
- Fixes #10344 for 1.19.4
- Does not include game tests