### PR TITLE
[1.21.4] Add fast graphics render type to block models

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -34,21 +34,26 @@
      public static RenderType getMovingBlockRenderType(BlockState p_109294_) {
          Block block = p_109294_.getBlock();
          if (block instanceof LeavesBlock) {
-@@ -376,6 +_,8 @@
+@@ -376,11 +_,14 @@
          }
      }
  
-+    /** @deprecated Forge: Use {@link net.minecraftforge.client.RenderTypeHelper#getEntityRenderType(RenderType, boolean)} while iterating through {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
++    /** @deprecated Forge: Use {@link net.minecraftforge.client.RenderTypeHelper#getEntityRenderType(RenderType)} while iterating through {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
 +    @Deprecated // Note: this method does NOT support model-based render types
      public static RenderType getRenderType(BlockState p_364446_) {
          RenderType rendertype = getChunkRenderType(p_364446_);
          return rendertype == RenderType.translucent() ? Sheets.translucentItemSheet() : Sheets.cutoutBlockSheet();
+     }
+ 
++    /* Forge: Use {@link net.minecraft.client.resources.model.BakedModel#getRenderPasses(ItemStack, boolean)} and {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(ItemStack, boolean)}. */
+     public static RenderType getRenderType(ItemStack p_363859_) {
+         if (p_363859_.getItem() instanceof BlockItem blockitem) {
+             Block block = blockitem.getBlock();
 @@ -390,12 +_,81 @@
          }
      }
  
-+    /** @deprecated Forge: Use {@link net.minecraft.client.resources.model.BakedModel#getRenderPasses(ItemStack, boolean)} and {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(ItemStack, boolean)}. */
-+    @Deprecated // Note: this method does NOT support model-based render types
++    // Note: this method does NOT support model-based render types
      public static RenderType getRenderLayer(FluidState p_109288_) {
 -        RenderType rendertype = TYPE_BY_FLUID.get(p_109288_.getType());
 +        RenderType rendertype = FLUID_RENDER_TYPES.get(net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(p_109288_.getType()));
@@ -59,6 +64,7 @@
          renderCutout = p_109292_;
 +    }
 +
++    /** Forge: Check if we are running in {@linkplain net.minecraft.client.Minecraft#useFancyGraphics() fancy graphics} to account for fast graphics render types */
 +    public static boolean isFancy() {
 +        return renderCutout;
 +    }
@@ -79,7 +85,7 @@
 +    });
 +
 +    /** @deprecated Use {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
-+    //@Deprecated(since = "1.19", forRemoval = true)
++    @Deprecated(since = "1.19")
 +    public static net.minecraftforge.client.ChunkRenderTypeSet getRenderLayers(BlockState state) {
 +       Block block = state.getBlock();
 +       if (block instanceof LeavesBlock) {
@@ -90,20 +96,20 @@
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    //@Deprecated(since = "1.19", forRemoval = true)
++    @Deprecated(since = "1.19")
 +    public static void setRenderLayer(Block block, RenderType type) {
 +       com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +       setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    //@Deprecated(since = "1.19", forRemoval = true)
++    @Deprecated(since = "1.19")
 +    public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +       setRenderLayer(block, createSetFromPredicate(predicate));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    //@Deprecated(since = "1.19", forRemoval = true)
++    @Deprecated(since = "1.19")
 +    public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +       checkClientLoading();
 +       BLOCK_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), layers);

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -43,7 +43,7 @@
      public static RenderType getRenderType(BlockState p_364446_) {
          RenderType rendertype = getChunkRenderType(p_364446_);
          return rendertype == RenderType.translucent() ? Sheets.translucentItemSheet() : Sheets.cutoutBlockSheet();
-@@ -390,12 +_,77 @@
+@@ -390,12 +_,81 @@
          }
      }
  
@@ -57,6 +57,10 @@
  
      public static void setFancy(boolean p_109292_) {
          renderCutout = p_109292_;
++    }
++
++    public static boolean isFancy() {
++        return renderCutout;
 +    }
 +
 +    private static final net.minecraftforge.client.ChunkRenderTypeSet CUTOUT_MIPPED = net.minecraftforge.client.ChunkRenderTypeSet.of(RenderType.cutoutMipped());

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -85,7 +85,7 @@
 +    });
 +
 +    /** @deprecated Use {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
-+    @Deprecated(forRemoval = true, since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public static net.minecraftforge.client.ChunkRenderTypeSet getRenderLayers(BlockState state) {
 +       Block block = state.getBlock();
 +       if (block instanceof LeavesBlock) {
@@ -96,20 +96,20 @@
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(forRemoval = true, since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public static void setRenderLayer(Block block, RenderType type) {
 +       com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +       setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(forRemoval = true, since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +       setRenderLayer(block, createSetFromPredicate(predicate));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(forRemoval = true, since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +       checkClientLoading();
 +       BLOCK_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), layers);

--- a/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemBlockRenderTypes.java.patch
@@ -85,7 +85,7 @@
 +    });
 +
 +    /** @deprecated Use {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)}. */
-+    @Deprecated(since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.19")
 +    public static net.minecraftforge.client.ChunkRenderTypeSet getRenderLayers(BlockState state) {
 +       Block block = state.getBlock();
 +       if (block instanceof LeavesBlock) {
@@ -96,20 +96,20 @@
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.19")
 +    public static void setRenderLayer(Block block, RenderType type) {
 +       com.google.common.base.Preconditions.checkArgument(type.getChunkLayerId() >= 0, "The argument must be a valid chunk render type returned by RenderType#chunkBufferLayers().");
 +       setRenderLayer(block, net.minecraftforge.client.ChunkRenderTypeSet.of(type));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.19")
 +    public static synchronized void setRenderLayer(Block block, java.util.function.Predicate<RenderType> predicate) {
 +       setRenderLayer(block, createSetFromPredicate(predicate));
 +    }
 +
 +    /** @deprecated Set your render type in your block model's JSON (eg. {@code "render_type": "cutout"}) or override {@link net.minecraft.client.resources.model.BakedModel#getRenderTypes(BlockState, net.minecraft.util.RandomSource, net.minecraftforge.client.model.data.ModelData)} */
-+    @Deprecated(since = "1.19")
++    @Deprecated(forRemoval = true, since = "1.19")
 +    public static synchronized void setRenderLayer(Block block, net.minecraftforge.client.ChunkRenderTypeSet layers) {
 +       checkClientLoading();
 +       BLOCK_RENDER_TYPES.put(net.minecraftforge.registries.ForgeRegistries.BLOCKS.getDelegateOrThrow(block), layers);

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockModel.java.patch
@@ -24,13 +24,13 @@
 +        if (this.customData.getCustomGeometry() != null)
 +            return this.customData.getCustomGeometry().bake(customData, p_378458_, p_378598_, p_111453_);
 +
-+        var wrapped = net.minecraftforge.client.ForgeHooksClient.wrapRenderType(p_378458_, this.customData.getRenderType());
++        var wrapped = net.minecraftforge.client.ForgeHooksClient.wrapRenderType(p_378458_, this.customData.getRenderType(), this.customData.getRenderTypeFast());
 +
          return this.elements.isEmpty() && this.parent != null
 -            ? this.parent.bake(p_378598_, p_378458_, p_111453_, p_111455_, p_377435_, p_378085_)
 -            : SimpleBakedModel.bakeElements(this.elements, p_378598_, p_378458_.sprites(), p_111453_, p_111455_, p_377435_, true, p_378085_);
 +            ? this.parent.bake(p_378598_, wrapped, p_111453_, p_111455_, p_377435_, p_378085_)
-+            : SimpleBakedModel.bakeElements(this.elements, p_378598_, p_378458_.sprites(), p_111453_, p_111455_, p_377435_, true, p_378085_, wrapped.renderType());
++            : SimpleBakedModel.bakeElements(this.elements, p_378598_, p_378458_.sprites(), p_111453_, p_111455_, p_377435_, true, p_378085_, wrapped.renderType(), wrapped.renderTypeFast());
      }
  
      @Nullable

--- a/patches/minecraft/net/minecraft/client/resources/model/ModelBaker.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelBaker.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/resources/model/ModelBaker.java
 +++ b/net/minecraft/client/resources/model/ModelBaker.java
-@@ -13,4 +_,10 @@
+@@ -13,4 +_,15 @@
  
      @VisibleForDebug
      ModelDebugName rootName();
@@ -8,6 +8,11 @@
 +    /** Forge: Return the render type to use when baking this model, its a dirty hack to pass down this value to parents */
 +    @org.jetbrains.annotations.Nullable
 +    default net.minecraftforge.client.RenderTypeGroup renderType() {
++        return null;
++    }
++
++    @org.jetbrains.annotations.Nullable
++    default net.minecraftforge.client.RenderTypeGroup renderTypeFast() {
 +        return null;
 +    }
  }

--- a/patches/minecraft/net/minecraft/client/resources/model/ModelBaker.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelBaker.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/resources/model/ModelBaker.java
 +++ b/net/minecraft/client/resources/model/ModelBaker.java
-@@ -13,4 +_,15 @@
+@@ -13,4 +_,16 @@
  
      @VisibleForDebug
      ModelDebugName rootName();
@@ -11,6 +11,7 @@
 +        return null;
 +    }
 +
++    /** Forge: Return the fast graphics render type to use when baking this model, its a dirty hack to pass down this value to parents */
 +    @org.jetbrains.annotations.Nullable
 +    default net.minecraftforge.client.RenderTypeGroup renderTypeFast() {
 +        return null;

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,15 +1,23 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -29,6 +_,25 @@
+@@ -29,7 +_,33 @@
      private final boolean usesBlockLight;
      private final TextureAtlasSprite particleIcon;
      private final ItemTransforms transforms;
+-
++    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} */
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
++    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fast graphics} */
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
 +    /*
++    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} * /
 +    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
++    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} * /
++    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypesFast;
++    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FABULOUS fabulous graphics} * /
 +    protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
 +    */
++    /** Forge: If this model's {@linkplain #blockRenderTypes block render types} are rendering cutout, to account for older leaves model JSONs */
 +    protected final boolean isRenderingCutout;
 +
 +    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
@@ -18,14 +26,15 @@
 +        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +    }
 +
-+    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
-+    @Deprecated
++    /** Forge: Consider using {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup for fast graphics} **/
 +    public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
 +        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +    }
