### PR TITLE
[1.20.1] Add fast graphics render type to block models

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -52,7 +52,7 @@
     public static RenderType m_109279_(ItemStack p_109280_, boolean p_109281_) {
        Item item = p_109280_.m_41720_();
        if (item instanceof BlockItem) {
-@@ -365,8 +_,73 @@
+@@ -365,8 +_,78 @@
     }
  
     public static RenderType m_109287_(FluidState p_109288_) {
@@ -124,6 +124,11 @@
 +
 +   private static net.minecraftforge.client.ChunkRenderTypeSet createSetFromPredicate(java.util.function.Predicate<RenderType> predicate) {
 +      return net.minecraftforge.client.ChunkRenderTypeSet.of(RenderType.m_110506_().stream().filter(predicate).toArray(RenderType[]::new));
++   }
++
++   /** Forge: Check if we are currently in fancy, to account for fast render types */
++   public static boolean isFancy() {
++      return f_109277_;
     }
  
     public static void m_109291_(boolean p_109292_) {

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -52,16 +52,23 @@
     public static RenderType m_109279_(ItemStack p_109280_, boolean p_109281_) {
        Item item = p_109280_.m_41720_();
        if (item instanceof BlockItem) {
-@@ -365,8 +_,78 @@
+@@ -365,11 +_,79 @@
     }
  
     public static RenderType m_109287_(FluidState p_109288_) {
 -      RenderType rendertype = f_109276_.get(p_109288_.m_76152_());
 +      RenderType rendertype = FLUID_RENDER_TYPES.get(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(p_109288_.m_76152_()));
        return rendertype != null ? rendertype : RenderType.m_110451_();
+    }
+ 
+    public static void m_109291_(boolean p_109292_) {
+       f_109277_ = p_109292_;
 +   }
 +
-+   // FORGE START
++   /** Forge: Check if we are running in {@linkplain net.minecraft.client.Minecraft#useFancyGraphics() fancy graphics} to account for fast graphics render types */
++   public static boolean isFancy() {
++      return f_109277_;
++   }
 +
 +   private static final net.minecraftforge.client.ChunkRenderTypeSet CUTOUT_MIPPED = net.minecraftforge.client.ChunkRenderTypeSet.of(RenderType.m_110457_());
 +   private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID = net.minecraftforge.client.ChunkRenderTypeSet.of(RenderType.m_110451_());
@@ -79,7 +86,7 @@
 +   });
 +
 +   /** @deprecated Use {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
-+   @Deprecated(since = "1.19")
++   @Deprecated(since = "1.21.4", forRemoval = true)
 +   public static net.minecraftforge.client.ChunkRenderTypeSet getRenderLayers(BlockState state) {
 +      Block block = state.m_60734_();
 +      if (block instanceof LeavesBlock) {
@@ -90,20 +97,20 @@
 +   }
 +
 +   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+   @Deprecated(since = "1.19")
++   @Deprecated(since = "1.21.4", forRemoval = true)
 +   public static void setRenderLayer(Block block, RenderType type) {
 +      com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +      setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +   }
 +
 +   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+   @Deprecated(since = "1.19")
++   @Deprecated(since = "1.21.4", forRemoval = true)
 +   public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +      setRenderLayer(block, createSetFromPredicate(predicate));
 +   }
 +
 +   /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+   @Deprecated(since = "1.19")
++   @Deprecated(since = "1.21.4", forRemoval = true)
 +   public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +      checkClientLoading();
 +      BLOCK_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), layers);
@@ -124,11 +131,5 @@
 +
 +   private static net.minecraftforge.client.ChunkRenderTypeSet createSetFromPredicate(java.util.function.Predicate<RenderType> predicate) {
 +      return net.minecraftforge.client.ChunkRenderTypeSet.of(RenderType.m_110506_().stream().filter(predicate).toArray(RenderType[]::new));
-+   }
-+
-+   /** Forge: Check if we are currently in fancy, to account for fast render types */
-+   public static boolean isFancy() {
-+      return f_109277_;
     }
- 
-    public static void m_109291_(boolean p_109292_) {
+ }

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -28,12 +28,16 @@
     }
  
     public List<BakedQuad> m_213637_(@Nullable BlockState p_235054_, @Nullable Direction p_235055_, RandomSource p_235056_) {
-@@ -70,6 +_,25 @@
+@@ -70,6 +_,38 @@
        return this.f_119487_;
     }
  
 +   @Override
 +   public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(@org.jetbrains.annotations.NotNull BlockState state, @org.jetbrains.annotations.NotNull RandomSource rand, @org.jetbrains.annotations.NotNull net.minecraftforge.client.model.data.ModelData data) {
++      if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
++         if (isRenderingCutout() && net.minecraftforge.client.ForgeHooksClient.isLeavesBlock(state))
++            return net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.m_110451_());
++      }
 +      if (blockRenderTypes != null)
 +         return blockRenderTypes;
 +      return BakedModel.super.getRenderTypes(state, rand, data);
@@ -49,6 +53,15 @@
 +             return fabulousItemRenderTypes;
 +      }
 +      return BakedModel.super.getRenderTypes(itemStack, fabulous);
++   }
++
++   // Forge: Check if this model is rendering cutout or cutout-mipped, as leaves can use either
++   private @Nullable Boolean isRenderingCutout = null;
++   private boolean isRenderingCutout() {
++      if (isRenderingCutout == null)
++         isRenderingCutout = blockRenderTypes != null && (blockRenderTypes.contains(net.minecraft.client.renderer.RenderType.m_110457_()) || blockRenderTypes.contains(net.minecraft.client.renderer.RenderType.m_110463_()));
++
++      return isRenderingCutout;
 +   }
 +
     @OnlyIn(Dist.CLIENT)

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,42 +1,62 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -26,8 +_,17 @@
+@@ -26,8 +_,26 @@
     protected final TextureAtlasSprite f_119485_;
     protected final ItemTransforms f_119486_;
     protected final ItemOverrides f_119487_;
 +   protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
++   protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
 +   protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
++   protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypesFast;
 +   protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
++   protected final boolean isRenderingCutout;
  
-+   /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++   /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
 +   @Deprecated
     public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, ItemOverrides p_119496_) {
 +      this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, p_119496_, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +   }
 +
