### PR TITLE
[1.20.1] Account for problematic mixins in patched-out code

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -4,7 +4,7 @@
        private final int f_35667_;
  
        public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
-+         if (Boolean.valueOf(false)) // FORGE: Modders can add custom villager types, so remove this validation
++         if (Boolean.valueOf(false)) // FORGE: Modders can add custom villager types, so remove this validation, weird condition is to make the compiler not strip this dead code, breaking some mixins
           BuiltInRegistries.f_256934_.m_123024_().filter((p_35680_) -> {
              return !p_35672_.containsKey(p_35680_);
           }).findAny().ifPresent((p_258962_) -> {

--- a/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -4,7 +4,7 @@
        private final int f_35667_;
  
        public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
-+         if (false) // FORGE: Modders can add custom villager types, so remove this validation
++         if (Boolean.valueOf(false)) // FORGE: Modders can add custom villager types, so remove this validation
           BuiltInRegistries.f_256934_.m_123024_().filter((p_35680_) -> {
              return !p_35672_.containsKey(p_35680_);
           }).findAny().ifPresent((p_258962_) -> {


### PR DESCRIPTION
## Usage of `Boolean.valueOf(false)` in patches

This PR is used to track, and inform developers about, why we sometimes use `Boolean.valueOf(false)` in our patches. Due to the onset of mixins in mods becoming mainstream, Forge may make patches that break existing mods due to patching out instructions that those mixins would target.

Our solution for now, until Forge is able to write its own mixins that can replace patches for trivial one-liners, is to simply wrap the old method call(s) in a `Boolean.valueOf(false)` branch. This prevents the decompiler from stripping out any dead bytecode, so that mixins from other mods will be able to target it.

> [!IMPORTANT]
> If you are a developer and you are writing a Mixin that targets vanilla code **and** fixes a bug in the process, you should set `require = 0` to ensure that your mixin does not crash the game if Forge needs to patch out any targeted bytecode.

---

> [!NOTE]
> Below is the original description of this PR.

The merging of #10315 added an `if (false)` patch to the constructor `VillagerTrades.EmeraldsForVillagerTypeItem`. While this normally wouldn't be a problem, there are problematic mixins that hook into this call that we have patched out, and those mixins usually just disable those calls anyways. By changing the patch to `if (Boolean.valueOf(false))`, the compiler keeps the bytecode in the method which doesn't cause the mixins to fail, but the intended result is the same and the validation is never invoked.

This will be ported and backported to newer and older versions later. 1.20.1 is the most affected by this issue, so I have made the PR for it first.