- 
++
++    /** Constructor with {@link net.minecraftforge.client.RenderTypeGroup RenderTypeGroup} for fancy and fast graphics. Preferred over {@link net.minecraft.client.renderer.ItemBlockRenderTypes#setRenderLayer(net.minecraft.world.level.block.Block, net.minecraft.client.renderer.RenderType) ItemBlockRenderTypes.setRenderLayer(Block, RenderType)}. */
      public SimpleBakedModel(
          List<BakedQuad> p_119489_,
+         Map<Direction, List<BakedQuad>> p_119490_,
 @@ -37,7 +_,9 @@
          boolean p_119492_,
          boolean p_119493_,
@@ -37,7 +46,7 @@
      ) {
          this.unculledFaces = p_119489_;
          this.culledFaces = p_119490_;
-@@ -46,6 +_,24 @@
+@@ -46,6 +_,25 @@
          this.usesBlockLight = p_119492_;
          this.particleIcon = p_119494_;
          this.transforms = p_119495_;
@@ -48,6 +57,7 @@
 +        this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
 +        /*
 +        this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
++        this.itemRenderTypesFast = hasRenderTypesFast ? List.of(renderTypesFast.entity()) : null;
 +        this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
 +        */
 +        this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.cutout() || renderTypes.block() == net.minecraft.client.renderer.RenderType.cutoutMipped());
@@ -77,8 +87,8 @@
              }
          }
  
-+        if (renderType != null) {
-+            if (renderTypeFast != null)
++        if (renderType != null && !renderType.isEmpty()) {
++            if (renderTypeFast != null && !renderTypeFast.isEmpty())
 +                simplebakedmodel$builder.renderTypes(renderType, renderTypeFast);
 +            else
 +                simplebakedmodel$builder.renderTypes(renderType);
@@ -87,11 +97,12 @@
          return simplebakedmodel$builder.build();
      }
  
-@@ -123,6 +_,35 @@
+@@ -123,6 +_,41 @@
          return this.transforms;
      }
  
 +    private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID_BLOCK = net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.solid());
++    //private static final List<net.minecraft.client.renderer.RenderType> SOLID_BLOCK_ITEM = List.of(net.minecraft.client.renderer.RenderType.solid());
 +
 +    @Override
 +    public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(BlockState state, RandomSource rand, net.minecraftforge.client.model.data.ModelData data) {
@@ -107,34 +118,61 @@
 +    /*
 +    @Override
 +    public List<net.minecraft.client.renderer.RenderType> getRenderTypes(net.minecraft.world.item.ItemStack itemStack, boolean fabulous) {
-+       if (!fabulous) {
-+          if (itemRenderTypes != null) {
-+              return itemRenderTypes;
-+          }
-+       } else {
-+          if (fabulousItemRenderTypes != null) {
-+              return fabulousItemRenderTypes;
-+          }
-+       }
-+       return BakedModel.super.getRenderTypes(itemStack, fabulous);
++        if (!fabulous) {
++            if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
++                if (itemRenderTypesFast != null)
++                    return itemRenderTypesFast;
++                if (isRenderingCutout && itemStack.getItem() instanceof net.minecraft.world.item.BlockItem blockItem && blockItem.getBlock() instanceof net.minecraft.world.level.block.LeavesBlock)
++                    return SOLID_BLOCK_ITEM;
++            }
++            if (itemRenderTypes != null)
++                return itemRenderTypes;
++        } else {
++            if (fabulousItemRenderTypes != null) {
++                return fabulousItemRenderTypes;
++            }
++        }
++        return BakedModel.super.getRenderTypes(itemStack, fabulous);
 +    }
 +    */
 +
      @OnlyIn(Dist.CLIENT)
      public static class Builder {
          private final ImmutableList.Builder<BakedQuad> unculledFaces = ImmutableList.builder();
-@@ -164,13 +_,27 @@
+@@ -164,13 +_,50 @@
              return this;
          }
  
 +        private net.minecraftforge.client.RenderTypeGroup renderTypes = net.minecraftforge.client.RenderTypeGroup.EMPTY;
 +        private net.minecraftforge.client.RenderTypeGroup renderTypesFast = net.minecraftforge.client.RenderTypeGroup.EMPTY;
 +
++        /**
++         * Sets the render type to be used for this model, and will be used for any graphics setting.
++         * <p>
++         * If you need to set a specific render type for
++         * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}, consider using
++         * {@link #renderTypes(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup)
++         * renderTypes(RenderTypeGroup, RenderTypeGroup)} instead which allows choosing render types for both fancy and
++         * fast graphics.
++         *
++         * @apiNote If this model is for {@linkplain net.minecraft.world.level.block.LeavesBlock leaves} and if the
++         * given render type is either {@linkplain net.minecraft.client.renderer.RenderType#cutout() cutout} or
++         * {@linkplain net.minecraft.client.renderer.RenderType#cutoutMipped() cutout mipped}, it will be overridden
++         * with {@linkplain net.minecraft.client.renderer.RenderType#solid() solid} when fast graphics is enabled.
++         * @see #renderTypes(net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup)
++         * renderTypes(RenderTypeGroup, RenderTypeGroup)
++         */
 +        public SimpleBakedModel.Builder renderTypes(net.minecraftforge.client.RenderTypeGroup renderTypes) {
-+            this.renderTypes = renderTypes;
-+            return this;
++            return this.renderTypes(renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +        }
 +
++        /**
++         * Sets the render types to be used for this model: one for
++         * {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} and one for
++         * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
++         *
++         * @see #renderTypes(net.minecraftforge.client.RenderTypeGroup)
++         */
 +        public SimpleBakedModel.Builder renderTypes(net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
 +            this.renderTypes = renderTypes;
 +            this.renderTypesFast = renderTypesFast;
@@ -148,6 +186,7 @@
                  Map<Direction, List<BakedQuad>> map = Maps.transformValues(this.culledFaces, ImmutableList.Builder::build);
                  return new SimpleBakedModel(
 -                    this.unculledFaces.build(), new EnumMap<>(map), this.hasAmbientOcclusion, this.usesBlockLight, this.isGui3d, this.particleIcon, this.transforms
++                    // Forge: Account for render types in model JSONs
 +                    this.unculledFaces.build(), new EnumMap<>(map), this.hasAmbientOcclusion, this.usesBlockLight, this.isGui3d, this.particleIcon, this.transforms, this.renderTypes, this.renderTypesFast
                  );
              }

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,41 +1,51 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -29,6 +_,18 @@
+@@ -29,6 +_,25 @@
      private final boolean usesBlockLight;
      private final TextureAtlasSprite particleIcon;
      private final ItemTransforms transforms;
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
++    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
 +    /*
 +    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
 +    protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
 +    */
 +    protected final boolean isRenderingCutout;
 +
-+    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
 +    @Deprecated
 +    public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_) {
 +        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +    }
++
++    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
++    @Deprecated
++    public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
++        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
++    }
  
      public SimpleBakedModel(
          List<BakedQuad> p_119489_,
-@@ -37,7 +_,8 @@
+@@ -37,7 +_,9 @@
          boolean p_119492_,
          boolean p_119493_,
          TextureAtlasSprite p_119494_,
 -        ItemTransforms p_119495_
 +        ItemTransforms p_119495_,
-+        net.minecraftforge.client.RenderTypeGroup renderTypes
++        net.minecraftforge.client.RenderTypeGroup renderTypes,
++        net.minecraftforge.client.RenderTypeGroup renderTypesFast
      ) {
          this.unculledFaces = p_119489_;
          this.culledFaces = p_119490_;
-@@ -46,6 +_,18 @@
+@@ -46,6 +_,24 @@
          this.usesBlockLight = p_119492_;
          this.particleIcon = p_119494_;
          this.transforms = p_119495_;
 +
 +        boolean hasRenderTypes = renderTypes != null && !renderTypes.isEmpty();
++        boolean hasRenderTypesFast = renderTypesFast != null && !renderTypesFast.isEmpty();
 +        this.blockRenderTypes = hasRenderTypes ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
++        this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
 +        /*
 +        this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
 +        this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
@@ -45,30 +55,39 @@
 +
 +    public static BakedModel bakeElements(List<BlockElement> p_377425_, TextureSlots p_378525_, SpriteGetter p_375793_, ModelState p_376680_, boolean p_375745_, boolean p_376866_, boolean p_376846_, ItemTransforms p_376883_) {
 +        return bakeElements(p_377425_, p_378525_, p_375793_, p_376680_, p_375745_, p_376866_, p_376846_, p_376883_, null);
++    }
++
++    public static BakedModel bakeElements(List<BlockElement> p_377425_, TextureSlots p_378525_, SpriteGetter p_375793_, ModelState p_376680_, boolean p_375745_, boolean p_376866_, boolean p_376846_, ItemTransforms p_376883_, @Nullable net.minecraftforge.client.RenderTypeGroup renderType) {
++        return bakeElements(p_377425_, p_378525_, p_375793_, p_376680_, p_375745_, p_376866_, p_376846_, p_376883_, renderType, null);
      }
  
      public static BakedModel bakeElements(
-@@ -56,7 +_,8 @@
+@@ -56,7 +_,9 @@
          boolean p_375745_,
          boolean p_376866_,
          boolean p_376846_,
 -        ItemTransforms p_376883_
 +        ItemTransforms p_376883_,
-+        @Nullable net.minecraftforge.client.RenderTypeGroup renderType
++        @Nullable net.minecraftforge.client.RenderTypeGroup renderType,
++        @Nullable net.minecraftforge.client.RenderTypeGroup renderTypeFast
      ) {
          TextureAtlasSprite textureatlassprite = findSprite(p_375793_, p_378525_, "particle");
          SimpleBakedModel.Builder simplebakedmodel$builder = new SimpleBakedModel.Builder(p_375745_, p_376866_, p_376846_, p_376883_)
-@@ -77,6 +_,9 @@
+@@ -77,6 +_,13 @@
              }
          }
  
-+        if (renderType != null)
-+            simplebakedmodel$builder.renderTypes(renderType);
++        if (renderType != null) {
++            if (renderTypeFast != null)
++                simplebakedmodel$builder.renderTypes(renderType, renderTypeFast);
++            else
++                simplebakedmodel$builder.renderTypes(renderType);
++        }
 +
          return simplebakedmodel$builder.build();
      }
  
-@@ -123,6 +_,33 @@
+@@ -123,6 +_,35 @@
          return this.transforms;
      }
  
@@ -77,6 +96,8 @@
 +    @Override
 +    public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(BlockState state, RandomSource rand, net.minecraftforge.client.model.data.ModelData data) {
 +        if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
++            if (blockRenderTypesFast != null)
++                return blockRenderTypesFast;
 +            if (isRenderingCutout && state.getBlock() instanceof net.minecraft.world.level.block.LeavesBlock)
 +                return SOLID_BLOCK;
 +        }
@@ -102,13 +123,21 @@
      @OnlyIn(Dist.CLIENT)
      public static class Builder {
          private final ImmutableList.Builder<BakedQuad> unculledFaces = ImmutableList.builder();
-@@ -164,13 +_,19 @@
+@@ -164,13 +_,27 @@
              return this;
          }
  
 +        private net.minecraftforge.client.RenderTypeGroup renderTypes = net.minecraftforge.client.RenderTypeGroup.EMPTY;
++        private net.minecraftforge.client.RenderTypeGroup renderTypesFast = net.minecraftforge.client.RenderTypeGroup.EMPTY;
++
 +        public SimpleBakedModel.Builder renderTypes(net.minecraftforge.client.RenderTypeGroup renderTypes) {
 +            this.renderTypes = renderTypes;
++            return this;
++        }
++
++        public SimpleBakedModel.Builder renderTypes(net.minecraftforge.client.RenderTypeGroup renderTypes, net.minecraftforge.client.RenderTypeGroup renderTypesFast) {
++            this.renderTypes = renderTypes;
++            this.renderTypesFast = renderTypesFast;
 +            return this;
 +        }
 +
@@ -119,7 +148,7 @@
                  Map<Direction, List<BakedQuad>> map = Maps.transformValues(this.culledFaces, ImmutableList.Builder::build);
                  return new SimpleBakedModel(
 -                    this.unculledFaces.build(), new EnumMap<>(map), this.hasAmbientOcclusion, this.usesBlockLight, this.isGui3d, this.particleIcon, this.transforms
-+                    this.unculledFaces.build(), new EnumMap<>(map), this.hasAmbientOcclusion, this.usesBlockLight, this.isGui3d, this.particleIcon, this.transforms, this.renderTypes
++                    this.unculledFaces.build(), new EnumMap<>(map), this.hasAmbientOcclusion, this.usesBlockLight, this.isGui3d, this.particleIcon, this.transforms, this.renderTypes, this.renderTypesFast
                  );
              }
          }

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -29,6 +_,17 @@
+@@ -29,6 +_,18 @@
      private final boolean usesBlockLight;
      private final TextureAtlasSprite particleIcon;
      private final ItemTransforms transforms;
@@ -9,6 +9,7 @@
 +    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
 +    protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
 +    */
++    protected final boolean isRenderingCutout;
 +
 +    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup} **/
 +    @Deprecated