++   /** @deprecated Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++   @Deprecated
 +   public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, ItemOverrides p_119496_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
++      this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, p_119496_, renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
++   }
++
++   public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, ItemOverrides p_119496_, net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
        this.f_119480_ = p_119489_;
        this.f_119481_ = p_119490_;
        this.f_119482_ = p_119491_;
-@@ -36,6 +_,9 @@
+@@ -36,6 +_,15 @@
        this.f_119485_ = p_119494_;
        this.f_119486_ = p_119495_;
        this.f_119487_ = p_119496_;
-+      this.blockRenderTypes = !renderTypes.isEmpty() ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
-+      this.itemRenderTypes = !renderTypes.isEmpty() ? List.of(renderTypes.entity()) : null;
-+      this.fabulousItemRenderTypes = !renderTypes.isEmpty() ? List.of(renderTypes.entityFabulous()) : null;
++
++      boolean hasRenderTypes = renderTypes != null && !renderTypes.isEmpty();
++      boolean hasRenderTypesFast = renderTypesFast != null && !renderTypesFast.isEmpty();
++      this.blockRenderTypes = hasRenderTypes ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
++      this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypesFast.block()) : null;
++      this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
++      this.itemRenderTypesFast = hasRenderTypesFast ? List.of(renderTypesFast.entity()) : null;
++      this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
++      this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110457_() || renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110463_());
     }
  
     public List<BakedQuad> m_213637_(@Nullable BlockState p_235054_, @Nullable Direction p_235055_, RandomSource p_235056_) {
-@@ -70,6 +_,38 @@
+@@ -70,6 +_,40 @@
        return this.f_119487_;
     }
  
++   private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID_BLOCK = net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.m_110451_());
++   private static final List<net.minecraft.client.renderer.RenderType> SOLID_ITEM_BLOCK = List.of(net.minecraft.client.renderer.RenderType.m_110451_());
++
 +   @Override
 +   public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(@org.jetbrains.annotations.NotNull BlockState state, @org.jetbrains.annotations.NotNull RandomSource rand, @org.jetbrains.annotations.NotNull net.minecraftforge.client.model.data.ModelData data) {
 +      if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
-+         if (isRenderingCutout() && net.minecraftforge.client.ForgeHooksClient.isLeavesBlock(state))
-+            return net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.m_110451_());
++         if (blockRenderTypesFast != null)
++            return blockRenderTypesFast;
++         if (isRenderingCutout && state.m_60734_() instanceof net.minecraft.world.level.block.LeavesBlock)
++            return SOLID_BLOCK;
 +      }
 +      if (blockRenderTypes != null)
 +         return blockRenderTypes;
@@ -46,6 +66,12 @@
 +   @Override
 +   public List<net.minecraft.client.renderer.RenderType> getRenderTypes(net.minecraft.world.item.ItemStack itemStack, boolean fabulous) {
 +      if (!fabulous) {
++         if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
++            if (itemRenderTypesFast != null)
++               return itemRenderTypesFast;
++            if (isRenderingCutout && itemStack.m_41720_() instanceof net.minecraft.world.item.BlockItem blockItem && blockItem.m_40614_() instanceof net.minecraft.world.level.block.LeavesBlock)
++               return SOLID_ITEM_BLOCK;
++         }
 +         if (itemRenderTypes != null)
 +             return itemRenderTypes;
 +      } else {
@@ -55,34 +81,31 @@
 +      return BakedModel.super.getRenderTypes(itemStack, fabulous);
 +   }
 +
-+   // Forge: Check if this model is rendering cutout or cutout-mipped, as leaves can use either
-+   private @Nullable Boolean isRenderingCutout = null;
-+   private boolean isRenderingCutout() {
-+      if (isRenderingCutout == null)
-+         isRenderingCutout = blockRenderTypes != null && (blockRenderTypes.contains(net.minecraft.client.renderer.RenderType.m_110457_()) || blockRenderTypes.contains(net.minecraft.client.renderer.RenderType.m_110463_()));
-+
-+      return isRenderingCutout;
-+   }
-+
     @OnlyIn(Dist.CLIENT)
     public static class Builder {
        private final List<BakedQuad> f_119508_ = Lists.newArrayList();
-@@ -116,11 +_,17 @@
+@@ -116,11 +_,23 @@
           return this;
        }
  
-+      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
 +      @Deprecated
        public BakedModel m_119533_() {
 +         return build(net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +      }
 +
++      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++      @Deprecated
 +      public BakedModel build(net.minecraftforge.client.RenderTypeGroup renderTypes) {
++         return this.build(renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
++      }
++
++      public BakedModel build(net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
           if (this.f_119512_ == null) {
              throw new RuntimeException("Missing particle!");
           } else {
 -            return new SimpleBakedModel(this.f_119508_, this.f_119509_, this.f_119511_, this.f_119513_, this.f_119514_, this.f_119512_, this.f_119515_, this.f_119510_);
-+            return new SimpleBakedModel(this.f_119508_, this.f_119509_, this.f_119511_, this.f_119513_, this.f_119514_, this.f_119512_, this.f_119515_, this.f_119510_, renderTypes);
++            return new SimpleBakedModel(this.f_119508_, this.f_119509_, this.f_119511_, this.f_119513_, this.f_119514_, this.f_119512_, this.f_119515_, this.f_119510_, renderTypes, renderTypesFast);
           }
        }
     }

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,14 +1,20 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -26,8 +_,26 @@
+@@ -26,8 +_,44 @@
     protected final TextureAtlasSprite f_119485_;
     protected final ItemTransforms f_119486_;
     protected final ItemOverrides f_119487_;
++   /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} */
 +   protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
++   /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} */
 +   protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
++   /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} */
 +   protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
++   /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} */
 +   protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypesFast;
++   /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FABULOUS fabulous graphics} */
 +   protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
++   /** Forge: If this model's {@linkplain #blockRenderTypes block render types} are rendering cutout, to account for older leaves model JSONs */
 +   protected final boolean isRenderingCutout;
  
 +   /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
@@ -17,13 +23,25 @@
 +      this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, p_119496_, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +   }
 +
-+   /** @deprecated Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
-+   @Deprecated
++   /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, ItemOverrides, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup for fast graphics} **/
++   @Deprecated(forRemoval = true, since = "1.21.4")
 +   public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, ItemOverrides p_119496_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
 +      this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, p_119496_, renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +   }
 +
-+   public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, ItemOverrides p_119496_, net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
++   /** Constructor with {@link net.minecraftforge.client.RenderTypeGroup RenderTypeGroup} for fancy and fast graphics. Preferred over {@link net.minecraft.client.renderer.ItemBlockRenderTypes#setRenderLayer(net.minecraft.world.level.block.Block, net.minecraft.client.renderer.RenderType) ItemBlockRenderTypes.setRenderLayer(Block, RenderType)}. */
++   public SimpleBakedModel(
++      List<BakedQuad> p_119489_,
++      Map<Direction, List<BakedQuad>> p_119490_,
++      boolean p_119491_,
++      boolean p_119492_,
++      boolean p_119493_,
++      TextureAtlasSprite p_119494_,
++      ItemTransforms p_119495_,
++      ItemOverrides p_119496_,
++      net.minecraftforge.client.RenderTypeGroup renderTypes,
++      net.minecraftforge.client.RenderTypeGroup renderTypesFast
++   ) {
        this.f_119480_ = p_119489_;
        this.f_119481_ = p_119490_;
        this.f_119482_ = p_119491_;
@@ -39,7 +57,7 @@
 +      this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
 +      this.itemRenderTypesFast = hasRenderTypesFast ? List.of(renderTypesFast.entity()) : null;
 +      this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
-+      this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110457_() || renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110463_());
++      this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110463_() || renderTypes.block() == net.minecraft.client.renderer.RenderType.m_110457_());
     }
  
     public List<BakedQuad> m_213637_(@Nullable BlockState p_235054_, @Nullable Direction p_235055_, RandomSource p_235056_) {
@@ -48,7 +66,7 @@
     }
  
 +   private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID_BLOCK = net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.m_110451_());
