### PR TITLE
 [1.20.6] Bump dependencies, most notably EventBus

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
         libs {
             library('forgespi', 'net.minecraftforge:forgespi:7.1.4') // Needs modlauncher
             library('modlauncher', 'net.minecraftforge:modlauncher:10.2.4') // Needs securemodules
-            library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
+            library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
             bundle('jimfs', ['guava', 'failureaccess'])
             
-            version('bootstrap', '2.1.3')
+            version('bootstrap', '2.1.8')
             library('bootstrap',      'net.minecraftforge', 'bootstrap'     ).versionRef('bootstrap') // Needs modlauncher
             library('bootstrap-api',  'net.minecraftforge', 'bootstrap-api' ).versionRef('bootstrap')
             library('bootstrap-dev',  'net.minecraftforge', 'bootstrap-dev' ).versionRef('bootstrap')

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,16 +28,16 @@ dependencyResolutionManagement {
             library('securemodules', 'net.minecraftforge:securemodules:2.2.19') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
-            library('coremods', 'net.minecraftforge:coremods:5.2.4')
+            library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
             library('mixin', 'org.spongepowered:mixin:0.8.5')
             library('nulls', 'org.jetbrains:annotations:24.1.0') // Got to have our null annotations!
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')
-            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.5')
+            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.8')
 
             // Google's InMemory File System. Used by ForgeDev Tests for now, but could be useful for a lot of things.
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')


### PR DESCRIPTION
- Backport of #10370 to 1.20.6
- Includes bumped EventBus backported from #10384
- Additionally bumped Bootstrap to 2.1.8
- Additionally bumped SecureModules to 2.2.21
- Does not bump NightConfig