### PR TITLE
[1.21.4] Re-introduce FluidStack item handlers

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -87,7 +87,7 @@
                      liquidblockcontainer1.placeLiquid(p_150717_, p_150718_, blockstate, flowingfluid.getSource(false));
                      this.playEmptySound(p_150716_, p_150717_, p_150718_);
                      return true;
-@@ -166,7 +_,32 @@
+@@ -166,7 +_,30 @@
  
      protected void playEmptySound(@Nullable Player p_40696_, LevelAccessor p_40697_, BlockPos p_40698_) {
          SoundEvent soundevent = this.content.is(FluidTags.LAVA) ? SoundEvents.BUCKET_EMPTY_LAVA : SoundEvents.BUCKET_EMPTY;
@@ -99,16 +99,14 @@
          p_40697_.gameEvent(p_40696_, GameEvent.FLUID_PLACE, p_40698_);
 +    }
 +
-+    /** Forge: TODO: Forge ItemStack capabilities - Lex 042724
 +    @Override
-+    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable net.minecraft.nbt.CompoundTag nbt) {
++    public @org.jetbrains.annotations.Nullable net.minecraftforge.common.capabilities.ICapabilityProvider getCapabilityProvider(ItemStack stack) {
 +        if (this.getClass() == BucketItem.class) {
 +            return new net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper(stack);
 +        } else {
-+            return super.initCapabilities(stack, nbt);
++            return super.getCapabilityProvider(stack);
 +        }
 +    }
-+    */
 +
 +    private final java.util.function.Supplier<? extends Fluid> fluidSupplier;
 +

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -14,6 +14,7 @@ import net.minecraft.commands.synchronization.SingletonArgumentInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
@@ -63,6 +64,7 @@ import net.minecraftforge.common.world.NoneStructureModifier;
 import net.minecraftforge.common.world.StructureModifier;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.*;
@@ -343,6 +345,14 @@ public class ForgeMod {
         INGREDIENT_SERIALIZERS.register("difference", () -> DifferenceIngredient.SERIALIZER);
         INGREDIENT_SERIALIZERS.register("intersection", () -> IntersectionIngredient.SERIALIZER);
     }