-+   private static final List<net.minecraft.client.renderer.RenderType> SOLID_ITEM_BLOCK = List.of(net.minecraft.client.renderer.RenderType.m_110451_());
++   private static final List<net.minecraft.client.renderer.RenderType> SOLID_BLOCK_ITEM = List.of(net.minecraft.client.renderer.RenderType.m_110451_());
 +
 +   @Override
 +   public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(@org.jetbrains.annotations.NotNull BlockState state, @org.jetbrains.annotations.NotNull RandomSource rand, @org.jetbrains.annotations.NotNull net.minecraftforge.client.model.data.ModelData data) {
@@ -70,13 +88,13 @@
 +            if (itemRenderTypesFast != null)
 +               return itemRenderTypesFast;
 +            if (isRenderingCutout && itemStack.m_41720_() instanceof net.minecraft.world.item.BlockItem blockItem && blockItem.m_40614_() instanceof net.minecraft.world.level.block.LeavesBlock)
-+               return SOLID_ITEM_BLOCK;
++               return SOLID_BLOCK_ITEM;
 +         }
 +         if (itemRenderTypes != null)
-+             return itemRenderTypes;
++            return itemRenderTypes;
 +      } else {
 +         if (fabulousItemRenderTypes != null)
-+             return fabulousItemRenderTypes;
++            return fabulousItemRenderTypes;
 +      }
 +      return BakedModel.super.getRenderTypes(itemStack, fabulous);
 +   }
@@ -84,27 +102,49 @@
     @OnlyIn(Dist.CLIENT)
     public static class Builder {
        private final List<BakedQuad> f_119508_ = Lists.newArrayList();
-@@ -116,11 +_,23 @@
+@@ -116,11 +_,45 @@
           return this;
        }
  
-+      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
 +      @Deprecated
        public BakedModel m_119533_() {
-+         return build(net.minecraftforge.client.RenderTypeGroup.EMPTY);
++         return build(net.minecraftforge.client.RenderTypeGroup.EMPTY, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +      }
 +
-+      /** @deprecated Forge: Use {@linkplain #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
-+      @Deprecated
++      /**
++       * Builds with the render type to be used for this model, which will be used for any graphics setting.
++       * <p>
++       * If you need to set a specific render type for
++       * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}, consider using
++       * {@link #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup)
++       * renderTypes(RenderTypeGroup, RenderTypeGroup)} instead which allows choosing render types for both fancy and
++       * fast graphics.
++       *
++       * @apiNote If this model is for {@linkplain net.minecraft.world.level.block.LeavesBlock leaves} and if the
++       * given render type is either {@linkplain net.minecraft.client.renderer.RenderType#cutout() cutout} or
++       * {@linkplain net.minecraft.client.renderer.RenderType#cutoutMipped() cutout mipped}, it will be overridden
++       * with {@linkplain net.minecraft.client.renderer.RenderType#solid() solid} when fast graphics is enabled.
++       * @see #build(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup)
++       * renderTypes(RenderTypeGroup, RenderTypeGroup)
++       */
 +      public BakedModel build(net.minecraftforge.client.RenderTypeGroup renderTypes) {
 +         return this.build(renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +      }
 +
++      /**
++       * Builds with the render types to be used for this model: one for
++       * {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} and one for
++       * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
++       *
++       * @see #build(net.minecraftforge.client.RenderTypeGroup)
++       */
 +      public BakedModel build(net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
           if (this.f_119512_ == null) {
              throw new RuntimeException("Missing particle!");
           } else {
 -            return new SimpleBakedModel(this.f_119508_, this.f_119509_, this.f_119511_, this.f_119513_, this.f_119514_, this.f_119512_, this.f_119515_, this.f_119510_);
++            // Forge: Account for render types in model JSONs
 +            return new SimpleBakedModel(this.f_119508_, this.f_119509_, this.f_119511_, this.f_119513_, this.f_119514_, this.f_119512_, this.f_119515_, this.f_119510_, renderTypes, renderTypesFast);
           }
        }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -96,7 +96,9 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeManager;
@@ -1249,11 +1251,6 @@ public class ForgeHooksClient
        } else {
            return Direction.getNearest(nX, nY, nZ);
        }
-    }
-
-    private static final Object2BooleanOpenHashMap<Block> LEAVES = new Object2BooleanOpenHashMap<>();
-    public static boolean isLeavesBlock(BlockState state) {
-        return LEAVES.computeIfAbsent(state.getBlock(), block -> block instanceof LeavesBlock);
     }
 
     // Make sure the below method is only ever called once (by forge).

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -16,6 +16,7 @@ import com.mojang.blaze3d.vertex.SheetedDecalTextureGenerator;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.datafixers.util.Either;
 import com.mojang.math.Constants;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.FileUtil;
 import net.minecraft.client.Camera;
 import net.minecraft.client.KeyMapping;
@@ -76,7 +77,6 @@ import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.ChatTypeDecoration;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.PlayerChatMessage;
 import net.minecraft.network.chat.Style;
@@ -99,12 +99,13 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackLinkedSet;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.FogType;
@@ -153,8 +154,6 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.util.MutableHashedLinkedMap;
-import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.IExtensionPoint;
@@ -1250,6 +1249,11 @@ public class ForgeHooksClient
        } else {
            return Direction.getNearest(nX, nY, nZ);
        }
+    }
+
+    private static final Object2BooleanOpenHashMap<Block> LEAVES = new Object2BooleanOpenHashMap<>();
+    public static boolean isLeavesBlock(BlockState state) {
+        return LEAVES.computeIfAbsent(state.getBlock(), block -> block instanceof LeavesBlock);
     }
 
     // Make sure the below method is only ever called once (by forge).

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -243,6 +243,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
             private final ItemTransforms transforms;
             private TextureAtlasSprite particle;
             private RenderTypeGroup lastRenderTypes = RenderTypeGroup.EMPTY;
+            private RenderTypeGroup lastRenderTypesFast = RenderTypeGroup.EMPTY;
 
             private Builder(boolean isAmbientOcclusion, boolean isGui3d, boolean isSideLit, TextureAtlasSprite particle, ItemOverrides overrides, ItemTransforms transforms)
             {
@@ -256,27 +257,38 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
 
             public void addLayer(BakedModel model)
             {
-                flushQuads(null);
+                flushQuads(RenderTypeGroup.EMPTY);
                 children.add(model);
             }
 
             private void addLayer(RenderTypeGroup renderTypes, List<BakedQuad> quads)
             {
-                var modelBuilder = IModelBuilder.of(isAmbientOcclusion, isSideLit, isGui3d, transforms, overrides, particle, renderTypes);
+                this.addLayer(renderTypes, RenderTypeGroup.EMPTY, quads);
+            }
+
+            private void addLayer(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, List<BakedQuad> quads)
+            {
+                var modelBuilder = IModelBuilder.of(isAmbientOcclusion, isSideLit, isGui3d, transforms, overrides, particle, renderTypes, renderTypesFast);
                 quads.forEach(modelBuilder::addUnculledFace);
                 children.add(modelBuilder.build());
             }
 
             private void flushQuads(RenderTypeGroup renderTypes)
             {
+                this.flushQuads(renderTypes, RenderTypeGroup.EMPTY);
+            }
+
+            private void flushQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast)
+            {
                 if (!Objects.equals(renderTypes, lastRenderTypes))
                 {
                     if (quads.size() > 0)
                     {
-                        addLayer(lastRenderTypes, quads);
+                        addLayer(lastRenderTypes, lastRenderTypesFast, quads);
                         quads.clear();
                     }
                     lastRenderTypes = renderTypes;
+                    lastRenderTypesFast = renderTypesFast;
                 }
             }
 
