### PR TITLE
[1.20.4] Bump dependencies, most notably EventBus

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -24,8 +24,8 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             library('forgespi', 'net.minecraftforge:forgespi:7.1.3') // Needs modlauncher
-            library('modlauncher', 'net.minecraftforge:modlauncher:10.1.2') // Needs securemodules
-            library('securemodules', 'net.minecraftforge:securemodules:2.2.10') // Needs unsafe
+            library('modlauncher', 'net.minecraftforge:modlauncher:10.2.4') // Needs securemodules
+            library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
@@ -44,7 +44,7 @@ dependencyResolutionManagement {
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')
             bundle('jimfs', ['guava', 'failureaccess'])
             
-            version('bootstrap', '2.1.0')
+            version('bootstrap', '2.1.8')
             library('bootstrap',      'net.minecraftforge', 'bootstrap'     ).versionRef('bootstrap') // Needs modlauncher
             library('bootstrap-api',  'net.minecraftforge', 'bootstrap-api' ).versionRef('bootstrap')
             library('bootstrap-dev',  'net.minecraftforge', 'bootstrap-dev' ).versionRef('bootstrap')

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,16 +29,16 @@ dependencyResolutionManagement {
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
-            library('coremods', 'net.minecraftforge:coremods:5.2.4')
+            library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.8')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
             library('mixin', 'org.spongepowered:mixin:0.8.5')
             library('nulls', 'org.jetbrains:annotations:23.0.0') // Got to have our null annotations!
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')
-            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.5')
+            library('maven-artifact', 'org.apache.maven:maven-artifact:3.8.8')
 
             // Google's InMemory File System. Used by ForgeDev Tests for now, but could be useful for a lot of things.
             library('jimfs', 'com.google.jimfs:jimfs:1.3.0')

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.26')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,7 +61,7 @@ dependencyResolutionManagement {
 
             // Terminal Console Appender.. essentually make pretty colors in the console, but it's been a PITA
             library('terminalconsoleappender', 'net.minecrell:terminalconsoleappender:1.2.0')
-            version('jline', '3.12.1')
+            version('jline', '3.25.1')
             library('jline-reader',       'org.jline', 'jline-reader'      ).versionRef('jline')
             library('jline-terminal',     'org.jline', 'jline-terminal'    ).versionRef('jline')
             library('jline-terminal-jna', 'org.jline', 'jline-terminal-jna').versionRef('jline') // Colors and tab completeion

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,8 +24,8 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             library('forgespi', 'net.minecraftforge:forgespi:7.1.3') // Needs modlauncher
-            library('modlauncher', 'net.minecraftforge:modlauncher:10.2.4') // Needs securemodules
-            library('securemodules', 'net.minecraftforge:securemodules:2.2.21') // Needs unsafe
+            library('modlauncher', 'net.minecraftforge:modlauncher:10.1.2') // Needs securemodules
+            library('securemodules', 'net.minecraftforge:securemodules:2.2.10') // Needs unsafe
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.1.1')
             library('antlr-runtime', 'org.antlr:antlr4-runtime:4.9.1') // Needed by Access Transformer because parsing a simple text file was too complicated


### PR DESCRIPTION
- Backport of #10370 to 1.20.4
- Includes bumped EventBus backported from #10384
- Additionally bumped Bootstrap to 2.1.8
- Does not bump AccessTransformers
- Does not bump NightConfig