@@ -28,15 +29,18 @@
      ) {
          this.unculledFaces = p_119489_;
          this.culledFaces = p_119490_;
-@@ -46,6 +_,15 @@
+@@ -46,6 +_,18 @@
          this.usesBlockLight = p_119492_;
          this.particleIcon = p_119494_;
          this.transforms = p_119495_;
-+        this.blockRenderTypes = !renderTypes.isEmpty() ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
++
++        boolean hasRenderTypes = renderTypes != null && !renderTypes.isEmpty();
++        this.blockRenderTypes = hasRenderTypes ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
 +        /*
-+        this.itemRenderTypes = !renderTypes.isEmpty() ? List.of(renderTypes.entity()) : null;
-+        this.fabulousItemRenderTypes = !renderTypes.isEmpty() ? List.of(renderTypes.entityFabulous()) : null;
++        this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
++        this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
 +        */
++        this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.cutout() || renderTypes.block() == net.minecraft.client.renderer.RenderType.cutoutMipped());
 +    }
 +
 +    public static BakedModel bakeElements(List<BlockElement> p_377425_, TextureSlots p_378525_, SpriteGetter p_375793_, ModelState p_376680_, boolean p_375745_, boolean p_376866_, boolean p_376846_, ItemTransforms p_376883_) {
@@ -64,13 +68,19 @@
          return simplebakedmodel$builder.build();
      }
  
-@@ -123,6 +_,27 @@
+@@ -123,6 +_,33 @@
          return this.transforms;
      }
  
++    private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID_BLOCK = net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.solid());
++
 +    @Override
 +    public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(BlockState state, RandomSource rand, net.minecraftforge.client.model.data.ModelData data) {
-+       return blockRenderTypes != null ? blockRenderTypes : BakedModel.super.getRenderTypes(state, rand, data);
++        if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
++            if (isRenderingCutout && state.getBlock() instanceof net.minecraft.world.level.block.LeavesBlock)
++                return SOLID_BLOCK;
++        }
++        return blockRenderTypes != null ? blockRenderTypes : BakedModel.super.getRenderTypes(state, rand, data);
 +    }
 +
 +    /*

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -54,7 +54,7 @@
 +        boolean hasRenderTypes = renderTypes != null && !renderTypes.isEmpty();
 +        boolean hasRenderTypesFast = renderTypesFast != null && !renderTypesFast.isEmpty();
 +        this.blockRenderTypes = hasRenderTypes ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
-+        this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
++        this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypesFast.block()) : null;
 +        /*
 +        this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
 +        this.itemRenderTypesFast = hasRenderTypesFast ? List.of(renderTypesFast.entity()) : null;

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -29,7 +_,34 @@
+@@ -29,7 +_,26 @@
      private final boolean usesBlockLight;
      private final TextureAtlasSprite particleIcon;
      private final ItemTransforms transforms;
@@ -9,14 +9,6 @@
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
 +    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} */
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
-+    /*
-+    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} * /
-+    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypes;
-+    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} * /
-+    protected final List<net.minecraft.client.renderer.RenderType> itemRenderTypesFast;
-+    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FABULOUS fabulous graphics} * /
-+    protected final List<net.minecraft.client.renderer.RenderType> fabulousItemRenderTypes;
-+    */
 +    /** Forge: If this model's {@linkplain #blockRenderTypes block render types} are rendering cutout, to account for older leaves model JSONs */
 +    protected final boolean isRenderingCutout;
 +
@@ -47,7 +39,7 @@
      ) {
          this.unculledFaces = p_119489_;
          this.culledFaces = p_119490_;
-@@ -46,6 +_,25 @@
+@@ -46,6 +_,20 @@
          this.usesBlockLight = p_119492_;
          this.particleIcon = p_119494_;
          this.transforms = p_119495_;
@@ -56,11 +48,6 @@
 +        boolean hasRenderTypesFast = renderTypesFast != null && !renderTypesFast.isEmpty();
 +        this.blockRenderTypes = hasRenderTypes ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypes.block()) : null;
 +        this.blockRenderTypesFast = hasRenderTypesFast ? net.minecraftforge.client.ChunkRenderTypeSet.of(renderTypesFast.block()) : null;
-+        /*
-+        this.itemRenderTypes = hasRenderTypes ? List.of(renderTypes.entity()) : null;
-+        this.itemRenderTypesFast = hasRenderTypesFast ? List.of(renderTypesFast.entity()) : null;
-+        this.fabulousItemRenderTypes = hasRenderTypes ? List.of(renderTypes.entityFabulous()) : null;
-+        */
 +        this.isRenderingCutout = hasRenderTypes && (renderTypes.block() == net.minecraft.client.renderer.RenderType.cutout() || renderTypes.block() == net.minecraft.client.renderer.RenderType.cutoutMipped());
 +    }
 +
@@ -98,12 +85,11 @@
          return simplebakedmodel$builder.build();
      }
  
-@@ -123,6 +_,41 @@
+@@ -123,6 +_,19 @@
          return this.transforms;
      }
  
 +    private static final net.minecraftforge.client.ChunkRenderTypeSet SOLID_BLOCK = net.minecraftforge.client.ChunkRenderTypeSet.of(net.minecraft.client.renderer.RenderType.solid());
-+    //private static final List<net.minecraft.client.renderer.RenderType> SOLID_BLOCK_ITEM = List.of(net.minecraft.client.renderer.RenderType.solid());
 +
 +    @Override
 +    public net.minecraftforge.client.ChunkRenderTypeSet getRenderTypes(BlockState state, RandomSource rand, net.minecraftforge.client.model.data.ModelData data) {
@@ -115,27 +101,6 @@
 +        }
 +        return blockRenderTypes != null ? blockRenderTypes : BakedModel.super.getRenderTypes(state, rand, data);
 +    }
-+
-+    /*
-+    @Override
-+    public List<net.minecraft.client.renderer.RenderType> getRenderTypes(net.minecraft.world.item.ItemStack itemStack, boolean fabulous) {
-+        if (!fabulous) {
-+            if (!net.minecraft.client.renderer.ItemBlockRenderTypes.isFancy()) {
-+                if (itemRenderTypesFast != null)
-+                    return itemRenderTypesFast;
-+                if (isRenderingCutout && itemStack.getItem() instanceof net.minecraft.world.item.BlockItem blockItem && blockItem.getBlock() instanceof net.minecraft.world.level.block.LeavesBlock)
-+                    return SOLID_BLOCK_ITEM;
-+            }
-+            if (itemRenderTypes != null)
-+                return itemRenderTypes;
-+        } else {
-+            if (fabulousItemRenderTypes != null) {
-+                return fabulousItemRenderTypes;
-+            }
-+        }
-+        return BakedModel.super.getRenderTypes(itemStack, fabulous);
-+    }
-+    */
 +
      @OnlyIn(Dist.CLIENT)
      public static class Builder {

--- a/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/SimpleBakedModel.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/client/resources/model/SimpleBakedModel.java
 +++ b/net/minecraft/client/resources/model/SimpleBakedModel.java
-@@ -29,7 +_,33 @@
+@@ -29,7 +_,34 @@
      private final boolean usesBlockLight;
      private final TextureAtlasSprite particleIcon;
      private final ItemTransforms transforms;
 -
 +    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} */
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypes;
-+    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fast graphics} */
++    /** Forge: Block render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} */
 +    protected final net.minecraftforge.client.ChunkRenderTypeSet blockRenderTypesFast;
 +    /*
 +    /** Forge: Item render types to be used with {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics} * /
@@ -26,7 +26,8 @@
 +        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +    }
 +
-+    /** Forge: Consider using {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup for fast graphics} **/
++    /** @deprecated Forge: Use {@linkplain #SimpleBakedModel(List, Map, boolean, boolean, boolean, TextureAtlasSprite, ItemTransforms, net.minecraftforge.client.RenderTypeGroup, net.minecraftforge.client.RenderTypeGroup) variant with RenderTypeGroup for fast graphics} **/
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public SimpleBakedModel(List<BakedQuad> p_119489_, Map<Direction, List<BakedQuad>> p_119490_, boolean p_119491_, boolean p_119492_, boolean p_119493_, TextureAtlasSprite p_119494_, ItemTransforms p_119495_, net.minecraftforge.client.RenderTypeGroup renderTypes) {
 +        this(p_119489_, p_119490_, p_119491_, p_119492_, p_119493_, p_119494_, p_119495_, renderTypes, net.minecraftforge.client.RenderTypeGroup.EMPTY);
 +    }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -934,7 +934,7 @@ public class ForgeHooksClient {
     }
 
     // a record for performance reasons