@@ -288,14 +300,24 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
 
             public Builder addQuads(RenderTypeGroup renderTypes, BakedQuad... quadsToAdd)
             {
-                flushQuads(renderTypes);
+                return this.addQuads(renderTypes, RenderTypeGroup.EMPTY, quadsToAdd);
+            }
+
+            public Builder addQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, BakedQuad... quadsToAdd)
+            {
+                flushQuads(renderTypes, renderTypesFast);
                 Collections.addAll(quads, quadsToAdd);
                 return this;
             }
 
             public Builder addQuads(RenderTypeGroup renderTypes, Collection<BakedQuad> quadsToAdd)
             {
-                flushQuads(renderTypes);
+                return this.addQuads(renderTypes, RenderTypeGroup.EMPTY, quadsToAdd);
+            }
+
+            public Builder addQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, Collection<BakedQuad> quadsToAdd)
+            {
+                flushQuads(renderTypes, renderTypesFast);
                 quads.addAll(quadsToAdd);
                 return this;
             }
@@ -304,7 +326,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
             {
                 if (quads.size() > 0)
                 {
-                    addLayer(lastRenderTypes, quads);
+                    addLayer(lastRenderTypes, lastRenderTypesFast, quads);
                 }
                 var childrenBuilder = ImmutableMap.<String, BakedModel>builder();
                 var itemPassesBuilder = ImmutableList.<BakedModel>builder();

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -257,7 +257,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel>
 
             public void addLayer(BakedModel model)
             {
-                flushQuads(RenderTypeGroup.EMPTY);
+                flushQuads(RenderTypeGroup.EMPTY, RenderTypeGroup.EMPTY);
                 children.add(model);
             }
 

--- a/src/main/java/net/minecraftforge/client/model/EmptyModel.java
+++ b/src/main/java/net/minecraftforge/client/model/EmptyModel.java
@@ -63,7 +63,7 @@ public class EmptyModel extends SimpleUnbakedGeometry<EmptyModel>
 
         public Baked()
         {
-            super(List.of(), Map.of(), false, false, false, UnitTextureAtlasSprite.INSTANCE, ItemTransforms.NO_TRANSFORMS, ItemOverrides.EMPTY, RenderTypeGroup.EMPTY);
+            super(List.of(), Map.of(), false, false, false, UnitTextureAtlasSprite.INSTANCE, ItemTransforms.NO_TRANSFORMS, ItemOverrides.EMPTY, RenderTypeGroup.EMPTY, RenderTypeGroup.EMPTY);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/ExtendedBlockModelDeserializer.java
+++ b/src/main/java/net/minecraftforge/client/model/ExtendedBlockModelDeserializer.java
@@ -73,6 +73,12 @@ public class ExtendedBlockModelDeserializer extends BlockModel.Deserializer
             model.customData.setRenderTypeHint(new ResourceLocation(renderTypeHintName));
         }
 
+        if (jsonobject.has("render_type_fast"))
+        {
+            var renderTypeHintName = GsonHelper.getAsString(jsonobject, "render_type_fast");
+            model.customData.setRenderTypeFastHint(new ResourceLocation(renderTypeHintName));
+        }
+
         if (jsonobject.has("visibility"))
         {
             JsonObject visibility = GsonHelper.getAsJsonObject(jsonobject, "visibility");

--- a/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
@@ -35,6 +35,16 @@ public interface IModelBuilder<T extends IModelBuilder<T>>
     }
 
     /**
+     * Creates a new model builder that uses the provided attributes in the final baked model.
+     */
+    static IModelBuilder<?> of(boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,
+                               ItemTransforms transforms, ItemOverrides overrides, TextureAtlasSprite particle,
+                               RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast)
+    {
+        return new Simple(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, overrides, particle, renderTypes, renderTypesFast);
+    }
+
+    /**
      * Creates a new model builder that collects quads to the provided list, returning
      * {@linkplain EmptyModel#BAKED an empty model} if you call {@link #build()}.
      */
@@ -53,6 +63,7 @@ public interface IModelBuilder<T extends IModelBuilder<T>>
     {
         private final SimpleBakedModel.Builder builder;
         private final RenderTypeGroup renderTypes;
+        private final RenderTypeGroup renderTypesFast;
 
         private Simple(boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,
                        ItemTransforms transforms, ItemOverrides overrides, TextureAtlasSprite particle,
@@ -60,6 +71,16 @@ public interface IModelBuilder<T extends IModelBuilder<T>>
         {
             this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, overrides).particle(particle);
             this.renderTypes = renderTypes;
+            this.renderTypesFast = RenderTypeGroup.EMPTY;
+        }
+
+        private Simple(boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,
+                       ItemTransforms transforms, ItemOverrides overrides, TextureAtlasSprite particle,
+                       RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast)
+        {
+            this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, overrides).particle(particle);
+            this.renderTypes = renderTypes;
+            this.renderTypesFast = renderTypesFast;
         }
 
         @Override
@@ -80,7 +101,7 @@ public interface IModelBuilder<T extends IModelBuilder<T>>
         @Override
         public BakedModel build()
         {
-            return builder.build(renderTypes);
+            return builder.build(renderTypes, renderTypesFast);
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
@@ -69,9 +69,7 @@ public interface IModelBuilder<T extends IModelBuilder<T>>
                        ItemTransforms transforms, ItemOverrides overrides, TextureAtlasSprite particle,
                        RenderTypeGroup renderTypes)
         {
-            this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, overrides).particle(particle);
-            this.renderTypes = renderTypes;
-            this.renderTypesFast = RenderTypeGroup.EMPTY;
+            this(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, overrides, particle, renderTypes, RenderTypeGroup.EMPTY);
         }
 
         private Simple(boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -45,12 +45,22 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
     private ImmutableList<Material> textures;
     private final Int2ObjectMap<ForgeFaceData> layerData;
     private final Int2ObjectMap<ResourceLocation> renderTypeNames;
+    private final Int2ObjectMap<ResourceLocation> renderTypeNamesFast;
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ForgeFaceData> layerData, Int2ObjectMap<ResourceLocation> renderTypeNames)
     {
         this.textures = textures;
         this.layerData = layerData;
         this.renderTypeNames = renderTypeNames;
+        this.renderTypeNamesFast = new Int2ObjectOpenHashMap<>();
+    }
+
+    private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ForgeFaceData> layerData, Int2ObjectMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ResourceLocation> renderTypeNamesFast)
+    {
+        this.textures = textures;
+        this.layerData = layerData;
+        this.renderTypeNames = renderTypeNames;
+        this.renderTypeNamesFast = renderTypeNamesFast;
     }
 
     @Override
@@ -82,7 +92,9 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
             var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> sprite, modelState, modelLocation);
             var renderTypeName = renderTypeNames.get(i);
             var renderTypes = renderTypeName != null ? context.getRenderType(renderTypeName) : null;
