### PR TITLE
Fix game test structure rotations being inconsistent

### DIFF
--- a/patches/minecraft/net/minecraft/gametest/framework/GameTestInfo.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/GameTestInfo.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/gametest/framework/GameTestInfo.java
++++ b/net/minecraft/gametest/framework/GameTestInfo.java
+@@ -265,7 +_,7 @@
+         BlockPos blockpos = this.getOrCalculateNorthwestCorner();
+         this.structureBlockEntity = StructureUtils.prepareTestStructure(this, blockpos, this.getRotation(), this.level);
+         this.structureBlockPos = this.structureBlockEntity.getBlockPos();
+-        StructureUtils.addCommandBlockAndButtonToStartTest(this.structureBlockPos, new BlockPos(1, 0, -1), this.getRotation(), this.level);
++        StructureUtils.addCommandBlockAndButtonToStartTest(this.structureBlockPos, new BlockPos(1, 0, -1), Rotation.NONE, this.level); // Forge: The control blocks are always in the North West Corner
+         StructureUtils.encaseStructure(this.getStructureBounds(), this.level, !this.testFunction.skyAccess());
+         this.listeners.forEach(p_127630_ -> p_127630_.testStructureLoaded(this));
+         return this;

--- a/patches/minecraft/net/minecraft/gametest/framework/ReportGameListener.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/ReportGameListener.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/gametest/framework/ReportGameListener.java
++++ b/net/minecraft/gametest/framework/ReportGameListener.java
+@@ -151,7 +_,7 @@
+     private static BlockPos getBeaconPos(GameTestInfo p_344999_) {
+         BlockPos blockpos = p_344999_.getStructureBlockPos();
+         BlockPos blockpos1 = new BlockPos(-1, -2, -1);
+-        return StructureTemplate.transform(blockpos.offset(blockpos1), Mirror.NONE, p_344999_.getRotation(), blockpos);
++        return blockpos.offset(blockpos1); // Forge: The control blocks are always in the North West Corner
+     }
+ 
+     private static void updateBeaconGlass(GameTestInfo p_343978_, Block p_344076_) {
+@@ -167,8 +_,8 @@
+         ServerLevel serverlevel = p_177739_.getLevel();
+         BlockPos blockpos = p_177739_.getStructureBlockPos();
+         BlockPos blockpos1 = new BlockPos(-1, 0, -1);
+-        BlockPos blockpos2 = StructureTemplate.transform(blockpos.offset(blockpos1), Mirror.NONE, p_177739_.getRotation(), blockpos);
+-        serverlevel.setBlockAndUpdate(blockpos2, Blocks.LECTERN.defaultBlockState().rotate(p_177739_.getRotation()));
++        BlockPos blockpos2 = blockpos.offset(blockpos1); // Forge: The control blocks are always in the North West Corner
++        serverlevel.setBlockAndUpdate(blockpos2, Blocks.LECTERN.defaultBlockState());
+         BlockState blockstate = serverlevel.getBlockState(blockpos2);
+         ItemStack itemstack = createBook(p_177739_.getTestName(), p_177739_.isRequired(), p_177740_);
+         LecternBlock.tryPlaceBook(null, serverlevel, blockpos2, blockstate, itemstack);

--- a/patches/minecraft/net/minecraft/gametest/framework/StructureUtils.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/StructureUtils.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/gametest/framework/StructureUtils.java
++++ b/net/minecraft/gametest/framework/StructureUtils.java
+@@ -132,10 +_,16 @@
+             .orElseThrow(() -> new IllegalStateException("Missing test structure: " + p_311701_.getStructureName()))
+             .getSize();
+         BoundingBox boundingbox = getStructureBoundingBox(p_311042_, vec3i, p_310584_);
+-        BlockPos blockpos = getStartCorner(p_311701_, p_311042_, p_310584_, p_312330_);
++        BlockPos blockpos = getStartCorner(p_311701_, p_311042_, Rotation.NONE, p_312330_); // Forge: The control blocks are always in the North West Corner
+         forceLoadChunks(boundingbox, p_312330_);
+         clearSpaceForStructure(boundingbox, p_312330_);
+-        return createStructureBlock(p_311701_, blockpos.below(), p_310584_, p_312330_);
++        var entity = createStructureBlock(p_311701_, blockpos.below(), p_310584_, p_312330_);
++        //Forge:  We need to offset the structure so that it will load within bounds.
++        if (p_310584_ != Rotation.NONE) {
++            var rotated = StructureTemplate.getZeroPositionWithTransform(BlockPos.ZERO, Mirror.NONE, p_310584_, entity.getStructureSize().getX(), entity.getStructureSize().getZ());
++            entity.setStructurePos(rotated.offset(new BlockPos(0, 1, 0)));
++        }
++        return entity;
+     }
+ 
+     public static void encaseStructure(AABB p_330422_, ServerLevel p_331249_, boolean p_328180_) {

--- a/patches/minecraft/net/minecraft/gametest/framework/TestCommand.java.patch
+++ b/patches/minecraft/net/minecraft/gametest/framework/TestCommand.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/gametest/framework/TestCommand.java
++++ b/net/minecraft/gametest/framework/TestCommand.java
+@@ -313,7 +_,11 @@
+                 return Optional.empty();
+             } else {
+                 TestFunction testfunction = optional.get();
+-                GameTestInfo gametestinfo = new GameTestInfo(testfunction, structureblockentity.getRotation(), p_328153_, p_330368_);
++                // Forge: The rotation is stored in the structure block, and added in the GameTestInfo constructor.
++                // So reverse it to find the manually specified rotation so the test runs the same every time.
++                var steps = StructureUtils.getRotationStepsForRotation(structureblockentity.getRotation()) - StructureUtils.getRotationStepsForRotation(testfunction.rotation());
++                if (steps < 0) steps += 4;
++                GameTestInfo gametestinfo = new GameTestInfo(testfunction, StructureUtils.getRotationForRotationSteps(steps), p_328153_, p_330368_);
+                 gametestinfo.setStructureBlockPos(p_332856_);
+                 return !verifyStructureExists(p_328153_, gametestinfo.getStructureName()) ? Optional.empty() : Optional.of(gametestinfo);
+             }


### PR DESCRIPTION
When you make a game test, you can specify the rotation steps in the annotation:
`@GameTest(template = "forge:empty3x3x3", rotationSteps = 1)`
If you do this, every time you click the button on the command block, the entire structure will rotate.
This fixes the issue by forcing the test infrastructure blocks to always be in the north west corner no matter to rotation specified by the annotation or command.