-    private record WrapedModelBaker(ModelBaker parent, RenderTypeGroup group, RenderTypeGroup groupFast) implements ModelBaker {
+    private record WrapedModelBaker(ModelBaker parent, RenderTypeGroup group, RenderTypeGroup renderTypeFast) implements ModelBaker {
         private WrapedModelBaker(ModelBaker parent, RenderTypeGroup group) {
             this(parent, group, RenderTypeGroup.EMPTY);
         }
@@ -942,11 +942,6 @@ public class ForgeHooksClient {
         @Override
         public RenderTypeGroup renderType() {
             return group;
-        }
-
-        @Override
-        public RenderTypeGroup renderTypeFast() {
-            return groupFast;
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -906,6 +906,11 @@ public class ForgeHooksClient {
             model.customData.setRenderTypeHint(ResourceLocation.parse(renderTypeHintName));
         }
 
+        if (json.has("render_type_fast")) {
+            var renderTypeHintName = GsonHelper.getAsString(json, "render_type_fast");
+            model.customData.setRenderTypeFastHint(ResourceLocation.parse(renderTypeHintName));
+        }
+
         if (json.has("visibility")) {
             var visibility = GsonHelper.getAsJsonObject(json, "visibility");
             for (var part : visibility.entrySet())
@@ -922,11 +927,26 @@ public class ForgeHooksClient {
         return new WrapedModelBaker(parent, group);
     }
 
+    public static ModelBaker wrapRenderType(ModelBaker parent, RenderTypeGroup group, RenderTypeGroup groupFast) {
+        if (group == null || group == RenderTypeGroup.EMPTY || parent.renderType() != null)
+            return parent;
+        return new WrapedModelBaker(parent, group, groupFast);
+    }
+
     // a record for performance reasons
-    private record WrapedModelBaker(ModelBaker parent, RenderTypeGroup group) implements ModelBaker {
+    private record WrapedModelBaker(ModelBaker parent, RenderTypeGroup group, RenderTypeGroup groupFast) implements ModelBaker {
+        private WrapedModelBaker(ModelBaker parent, RenderTypeGroup group) {
+            this(parent, group, RenderTypeGroup.EMPTY);
+        }
+
         @Override
         public RenderTypeGroup renderType() {
             return group;
+        }
+
+        @Override
+        public RenderTypeGroup renderTypeFast() {
+            return groupFast;
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -198,6 +198,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
             private final ItemTransforms transforms;
             private TextureAtlasSprite particle;
             private RenderTypeGroup lastRenderTypes = RenderTypeGroup.EMPTY;
+            private RenderTypeGroup lastRenderTypesFast = RenderTypeGroup.EMPTY;
 
             private Builder(boolean isAmbientOcclusion, boolean isGui3d, boolean isSideLit, TextureAtlasSprite particle, ItemTransforms transforms) {
                 this.isAmbientOcclusion = isAmbientOcclusion;
@@ -208,23 +209,32 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
             }
 
             public void addLayer(BakedModel model) {
-                flushQuads(null);
+                flushQuads(RenderTypeGroup.EMPTY);
                 children.add(model);
             }
 
             private void addLayer(RenderTypeGroup renderTypes, List<BakedQuad> quads) {
-                var modelBuilder = IModelBuilder.of(isAmbientOcclusion, isSideLit, isGui3d, transforms, particle, renderTypes);
+                this.addLayer(renderTypes, RenderTypeGroup.EMPTY, quads);
+            }
+
+            private void addLayer(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, List<BakedQuad> quads) {
+                var modelBuilder = IModelBuilder.of(isAmbientOcclusion, isSideLit, isGui3d, transforms, particle, renderTypes, renderTypesFast);
                 quads.forEach(modelBuilder::addUnculledFace);
                 children.add(modelBuilder.build());
             }
 
             private void flushQuads(RenderTypeGroup renderTypes) {
+                this.flushQuads(renderTypes, RenderTypeGroup.EMPTY);
+            }
+
+            private void flushQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast) {
                 if (!Objects.equals(renderTypes, lastRenderTypes)) {
                     if (!quads.isEmpty()) {
-                        addLayer(lastRenderTypes, quads);
+                        addLayer(lastRenderTypes, lastRenderTypesFast, quads);
                         quads.clear();
                     }
                     lastRenderTypes = renderTypes;
+                    lastRenderTypesFast = renderTypesFast;
                 }
             }
 
@@ -234,20 +244,28 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
             }
 
             public Builder addQuads(RenderTypeGroup renderTypes, BakedQuad... quadsToAdd) {
-                flushQuads(renderTypes);
+                return this.addQuads(renderTypes, RenderTypeGroup.EMPTY, quadsToAdd);
+            }
+
+            public Builder addQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, BakedQuad... quadsToAdd) {
+                flushQuads(renderTypes, renderTypesFast);
                 Collections.addAll(quads, quadsToAdd);
                 return this;
             }
 
             public Builder addQuads(RenderTypeGroup renderTypes, Collection<BakedQuad> quadsToAdd) {
-                flushQuads(renderTypes);
+                return this.addQuads(renderTypes, RenderTypeGroup.EMPTY, quadsToAdd);
+            }
+
+            public Builder addQuads(RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast, Collection<BakedQuad> quadsToAdd) {
+                flushQuads(renderTypes, renderTypesFast);
                 quads.addAll(quadsToAdd);
                 return this;
             }
 
             public BakedModel build() {
                 if (!quads.isEmpty()) {
-                    addLayer(lastRenderTypes, quads);
+                    addLayer(lastRenderTypes, lastRenderTypesFast, quads);
                 }
                 var childrenBuilder = ImmutableMap.<String, BakedModel>builder();
                 var itemPassesBuilder = ImmutableList.<BakedModel>builder();

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -209,7 +209,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
             }
 
             public void addLayer(BakedModel model) {
-                flushQuads(RenderTypeGroup.EMPTY);
+                flushQuads(RenderTypeGroup.EMPTY, RenderTypeGroup.EMPTY);
                 children.add(model);
             }
 

--- a/src/main/java/net/minecraftforge/client/model/EmptyModel.java
+++ b/src/main/java/net/minecraftforge/client/model/EmptyModel.java
@@ -17,6 +17,7 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.SimpleBakedModel;
+import net.minecraftforge.client.RenderTypeGroup;
 import net.minecraftforge.client.model.geometry.IGeometryBakingContext;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
 import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
@@ -49,7 +50,7 @@ public class EmptyModel extends SimpleUnbakedGeometry<EmptyModel> {
         private static final Material MISSING_TEXTURE = new Material(TextureAtlas.LOCATION_BLOCKS, MissingTextureAtlasSprite.getLocation());
 
         public Baked() {
-            super(List.of(), Map.of(), false, false, false, UnitTextureAtlasSprite.INSTANCE, ItemTransforms.NO_TRANSFORMS/*, RenderTypeGroup.EMPTY*/);
+            super(List.of(), Map.of(), false, false, false, UnitTextureAtlasSprite.INSTANCE, ItemTransforms.NO_TRANSFORMS, RenderTypeGroup.EMPTY, RenderTypeGroup.EMPTY);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
@@ -79,8 +79,7 @@ public interface IModelBuilder<T extends IModelBuilder<T>> {
             boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,
             ItemTransforms transforms, TextureAtlasSprite particle, RenderTypeGroup renderTypes
         ) {
-            this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms).particle(particle);
-            this.builder.renderTypes(renderTypes);
+            this(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, particle, renderTypes, RenderTypeGroup.EMPTY);
         }
 
         private Simple(

--- a/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
@@ -46,6 +46,18 @@ public interface IModelBuilder<T extends IModelBuilder<T>> {
         return new Simple(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, particle, renderTypes);
     }
 
+    static IModelBuilder<?> of(
+        boolean hasAmbientOcclusion,
+        boolean usesBlockLight,
+        boolean isGui3d,
+        ItemTransforms transforms,
+        TextureAtlasSprite particle,
+        RenderTypeGroup renderTypes,
+        RenderTypeGroup renderTypesFast
+    ){
+        return new Simple(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms, particle, renderTypes, renderTypesFast);
+    }
+
     /**
      * Creates a new model builder that collects quads to the provided list, returning
      * {@linkplain EmptyModel#BAKED an empty model} if you call {@link #build()}.
@@ -69,6 +81,14 @@ public interface IModelBuilder<T extends IModelBuilder<T>> {
         ) {
             this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms).particle(particle);
             this.builder.renderTypes(renderTypes);
+        }
+
+        private Simple(
+            boolean hasAmbientOcclusion, boolean usesBlockLight, boolean isGui3d,
+            ItemTransforms transforms, TextureAtlasSprite particle, RenderTypeGroup renderTypes, RenderTypeGroup renderTypesFast
+        ) {
+            this.builder = new SimpleBakedModel.Builder(hasAmbientOcclusion, usesBlockLight, isGui3d, transforms).particle(particle);
+            this.builder.renderTypes(renderTypes, renderTypesFast);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -40,9 +40,7 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
     private final Int2ObjectMap<ResourceLocation> renderTypeFastNames;
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ResourceLocation> renderTypeNames) {
-        this.textures = textures;
-        this.renderTypeNames = renderTypeNames;
-        this.renderTypeFastNames = new Int2ObjectOpenHashMap<>();
+        this(textures, renderTypeNames, new Int2ObjectOpenHashMap<>());
     }
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ResourceLocation> renderTypeFastNames) {
@@ -90,36 +88,28 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
 
         @Override
         public ItemLayerModel read(JsonObject jsonObject, JsonDeserializationContext deserializationContext) {
+            var renderTypeNames = readRenderTypeNames(jsonObject, "render_types");
+            var renderTypeFastNames = readRenderTypeNames(jsonObject, "render_types_fast");
+            return new ItemLayerModel(null, renderTypeNames, renderTypeFastNames);
+        }
+
+        private static Int2ObjectMap<ResourceLocation> readRenderTypeNames(JsonObject jsonObject, String key) {
             var renderTypeNames = new Int2ObjectOpenHashMap<ResourceLocation>();
-            if (jsonObject.has("render_types")) {
-                var renderTypes = jsonObject.getAsJsonObject("render_types");
+            if (jsonObject.has(key)) {
+                var renderTypes = jsonObject.getAsJsonObject(key);
                 for (var entry : renderTypes.entrySet()) {
                     var renderType = ResourceLocation.parse(entry.getKey());
                     for (var layer : entry.getValue().getAsJsonArray())
                         if (renderTypeNames.put(layer.getAsInt(), renderType) != null)
-                            throw new JsonParseException("Registered duplicate render type for layer " + layer);
+                            throw new JsonParseException("Registered duplicate " + key + " for layer " + layer);
                 }
             }
 
-            var renderTypeFastNames = new Int2ObjectOpenHashMap<ResourceLocation>();
-            if (jsonObject.has("render_types_fast")) {
-                var renderTypes = jsonObject.getAsJsonObject("render_types_fast");
-                for (var entry : renderTypes.entrySet()) {
-                    var renderType = ResourceLocation.parse(entry.getKey());
-                    for (var layer : entry.getValue().getAsJsonArray())
-                        if (renderTypeFastNames.put(layer.getAsInt(), renderType) != null)
-                            throw new JsonParseException("Registered duplicate render type for layer " + layer);
-                }
-            }
-
-            return new ItemLayerModel(null, renderTypeNames, renderTypeFastNames);
+            return renderTypeNames;
         }
 
+        @Deprecated(forRemoval = true, since = "1.21.4")
         protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning) {
-            this.readLayerData(jsonObject, name, renderTypeNames, new Int2ObjectOpenHashMap<>(), layerData, logWarning);
-        }
-
-        protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectOpenHashMap<ResourceLocation> renderTypeFastNames, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning) {
             if (!jsonObject.has(name))
                 return;
 

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -37,10 +37,18 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
     @Nullable
     private ImmutableList<Material> textures;
     private final Int2ObjectMap<ResourceLocation> renderTypeNames;
+    private final Int2ObjectMap<ResourceLocation> renderTypeFastNames;
 
     private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ResourceLocation> renderTypeNames) {
         this.textures = textures;
         this.renderTypeNames = renderTypeNames;
+        this.renderTypeFastNames = new Int2ObjectOpenHashMap<>();
+    }
+
+    private ItemLayerModel(@Nullable ImmutableList<Material> textures, Int2ObjectMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ResourceLocation> renderTypeFastNames) {
+        this.textures = textures;
+        this.renderTypeNames = renderTypeNames;
+        this.renderTypeFastNames = renderTypeFastNames;
     }
 
     @Override
@@ -69,7 +77,9 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
             var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> sprite, modelState);
             var renderTypeName = renderTypeNames.get(i);
             var renderTypes = renderTypeName != null ? context.getRenderType(renderTypeName) : null;
-            builder.addQuads(renderTypes != null ? renderTypes : normalRenderTypes, quads);
+            var renderTypeFastName = renderTypeFastNames.get(i);
+            var renderTypesFast = renderTypeFastName != null ? context.getRenderType(renderTypeFastName) : null;
+            builder.addQuads(renderTypes != null ? renderTypes : normalRenderTypes, renderTypesFast != null ? renderTypesFast : RenderTypeGroup.EMPTY, quads);
         }
 
         return builder.build();
@@ -91,10 +101,25 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
                 }
             }
 
-            return new ItemLayerModel(null, renderTypeNames);
+            var renderTypeFastNames = new Int2ObjectOpenHashMap<ResourceLocation>();
+            if (jsonObject.has("render_types_fast")) {
+                var renderTypes = jsonObject.getAsJsonObject("render_types_fast");
+                for (var entry : renderTypes.entrySet()) {
+                    var renderType = ResourceLocation.parse(entry.getKey());
+                    for (var layer : entry.getValue().getAsJsonArray())
+                        if (renderTypeFastNames.put(layer.getAsInt(), renderType) != null)
+                            throw new JsonParseException("Registered duplicate render type for layer " + layer);
+                }
+            }
+
+            return new ItemLayerModel(null, renderTypeNames, renderTypeFastNames);
         }
 
         protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning) {
+            this.readLayerData(jsonObject, name, renderTypeNames, new Int2ObjectOpenHashMap<>(), layerData, logWarning);
+        }
+
+        protected void readLayerData(JsonObject jsonObject, String name, Int2ObjectOpenHashMap<ResourceLocation> renderTypeNames, Int2ObjectOpenHashMap<ResourceLocation> renderTypeFastNames, Int2ObjectMap<ForgeFaceData> layerData, boolean logWarning) {
             if (!jsonObject.has(name))
                 return;
 

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -257,6 +257,42 @@ public abstract class BlockStateProvider implements DataProvider {
             models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType));
     }
 
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), renderType, renderTypeFast);
+    }
+
+    public void logBlockWithRenderTypeAndFast(RotatedPillarBlock block, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), extend(blockTexture(block), "_top"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation baseName, String renderType, String renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, extend(baseName, "_side"), extend(baseName, "_end"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation side, ResourceLocation end, String renderType, String renderTypeFast) {
+        axisBlock(block,
+            models().cubeColumn(name(block), side, end).renderType(renderType, renderTypeFast),
+            models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType, renderTypeFast));
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), renderType, renderTypeFast);
+    }
+
+    public void logBlockWithRenderType(RotatedPillarBlock block, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, blockTexture(block), extend(blockTexture(block), "_top"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation baseName, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlockWithRenderTypeAndFast(block, extend(baseName, "_side"), extend(baseName, "_end"), renderType, renderTypeFast);
+    }
+
+    public void axisBlockWithRenderTypeAndFast(RotatedPillarBlock block, ResourceLocation side, ResourceLocation end, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        axisBlock(block,
+            models().cubeColumn(name(block), side, end).renderType(renderType, renderTypeFast),
+            models().cubeColumnHorizontal(name(block) + "_horizontal", side, end).renderType(renderType, renderTypeFast));
+    }
+
     public void axisBlock(RotatedPillarBlock block, ModelFile vertical, ModelFile horizontal) {
         getVariantBuilder(block)
             .partialState().with(RotatedPillarBlock.AXIS, Axis.Y)
@@ -388,6 +424,38 @@ public abstract class BlockStateProvider implements DataProvider {
         stairsBlockInternalWithRenderType(block, name + "_stairs", side, bottom, top, renderType);
     }
 
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, name, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, key(block).toString(), side, bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, name + "_stairs", side, bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockWithRenderTypeAndFast(block, name, texture, texture, texture, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, key(block).toString(), side, bottom, top, renderType, renderTypeFast);
+    }
+
+    public void stairsBlockWithRenderTypeAndFast(StairBlock block, String name, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        stairsBlockInternalWithRenderTypeAndFast(block, name + "_stairs", side, bottom, top, renderType, renderTypeFast);
+    }
+
     private void stairsBlockInternal(StairBlock block, String baseName, ResourceLocation side, ResourceLocation bottom, ResourceLocation top) {
         ModelFile stairs = models().stairs(baseName, side, bottom, top);
         ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top);
@@ -399,6 +467,13 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile stairs = models().stairs(baseName, side, bottom, top).renderType(renderType);
         ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top).renderType(renderType);
         ModelFile stairsOuter = models().stairsOuter(baseName + "_outer", side, bottom, top).renderType(renderType);
+        stairsBlock(block, stairs, stairsInner, stairsOuter);
+    }
+
+    private void stairsBlockInternalWithRenderTypeAndFast(StairBlock block, String baseName, ResourceLocation side, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile stairs = models().stairs(baseName, side, bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile stairsInner = models().stairsInner(baseName + "_inner", side, bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile stairsOuter = models().stairsOuter(baseName + "_outer", side, bottom, top).renderType(renderType, renderTypeFast);
         stairsBlock(block, stairs, stairsInner, stairsOuter);
     }
 
@@ -539,6 +614,32 @@ public abstract class BlockStateProvider implements DataProvider {
             models().fenceSide(name + "_fence_side", texture).renderType(renderType));
     }
 
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        String baseName = key(block).toString();
+        fourWayBlock(block,
+            models().fencePost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(baseName + "_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fourWayBlock(block,
+            models().fencePost(name + "_fence_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(name + "_fence_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        String baseName = key(block).toString();
+        fourWayBlock(block,
+            models().fencePost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(baseName + "_side", texture).renderType(renderType, renderTypeFast));
+    }
+
+    public void fenceBlockWithRenderTypeAndFast(FenceBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fourWayBlock(block,
+            models().fencePost(name + "_fence_post", texture).renderType(renderType, renderTypeFast),
+            models().fenceSide(name + "_fence_side", texture).renderType(renderType, renderTypeFast));
+    }
+
     public void fenceGateBlock(FenceGateBlock block, ResourceLocation texture) {
         fenceGateBlockInternal(block, key(block).toString(), texture);
     }
@@ -563,6 +664,22 @@ public abstract class BlockStateProvider implements DataProvider {
         fenceGateBlockInternalWithRenderType(block, name + "_fence_gate", texture, renderType);
     }
 
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, name + "_fence_gate", texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, renderType, renderTypeFast);
+    }
+
+    public void fenceGateBlockWithRenderTypeAndFast(FenceGateBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        fenceGateBlockInternalWithRenderTypeAndFast(block, name + "_fence_gate", texture, renderType, renderTypeFast);
+    }
+
     private void fenceGateBlockInternal(FenceGateBlock block, String baseName, ResourceLocation texture) {
         ModelFile gate = models().fenceGate(baseName, texture);
         ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture);
@@ -576,6 +693,14 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture).renderType(renderType);
         ModelFile gateWall = models().fenceGateWall(baseName + "_wall", texture).renderType(renderType);
         ModelFile gateWallOpen = models().fenceGateWallOpen(baseName + "_wall_open", texture).renderType(renderType);
+        fenceGateBlock(block, gate, gateOpen, gateWall, gateWallOpen);
+    }
+
+    private void fenceGateBlockInternalWithRenderTypeAndFast(FenceGateBlock block, String baseName, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile gate = models().fenceGate(baseName, texture).renderType(renderType, renderTypeFast);
+        ModelFile gateOpen = models().fenceGateOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast);
+        ModelFile gateWall = models().fenceGateWall(baseName + "_wall", texture).renderType(renderType, renderTypeFast);
+        ModelFile gateWallOpen = models().fenceGateWallOpen(baseName + "_wall_open", texture).renderType(renderType, renderTypeFast);
         fenceGateBlock(block, gate, gateOpen, gateWall, gateWallOpen);
     }
 
@@ -620,6 +745,22 @@ public abstract class BlockStateProvider implements DataProvider {
         wallBlockInternalWithRenderType(block, name + "_wall", texture, renderType);
     }
 
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, ResourceLocation texture, String renderType, String renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, String name, ResourceLocation texture, String renderType, String renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, name + "_wall", texture, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, renderType, renderTypeFast);
+    }
+
+    public void wallBlockWithRenderTypeAndFast(WallBlock block, String name, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlockInternalWithRenderTypeAndFast(block, name + "_wall", texture, renderType, renderTypeFast);
+    }
+
     private void wallBlockInternal(WallBlock block, String baseName, ResourceLocation texture) {
         wallBlock(block, models().wallPost(baseName + "_post", texture),
             models().wallSide(baseName + "_side", texture),
@@ -630,6 +771,12 @@ public abstract class BlockStateProvider implements DataProvider {
         wallBlock(block, models().wallPost(baseName + "_post", texture).renderType(renderType),
             models().wallSide(baseName + "_side", texture).renderType(renderType),
             models().wallSideTall(baseName + "_side_tall", texture).renderType(renderType));
+    }
+
+    private void wallBlockInternalWithRenderTypeAndFast(WallBlock block, String baseName, ResourceLocation texture, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        wallBlock(block, models().wallPost(baseName + "_post", texture).renderType(renderType, renderTypeFast),
+            models().wallSide(baseName + "_side", texture).renderType(renderType, renderTypeFast),
+            models().wallSideTall(baseName + "_side_tall", texture).renderType(renderType, renderTypeFast));
     }
 
     public static final ImmutableMap<Direction, Property<WallSide>> WALL_PROPS = ImmutableMap.<Direction, Property<WallSide>>builder()
@@ -684,6 +831,22 @@ public abstract class BlockStateProvider implements DataProvider {
         paneBlockInternalWithRenderType(block, name + "_pane", pane, edge, renderType);
     }
 
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, ResourceLocation pane, ResourceLocation edge, String renderType, String renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, key(block).toString(), pane, edge, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, String name, ResourceLocation pane, ResourceLocation edge, String renderType, String renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, name + "_pane", pane, edge, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, key(block).toString(), pane, edge, renderType, renderTypeFast);
+    }
+
+    public void paneBlockWithRenderTypeAndFast(IronBarsBlock block, String name, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        paneBlockInternalWithRenderTypeAndFast(block, name + "_pane", pane, edge, renderType, renderTypeFast);
+    }
+
     private void paneBlockInternal(IronBarsBlock block, String baseName, ResourceLocation pane, ResourceLocation edge) {
         ModelFile post = models().panePost(baseName + "_post", pane, edge);
         ModelFile side = models().paneSide(baseName + "_side", pane, edge);
@@ -699,6 +862,15 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile sideAlt = models().paneSideAlt(baseName + "_side_alt", pane, edge).renderType(renderType);
         ModelFile noSide = models().paneNoSide(baseName + "_noside", pane).renderType(renderType);
         ModelFile noSideAlt = models().paneNoSideAlt(baseName + "_noside_alt", pane).renderType(renderType);
+        paneBlock(block, post, side, sideAlt, noSide, noSideAlt);
+    }
+
+    private void paneBlockInternalWithRenderTypeAndFast(IronBarsBlock block, String baseName, ResourceLocation pane, ResourceLocation edge, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile post = models().panePost(baseName + "_post", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile side = models().paneSide(baseName + "_side", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile sideAlt = models().paneSideAlt(baseName + "_side_alt", pane, edge).renderType(renderType, renderTypeFast);
+        ModelFile noSide = models().paneNoSide(baseName + "_noside", pane).renderType(renderType, renderTypeFast);
+        ModelFile noSideAlt = models().paneNoSideAlt(baseName + "_noside_alt", pane).renderType(renderType, renderTypeFast);
         paneBlock(block, post, side, sideAlt, noSide, noSideAlt);
     }
 
@@ -741,6 +913,22 @@ public abstract class BlockStateProvider implements DataProvider {
         doorBlockInternalWithRenderType(block, name + "_door", bottom, top, renderType);
     }
 
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, String name, ResourceLocation bottom, ResourceLocation top, String renderType, String renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, name + "_door", bottom, top, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), bottom, top, renderType, renderTypeFast);
+    }
+
+    public void doorBlockWithRenderTypeAndFast(DoorBlock block, String name, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        doorBlockInternalWithRenderTypeAndFast(block, name + "_door", bottom, top, renderType, renderTypeFast);
+    }
+
     private void doorBlockInternal(DoorBlock block, String baseName, ResourceLocation bottom, ResourceLocation top) {
         ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom_left", bottom, top);
         ModelFile bottomLeftOpen = models().doorBottomLeftOpen(baseName + "_bottom_left_open", bottom, top);
@@ -762,6 +950,18 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile topLeftOpen = models().doorTopLeftOpen(baseName + "_top_left_open", bottom, top).renderType(renderType);
         ModelFile topRight = models().doorTopRight(baseName + "_top_right", bottom, top).renderType(renderType);
         ModelFile topRightOpen = models().doorTopRightOpen(baseName + "_top_right_open", bottom, top).renderType(renderType);
+        doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
+    }
+
+    private void doorBlockInternalWithRenderTypeAndFast(DoorBlock block, String baseName, ResourceLocation bottom, ResourceLocation top, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile bottomLeft = models().doorBottomLeft(baseName + "_bottom_left", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomLeftOpen = models().doorBottomLeftOpen(baseName + "_bottom_left_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomRight = models().doorBottomRight(baseName + "_bottom_right", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile bottomRightOpen = models().doorBottomRightOpen(baseName + "_bottom_right_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topLeft = models().doorTopLeft(baseName + "_top_left", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topLeftOpen = models().doorTopLeftOpen(baseName + "_top_left_open", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topRight = models().doorTopRight(baseName + "_top_right", bottom, top).renderType(renderType, renderTypeFast);
+        ModelFile topRightOpen = models().doorTopRightOpen(baseName + "_top_right_open", bottom, top).renderType(renderType, renderTypeFast);
         doorBlock(block, bottomLeft, bottomLeftOpen, bottomRight, bottomRightOpen, topLeft, topLeftOpen, topRight, topRightOpen);
     }
 
@@ -831,6 +1031,22 @@ public abstract class BlockStateProvider implements DataProvider {
         trapdoorBlockInternalWithRenderType(block, name + "_trapdoor", texture, orientable, renderType);
     }
 
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, ResourceLocation texture, boolean orientable, String renderType, String renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, orientable, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, String name, ResourceLocation texture, boolean orientable, String renderType, String renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, name + "_trapdoor", texture, orientable, ResourceLocation.tryParse(renderType), ResourceLocation.tryParse(renderTypeFast));
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, key(block).toString(), texture, orientable, renderType, renderTypeFast);
+    }
+
+    public void trapdoorBlockWithRenderTypeAndFast(TrapDoorBlock block, String name, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        trapdoorBlockInternalWithRenderTypeAndFast(block, name + "_trapdoor", texture, orientable, renderType, renderTypeFast);
+    }
+
     private void trapdoorBlockInternal(TrapDoorBlock block, String baseName, ResourceLocation texture, boolean orientable) {
         ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture) : models().trapdoorBottom(baseName + "_bottom", texture);
         ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture) : models().trapdoorTop(baseName + "_top", texture);
@@ -842,6 +1058,13 @@ public abstract class BlockStateProvider implements DataProvider {
         ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture).renderType(renderType) : models().trapdoorBottom(baseName + "_bottom", texture).renderType(renderType);
         ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture).renderType(renderType) : models().trapdoorTop(baseName + "_top", texture).renderType(renderType);
         ModelFile open = orientable ? models().trapdoorOrientableOpen(baseName + "_open", texture).renderType(renderType) : models().trapdoorOpen(baseName + "_open", texture).renderType(renderType);
+        trapdoorBlock(block, bottom, top, open, orientable);
+    }
+
+    private void trapdoorBlockInternalWithRenderTypeAndFast(TrapDoorBlock block, String baseName, ResourceLocation texture, boolean orientable, ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        ModelFile bottom = orientable ? models().trapdoorOrientableBottom(baseName + "_bottom", texture).renderType(renderType, renderTypeFast) : models().trapdoorBottom(baseName + "_bottom", texture).renderType(renderType, renderTypeFast);
+        ModelFile top = orientable ? models().trapdoorOrientableTop(baseName + "_top", texture).renderType(renderType, renderTypeFast) : models().trapdoorTop(baseName + "_top", texture).renderType(renderType, renderTypeFast);
+        ModelFile open = orientable ? models().trapdoorOrientableOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast) : models().trapdoorOpen(baseName + "_open", texture).renderType(renderType, renderTypeFast);
         trapdoorBlock(block, bottom, top, open, orientable);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -155,30 +155,50 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     /**
-     * Set the render type for this model.
+     * Set the render type for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     * <p>
+     * Consider using {@linkplain #renderType(String, String)} if you need to set a render type for
+     * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
      *
-     * @param renderType the render type. Must be registered via
-     *                   {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent}
+     * @param renderType the render type
      * @return this builder
-     * @throws NullPointerException  if {@code renderType} is {@code null}
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     * @see #renderType(String, String)
      */
     public T renderType(String renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         return renderType(ResourceLocation.parse(renderType));
     }
 
+    /**
+     * Set the render types for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     *
+     * @param renderType     the render type for {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics}
+     * @param renderTypeFast the render type for {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}
+     * @return this builder
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     */
     public T renderType(String renderType, String renderTypeFast) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         return renderType(ResourceLocation.parse(renderType), ResourceLocation.parse(renderTypeFast));
     }
 
     /**
-     * Set the render type for this model.
+     * Set the render type for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     * <p>
+     * Consider using {@linkplain #renderType(ResourceLocation, ResourceLocation)} if you need to set a render type for
+     * {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}.
      *
-     * @param renderType the render type. Must be registered via
-     *                   {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent}
+     * @param renderType the render type
      * @return this builder
-     * @throws NullPointerException  if {@code renderType} is {@code null}
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     * @see #renderType(ResourceLocation, ResourceLocation)
      */
     public T renderType(ResourceLocation renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
@@ -187,6 +207,16 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         return self();
     }
 
+    /**
+     * Set the render types for this model. Any render types to be used must be registered via
+     * {@link net.minecraftforge.client.event.RegisterNamedRenderTypesEvent RegisterNamedRenderTypesEvent}.
+     *
+     * @param renderType     the render type for {@linkplain net.minecraft.client.GraphicsStatus#FANCY fancy graphics}
+     * @param renderTypeFast the render type for {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics}
+     * @return this builder
+     *
+     * @throws NullPointerException if {@code renderType} is {@code null}
+     */
     public T renderType(ResourceLocation renderType, ResourceLocation renderTypeFast) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -65,6 +65,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     protected final ExistingFileHelper existingFileHelper;
 
     protected String renderType = null;
+    protected String renderTypeFast = null;
     protected boolean ambientOcclusion = true;
     protected GuiLight guiLight = null;
 
@@ -166,6 +167,11 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         return renderType(ResourceLocation.parse(renderType));
     }
 
+    public T renderType(String renderType, String renderTypeFast) {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        return renderType(ResourceLocation.parse(renderType), ResourceLocation.parse(renderTypeFast));
+    }
+
     /**
      * Set the render type for this model.
      *
@@ -177,6 +183,15 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     public T renderType(ResourceLocation renderType) {
         Preconditions.checkNotNull(renderType, "Render type must not be null");
         this.renderType = renderType.toString();
+        this.renderTypeFast = null;
+        return self();
+    }
+
+    public T renderType(ResourceLocation renderType, ResourceLocation renderTypeFast) {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");
+        this.renderType = renderType.toString();
+        this.renderTypeFast = renderType.toString();
         return self();
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -372,7 +372,8 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataPr
     }
 
     public T leaves(String name, ResourceLocation texture) {
-        return singleTexture(name, BLOCK_FOLDER + "/leaves", "all", texture);
+        return singleTexture(name, BLOCK_FOLDER + "/leaves", "all", texture)
+            .renderType("cutout_mipped", "solid");
     }
 
     /**

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -39,6 +39,7 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
 
     private final Int2ObjectMap<ForgeFaceData> faceData = new Int2ObjectOpenHashMap<>();
     private final Map<ResourceLocation, IntSet> renderTypes = new LinkedHashMap<>();
+    private final Map<ResourceLocation, IntSet> renderTypesFast = new LinkedHashMap<>();
     private final IntSet layersWithRenderTypes = new IntOpenHashSet();
 
     protected ItemLayerModelBuilder(T parent, ExistingFileHelper existingFileHelper)
@@ -121,6 +122,23 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         return renderType(asLoc, layers);
     }
 
+    public ItemLayerModelBuilder<T> renderType(String renderType, String renderTypeFast, int... layers)
+    {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");
+        ResourceLocation asLoc;
+        if (renderType.contains(":"))
+            asLoc = ResourceLocation.parse(renderType);
+        else
+            asLoc = parent.getLocation().withPath(renderType);
+        ResourceLocation asLocFast;
+        if (renderTypeFast.contains(":"))
+            asLocFast = ResourceLocation.parse(renderTypeFast);
+        else
+            asLocFast = parent.getLocation().withPath(renderTypeFast);
+        return renderType(asLoc, asLocFast, layers);
+    }
+
     /**
      * Set the render type for a set of layers.
      *
@@ -145,6 +163,25 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         var renderTypeLayers = renderTypes.computeIfAbsent(renderType, $ -> new IntOpenHashSet());
         Arrays.stream(layers).forEach(layer -> {
             renderTypeLayers.add(layer);
+            layersWithRenderTypes.add(layer);
+        });
+        return this;
+    }
+
+    public ItemLayerModelBuilder<T> renderType(ResourceLocation renderType, ResourceLocation renderTypeFast, int... layers)
+    {
+        Preconditions.checkNotNull(renderType, "Render type must not be null");
+        Preconditions.checkNotNull(renderTypeFast, "Fast graphics render type must not be null");
+        Preconditions.checkNotNull(layers, "Layers must not be null");
+        Preconditions.checkArgument(layers.length > 0, "At least one layer must be specified");
+        Preconditions.checkArgument(Arrays.stream(layers).allMatch(i -> i >= 0), "All layers must be >= 0");
+        var alreadyAssigned = Arrays.stream(layers).filter(layersWithRenderTypes::contains).toArray();
+        Preconditions.checkArgument(alreadyAssigned.length == 0, "Attempted to re-assign layer render types: " + Arrays.toString(alreadyAssigned));
+        var renderTypeLayers = renderTypes.computeIfAbsent(renderType, $ -> new IntOpenHashSet());
+        var renderTypeFastLayers = renderTypesFast.computeIfAbsent(renderType, $ -> new IntOpenHashSet());
+        Arrays.stream(layers).forEach(layer -> {
+            renderTypeLayers.add(layer);
+            renderTypeFastLayers.add(layer);
             layersWithRenderTypes.add(layer);
         });
         return this;
@@ -175,6 +212,14 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
             renderTypes.add(renderType.toString(), array);
         });
         json.add("render_types", renderTypes);
+
+        JsonObject renderTypesFast = new JsonObject();
+        this.renderTypes.forEach((renderType, layers) -> {
+            JsonArray array = new JsonArray();
+            layers.intStream().sorted().forEach(array::add);
+            renderTypesFast.add(renderType.toString(), array);
+        });
+        json.add("render_types_fast", renderTypesFast);
 
         return json;
     }

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -214,10 +214,10 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         json.add("render_types", renderTypes);
 
         JsonObject renderTypesFast = new JsonObject();
-        this.renderTypes.forEach((renderType, layers) -> {
+        this.renderTypesFast.forEach((renderTypeFast, layers) -> {
             JsonArray array = new JsonArray();
             layers.intStream().sorted().forEach(array::add);
-            renderTypesFast.add(renderType.toString(), array);
+            renderTypesFast.add(renderTypeFast.toString(), array);
         });
         json.add("render_types_fast", renderTypesFast);
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/BlockGeometryBakingContext.java
@@ -35,6 +35,8 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext {
     private Transformation rootTransform;
     @Nullable
     private ResourceLocation renderTypeHint;
+    @Nullable
+    private ResourceLocation renderTypeFastHint;
     private boolean gui3d = true;
 
     @ApiStatus.Internal
@@ -111,8 +113,21 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext {
         return pctx == null ? null: pctx.getRenderTypeHint();
     }
 
+    @Nullable
+    @Override
+    public ResourceLocation getRenderTypeFastHint() {
+        if (renderTypeFastHint != null)
+            return renderTypeFastHint;
+        var pctx = parentContext();
+        return pctx == null ? null: pctx.getRenderTypeFastHint();
+    }
+
     public void setRenderTypeHint(ResourceLocation renderTypeHint) {
         this.renderTypeHint = renderTypeHint;
+    }
+
+    public void setRenderTypeFastHint(ResourceLocation renderTypeFastHint) {
+        this.renderTypeFastHint = renderTypeFastHint;
     }
 
     public void setGui3d(boolean gui3d) {
@@ -124,6 +139,7 @@ public class BlockGeometryBakingContext implements IGeometryBakingContext {
         this.rootTransform = other.rootTransform;
         this.visibilityData.copyFrom(other.visibilityData);
         this.renderTypeHint = other.renderTypeHint;
+        this.renderTypeFastHint = other.renderTypeFastHint;
         this.gui3d = other.gui3d;
     }
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/IGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IGeometryBakingContext.java
@@ -54,6 +54,13 @@ public interface IGeometryBakingContext {
     ResourceLocation getRenderTypeHint();
 
     /**
+     * @return a hint of the {@linkplain net.minecraft.client.GraphicsStatus#FAST fast graphics} render type this model
+     * should use. Custom loaders may ignore this.
+     */
+    @Nullable
+    default ResourceLocation getRenderTypeFastHint() { return null; }
+
+    /**
      * Queries the visibility of a component of this model.
      *
      * @param component The component for which to query visibility
@@ -74,6 +81,14 @@ public interface IGeometryBakingContext {
      */
     default RenderTypeGroup getRenderType() {
         var hint = getRenderTypeHint();
+        return hint == null ? RenderTypeGroup.EMPTY : getRenderType(hint);
+    }
+
+    /**
+     * {@return a {@link RenderTypeGroup} from the {@link #getRenderTypeHint()}, or the empty group if not found.}
+     */
+    default RenderTypeGroup getRenderTypeFast() {
+        var hint = getRenderTypeFastHint();
         return hint == null ? RenderTypeGroup.EMPTY : getRenderType(hint);
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/geometry/SimpleUnbakedGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/SimpleUnbakedGeometry.java
@@ -23,7 +23,7 @@ public abstract class SimpleUnbakedGeometry<T extends SimpleUnbakedGeometry<T>> 
         var particle = baker.sprites().maybeMissing(textures, "particle");
 
         IModelBuilder<?> builder = IModelBuilder.of(context.useAmbientOcclusion(), context.useBlockLight(), context.isGui3d(),
-                context.getTransforms(), particle, context.getRenderType());
+                context.getTransforms(), particle, context.getRenderType(), context.getRenderTypeFast());
 
         addQuads(context, builder, baker, textures, modelState);
 

--- a/src/main/java/net/minecraftforge/client/model/geometry/StandaloneGeometryBakingContext.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/StandaloneGeometryBakingContext.java
@@ -28,6 +28,8 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
     private final Transformation rootTransform;
     @Nullable
     private final ResourceLocation renderTypeHint;
+    @Nullable
+    private final ResourceLocation renderTypeFastHint;
     private final BiPredicate<String, Boolean> visibilityTest;
 
     private StandaloneGeometryBakingContext(
@@ -37,12 +39,24 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
         @Nullable ResourceLocation renderTypeHint,
         BiPredicate<String, Boolean> visibilityTest
     ) {
+        this(isGui3d, useBlockLight, useAmbientOcclusion, transforms, rootTransform, renderTypeHint, null, visibilityTest);
+    }
+
+    private StandaloneGeometryBakingContext(
+        boolean isGui3d,
+        boolean useBlockLight, boolean useAmbientOcclusion,
+        ItemTransforms transforms, Transformation rootTransform,
+        @Nullable ResourceLocation renderTypeHint,
+        @Nullable ResourceLocation renderTypeFastHint,
+        BiPredicate<String, Boolean> visibilityTest
+    ) {
         this.isGui3d = isGui3d;
         this.useBlockLight = useBlockLight;
         this.useAmbientOcclusion = useAmbientOcclusion;
         this.transforms = transforms;
         this.rootTransform = rootTransform;
         this.renderTypeHint = renderTypeHint;
+        this.renderTypeFastHint = renderTypeFastHint;
         this.visibilityTest = visibilityTest;
     }
 
@@ -77,6 +91,12 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
         return renderTypeHint;
     }
 
+    @Nullable
+    @Override
+    public ResourceLocation getRenderTypeFastHint() {
+        return renderTypeFastHint;
+    }
+
     @Override
     public boolean isComponentVisible(String component, boolean fallback) {
         return visibilityTest.test(component, fallback);
@@ -98,6 +118,8 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
         private Transformation rootTransform = Transformation.identity();
         @Nullable
         private ResourceLocation renderTypeHint;
+        @Nullable
+        private ResourceLocation renderTypeFastHint;
         private BiPredicate<String, Boolean> visibilityTest = (c, def) -> def;
 
         private Builder() { }
@@ -109,6 +131,7 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
             this.transforms = parent.getTransforms();
             this.rootTransform = parent.getRootTransform();
             this.renderTypeHint = parent.getRenderTypeHint();
+            this.renderTypeFastHint = parent.getRenderTypeFastHint();
             this.visibilityTest = parent::isComponentVisible;
         }
 
@@ -142,6 +165,12 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
             return this;
         }
 
+        public Builder withRenderTypeHint(ResourceLocation renderTypeHint, ResourceLocation renderTypeFastHint) {
+            this.renderTypeHint = renderTypeHint;
+            this.renderTypeFastHint = renderTypeFastHint;
+            return this;
+        }
+
         @SuppressWarnings("deprecation")
         public Builder withVisibleComponents(Object2BooleanMap<String> parts) {
             this.visibilityTest = parts::getOrDefault;
@@ -149,7 +178,7 @@ public class StandaloneGeometryBakingContext implements IGeometryBakingContext {
         }
 
         public StandaloneGeometryBakingContext build() {
-            return new StandaloneGeometryBakingContext(isGui3d, useBlockLight, useAmbientOcclusion, transforms, rootTransform, renderTypeHint, visibilityTest);
+            return new StandaloneGeometryBakingContext(isGui3d, useBlockLight, useAmbientOcclusion, transforms, rootTransform, renderTypeHint, renderTypeFastHint, visibilityTest);
         }
     }
 }

--- a/src/test/generated/model_render_type/assets/model_render_type/blockstates/old_leaves.json
+++ b/src/test/generated/model_render_type/assets/model_render_type/blockstates/old_leaves.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "model_render_type:block/old_leaves"
+    }
+  }
+}