-            builder.addQuads(renderTypes != null ? renderTypes : normalRenderTypes, quads);
+            var renderTypeNameFast = renderTypeNamesFast.get(i);
+            var renderTypesFast = renderTypeNameFast != null ? context.getRenderType(renderTypeNameFast) : null;
+            builder.addQuads(renderTypes != null ? renderTypes : normalRenderTypes, renderTypesFast != null ? renderTypesFast : RenderTypeGroup.EMPTY, quads);
         }
 
         return builder.build();
@@ -108,16 +120,34 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
                 }
             }
 
+            var renderTypeNamesFast = new Int2ObjectOpenHashMap<ResourceLocation>();
+            if (jsonObject.has("render_types_fast"))
+            {
+                var renderTypes = jsonObject.getAsJsonObject("render_types_fast");
+                for (Map.Entry<String, JsonElement> entry : renderTypes.entrySet())
+                {
+                    var renderType = new ResourceLocation(entry.getKey());
+                    for (var layer : entry.getValue().getAsJsonArray())
+                        if (renderTypeNamesFast.put(layer.getAsInt(), renderType) != null)
+                            throw new JsonParseException("Registered duplicate fast graphics render type for layer " + layer);
+                }
+            }
+
             var emissiveLayers = new Int2ObjectArrayMap<ForgeFaceData>();
             if(jsonObject.has("forge_data"))
             {
                 JsonObject forgeData = jsonObject.get("forge_data").getAsJsonObject();
-                readLayerData(forgeData, "layers", renderTypeNames, emissiveLayers, false);    
+                readLayerData(forgeData, "layers", renderTypeNames, renderTypeNamesFast, emissiveLayers, false);
             }
-            return new ItemLayerModel(null, emissiveLayers, renderTypeNames);
+            return new ItemLayerModel(null, emissiveLayers, renderTypeNames, renderTypeNamesFast);
         }
 
         protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning)
+        {
+            this.readLayerData(jsonObject, name, renderTypeNames, new Int2ObjectOpenHashMap<>(), layerData, logWarning);
+        }
+
+        protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNamesFast, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning)
         {
             if (!jsonObject.has(name))
             {

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -49,10 +49,7 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ForgeFaceData> layerData, Int2ObjectMap<ResourceLocation> renderTypeNames)
     {
-        this.textures = textures;
-        this.layerData = layerData;
-        this.renderTypeNames = renderTypeNames;
-        this.renderTypeNamesFast = new Int2ObjectOpenHashMap<>();
+        this(textures, layerData, renderTypeNames, new Int2ObjectOpenHashMap<>());
     }
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ForgeFaceData> layerData, Int2ObjectMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ResourceLocation> renderTypeNamesFast)
@@ -147,6 +144,7 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel>
             this.readLayerData(jsonObject, name, renderTypeNames, new Int2ObjectOpenHashMap<>(), layerData, logWarning);
         }
 
+        @Deprecated(forRemoval = true, since = "1.21.4")
         protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNamesFast, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning)
         {
             if (!jsonObject.has(name))

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -251,6 +251,42 @@ public abstract class BlockStateProvider implements DataProvider {
             models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType));
     }
 
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), renderType, renderTypeFast);
+    }
+
+    public void logBlockWithRenderTypeAndFast(RotatedPillarBlock block, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), extend(blockTexture(block), "_top"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation baseName, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, extend(baseName, "_side"), extend(baseName, "_end"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation side, ResourceLocation end, String renderType, String renderTypeFast) {
+        axisBlock(block,
+            models().cubeColumn(name(block), side, end).renderType(renderType, renderTypeFast),
+            models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType, renderTypeFast));
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), renderType, renderTypeFast);
+    }
+
+    public void logBlockWithRenderType(RotatedPillarBlock block, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), extend(blockTexture(block), "_top"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation baseName, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, extend(baseName, "_side"), extend(baseName, "_end"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation side, ResourceLocation end, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlock(block,
+            models().cubeColumn(name(block), side, end).renderType(renderType, renderTypeFast),
+            models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType, renderTypeFast));
+    }
+
     public void axisBlock(RotatedPillarBlock block, ModelFile vertical, ModelFile horizontal) {
         getVariantBuilder(block)
             .partialState().with(RotatedPillarBlock.AXIS, Axis.Y)
@@ -382,6 +418,38 @@ public abstract class BlockStateProvider implements DataProvider {
         stairsBlockInternalWithRenderType(block, name + "_stairs", side, bottom, top, renderType);
     }
 
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, name, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, key(block).toString(), side, bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, name + "_stairs", side, bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, name, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, key(block).toString(), side, bottom, top, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, name + "_stairs", side, bottom, top, renderType, renderTypeFast);
+    }
+
     private void stairsBlockInternal(StairBlock block, String baseName, ResourceLocation side, ResourceLocation bottom, ResourceLocation top) {
         ModelFile stairs = models().stairs(baseName, side, bottom, top);
         ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top);
@@ -393,6 +461,13 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile stairs = models().stairs(baseName, side, bottom, top).renderType(renderType);
         ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top).renderType(renderType);
         ModelFile stairsOuter = models().stairsOuter(baseName + "_outer", side, bottom, top).renderType(renderType);
+        stairsBlock(block, stairs, stairsInner, stairsOuter);
+    }
+
+    private void stairsBlockInternalWithRenderTypeAndFast(StairBlock block, String baseName, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile stairs = models().stairs(baseName, side, bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile stairsOuter = models().stairsOuter(baseName + "_outer", side, bottom, top).renderType(renderType, renderTypeFast);
         stairsBlock(block, stairs, stairsInner, stairsOuter);
     }
 
@@ -533,6 +608,32 @@ public abstract class BlockStateProvider implements DataProvider {
             models().fenceSide(name + "_fence_side", texture).renderType(renderType));
     }
 
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        String baseName = key(block).toString();
+        fourWayBlock(block,
+            models().fencePost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(baseName + "_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fourWayBlock(block,
+            models().fencePost(name + "_fence_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(name + "_fence_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        String baseName = key(block).toString();
+        fourWayBlock(block,
+            models().fencePost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(baseName + "_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fourWayBlock(block,
+            models().fencePost(name + "_fence_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(name + "_fence_side", texture).renderType(renderType, renderTypeFast));
+    }
+
     public void fenceGateBlock(FenceGateBlock block, ResourceLocation texture) {
         fenceGateBlockInternal(block, key(block).toString(), texture);
     }
@@ -557,6 +658,22 @@ public abstract class BlockStateProvider implements DataProvider {
         fenceGateBlockInternalWithRenderType(block, name + "_fence_gate", texture, renderType);
     }
 
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, name + "_fence_gate", texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, renderType, renderTypeFast);
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, name + "_fence_gate", texture, renderType, renderTypeFast);
+    }
+
     private void fenceGateBlockInternal(FenceGateBlock block, String baseName, ResourceLocation texture) {
         ModelFile gate = models().fenceGate(baseName, texture);
         ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture);
@@ -570,6 +687,14 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture).renderType(renderType);
         ModelFile gateWall = models().fenceGateWall(baseName + "_wall", texture).renderType(renderType);
         ModelFile gateWallOpen = models().fenceGateWallOpen(baseName + "_wall_open", texture).renderType(renderType);
+        fenceGateBlock(block, gate, gateOpen, gateWall, gateWallOpen);
+    }
+
+    private void fenceGateBlockInternalWithRenderTypeAndFast(FenceGateBlock block, String baseName, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile gate = models().fenceGate(baseName, texture).renderType(renderType, renderTypeFast);
+        ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast);
+        ModelFile gateWall = models().fenceGateWall(baseName + "_wall", texture).renderType(renderType, renderTypeFast);
+        ModelFile gateWallOpen = models().fenceGateWallOpen(baseName + "_wall_open", texture).renderType(renderType, renderTypeFast);
         fenceGateBlock(block, gate, gateOpen, gateWall, gateWallOpen);
     }
 
