### PR TITLE
[1.21.4] Give ItemStack context to IForgeItem.getCapabilityProvider

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -18,7 +18,7 @@
          this.count = p_332766_;
          this.components = p_333722_;
          this.getItem().verifyComponentsAfterLoad(this);
-+        gatherCapabilities(() -> this.item.getCapabilityProvider());
++        gatherCapabilities(() -> this.item.getCapabilityProvider(this));
      }
  
      private ItemStack(@Nullable Void p_282703_) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -619,7 +619,7 @@ public interface IForgeItem {
      * @deprecated Use the itemstack-sensitive version instead: {@link #getCapabilityProvider(ItemStack)}
      */
     @Nullable
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.21.4")
     default ICapabilityProvider getCapabilityProvider() {
         return null;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -615,9 +615,18 @@ public interface IForgeItem {
 
     /**
      * @return The Default Capability Provider for this item, if any.
+     *
+     * @deprecated Use the itemstack-sensitive version instead: {@link #getCapabilityProvider(ItemStack)}
      */
     @Nullable
+    @Deprecated(forRemoval = true)
     default ICapabilityProvider getCapabilityProvider() {
         return null;
+    }
+
+    /** @return The Default Capability Provider for this item, if any, accounting for the given itemstack. */
+    @Nullable
+    default ICapabilityProvider getCapabilityProvider(ItemStack stack) {
+        return this.getCapabilityProvider();
     }
 }


### PR DESCRIPTION
Name entails. This isn't an issue when using `AttachCapabilitiesEvent<ItemStack>` since the item stack object is given there, but when overriding `IForgeItem.getCapabilityProvider`, the modder does not have access to the actual item stack that capabilities are being gathered for.

- Fixes #10403.