### PR TITLE
[1.21.4] Gate client test mods behind clientSideOnly

### DIFF
--- a/src/test/resources/additional_model/META-INF/mods.toml
+++ b/src/test/resources/additional_model/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true

--- a/src/test/resources/custom_gui_event_test/META-INF/mods.toml
+++ b/src/test/resources/custom_gui_event_test/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true

--- a/src/test/resources/gui_layer_test/META-INF/mods.toml
+++ b/src/test/resources/gui_layer_test/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true

--- a/src/test/resources/late_bound_id_mapper/META-INF/mods.toml
+++ b/src/test/resources/late_bound_id_mapper/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true

--- a/src/test/resources/model_render_type/META-INF/mods.toml
+++ b/src/test/resources/model_render_type/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true


### PR DESCRIPTION
Name entails. Fixes `forge server gametest test` failing to start.