@@ -614,6 +739,22 @@ public abstract class BlockStateProvider implements DataProvider {
         wallBlockInternalWithRenderType(block, name + "_wall", texture, renderType);
     }
 
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, name + "_wall", texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, renderType, renderTypeFast);
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, name + "_wall", texture, renderType, renderTypeFast);
+    }
+
     private void wallBlockInternal(WallBlock block, String baseName, ResourceLocation texture) {
         wallBlock(block, models().wallPost(baseName + "_post", texture),
             models().wallSide(baseName + "_side", texture),
@@ -624,6 +765,12 @@ public abstract class BlockStateProvider implements DataProvider {
         wallBlock(block, models().wallPost(baseName + "_post", texture).renderType(renderType),
             models().wallSide(baseName + "_side", texture).renderType(renderType),
             models().wallSideTall(baseName + "_side_tall", texture).renderType(renderType));
+    }
+
+    private void wallBlockInternalWithRenderTypeAndFast(WallBlock block, String baseName, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlock(block, models().wallPost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().wallSide(baseName + "_side", texture).renderType(renderType, renderTypeFast),
+            models().wallSideTall(baseName + "_side_tall", texture).renderType(renderType, renderTypeFast));
     }
 
     public static final ImmutableMap<Direction, Property<WallSide>> WALL_PROPS = ImmutableMap.<Direction, Property<WallSide>>builder()
@@ -678,6 +825,22 @@ public abstract class BlockStateProvider implements DataProvider {
         paneBlockInternalWithRenderType(block, name + "_pane", pane, edge, renderType);
     }
 
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, ResourceLocation pane, ResourceLocation edge, String renderType, String renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, key(block).toString(), pane, edge, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, String name, ResourceLocation pane, ResourceLocation edge, String renderType, String renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, name + "_pane", pane, edge, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, key(block).toString(), pane, edge, renderType, renderTypeFast);
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, String name, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, name + "_pane", pane, edge, renderType, renderTypeFast);
+    }
+
     private void paneBlockInternal(IronBarsBlock block, String baseName, ResourceLocation pane, ResourceLocation edge) {
         ModelFile post = models().panePost(baseName + "_post", pane, edge);
         ModelFile side = models().paneSide(baseName + "_side", pane, edge);
@@ -693,6 +856,15 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile sideAlt = models().paneSideAlt(baseName + "_side_alt", pane, edge).renderType(renderType);
         ModelFile noSide = models().paneNoSide(baseName + "_noside", pane).renderType(renderType);
         ModelFile noSideAlt = models().paneNoSideAlt(baseName + "_noside_alt", pane).renderType(renderType);
+        paneBlock(block, post, side, sideAlt, noSide, noSideAlt);
+    }
+
+    private void paneBlockInternalWithRenderTypeAndFast(IronBarsBlock block, String baseName, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile post = models().panePost(baseName + "_post", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile side = models().paneSide(baseName + "_side", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile sideAlt = models().paneSideAlt(baseName + "_side_alt", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile noSide = models().paneNoSide(baseName + "_noside", pane).renderType(renderType, renderTypeFast);
+        ModelFile noSideAlt = models().paneNoSideAlt(baseName + "_noside_alt", pane).renderType(renderType, renderTypeFast);
         paneBlock(block, post, side, sideAlt, noSide, noSideAlt);
     }
 
@@ -735,6 +907,22 @@ public abstract class BlockStateProvider implements DataProvider {
         doorBlockInternalWithRenderType(block, name + "_door", bottom, top, renderType);
     }
 
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, String name, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, name + "_door", bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), bottom, top, renderType, renderTypeFast);
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, String name, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, name + "_door", bottom, top, renderType, renderTypeFast);
+    }
+
     private void doorBlockInternal(DoorBlock block, String baseName, ResourceLocation bottom, ResourceLocation top) {
         ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom_left", bottom, top);
         ModelFile bottomLeftOpen = models().doorBottomLeftOpen(baseName + "_bottom_left_open", bottom, top);
@@ -756,6 +944,18 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile topLeftOpen = models().doorTopLeftOpen(baseName + "_top_left_open", bottom, top).renderType(renderType);
         ModelFile topRight = models().doorTopRight(baseName + "_top_right", bottom, top).renderType(renderType);
         ModelFile topRightOpen = models().doorTopRightOpen(baseName + "_top_right_open", bottom, top).renderType(renderType);
+        doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
+    }
+
+    private void doorBlockInternalWithRenderTypeAndFast(DoorBlock block, String baseName, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom_left", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomLeftOpen = models().doorBottomLeftOpen(baseName + "_bottom_left_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomRight = models().doorBottomRight(baseName + "_bottom_right", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomRightOpen = models().doorBottomRightOpen(baseName + "_bottom_right_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topLeft = models().doorTopLeft(baseName + "_top_left", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topLeftOpen = models().doorTopLeftOpen(baseName + "_top_left_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topRight = models().doorTopRight(baseName + "_top_right", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topRightOpen = models().doorTopRightOpen(baseName + "_top_right_open", bottom, top).renderType(renderType, renderTypeFast);
         doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
     }
 
@@ -825,6 +1025,22 @@ public abstract class BlockStateProvider implements DataProvider {
         trapdoorBlockInternalWithRenderType(block, name + "_trapdoor", texture, orientable, renderType);
     }
 
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, ResourceLocation texture, boolean orientable, String renderType, String renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, orientable, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, String name, ResourceLocation texture, boolean orientable, String renderType, String renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, name + "_trapdoor", texture, orientable, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, orientable, renderType, renderTypeFast);
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, String name, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, name + "_trapdoor", texture, orientable, renderType, renderTypeFast);
+    }
+
     private void trapdoorBlockInternal(TrapDoorBlock block, String baseName, ResourceLocation texture, boolean orientable) {
         ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture) : models().trapdoorBottom(baseName + "_bottom", texture);
         ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture) : models().trapdoorTop(baseName + "_top", texture);
@@ -836,6 +1052,13 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture).renderType(renderType) : models().trapdoorBottom(baseName + "_bottom", texture).renderType(renderType);
         ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture).renderType(renderType) : models().trapdoorTop(baseName + "_top", texture).renderType(renderType);
         ModelFile open = orientable ? models().trapdoorOrientableOpen(baseName + "_open", texture).renderType(renderType) : models().trapdoorOpen(baseName + "_open", texture).renderType(renderType);