--- a/src/test/generated/model_render_type/assets/model_render_type/items/old_leaves.json
+++ b/src/test/generated/model_render_type/assets/model_render_type/items/old_leaves.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "model_render_type:block/old_leaves"
+  }
+}

--- a/src/test/generated/model_render_type/assets/model_render_type/models/block/cutout_block.json
+++ b/src/test/generated/model_render_type/assets/model_render_type/models/block/cutout_block.json
@@ -1,6 +1,7 @@
 {
   "parent": "minecraft:block/cross",
   "render_type": "minecraft:cutout",
+  "render_type_fast": "minecraft:solid",
   "textures": {
     "cross": "minecraft:block/acacia_sapling"
   }

--- a/src/test/generated/model_render_type/assets/model_render_type/models/block/old_leaves.json
+++ b/src/test/generated/model_render_type/assets/model_render_type/models/block/old_leaves.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/leaves",
+  "render_type": "minecraft:cutout_mipped",
+  "textures": {
+    "all": "minecraft:block/oak_leaves"
+  }
+}

--- a/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
@@ -133,11 +133,11 @@ public class ModelRenderLayerTest extends BaseTestMod {
 
         ItemBlockRenderTypes.setFancy(true);
         var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
-        helper.assertTrue(layer.contains(RenderType.cutout()), "Block model does not contain the current render type for fancy graphics. Expected: cutout");
+        helper.assertTrue(layer.contains(RenderType.cutout()), "Block model does not contain the correct render type for fancy graphics. Expected: cutout");
 
         ItemBlockRenderTypes.setFancy(false);
         layer = model.getRenderTypes(state, random, ModelData.EMPTY);
-        helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the current render type for fast graphics. Expected: solid");
+        helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the correct render type for fast graphics. Expected: solid");
 
         helper.succeed();
     }