+
+    private static final DeferredRegister<DataComponentType<?>> DATA_COMPONENTS = deferred(Registries.DATA_COMPONENT_TYPE);
+    public static final RegistryObject<DataComponentType<FluidStack>> FLUID_STACK_DATA = DATA_COMPONENTS.register("fluidstack", () ->
+        DataComponentType.<FluidStack>builder()
+            .persistent(FluidStack.CODEC)
+            .networkSynchronized(FluidStack.STREAM_CODEC)
+            .build()
+    );
 
 
     private static boolean enableMilkFluid = false;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -430,29 +430,6 @@ public interface IForgeItem {
     }
 
     /**
-     * Called from ItemStack.setItem, will hold extra data for the life of this
-     * ItemStack. Can be retrieved from stack.getCapabilities() The NBT can be null
-     * if this is not called from readNBT or if the item the stack is changing FROM
-     * is different then this item, or the previous item had no capabilities.
-     *
-     * This is called BEFORE the stacks item is set so you can use stack.getItem()
-     * to see the OLD item. Remember that getItem CAN return null.
-     *
-     * @param stack The ItemStack
-     * @param nbt   NBT of this item serialized, or null.
-     * @return A holder instance associated with this ItemStack where you can hold
-     *         capabilities for the life of this item.
-     *
-     *
-     * Forge: TODO: Forge ItemStack capabilities - Lex 042724
-     * /
-    @Nullable
-    default ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
-        return ShulkerItemStackInvWrapper.createDefaultProvider(stack);
-    }
-    */
-
-    /**
      * Can this Item disable a shield
      *
      * @param stack    The ItemStack

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -9,12 +9,15 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -49,6 +52,19 @@ public class FluidStack
                 tag.ifPresent(stack::setTag);
                 return stack;
             })
+    );
+    public static final StreamCodec<RegistryFriendlyByteBuf, FluidStack> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.registry(Registries.FLUID),
+        FluidStack::getFluid,
+        ByteBufCodecs.VAR_INT,
+        FluidStack::getAmount,
+        ByteBufCodecs.OPTIONAL_COMPOUND_TAG,
+        stack -> Optional.ofNullable(stack.getTag()),
+        (fluid, amount, tag) -> {
+            FluidStack stack = new FluidStack(fluid, amount);
+            tag.ifPresent(stack::setTag);
+            return stack;
+        }
     );
 
     private boolean isEmpty;

--- a/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
@@ -3,39 +3,34 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-/** Forge: TODO: Forge ItemStack capabilities - Lex 042724
 package net.minecraftforge.fluids.capability;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A simple fluid container, to replace the functionality of the old FluidContainerRegistry and IFluidContainerItem.
- * This fluid container may be set so that is can only completely filled or empty. (binary)
- * It may also be set so that it gets consumed when it is drained. (consumable)
- * /
-public class ItemFluidContainer extends Item
-{
+ * <ul>
+ *     <li>This fluid container may be set so that is can only completely filled or empty. (binary)</li>
+ *     <li>It may also be set so that it gets consumed when it is drained. (consumable)</li>
+ * </ul>
+ */
+public class ItemFluidContainer extends Item {
     protected final int capacity;
 
     /**
-     * @param capacity   The maximum capacity of this fluid container.
-     * /
-    public ItemFluidContainer(Item.Properties properties, int capacity)
-    {
+     * @param capacity The maximum capacity of this fluid container.
+     */
+    public ItemFluidContainer(Item.Properties properties, int capacity) {
         super(properties);
         this.capacity = capacity;
     }
 
     @Override
-    public ICapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable CompoundTag nbt)
-    {
+    public @Nullable ICapabilityProvider getCapabilityProvider(ItemStack stack) {
         return new FluidHandlerItemStack(stack, capacity);
     }
 }
