### PR TITLE
[1.21.4] Fix corrupted and invalidly symlinked worlds crashing on level select

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
@@ -9,13 +9,14 @@
      public static final Component PLAY_WORLD = Component.translatable("selectWorld.select");
      private final LevelSettings settings;
      private final LevelVersion levelVersion;
-@@ -275,6 +_,11 @@
+@@ -275,6 +_,12 @@
          public boolean canRecreate() {
              return false;
          }
 +    }
 +
 +    // TODO Forge: Remove in 1.22. It is kept here for binary compatibility, but already exists in IForgeLevelSummary
++    @Deprecated(forRemoval = true, since = "1.21.4")
 +    public boolean isLifecycleExperimental() {
 +        return net.minecraftforge.common.extensions.IForgeLevelSummary.super.isLifecycleExperimental();
      }

--- a/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
@@ -1,13 +1,23 @@
 --- a/net/minecraft/world/level/storage/LevelSummary.java
 +++ b/net/minecraft/world/level/storage/LevelSummary.java
-@@ -277,6 +_,10 @@
-         }
-     }
+@@ -14,7 +_,7 @@
+ import net.minecraft.world.level.LevelSettings;
+ import org.apache.commons.lang3.StringUtils;
  
-+    public boolean isLifecycleExperimental() {
-+        return this.settings.getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
+-public class LevelSummary implements Comparable<LevelSummary> {
++public class LevelSummary implements Comparable<LevelSummary>, net.minecraftforge.common.extensions.IForgeLevelSummary {
+     public static final Component PLAY_WORLD = Component.translatable("selectWorld.select");
+     private final LevelSettings settings;
+     private final LevelVersion levelVersion;
+@@ -275,6 +_,11 @@
+         public boolean canRecreate() {
+             return false;
+         }
 +    }
 +
++    // TODO Forge: Remove in 1.22. It is kept here for binary compatibility, but already exists in IForgeLevelSummary
++    public boolean isLifecycleExperimental() {
++        return net.minecraftforge.common.extensions.IForgeLevelSummary.super.isLifecycleExperimental();
+     }
+ 
      public static class SymlinkLevelSummary extends LevelSummary {
-         private static final Component MORE_INFO_BUTTON = Component.translatable("symlink_warning.more_info");
-         private static final Component INFO = Component.translatable("symlink_warning.title").withColor(-65536);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.world.level.storage.LevelSummary;
+
+public interface IForgeLevelSummary {
+    private LevelSummary self() {
+        return (LevelSummary) this;
+    }
+
+    /**
+     * Checks if the Forge lifecycle of this level is experimental. This is used to render the experimental warning
+     * tooltip on the level select screen.
+     *
+     * @return {@code true} if the level is experimental
+     */
+    default boolean isLifecycleExperimental() {
+        return this.self().getSettings().getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
@@ -14,6 +14,9 @@ public interface IForgeLevelSummary {
      * @return {@code true} if the level is experimental
      */
     default boolean isLifecycleExperimental() {
-        return this.self().getSettings().getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
+        // NOTE: Because CorruptedLevelSummary and SymlinkLevelSummary can have null settings, we need to check it
+        var settings = this.self().getSettings();
+
+        return settings != null && settings.getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
     }
 }


### PR DESCRIPTION
This PR cleans up the extensions made to `LevelSummary` and fixes a bug with corrupted and symlinked worlds which are represented by `CorruptedLevelSummary` and `SymlinkLevelSummary` respectively.

The issue with these classes is that they feed the super constructor a null `LevelSettings`, which is then used by `#isLifecycleExperimental` to determine whether or not an experimental warning tooltip should be displayed on the level select screen. This causes the game to crash with a null pointer exception. Basically: if a world is corrupted or you have an illegally symlinked world, you can kiss goodbye to opening any worlds at all from the level select screen.

So yes, a null-check is indeed necessary to prevent this from happening. Aside from that, I've also moved `#isLifecycleExperimental` to new extension interface `IForgeLevelSummary`, since a patch to add a single method in the class in the first place is pretty ridiculous since the settings are accessible from `#getSettings`. Although that might not have been the case in the past, which would explain why it's done like this.

> [!NOTE]
> To keep binary compatibility, `LevelSummary#isLifecycleExperimental` still exists as a method in that class, but instead delegates to `IForgeLevelSummary.super.isLifecycleExperimental()`. We should delete the method inside of `LevelSummary` either in 1.21.5 or in 1.22.

- Fixes #9868 for 1.21.4.