+        trapdoorBlock(block, bottom, top, open, orientable);
+    }
+
+    private void trapdoorBlockInternalWithRenderTypeAndFast(TrapDoorBlock block, String baseName, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture).renderType(renderType, renderTypeFast) : models().trapdoorBottom(baseName + "_bottom", texture).renderType(renderType, renderTypeFast);
+        ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture).renderType(renderType, renderTypeFast) : models().trapdoorTop(baseName + "_top", texture).renderType(renderType, renderTypeFast);
+        ModelFile open = orientable ? models().trapdoorOrientableOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast) : models().trapdoorOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast);
         trapdoorBlock(block, bottom, top, open, orientable);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -60,6 +60,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     protected final ExistingFileHelper existingFileHelper;
 
     protected String renderType = null;
+    protected String renderTypeFast = null;
     protected boolean ambientOcclusion = true;
     protected GuiLight guiLight = null;
 
@@ -161,6 +162,12 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         return renderType(new ResourceLocation(renderType));
     }
 
+    public T renderType(String renderType, String renderTypeFast) {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Render type for fast graphics must not be null");
+        return renderType(new ResourceLocation(renderType), new ResourceLocation(renderTypeFast));
+    }
+
     /**
      * Set the render type for this model.
      *
@@ -172,6 +179,14 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     public T renderType(ResourceLocation renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         this.renderType = renderType.toString();
+        return self();
+    }
+
+    public T renderType(ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Render type for fast graphics must not be null");
+        this.renderType = renderType.toString();
+        this.renderTypeFast = renderTypeFast.toString();
         return self();
     }
 
@@ -254,6 +269,10 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
 
         if (this.renderType != null) {
             root.addProperty("render_type", this.renderType);
+        }
+
+        if (this.renderTypeFast != null) {
+            root.addProperty("render_type_fast", this.renderTypeFast);
         }
 
         Map<ItemDisplayContext, ItemTransform> transforms = this.transforms.build();

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -179,6 +179,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     public T renderType(ResourceLocation renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         this.renderType = renderType.toString();
+        this.renderTypeFast = null;
         return self();
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -150,18 +150,33 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     /**
-     * Set the render type for this model.
+     * Set the render type for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     * <p>
+     * Consider using {@linkplain #renderType(String, String)} if you need to set a render type for
+     * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
      *
-     * @param renderType the render type. Must be registered via
-     *                   {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent}
+     * @param renderType the render type
      * @return this builder
-     * @throws NullPointerException  if {@code renderType} is {@code null}
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     * @see #renderType(String, String)
      */
     public T renderType(String renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         return renderType(new ResourceLocation(renderType));
     }
 
+    /**
+     * Set the render types for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     *
+     * @param renderType     the render type for {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics}
+     * @param renderTypeFast the render type for {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}
+     * @return this builder
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     */
     public T renderType(String renderType, String renderTypeFast) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         Preconditions.checkNotNull(renderTypeFast, "Render type for fast graphics must not be null");
@@ -169,12 +184,17 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     /**
-     * Set the render type for this model.
+     * Set the render type for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     * <p>
+     * Consider using {@linkplain #renderType(ResourceLocation, ResourceLocation)} if you need to set a render type for
+     * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
      *
-     * @param renderType the render type. Must be registered via
-     *                   {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent}
+     * @param renderType the render type
      * @return this builder
-     * @throws NullPointerException  if {@code renderType} is {@code null}
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     * @see #renderType(ResourceLocation, ResourceLocation)
      */
     public T renderType(ResourceLocation renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
@@ -183,6 +203,16 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         return self();
     }
 
