### PR TITLE
[1.20.1] Ensure NetworkConstants is loaded before mod construction

### DIFF
--- a/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/server/Bootstrap.java
 +++ b/net/minecraft/server/Bootstrap.java
-@@ -54,6 +_,8 @@
+@@ -54,6 +_,9 @@
                 CauldronInteraction.m_175649_();
                 BuiltInRegistries.m_257498_();
                 CreativeModeTabs.m_280019_();
 +               net.minecraftforge.registries.GameData.vanillaSnapshot();
++               net.minecraftforge.network.NetworkHooks.init();
 +               if (false) // skip redirectOutputToLog, Forge already redirects stdout and stderr output to log so that they print with more context
                 m_135890_();
                 f_285608_.set(Duration.between(instant, Instant.now()).toMillis());

--- a/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
@@ -1,10 +1,14 @@
 --- a/net/minecraft/server/Bootstrap.java
 +++ b/net/minecraft/server/Bootstrap.java
-@@ -54,6 +_,9 @@
+@@ -54,6 +_,13 @@
                 CauldronInteraction.m_175649_();
                 BuiltInRegistries.m_257498_();
                 CreativeModeTabs.m_280019_();
 +               net.minecraftforge.registries.GameData.vanillaSnapshot();
++               // Forge: Hacky fix to ensure that NetworkConstants is loaded before mods are constructed.
++               // Many older mods use network internals that shouldn't be used, yet are exposed so they get used anyways.
++               // This can cause class-loading issues with ForgeMod loading NetworkConstants and HandshakeResolver.
++               // To ensure that doesn't happen, we load it here and now. This is not an issue in 1.20.2 and newer.
 +               net.minecraftforge.network.NetworkHooks.init();
 +               if (false) // skip redirectOutputToLog, Forge already redirects stdout and stderr output to log so that they print with more context
                 m_135890_();

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -426,7 +426,6 @@ public class ForgeMod
             return uuid.toString();
         });
 
-        LOGGER.debug(FORGEMOD, "Loading Network data for FML net version: {}", NetworkConstants.init());
         CrashReportCallables.registerCrashCallable("FML", ForgeVersion::getSpec);
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 

--- a/src/main/java/net/minecraftforge/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/network/NetworkHooks.java
@@ -47,6 +47,11 @@ public class NetworkHooks
 {
     private static final Logger LOGGER = LogManager.getLogger();
 
+    public static void init()
+    {
+        LOGGER.debug("Loading Network data for FML net version: {}", NetworkConstants.init());
+    }
+
     public static String getFMLVersion(final String ip)
     {
         return ip.contains("\0") ? Objects.equals(ip.split("\0")[1], NetworkConstants.NETVERSION) ? NetworkConstants.NETVERSION : ip.split("\0")[1] : NetworkConstants.NOVERSION;


### PR DESCRIPTION
**wake up babe it's another class-loading issue in forge**

This PR attempts to solve a class-loading issue where the initialization of `NetworkConstants` could cause a deadlock on mod construction. In a nutshell, `NetworkConstants` is initialized as late as the Forge mod's mod construction, where another mod might want to access `HandshakeHandler` which itself also needs to initialize `NetworkConstants`. So, `NetworkHooks#init` delegates to `NetworkConstants#init`, and this is called from `Bootstrap#bootStrap`.

The example shown in #9505 involves the parallel loading of the Forge mod as well as Abnormals' Environmental. On mod construction, Environmental immediately attempts to begin setting up its network protocals and calls on `HandshakeHandler` to do this. `HandshakeHandler` needs to get the handshake channel for Environmental, *and* it also needs to run through the static initialization which involves creating a marker that parents off of marker `NetworkConstants.FMLNETMARKER`. While this is happening, `ForgeMod` loads and immediately tries to run `NetworkConstants#init`, and I believe this exact moment is where the JVM shits itself.

The one problem is that I don't have any sort of reliable way to test this. So, this PR is another case of "trust me bro". If anyone has suggestions on reliable reproduction cases, I'm all ears. But as far as I'm aware, the situation I've stated above makes sense and warrants me at least creating this PR.

Here's the debug log output with this PR:
```log
[19:19:17] [pool-4-thread-1/DEBUG] [ne.mi.ne.NetworkHooks/]: Loading Network data for FML net version: FML3
// ...
[19:19:18] [Render thread/DEBUG] [ne.mi.fm.ModWorkManager/LOADING]: Using 16 threads for parallel mod-loading
[19:19:18] [Render thread/DEBUG] [ne.mi.fm.ja.FMLJavaModLanguageProvider/LOADING]: Loading FMLModContainer from classloader cpw.mods.modlauncher.TransformingClassLoader@42a0501e - got cpw.mods.cl.ModuleClassLoader@4482469c
[19:19:18] [Render thread/DEBUG] [ne.mi.fm.ja.FMLModContainer/LOADING]: Creating FMLModContainer instance for net.minecraftforge.common.ForgeMod
```

- Fixes #9505 for 1.20.1.
- This issue does not affect any versions past 1.20.2 due to the networking rewrite.