@@ -157,11 +157,11 @@ public class ModelRenderLayerTest extends BaseTestMod {
 
         ItemBlockRenderTypes.setFancy(true);
         var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
-        helper.assertTrue(layer.contains(RenderType.cutoutMipped()), "Block model does not contain the current render type for fancy graphics. Expected: cutout_mipped");
+        helper.assertTrue(layer.contains(RenderType.cutoutMipped()), "Block model does not contain the correct render type for fancy graphics. Expected: cutout_mipped");
 
         ItemBlockRenderTypes.setFancy(false);
         layer = model.getRenderTypes(state, random, ModelData.EMPTY);
-        helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the current render type for fast graphics. Expected: solid");
+        helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the correct render type for fast graphics. Expected: solid");
 
         helper.succeed();
     }

--- a/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
@@ -129,6 +129,7 @@ public class ModelRenderLayerTest extends BaseTestMod {
         var state = BLOCK.get().defaultBlockState();
         var random = helper.getLevel().random;
         boolean originalRenderState = ItemBlockRenderTypes.isFancy();
+        helper.addCleanup(passed -> ItemBlockRenderTypes.setFancy(originalRenderState));
 
         ItemBlockRenderTypes.setFancy(true);
         var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
@@ -138,7 +139,6 @@ public class ModelRenderLayerTest extends BaseTestMod {
         layer = model.getRenderTypes(state, random, ModelData.EMPTY);
         helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the current render type for fast graphics. Expected: solid");
 
-        ItemBlockRenderTypes.setFancy(originalRenderState);
         helper.succeed();
     }
 
@@ -153,6 +153,7 @@ public class ModelRenderLayerTest extends BaseTestMod {
         var state = OLD_LEAVES.get().defaultBlockState();
         var random = helper.getLevel().random;
         boolean originalRenderState = ItemBlockRenderTypes.isFancy();
+        helper.addCleanup(passed -> ItemBlockRenderTypes.setFancy(originalRenderState));
 
         ItemBlockRenderTypes.setFancy(true);
         var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
@@ -162,7 +163,6 @@ public class ModelRenderLayerTest extends BaseTestMod {
         layer = model.getRenderTypes(state, random, ModelData.EMPTY);
         helper.assertTrue(layer.contains(RenderType.solid()), "Block model does not contain the current render type for fast graphics. Expected: solid");
 
-        ItemBlockRenderTypes.setFancy(originalRenderState);
         helper.succeed();
     }
 

--- a/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.debug.client;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
@@ -26,6 +27,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.SaplingBlock;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.grower.TreeGrower;
@@ -72,8 +74,28 @@ public class ModelRenderLayerTest extends BaseTestMod {
         )
     );
 
+    private static final String OLD_LEAVES_NAME = "old_leaves";
+    private static final BlockBehaviour.StatePredicate FALSE = (state, level, pos) -> false;
+    public static final RegistryObject<LeavesBlock> OLD_LEAVES = BLOCKS.register(OLD_LEAVES_NAME,
+        () -> new LeavesBlock(
+            BlockBehaviour.Properties.of()
+                .setId(BLOCKS.key(OLD_LEAVES_NAME))
+                .mapColor(MapColor.PLANT)
+                .strength(0.2F)
+                .randomTicks()
+                .sound(SoundType.GRASS)
+                .noOcclusion()
+                .isSuffocating(FALSE)
+                .isViewBlocking(FALSE)
+                .ignitedByLava()
+                .pushReaction(PushReaction.DESTROY)
+                .isRedstoneConductor(FALSE)
+        )
+    );
+
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Registries.ITEM, MODID);
     public static final RegistryObject<Item> ITEM = ITEMS.register(BLOCK_NAME, () -> new BlockItem(BLOCK.get(), new Item.Properties().setId(ITEMS.key(BLOCK_NAME))));