+    /**
+     * Set the render types for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     *
+     * @param renderType     the render type for {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics}
+     * @param renderTypeFast the render type for {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}
+     * @return this builder
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     */
     public T renderType(ResourceLocation renderType, ResourceLocation renderTypeFast) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         Preconditions.checkNotNull(renderTypeFast, "Render type for fast graphics must not be null");

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -369,7 +369,8 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataPr
     }
 
     public T leaves(String name, ResourceLocation texture) {
-        return singleTexture(name, BLOCK_FOLDER + "/leaves", "all", texture);
+        return singleTexture(name, BLOCK_FOLDER + "/leaves", "all", texture)
+            .renderType("cutout_mipped", "solid");
     }
 
     /**

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -33,6 +33,7 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
 
     private final Int2ObjectMap<ForgeFaceData> faceData = new Int2ObjectOpenHashMap<>();
     private final Map<ResourceLocation, IntSet> renderTypes = new LinkedHashMap<>();
+    private final Map<ResourceLocation, IntSet> renderTypesFast = new LinkedHashMap<>();
     private final IntSet layersWithRenderTypes = new IntOpenHashSet();
 
     protected ItemLayerModelBuilder(T parent, ExistingFileHelper existingFileHelper)
@@ -115,6 +116,23 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         return renderType(asLoc, layers);
     }
 
+    public ItemLayerModelBuilder<T> renderType(String renderType, String renderTypeFast, int... layers)
+    {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");
+        ResourceLocation asLoc;
+        if (renderType.contains(":"))
+            asLoc = new ResourceLocation(renderType);
+        else
+            asLoc = new ResourceLocation(parent.getLocation().getNamespace(), renderType);
+        ResourceLocation asLocFast;
+        if (renderTypeFast.contains(":"))
+            asLocFast = new ResourceLocation(renderTypeFast);
+        else
+            asLocFast = new ResourceLocation(parent.getLocation().getNamespace(), renderTypeFast);
+        return renderType(asLoc, asLocFast, layers);
+    }
+
     /**
      * Set the render type for a set of layers.
      *
@@ -144,6 +162,25 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         return this;
     }
 
+    public ItemLayerModelBuilder<T> renderType(ResourceLocation renderType, ResourceLocation renderTypeFast, int... layers)
+    {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");
+        Preconditions.checkNotNull(layers, "Layers must not be null");
+        Preconditions.checkArgument(layers.length > 0, "At least one layer must be specified");
+        Preconditions.checkArgument(Arrays.stream(layers).allMatch(i -> i >= 0), "All layers must be >= 0");
+        var alreadyAssigned = Arrays.stream(layers).filter(layersWithRenderTypes::contains).toArray();
+        Preconditions.checkArgument(alreadyAssigned.length == 0, "Attempted to re-assign layer render types: " + Arrays.toString(alreadyAssigned));
+        var renderTypeLayers = renderTypes.computeIfAbsent(renderType, $ -> new IntOpenHashSet());
+        var renderTypeFastLayers = renderTypesFast.computeIfAbsent(renderType, $ -> new IntOpenHashSet());
+        Arrays.stream(layers).forEach(layer -> {
+            renderTypeLayers.add(layer);
+            renderTypeFastLayers.add(layer);
+            layersWithRenderTypes.add(layer);
+        });
+        return this;
+    }
+
     @Override
     public JsonObject toJson(JsonObject json)
     {
@@ -167,6 +204,14 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
             renderTypes.add(renderType.toString(), array);
         });
         json.add("render_types", renderTypes);
+
+        JsonObject renderTypesFast = new JsonObject();
+        this.renderTypesFast.forEach((renderType, layers) -> {
+            JsonArray array = new JsonArray();
+            layers.intStream().sorted().forEach(array::add);
+            renderTypesFast.add(renderType.toString(), array);
+        });
+        json.add("render_types_fast", renderTypesFast);
 
         return json;
     }

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -206,10 +206,10 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         json.add("render_types", renderTypes);
 
         JsonObject renderTypesFast = new JsonObject();
-        this.renderTypesFast.forEach((renderType, layers) -> {
+        this.renderTypesFast.forEach((renderTypeFast, layers) -> {
             JsonArray array = new JsonArray();
             layers.intStream().sorted().forEach(array::add);
-            renderTypesFast.add(renderType.toString(), array);
+            renderTypesFast.add(renderTypeFast.toString(), array);
         });
         json.add("render_types_fast", renderTypesFast);
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
@@ -41,6 +41,8 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
     private Transformation rootTransform;
     @Nullable
     private ResourceLocation renderTypeHint;
+    @Nullable
+    private ResourceLocation renderTypeFastHint;
     private boolean gui3d = true;
 
     @ApiStatus.Internal
@@ -137,9 +139,23 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
         return owner.parent != null ? owner.parent.customData.getRenderTypeHint() : null;
     }
 
+    @Nullable
+    @Override
+    public ResourceLocation getRenderTypeFastHint()
+    {
+        if (renderTypeFastHint != null)
+            return renderTypeFastHint;
+        return owner.parent != null ? owner.parent.customData.getRenderTypeFastHint() : null;
+    }
+
     public void setRenderTypeHint(ResourceLocation renderTypeHint)
     {
         this.renderTypeHint = renderTypeHint;
+    }
+
+    public void setRenderTypeFastHint(ResourceLocation renderTypeFastHint)
+    {
+        this.renderTypeFastHint = renderTypeFastHint;
     }
 
     public void setGui3d(boolean gui3d)
@@ -153,6 +169,7 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext
         this.rootTransform = other.rootTransform;
         this.visibilityData.copyFrom(other.visibilityData);
         this.renderTypeHint = other.renderTypeHint;
+        this.renderTypeFastHint = other.renderTypeFastHint;
         this.gui3d = other.gui3d;
     }
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/IGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IGeometryBakingContext.java
@@ -76,6 +76,13 @@ public interface IGeometryBakingContext
     ResourceLocation getRenderTypeHint();
 
     /**
+     * @return a hint of the render type this model should use while using the
+     * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics status}. Custom loaders may ignore this.
+     */
+    @Nullable
+    default ResourceLocation getRenderTypeFastHint() { return null; }
+
+    /**
      * Queries the visibility of a component of this model.
      *
      * @param component The component for which to query visibility

--- a/src/main/java/net/minecraftforge/client/model/geometry/SimpleUnbakedGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/SimpleUnbakedGeometry.java
@@ -30,8 +30,10 @@ public abstract class SimpleUnbakedGeometry<T extends SimpleUnbakedGeometry<T>> 
 
         var renderTypeHint = context.getRenderTypeHint();
         var renderTypes = renderTypeHint != null ? context.getRenderType(renderTypeHint) : RenderTypeGroup.EMPTY;
+        var renderTypeFastHint = context.getRenderTypeFastHint();
+        var renderTypesFast = renderTypeFastHint != null ? context.getRenderType(renderTypeFastHint) : RenderTypeGroup.EMPTY;
         IModelBuilder<?> builder = IModelBuilder.of(context.useAmbientOcclusion(), context.useBlockLight(), context.isGui3d(),
-                context.getTransforms(), overrides, particle, renderTypes);
+                context.getTransforms(), overrides, particle, renderTypes, renderTypesFast);
 
         addQuads(context, builder, baker, spriteGetter, modelState, modelLocation);
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/StandaloneGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/StandaloneGeometryBakingContext.java
@@ -54,6 +54,8 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
     private final Transformation rootTransform;
     @Nullable
     private final ResourceLocation renderTypeHint;
+    @Nullable
+    private final ResourceLocation renderTypeFastHint;
     private final BiPredicate<String, Boolean> visibilityTest;
 
     private StandaloneGeometryBakingContext(ResourceLocation modelName, Predicate<String> materialCheck,
@@ -72,6 +74,28 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
         this.transforms = transforms;
         this.rootTransform = rootTransform;
         this.renderTypeHint = renderTypeHint;
+        this.renderTypeFastHint = null;
+        this.visibilityTest = visibilityTest;
+    }
+
+    private StandaloneGeometryBakingContext(ResourceLocation modelName, Predicate<String> materialCheck,
+                                            Function<String, Material> materialLookup, boolean isGui3d,
+                                            boolean useBlockLight, boolean useAmbientOcclusion,
+                                            ItemTransforms transforms, Transformation rootTransform,
+                                            @Nullable ResourceLocation renderTypeHint,
+                                            @Nullable ResourceLocation renderTypeFastHint,
+                                            BiPredicate<String, Boolean> visibilityTest)
+    {
+        this.modelName = modelName;
+        this.materialCheck = materialCheck;
+        this.materialLookup = materialLookup;
+        this.isGui3d = isGui3d;
+        this.useBlockLight = useBlockLight;
+        this.useAmbientOcclusion = useAmbientOcclusion;
+        this.transforms = transforms;
+        this.rootTransform = rootTransform;
+        this.renderTypeHint = renderTypeHint;
+        this.renderTypeFastHint = renderTypeFastHint;
         this.visibilityTest = visibilityTest;
     }
 
@@ -130,6 +154,13 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
         return renderTypeHint;
     }
 
+    @Nullable
+    @Override
+    public ResourceLocation getRenderTypeFastHint()
+    {
+        return renderTypeFastHint;
+    }
+
     @Override
     public boolean isComponentVisible(String component, boolean fallback)
     {
@@ -158,6 +189,8 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
         private Transformation rootTransform = Transformation.identity();
         @Nullable
         private ResourceLocation renderTypeHint;
+        @Nullable
+        private ResourceLocation renderTypeFastHint;
         private BiPredicate<String, Boolean> visibilityTest = (c, def) -> def;
 
         private Builder()
@@ -174,6 +207,7 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
             this.transforms = parent.getTransforms();
             this.rootTransform = parent.getRootTransform();
             this.renderTypeHint = parent.getRenderTypeHint();
+            this.renderTypeFastHint = parent.getRenderTypeFastHint();
             this.visibilityTest = parent::isComponentVisible;
         }
 
@@ -232,6 +266,13 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
             return this;
         }
 
+        public Builder withRenderTypeHint(ResourceLocation renderTypeHint, ResourceLocation renderTypeFastHint)
+        {
+            this.renderTypeHint = renderTypeHint;
+            this.renderTypeFastHint = renderTypeFastHint;
+            return this;
+        }
+
         public Builder withVisibleComponents(Object2BooleanMap<String> parts)
         {
             this.visibilityTest = parts::getOrDefault;
@@ -240,7 +281,7 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext
 
         public StandaloneGeometryBakingContext build(ResourceLocation modelName)
         {
-            return new StandaloneGeometryBakingContext(modelName, materialCheck, materialLookup, isGui3d, useBlockLight, useAmbientOcclusion, transforms, rootTransform, renderTypeHint, visibilityTest);
+            return new StandaloneGeometryBakingContext(modelName, materialCheck, materialLookup, isGui3d, useBlockLight, useAmbientOcclusion, transforms, rootTransform, renderTypeHint, renderTypeFastHint, visibilityTest);
         }
     }
 }


### PR DESCRIPTION
- Backport of #10394 to 1.20.1.
  - The description that was originally posted in this PR can be found there.
- Fixes #10389 for 1.20.1.