-*/

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -3,132 +3,97 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-/** Forge: TODO: Forge ItemStack capabilities - Lex 042724
 package net.minecraftforge.fluids.capability.templates;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fluids.*;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * FluidHandlerItemStack is a template capability provider for ItemStacks.
- * Data is stored directly in the vanilla NBT, in the same way as the old ItemFluidContainer.
- *
+ * Data is stored using the {@linkplain ForgeMod#FLUID_STACK_DATA fluidstack data component}.
+ * <p>
  * This class allows an ItemStack to contain any partial level of fluid up to its capacity, unlike {@link FluidHandlerItemStackSimple}
  *
  * Additional examples are provided to enable consumable fluid containers (see {@link Consumable}),
  * fluid containers with different empty and full items (see {@link SwapEmpty},
- * /
+ */
 public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProvider
 {
-    public static final String FLUID_NBT_KEY = "Fluid";
-
     private final LazyOptional<IFluidHandlerItem> holder = LazyOptional.of(() -> this);
 
-    @NotNull
     protected ItemStack container;
     protected int capacity;
 
     /**
      * @param container  The container itemStack, data is stored on it directly as NBT.
      * @param capacity   The maximum capacity of this fluid tank.
-     * /
-    public FluidHandlerItemStack(@NotNull ItemStack container, int capacity)
-    {
+     */
+    public FluidHandlerItemStack(ItemStack container, int capacity) {
         this.container = container;
         this.capacity = capacity;
     }
 
-    @NotNull
     @Override
-    public ItemStack getContainer()
-    {
+    public ItemStack getContainer() {
         return container;
     }
 
-    @NotNull
-    public FluidStack getFluid()
-    {
-        CompoundTag tagCompound = container.getTag();
-        if (tagCompound == null || !tagCompound.contains(FLUID_NBT_KEY))
-        {
-            return FluidStack.EMPTY;
-        }
-        return FluidStack.loadFluidStackFromNBT(tagCompound.getCompound(FLUID_NBT_KEY));
+    public FluidStack getFluid() {
+        return container.getOrDefault(ForgeMod.FLUID_STACK_DATA.get(), FluidStack.EMPTY);
     }
 
-    protected void setFluid(FluidStack fluid)
-    {
-        if (!container.hasTag())
-        {
-            container.setTag(new CompoundTag());
-        }
-
-        CompoundTag fluidTag = new CompoundTag();
-        fluid.writeToNBT(fluidTag);
-        container.getTag().put(FLUID_NBT_KEY, fluidTag);
+    protected void setFluid(FluidStack fluid) {
+        container.set(ForgeMod.FLUID_STACK_DATA.get(), fluid);
     }
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
-    @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return capacity;
     }
 
     @Override
-    public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
+    public boolean isFluidValid(int tank, FluidStack stack) {
         return true;
     }
 
     @Override
-    public int fill(FluidStack resource, FluidAction doFill)
-    {
-        if (container.getCount() != 1 || resource.isEmpty() || !canFillFluidType(resource))
-        {
+    public int fill(FluidStack resource, FluidAction doFill) {
+        if (container.getCount() != 1 || resource.isEmpty() || !canFillFluidType(resource)) {
             return 0;
         }
 
         FluidStack contained = getFluid();
-        if (contained.isEmpty())
-        {
+        if (contained.isEmpty()) {
             int fillAmount = Math.min(capacity, resource.getAmount());
 
-            if (doFill.execute())
-            {
+            if (doFill.execute()) {
                 FluidStack filled = resource.copy();
                 filled.setAmount(fillAmount);
                 setFluid(filled);
             }
 
             return fillAmount;
-        }
-        else
-        {
-            if (contained.isFluidEqual(resource))
-            {
+        } else {
+            if (contained.isFluidEqual(resource)) {
                 int fillAmount = Math.min(capacity - contained.getAmount(), resource.getAmount());
 
                 if (doFill.execute() && fillAmount > 0) {
@@ -143,92 +108,70 @@ public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProv
         }
     }
 
-    @NotNull
     @Override
-    public FluidStack drain(FluidStack resource, FluidAction action)
-    {
+    public FluidStack drain(FluidStack resource, FluidAction action) {
         if (container.getCount() != 1 || resource.isEmpty() || !resource.isFluidEqual(getFluid()))
-        {
             return FluidStack.EMPTY;
-        }
+
         return drain(resource.getAmount(), action);
     }
 
-    @NotNull
     @Override
-    public FluidStack drain(int maxDrain, FluidAction action)
-    {
+    public FluidStack drain(int maxDrain, FluidAction action) {
         if (container.getCount() != 1 || maxDrain <= 0)
-        {
             return FluidStack.EMPTY;
-        }
 
         FluidStack contained = getFluid();
         if (contained.isEmpty() || !canDrainFluidType(contained))
-        {
             return FluidStack.EMPTY;
-        }
 
         final int drainAmount = Math.min(contained.getAmount(), maxDrain);
 
         FluidStack drained = contained.copy();
         drained.setAmount(drainAmount);
 
-        if (action.execute())
-        {
+        if (action.execute()) {
             contained.shrink(drainAmount);
             if (contained.isEmpty())
-            {
                 setContainerToEmpty();
-            }
             else
-            {
                 setFluid(contained);
-            }
         }
 
         return drained;
     }
 
-    public boolean canFillFluidType(FluidStack fluid)
-    {
+    public boolean canFillFluidType(FluidStack fluid) {
         return true;
     }
 
-    public boolean canDrainFluidType(FluidStack fluid)
-    {
+    public boolean canDrainFluidType(FluidStack fluid) {
         return true;
     }
 
     /**
      * Override this method for special handling.
      * Can be used to swap out or destroy the container.
-     * /
-    protected void setContainerToEmpty()
-    {
-        container.removeTagKey(FLUID_NBT_KEY);
+     */
+    protected void setContainerToEmpty() {
+        container.remove(ForgeMod.FLUID_STACK_DATA.get());
     }
 
     @Override
-    @NotNull
-    public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
-    {
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
         return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
     }
 
     /**
      * Destroys the container item when it's emptied.
-     * /
-    public static class Consumable extends FluidHandlerItemStack
-    {
-        public Consumable(ItemStack container, int capacity)
-        {
+     */
+    public static class Consumable extends FluidHandlerItemStack {
+        public Consumable(ItemStack container, int capacity) {
             super(container, capacity);
         }
 
         @Override
-        protected void setContainerToEmpty()
-        {
+        protected void setContainerToEmpty() {
             super.setContainerToEmpty();
             container.shrink(1);
         }
@@ -236,23 +179,19 @@ public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProv
 
     /**
      * Swaps the container item for a different one when it's emptied.
-     * /
-    public static class SwapEmpty extends FluidHandlerItemStack
-    {
+     */
+    public static class SwapEmpty extends FluidHandlerItemStack {
         protected final ItemStack emptyContainer;
 
-        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity)
-        {
+        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity) {
             super(container, capacity);
             this.emptyContainer = emptyContainer;
         }
 
         @Override
-        protected void setContainerToEmpty()
-        {
+        protected void setContainerToEmpty() {
             super.setContainerToEmpty();
             container = emptyContainer;
         }
     }
 }
-*/

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-/** Forge: TODO: Forge ItemStack capabilities - Lex 042724
 package net.minecraftforge.fluids.capability.templates;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -16,101 +15,69 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * FluidHandlerItemStackSimple is a template capability provider for ItemStacks.
- * Data is stored directly in the vanilla NBT, in the same way as the old ItemFluidContainer.
- *
+ * Data is stored using the {@linkplain ForgeMod#FLUID_STACK_DATA fluidstack data component}.
+ * <p>
  * This implementation only allows item containers to be fully filled or emptied, similar to vanilla buckets.
- * /
-public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabilityProvider
-{
-    public static final String FLUID_NBT_KEY = "Fluid";
-
+ */
+public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabilityProvider {
     private final LazyOptional<IFluidHandlerItem> holder = LazyOptional.of(() -> this);
 
-    @NotNull
     protected ItemStack container;
     protected int capacity;
 
     /**
      * @param container  The container itemStack, data is stored on it directly as NBT.
      * @param capacity   The maximum capacity of this fluid tank.
-     * /
-    public FluidHandlerItemStackSimple(@NotNull ItemStack container, int capacity)
-    {
+     */
+    public FluidHandlerItemStackSimple(ItemStack container, int capacity) {
         this.container = container;
         this.capacity = capacity;
     }
 
-    @NotNull
     @Override
-    public ItemStack getContainer()
-    {
+    public ItemStack getContainer() {
         return container;
     }
 
-    @NotNull
-    public FluidStack getFluid()
-    {
-        CompoundTag tagCompound = container.getTag();
-        if (tagCompound == null || !tagCompound.contains(FLUID_NBT_KEY))
-        {
-            return FluidStack.EMPTY;
-        }
-        return FluidStack.loadFluidStackFromNBT(tagCompound.getCompound(FLUID_NBT_KEY));
+    public FluidStack getFluid() {
+        return container.getOrDefault(ForgeMod.FLUID_STACK_DATA.get(), FluidStack.EMPTY);
     }
 
-    protected void setFluid(FluidStack fluid)
-    {
-        if (!container.hasTag())
-        {
-            container.setTag(new CompoundTag());
-        }
-
-        CompoundTag fluidTag = new CompoundTag();
-        fluid.writeToNBT(fluidTag);
-        container.getTag().put(FLUID_NBT_KEY, fluidTag);
+    protected void setFluid(FluidStack fluid) {
+        container.set(ForgeMod.FLUID_STACK_DATA.get(), fluid);
     }
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
-    @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return capacity;
     }
 
     @Override
-    public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
+    public boolean isFluidValid(int tank, FluidStack stack) {
         return true;
     }
 
     @Override
-    public int fill(@NotNull FluidStack resource, FluidAction action)
-    {
+    public int fill(FluidStack resource, FluidAction action) {
         if (container.getCount() != 1 || resource.isEmpty() || !canFillFluidType(resource))
-        {
             return 0;
-        }
 
         FluidStack contained = getFluid();
-        if (contained.isEmpty())
-        {
+        if (contained.isEmpty()) {
             int fillAmount = Math.min(capacity, resource.getAmount());
             if (fillAmount == capacity) {
                 if (action.execute()) {
@@ -126,39 +93,29 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
         return 0;
     }
 
-    @NotNull
     @Override
-    public FluidStack drain(FluidStack resource, FluidAction action)
-    {
+    public FluidStack drain(FluidStack resource, FluidAction action) {
         if (container.getCount() != 1 || resource.isEmpty() || !resource.isFluidEqual(getFluid()))
-        {
             return FluidStack.EMPTY;
-        }
+
         return drain(resource.getAmount(), action);
     }
 
-    @NotNull
     @Override
-    public FluidStack drain(int maxDrain, FluidAction action)
-    {
+    public FluidStack drain(int maxDrain, FluidAction action) {
         if (container.getCount() != 1 || maxDrain <= 0)
-        {
             return FluidStack.EMPTY;
-        }
 
         FluidStack contained = getFluid();
         if (contained.isEmpty() || !canDrainFluidType(contained))
-        {
             return FluidStack.EMPTY;
-        }
 
         final int drainAmount = Math.min(contained.getAmount(), maxDrain);
         if (drainAmount == capacity) {
             FluidStack drained = contained.copy();
 
-            if (action.execute()) {
+            if (action.execute())
                 setContainerToEmpty();
-            }
 
             return drained;
         }
@@ -166,46 +123,40 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
         return FluidStack.EMPTY;
     }
 
-    public boolean canFillFluidType(FluidStack fluid)
-    {
+    public boolean canFillFluidType(FluidStack fluid) {
         return true;
     }
 
-    public boolean canDrainFluidType(FluidStack fluid)
-    {
+    public boolean canDrainFluidType(FluidStack fluid) {
         return true;
     }
 
     /**
      * Override this method for special handling.
+     * <p>
      * Can be used to swap out the container's item for a different one with "container.setItem".
+     * <p>
      * Can be used to destroy the container with "container.stackSize--"
-     * /
-    protected void setContainerToEmpty()
-    {
-        container.removeTagKey(FLUID_NBT_KEY);
+     */
+    protected void setContainerToEmpty() {
+        container.remove(ForgeMod.FLUID_STACK_DATA.get());
     }
 
     @Override
-    @NotNull
-    public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
-    {
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
         return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
     }
 
     /**
      * Destroys the container item when it's emptied.
-     * /
-    public static class Consumable extends FluidHandlerItemStackSimple
-    {
-        public Consumable(ItemStack container, int capacity)
-        {
+     */
+    public static class Consumable extends FluidHandlerItemStackSimple {
+        public Consumable(ItemStack container, int capacity) {
             super(container, capacity);
         }
 
         @Override
-        protected void setContainerToEmpty()
-        {
+        protected void setContainerToEmpty() {
             super.setContainerToEmpty();
             container.shrink(1);
         }
@@ -213,23 +164,19 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
 
     /**
      * Swaps the container item for a different one when it's emptied.
-     * /
-    public static class SwapEmpty extends FluidHandlerItemStackSimple
-    {
+     */
+    public static class SwapEmpty extends FluidHandlerItemStackSimple {
         protected final ItemStack emptyContainer;
 
-        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity)
-        {
+        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity) {
             super(container, capacity);
             this.emptyContainer = emptyContainer;
         }
 
         @Override
-        protected void setContainerToEmpty()
-        {
+        protected void setContainerToEmpty() {
             super.setContainerToEmpty();
             container = emptyContainer;
         }
     }
 }
-*/


### PR DESCRIPTION
Name entails. This is the same system used pre-1.20.6. The only differences are that data is stored using a data component and I cleaned up the formatting of the relevant files a little bit.

- Fixes #10408 for 1.21.4.