+    public static final RegistryObject<BlockItem> OLD_LEAVES_ITEM = ITEMS.register(OLD_LEAVES_NAME, () -> new BlockItem(OLD_LEAVES.get(), new Item.Properties().setId(ITEMS.key(OLD_LEAVES_NAME))));
 
     private static ResourceLocation rl(String path) {
         return ResourceLocation.fromNamespaceAndPath(MODID, path);
@@ -104,8 +126,25 @@ public class ModelRenderLayerTest extends BaseTestMod {
         var state = BLOCK.get().defaultBlockState();
         var random = helper.getLevel().random;
         var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
-        if (!layer.contains(RenderType.cutout()))
-            helper.fail("Block model does not have cutout layer");
+        helper.assertTrue(layer.contains(Minecraft.useFancyGraphics() ? RenderType.cutout() : RenderType.solid()), "Block model does not contain the current render type for the current graphics settings. Setting: " + Minecraft.useFancyGraphics() + " Expected: " + (Minecraft.useFancyGraphics() ? RenderType.cutout() : RenderType.solid()));
+
+        helper.succeed();
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void old_leaves_render_type(GameTestHelper helper) {
+        var manager = Minecraft.getInstance().getModelManager();
+
+        var key = new ModelResourceLocation(rl(OLD_LEAVES_NAME), "");
+        var model = manager.getModel(key);
+
+        if (model == manager.getMissingModel())
+            helper.fail("Failed to retreive " + key + " block model");
+
+        var state = OLD_LEAVES.get().defaultBlockState();
+        var random = helper.getLevel().random;
+        var layer = model.getRenderTypes(state, random, ModelData.EMPTY);
+        helper.assertTrue(layer.contains(Minecraft.useFancyGraphics() ? RenderType.cutoutMipped() : RenderType.solid()), "Block model does not contain the current render type for the current graphics settings. Setting: " + Minecraft.useFancyGraphics() + " Expected: " + (Minecraft.useFancyGraphics() ? RenderType.cutout() : RenderType.solid()));
 
         helper.succeed();
     }
@@ -127,16 +166,29 @@ public class ModelRenderLayerTest extends BaseTestMod {
             return new BlockModelGenerators(blocks, items, models) {
                 @Override
                 public void run() {
+                    // CUTOUT BLOCK
                     var textures = PlantType.NOT_TINTED.getTextureMapping(Blocks.ACACIA_SAPLING);
                     var cutout = PlantType.NOT_TINTED.getCross().create(BLOCK.get(), textures, (name, model) -> {
                         var json = model.get().getAsJsonObject();
                         json.addProperty("render_type", "minecraft:cutout");
+                        json.addProperty("render_type_fast", "minecraft:solid");
                         this.modelOutput.accept(name, () -> json);
                     });
                     this.blockStateOutput.accept(createSimpleBlock(BLOCK.get(), cutout));
 
                     var item = ModelTemplates.FLAT_ITEM.create(ITEM.get(), TextureMapping.layer0(Blocks.ACACIA_SAPLING), this.modelOutput);
                     this.itemModelOutput.accept(ITEM.get(), ItemModelUtils.plainModel(item));
+
+
+                    // OLD LEAVES
+                    var oldLeavesCutout = ModelTemplates.LEAVES.create(OLD_LEAVES.get(), TextureMapping.cube(Blocks.OAK_LEAVES), (name, model) -> {
+                        var json = model.get().getAsJsonObject();
+                        json.addProperty("render_type", "minecraft:cutout_mipped");
+                        this.modelOutput.accept(name, () -> json);
+                    });
+                    this.blockStateOutput.accept(createSimpleBlock(OLD_LEAVES.get(), oldLeavesCutout));
+
+                    this.itemModelOutput.accept(OLD_LEAVES_ITEM.get(), ItemModelUtils.plainModel(oldLeavesCutout));
                 }
             };
         }


### PR DESCRIPTION
This PR was primarily created to address the issue of model JSON-based render types overriding vanilla's behavior of giving any instance of `LeavesBlock` the solid render type. However, I figured since the issue needed to be fixed anyway, I also added the `"render_type_fast"` member to the model json which gives the ability for modders to add fast graphics render types to their models.

As it is implied, fast graphics render types are only used when the game is set to fast graphics in the options menu. This property is checked using `!ItemBlockRenderLayers.isFancy()` which itself is set by vanilla in the level renderer. Traditionally in vanilla, all blocks only adhere to the render type that is given to them in this class. However since Forge uses render types as defined in the model's JSON file, it attempts to use that first *before* defaulting back to the vanilla logic of first checking for leaves and then getting the block's render type.

> [!IMPORTANT]
> Since item models have changed in 1.21.4, there is no additional check for item stacks as block items for leaves. That has be accounted for in backports to older versions, however.

The system implemented in `SimpleBakedModel` will first check if we are in fast graphics and attempt to use any defined fast graphics render types. If none exist, then we check if the main render type is rendering cutout (either cutout or cutout mipped) *and* if the block we are rendering for is an instance of `LeavesBlock`. If both of these conditions are met, then we render the solid render type. Render types in the fancy graphics mode remain unaffected. 

> [!NOTE]
> While this might seem unnecessary, it is to account for backwards compatibility with block models that will likely not be regenerated to add in a fast graphics render type. All previously existing item models will continue to work under this extension of the system.

I've added `-WithRenderTypeAndFast` sister method variants to all the related methods in `BlockStateProvider` to account for this change. An important thing to note is that I've modified the default `leaves` method in `ModelProvider` to use a normal render type of `"cutout_mipped"` and a fast graphics render type of `"solid"`.

- Fixes #10389 for 1.21.4.
- Although it may seem unreasonable, I've kept binary compatibility even for private and package-private methods. I am aware that some cheeky coremods might be hooking into these systems that I am modifying.