### PR TITLE
[1.20.6] Backport even more future ResourceLocation methods

### DIFF
--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -29,10 +29,11 @@
      public String toDebugFileName() {
          return this.toString().replace('/', '_').replace(':', '_');
      }
-@@ -279,5 +_,15 @@
+@@ -278,6 +_,55 @@
+ 
          public JsonElement serialize(ResourceLocation p_135855_, Type p_135856_, JsonSerializationContext p_135857_) {
              return new JsonPrimitive(p_135855_.toString());
-         }
++        }
 +    }
 +
 +    /** Forge: Backport of Vanilla 1.21 method */
@@ -43,5 +44,44 @@
 +    /** Forge: Backport of Vanilla 1.21 method */
 +    public static ResourceLocation parse(String location) {
 +        return new ResourceLocation(location);
++    }
++
++    /** Forge: Backport of Vanilla 1.21 method */
++    public static ResourceLocation withDefaultNamespace(String path) {
++        return new ResourceLocation(DEFAULT_NAMESPACE, assertValidPath(DEFAULT_NAMESPACE, path), null);
++    }
++
++    /** Forge: Backport of Vanilla 1.21 method */
++    public static ResourceLocation bySeparator(String location, char separator) {
++        int i = location.indexOf(separator);
++        if (i >= 0) {
++            String s = location.substring(i + 1);
++            if (i != 0) {
++                String s1 = location.substring(0, i);
++                return new ResourceLocation(s1, s);
++            } else {
++                return withDefaultNamespace(s);
++            }
++        } else {
++            return withDefaultNamespace(location);
++        }
++    }
++
++    /** Forge: Backport of Vanilla 1.21 method */
++    public static @Nullable ResourceLocation tryBySeparator(String location, char separator) {
++        int i = location.indexOf(separator);
++        if (i >= 0) {
++            String s = location.substring(i + 1);
++            if (!isValidPath(s)) {
++                return null;
++            } else if (i != 0) {
++                String s1 = location.substring(0, i);
++                return isValidNamespace(s1) ? new ResourceLocation(s1, s, null) : null;
++            } else {
++                return new ResourceLocation(DEFAULT_NAMESPACE, s, null);
++            }
++        } else {
++            return isValidPath(location) ? new ResourceLocation(DEFAULT_NAMESPACE, location, null) : null;
+         }
      }
  }

--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -1,20 +1,28 @@
 --- a/net/minecraft/resources/ResourceLocation.java
 +++ b/net/minecraft/resources/ResourceLocation.java
-@@ -38,6 +_,7 @@
+@@ -38,6 +_,8 @@
          this.path = p_249394_;
      }
  
-+    /** Forge: Consider using {@link #fromNamespaceAndPath(String, String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
++    /** @deprecated Forge: Consider using {@link #fromNamespaceAndPath(String, String)} instead, as Mojang made this constructor private in 1.21 */
++    @Deprecated(forRemoval = true, since = "1.20.6")
      public ResourceLocation(String p_135811_, String p_135812_) {
          this(assertValidNamespace(p_135811_, p_135812_), assertValidPath(p_135811_, p_135812_), null);
      }
-@@ -46,6 +_,7 @@
+@@ -46,10 +_,14 @@
          this(p_135814_[0], p_135814_[1]);
      }
  
-+    /** Forge: Consider using {@link #parse(String)} instead, as Mojang made this constructor private in Vanilla 1.21 */
++    /** @deprecated Forge: Consider using {@link #parse(String)} instead, as Mojang made this constructor private in 1.21 */
++    @Deprecated(forRemoval = true, since = "1.20.6")
      public ResourceLocation(String p_135809_) {
          this(decompose(p_135809_, ':'));
+     }
+ 
++    /** @deprecated Forge: Consider using {@link #bySeparator(String, char)} instead, as Mojang removed this method in 1.21 */
++    @Deprecated(forRemoval = true, since = "1.20.6")
+     public static ResourceLocation of(String p_135823_, char p_135824_) {
+         return new ResourceLocation(decompose(p_135823_, p_135824_));
      }
 @@ -147,6 +_,12 @@
          return i;

--- a/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourceLocation.java.patch
@@ -29,45 +29,41 @@
      public String toDebugFileName() {
          return this.toString().replace('/', '_').replace(':', '_');
      }
-@@ -278,6 +_,55 @@
+@@ -278,6 +_,51 @@
  
          public JsonElement serialize(ResourceLocation p_135855_, Type p_135856_, JsonSerializationContext p_135857_) {
              return new JsonPrimitive(p_135855_.toString());
 +        }
 +    }
 +
-+    /** Forge: Backport of Vanilla 1.21 method */
++    /** Forge: This is a backported method from 1.21, and is the replacement for {@link #ResourceLocation(String, String)}. */
 +    public static ResourceLocation fromNamespaceAndPath(String namespace, String path) {
 +        return new ResourceLocation(namespace, path);
 +    }
 +
-+    /** Forge: Backport of Vanilla 1.21 method */
++    /** Forge: This is a backported method from 1.21, and is the replacement for {@link #ResourceLocation(String)}. */
 +    public static ResourceLocation parse(String location) {
 +        return new ResourceLocation(location);
 +    }
 +
