### PR TITLE
[1.21.4] Update context in AddReloadListenerEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -27,7 +27,7 @@
                          p_358539_.layers(), p_358539_.lookupWithUpdatedTags(), p_250212_, p_249301_, p_366334_, p_251126_
                      );
 +                    var listeners = new java.util.ArrayList<>(reloadableserverresources.listeners());
-+                    listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources, p_358539_.layers(), p_358539_.lookupWithUpdatedTags(), p_330376_.compositeAccess()));
++                    listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources, p_358539_.lookupWithUpdatedTags(), p_330376_.compositeAccess()));
                      return SimpleReloadInstance.create(
 -                            p_248588_, reloadableserverresources.listeners(), p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()
 +                            p_248588_, listeners, p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()

--- a/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/minecraft/net/minecraft/server/ReloadableServerResources.java.patch
@@ -27,7 +27,7 @@
                          p_358539_.layers(), p_358539_.lookupWithUpdatedTags(), p_250212_, p_249301_, p_366334_, p_251126_
                      );
 +                    var listeners = new java.util.ArrayList<>(reloadableserverresources.listeners());
-+                    listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources, p_330376_.compositeAccess()));
++                    listeners.addAll(net.minecraftforge.event.ForgeEventFactory.onResourceReload(reloadableserverresources, p_358539_.layers(), p_358539_.lookupWithUpdatedTags(), p_330376_.compositeAccess()));
                      return SimpleReloadInstance.create(
 -                            p_248588_, reloadableserverresources.listeners(), p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()
 +                            p_248588_, listeners, p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -94,7 +94,7 @@ public class ForgeInternalHandler {
 
     @SubscribeEvent
     public void onResourceReload(AddReloadListenerEvent event) {
-        INSTANCE = new LootModifierManager(event.getRegistryAccess());
+        INSTANCE = new LootModifierManager(event.getRegistries());
         event.addListener(INSTANCE);
     }
 

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -33,17 +33,11 @@ public class AddReloadListenerEvent extends Event {
     private final List<PreparableReloadListener> listeners = new ArrayList<>();
     private final ReloadableServerResources serverResources;
 
+    private final HolderLookup.Provider registries;
     @Deprecated(forRemoval = true, since = "1.21.4")
     private final RegistryAccess registryAccess;
 
-    private final LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess;
-    private final HolderLookup.Provider registries;
-
-    /**
-     * IF YOU ARE A MODDER YOU SHOULD NOT BE USING THIS!!! THIS IS ONLY KEPT FOR BIN COMPAT! EXPECT ISSUES!
-     *
-     * @deprecated Does not provide additional context. Use {@link #AddReloadListenerEvent(ReloadableServerResources, LayeredRegistryAccess, HolderLookup.Provider, RegistryAccess)} instead.
-     */
+    /** @deprecated Does not provide additional context. Use {@link #AddReloadListenerEvent(ReloadableServerResources, HolderLookup.Provider, RegistryAccess)} instead. */
     @Deprecated(forRemoval = true, since = "1.21.4")
     public AddReloadListenerEvent(
         ReloadableServerResources serverResources,
@@ -51,7 +45,6 @@ public class AddReloadListenerEvent extends Event {
     ) {
         this(
             serverResources,
-            new LayeredRegistryAccess<>(List.of(RegistryLayer.RELOADABLE)).replaceFrom(RegistryLayer.RELOADABLE, List.of((RegistryAccess.Frozen) registryAccess)),
             registryAccess,
             registryAccess
         );
@@ -59,14 +52,12 @@ public class AddReloadListenerEvent extends Event {
 
     public AddReloadListenerEvent(
         ReloadableServerResources serverResources,
-        LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess,
         HolderLookup.Provider registries,
         @Deprecated(forRemoval = true, since = "1.21.4") RegistryAccess registryAccess
     ) {
         this.serverResources = serverResources;
-        this.registryAccess = registryAccess;
-        this.layeredRegistryAccess = layeredRegistryAccess;
         this.registries = registries;
+        this.registryAccess = registryAccess;
     }
 
    /**
@@ -93,15 +84,6 @@ public class AddReloadListenerEvent extends Event {
      */
     public ICondition.IContext getConditionContext() {
         return serverResources.getConditionContext();
-    }
-
-    /**
-     * @return Registry access provider based on layer. Recommended to use {@link RegistryLayer#RELOADABLE}.
-     *
-     * @see net.minecraft.server.ReloadableServerRegistries.LoadResult#layers()
-     */
-    public LayeredRegistryAccess<RegistryLayer> getLayeredRegistryAccess() {
-        return layeredRegistryAccess;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -85,5 +85,10 @@ public class AddReloadListenerEvent extends Event {
             else
                 return CompletableFuture.completedFuture(null);
         }
+
+        @Override
+        public String getName() {
+            return wrapped.getName();
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -71,12 +71,7 @@ public class AddReloadListenerEvent extends Event {
         return registryAccess;
     }
 
-    private static class WrappedStateAwareListener implements PreparableReloadListener {
-        private final PreparableReloadListener wrapped;
-
-        private WrappedStateAwareListener(final PreparableReloadListener wrapped) {
-            this.wrapped = wrapped;
-        }
+    private record WrappedStateAwareListener(PreparableReloadListener wrapped) implements PreparableReloadListener {
 
         @Override
         public CompletableFuture<Void> reload(final PreparationBarrier stage, final ResourceManager resourceManager, final Executor backgroundExecutor, final Executor gameExecutor) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -720,8 +720,8 @@ public final class ForgeEventFactory {
         return fire(new AddReloadListenerEvent(serverResources, registryAccess)).getListeners();
     }
 
-    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess, HolderLookup.Provider lookupProvider, @Deprecated(forRemoval = true, since = "1.21.4") RegistryAccess registryAccess) {
-        return fire(new AddReloadListenerEvent(serverResources, layeredRegistryAccess, lookupProvider, registryAccess)).getListeners();
+    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, HolderLookup.Provider lookupProvider, @Deprecated(forRemoval = true, since = "1.21.4") RegistryAccess registryAccess) {
+        return fire(new AddReloadListenerEvent(serverResources, lookupProvider, registryAccess)).getListeners();
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -14,7 +14,10 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.LayeredRegistryAccess;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.server.RegistryLayer;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
@@ -712,8 +715,13 @@ public final class ForgeEventFactory {
         return fire(new SleepFinishedTimeEvent(level, newTime, minTime)).getNewTime();
     }
 
+    @Deprecated(forRemoval = true, since = "1.21.4")
     public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, RegistryAccess registryAccess) {
         return fire(new AddReloadListenerEvent(serverResources, registryAccess)).getListeners();
+    }
+
+    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess, HolderLookup.Provider lookupProvider, @Deprecated(forRemoval = true, since = "1.21.4") RegistryAccess registryAccess) {
+        return fire(new AddReloadListenerEvent(serverResources, layeredRegistryAccess, lookupProvider, registryAccess)).getListeners();
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context) {

--- a/src/test/generated/global_loot_test/data/global_loot_test/loot_modifiers/wheat_harvest.json
+++ b/src/test/generated/global_loot_test/data/global_loot_test/loot_modifiers/wheat_harvest.json
@@ -4,7 +4,7 @@
     {
       "condition": "minecraft:match_tool",
       "predicate": {
-        "items": "minecraft:shears"
+        "items": "#c:tools/shear"
       }
     },
     {

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -232,6 +232,7 @@ public class GlobalLootModifiersTest extends BaseTestMod {
             // This has no game test because it relies on random number generation and I can't be bothered to try and force that right now.
             add("wheat_harvest", new WheatSeedsConverterModifier(
                 new LootItemCondition[] {
+                    // the #c:tools_shear tag is used here to test parsing of tags in LootModiferManager
                     MatchTool.toolMatches(ItemPredicate.Builder.item().of(items, Tags.Items.TOOLS_SHEAR)).build(),
                     LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.WHEAT).build()
                 },

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -54,6 +54,7 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePropertyCondition;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.predicates.MatchTool;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.crafting.conditions.IConditionBuilder;
 import net.minecraftforge.common.data.DatapackBuiltinEntriesProvider;
 import net.minecraftforge.common.data.GlobalLootModifierProvider;
@@ -231,7 +232,7 @@ public class GlobalLootModifiersTest extends BaseTestMod {
             // This has no game test because it relies on random number generation and I can't be bothered to try and force that right now.
             add("wheat_harvest", new WheatSeedsConverterModifier(
                 new LootItemCondition[] {
-                    MatchTool.toolMatches(ItemPredicate.Builder.item().of(items, Items.SHEARS)).build(),
+                    MatchTool.toolMatches(ItemPredicate.Builder.item().of(items, Tags.Items.TOOLS_SHEAR)).build(),
                     LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.WHEAT).build()
                 },
                 3, Items.WHEAT_SEEDS, Items.WHEAT)


### PR DESCRIPTION
The way server resources are loaded have changed since when this event was created. It has, for a long time, only given the context of the server resources and a registry access in the event. But now the server resources use a different context when accessing registries from within the listeners, found in `ReloadableServerRegistries.LoadResult`. Simply using the composite registry access isn't enough anymore, because it will not contain all information needed for everything to work, such as loot modifiers. The best way to test for this is to use a reload listener that needs access to tags.

I believe part of this is because the event is currently using a registry access that was cached from startup. So, every object up until the `RegistryLayer.STATIC` layer can be referenced, but since tags exist in the `RELOADABLE` layer, they haven't yet been added to the registry access. This means reloading all data resources in a world (using `/reload`) will give the reload listeners the context they need, but at that point it is probably too late.

This PR gives AddReloadListenerEvent this new context so that reload listeners can properly take advantage of the info in the registries the same way vanilla's reload listeners would. In short, it takes both values from the `ReloadableServerRegistries.LoadResult` and gives them to the event.

- Fixes #10409 for 1.21.4.

> [!CAUTION]
> This PR preserved a lot of now-deprecated methods for the sole purpose of preserving binary compat. If you are a modder, you should not be firing `AddReloadListenersEvent` on your own anyways.