### PR TITLE
[1.21.4] Bump EventBus to fix super listeners not working

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 


### PR DESCRIPTION
Name entails. EventBus 2.2.26 had a bug where event listeners of a super class (i.e. `ModConfigEvent` as opposed to `ModConfigEvent.Load`) were ignored.