-+    /** Forge: Backport of Vanilla 1.21 method */
++    /**
++     * Forge: This is a backported method from 1.21, and acts as an alternative to using {@link #parse(String)}. If you
++     * know for sure you are going to be using the {@linkplain #DEFAULT_NAMESPACE default namespace}
++     * ({@code "minecraft"}), use this.
++     */
 +    public static ResourceLocation withDefaultNamespace(String path) {
 +        return new ResourceLocation(DEFAULT_NAMESPACE, assertValidPath(DEFAULT_NAMESPACE, path), null);
 +    }
 +
-+    /** Forge: Backport of Vanilla 1.21 method */
++    /** Forge: This is a backported method from 1.21, and is the replacement for {@link #of(String, char)}. */
 +    public static ResourceLocation bySeparator(String location, char separator) {
-+        int i = location.indexOf(separator);
-+        if (i >= 0) {
-+            String s = location.substring(i + 1);
-+            if (i != 0) {
-+                String s1 = location.substring(0, i);
-+                return new ResourceLocation(s1, s);
-+            } else {
-+                return withDefaultNamespace(s);
-+            }
-+        } else {
-+            return withDefaultNamespace(location);
-+        }
++        return of(location, separator);
 +    }
 +
-+    /** Forge: Backport of Vanilla 1.21 method */
++    /**
++     * Forge: This is a backported method from 1.21, and is the same as {@link #bySeparator(String, char)} but returns
++     * {@code null} if a resource location cannot be created.
++     */
 +    public static @Nullable ResourceLocation tryBySeparator(String location, char separator) {
 +        int i = location.indexOf(separator);
 +        if (i >= 0) {

--- a/src/test/java/net/minecraftforge/debug/resource/ResourceLocationTest.java
+++ b/src/test/java/net/minecraftforge/debug/resource/ResourceLocationTest.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.debug.resource;
+
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.gametest.GameTestHolder;
+
+import java.util.Objects;
+
+@Mod(ResourceLocationTest.MODID)
+@GameTestHolder("forge." + ResourceLocationTest.MODID)
+public final class ResourceLocationTest {
+    static final String MODID = "resource_location";
+
+    @SuppressWarnings("removal") // intentionally using old constructors and methods for testing purposes
+    @GameTest(template = "forge:empty3x3x3")
+    public static void backported_methods(GameTestHelper helper) {
+        var mcLoc = new ResourceLocation("test");
+        var forgeLoc = new ResourceLocation("forge", "test");
+
+        assertValueEqual(forgeLoc, ResourceLocation.fromNamespaceAndPath("forge", "test"), "resource location from namespace and path (forge)");
+        assertValueEqual(mcLoc, ResourceLocation.withDefaultNamespace("test"), "resource location with default namespace");
+        assertValueEqual(mcLoc, ResourceLocation.parse("test"), "resource location parse");
+        assertValueEqual(mcLoc, ResourceLocation.parse("minecraft:test"), "resource location parse (with minecraft namespace)");
+        assertValueEqual(forgeLoc, ResourceLocation.parse("forge:test"), "resource location parse (with forge namespace)");
+        assertValueEqual(mcLoc, ResourceLocation.bySeparator("minecraft/test", '/'), "resource location by separator");
+        assertValueEqual(ResourceLocation.of("forge/of_test", '/'), ResourceLocation.bySeparator("forge/of_test", '/'), "resource location by separator (compared to of)");
+        assertValueEqual(mcLoc, ResourceLocation.tryBySeparator("minecraft/test", '/'), "resource location by separator");
+        assertValueEqual(null, ResourceLocation.tryBySeparator("minecraft:?/awd&", '/'), "resource location by separator (invalid)");
+
+        helper.succeed();
+    }
+
+    // I don't want to backport IForgeGameTestHelper stuff right now, so this will do - Jonathing
+    private static void assertValueEqual(ResourceLocation expected, ResourceLocation actual, String name) {
+        if (!Objects.equals(expected, actual)) {
+            throw new GameTestAssertException("Expected " + name + " to be " + expected + ", but got " + actual);
+        }
+    }
+}


### PR DESCRIPTION
This PR backports even more methods from 1.21's ResourceLocation that modders may want to take advantage of. This will also help in the ease of porting for those who are still on older versions.

> [!NOTE]
> I intend to backport this PR all the way back to 1.18.2. When I do, I will also add other methods not included in this PR, such as `#withPath`, `#withSuffix`, and `#withPrefix`, as they have been part of the class since 1.19.3.

> [!CAUTION]
> This PR deprecates, for removal since "1.20.6", the two constructors and `#of`. Mojang have made these methods inaccessible in Minecraft 1.21. I don't think this should have any impact, but let me know if that might cause some weird issue.

## withDefaultNamespace

`#withDefaultNamespace` is a method that forces the namespace to be set to `DEFAULT_NAMESPACE` (i.e. `"minecraft"`). In this backport, the constructor `new ResourceLocation(String, String, Dummy)` is used to skip the unnecessary processing of the namespace since it will always be correct. This is how this method functions in 1.21.

## bySeparator

`#bySeparator` is the replacement of `#of` in 1.21, and thus I added it here so modders can begin using it instead. The logic inside of `#of` is equivalent to that in 1.21, so I simply have it delegate there so as to not write duplicate code.

## tryBySeparator

A sister to `#bySeparator` and similarly to `#tryParse`, `#tryBySeparator` will return `null` if a ResourceLocation would otherwise fail to create in `#bySeparator` instead of throwing an exception. The logic for this method has been copied from 1.21 with the main difference being the usage of constructor `new ResourceLocation(String, String, Dummy)` so as to not re-validate namespace and path which will have already been validated inside this method.
