### PR TITLE
[1.19.2] Fix continuing to use items after dropping or when a shield breaks

### DIFF
--- a/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
@@ -8,7 +8,14 @@
        return false;
     }
  
-@@ -289,6 +_,8 @@
+@@ -283,12 +_,15 @@
+ 
+    public boolean m_108700_(boolean p_108701_) {
+       ServerboundPlayerActionPacket.Action serverboundplayeractionpacket$action = p_108701_ ? ServerboundPlayerActionPacket.Action.DROP_ALL_ITEMS : ServerboundPlayerActionPacket.Action.DROP_ITEM;
++      if (m_6117_() && m_7655_() == InteractionHand.MAIN_HAND && (p_108701_ || m_21211_().m_41613_() == 1)) m_5810_(); // Forge: fix MC-231097 on the clientside
+       ItemStack itemstack = this.m_150109_().m_182403_(p_108701_);
+       this.f_108617_.m_104955_(new ServerboundPlayerActionPacket(serverboundplayeractionpacket$action, BlockPos.f_121853_, Direction.DOWN));
+       return !itemstack.m_41619_();
     }
  
     public void m_240287_(String p_240288_, @Nullable Component p_240289_) {

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayer.java.patch
@@ -289,12 +289,13 @@
     public TextFilter m_8967_() {
        return this.f_8939_;
     }
-@@ -1534,11 +_,13 @@
+@@ -1534,11 +_,14 @@
  
     public boolean m_182294_(boolean p_182295_) {
        Inventory inventory = this.m_150109_();
 +      ItemStack selected = inventory.m_36056_();
 +      if (selected.m_41619_() || !selected.onDroppedByPlayer(this)) return false;
++      if (m_6117_() && m_7655_() == InteractionHand.MAIN_HAND && (p_182295_ || selected.m_41613_() == 1)) m_5810_(); // Forge: fix MC-231097 on the serverside
        ItemStack itemstack = inventory.m_182403_(p_182295_);
        this.f_36096_.m_182417_(inventory, inventory.f_35977_).ifPresent((p_182293_) -> {
           this.f_36096_.m_150404_(p_182293_, inventory.m_36056_());

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,11 +135,12 @@
           if (!this.f_19853_.f_46443_) {
              this.m_36246_(Stats.f_12982_.m_12902_(this.f_20935_.m_41720_()));
           }
-@@ -887,6 +_,7 @@
+@@ -887,6 +_,8 @@
              InteractionHand interactionhand = this.m_7655_();
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
++               this.m_5810_(); // Forge: fix MC-168573
              });
              if (this.f_20935_.m_41619_()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -135,15 +135,23 @@
           if (!this.f_19853_.f_46443_) {
              this.m_36246_(Stats.f_12982_.m_12902_(this.f_20935_.m_41720_()));
           }
-@@ -887,6 +_,8 @@
+@@ -885,10 +_,15 @@
+          if (p_36383_ >= 3.0F) {
+             int i = 1 + Mth.m_14143_(p_36383_);
              InteractionHand interactionhand = this.m_7655_();
++            // FORGE: cache this.useItem -- if this.stopUsingItem() is called, it will be set to ItemStack.EMPTY
++            ItemStack currentItem = this.f_20935_;
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
 +               this.m_5810_(); // Forge: fix MC-168573
              });
-             if (this.f_20935_.m_41619_()) {
+-            if (this.f_20935_.m_41619_()) {
++            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY
++            if (currentItem.m_41619_()) {
                 if (interactionhand == InteractionHand.MAIN_HAND) {
+                   this.m_8061_(EquipmentSlot.MAINHAND, ItemStack.f_41583_);
+                } else {
 @@ -905,10 +_,13 @@
  
     protected void m_6475_(DamageSource p_36312_, float p_36313_) {

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -144,7 +144,7 @@
              this.f_20935_.m_41622_(i, this, (p_219739_) -> {
                 p_219739_.m_21190_(interactionhand);
 +               net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, this.f_20935_, interactionhand);
-+               this.m_5810_(); // Forge: fix MC-168573
++               if (this.f_20935_ == currentItem) this.m_5810_(); // Forge: fix MC-168573
              });
 -            if (this.f_20935_.m_41619_()) {
 +            // FORGE: use cached item since this.useItem could be ItemStack.EMPTY


### PR DESCRIPTION
- Backport of #10375 to 1.19.2
- Backport of #9344 to 1.19.2
- Fixes [MC-231097](https://bugs.mojang.com/browse/MC-231097) for 1.19.2
- Fixes [MC-168573](https://bugs.mojang.com/browse/MC-168573) for 1.19.2
- Does not include game tests