### PR TITLE
Hanging Pale Moss not dropping with modded shears

### DIFF
--- a/src/main/generated/data/minecraft/loot_table/blocks/pale_hanging_moss.json
+++ b/src/main/generated/data/minecraft/loot_table/blocks/pale_hanging_moss.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:any_of",
+          "terms": [
+            {
+              "action": "shears_dig",
+              "condition": "forge:can_tool_perform_action"
+            },
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pale_hanging_moss"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "minecraft:blocks/pale_hanging_moss"
+}

--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -130,10 +130,10 @@ public final class ForgeLootTableProvider extends LootTableProvider {
                 } else if (invLootCondition instanceof CompositeLootItemCondition compositeLootItemCondition && findAndReplaceInComposite(compositeLootItemCondition, from, toolAction)) {
                     found = true;
                 }
+            } else if (lootCondition instanceof CompositeLootItemCondition compositeLootItemCondition && findAndReplaceInComposite(compositeLootItemCondition, from, toolAction)) {
+                found = true;
             }
         }
-
-
 
         return found;
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -124,6 +124,10 @@ public interface IForgeGameTestHelper {
     }
 
     default ServerPlayer makeMockServerPlayer() {
+        return makeMockServerPlayer(true);
+    }
+
+    default ServerPlayer makeMockServerPlayer(boolean creative) {
         var level = self().getLevel();
         var cookie = CommonListenerCookie.createInitial(new GameProfile(UUID.randomUUID(), "test-mock-player"), false);
         var player = new ServerPlayer(level.getServer(), level, cookie.gameProfile(), cookie.clientInformation()) {
@@ -132,7 +136,7 @@ public interface IForgeGameTestHelper {
             }
 
             public boolean isCreative() {
-                return true;
+                return creative;
             }
         };
         var connection = new Connection(PacketFlow.SERVERBOUND);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -16,6 +16,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import com.mojang.authlib.GameProfile;
@@ -184,6 +185,25 @@ public interface IForgeGameTestHelper {
                     self().setBlock(pos, block);
             }
         }
+    }
+
+    default void setAndAssertBlock(int x, int y, int z, Block block) {
+        this.setAndAssertBlock(x, y, z, block.defaultBlockState());
+    }
+
+    default void setAndAssertBlock(int x, int y, int z, BlockState state) {
+        this.setAndAssertBlock(new BlockPos(x, y, z), state);
+    }
+
+    default void setAndAssertBlock(BlockPos pos, Block block) {
+        this.setAndAssertBlock(pos, block.defaultBlockState());
+    }
+
+    default void setAndAssertBlock(BlockPos pos, BlockState state) {
+        this.assertTrue(
+                this.self().getLevel().setBlock(this.self().absolutePos(pos), state, Block.UPDATE_ALL),
+                () -> "Failed to set block at pos %s : %s".formatted(pos, state.getBlock())
+        );
     }
 
     default <T> Flag<T> flag(String name) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -16,7 +16,11 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
 import com.mojang.authlib.GameProfile;
@@ -204,6 +208,13 @@ public interface IForgeGameTestHelper {
                 this.self().getLevel().setBlock(this.self().absolutePos(pos), state, Block.UPDATE_ALL),
                 () -> "Failed to set block at pos %s : %s".formatted(pos, state.getBlock())
         );
+    }
+
+    default void removeAllItemEntitiesInRange(BlockPos pos, double range) {
+        BlockPos blockpos = this.self().absolutePos(pos);
+        for (ItemEntity itemEntity : this.self().getLevel().getEntities(EntityType.ITEM, new AABB(blockpos).inflate(range), Entity::isAlive)) {
+            itemEntity.remove(Entity.RemovalReason.DISCARDED);
+        }
     }
 
     default <T> Flag<T> flag(String name) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
@@ -29,7 +29,10 @@ public class ShearsLootTests extends BaseTestMod {
     public static final String MODID = "shears_loot";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
-    private static final RegistryObject<Item> MODDED_SHEARS = ITEMS.register("modded_shears", ModdedShearsItem::new);
+    private static final RegistryObject<Item> MODDED_SHEARS = ITEMS.register("modded_shears", () -> new ShearsItem(new Item.Properties()
+            .component(DataComponents.TOOL, ShearsItem.createToolProperties())
+            .setId(ITEMS.key("modded_shears"))
+    ));
 
     public ShearsLootTests(FMLJavaModLoadingContext context) {
         super(context);
@@ -69,8 +72,6 @@ public class ShearsLootTests extends BaseTestMod {
         var center = new BlockPos(1, 1, 1);
 
         player.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(MODDED_SHEARS.get()));
-        helper.setAndAssertBlock(1, 0, 1, Blocks.DIRT); //top
-        helper.setAndAssertBlock(1, 2, 1, Blocks.DIRT); //bottom
 
         for (Block block : shearsDropBlocks) {
             helper.setAndAssertBlock(center, block);
@@ -78,15 +79,10 @@ public class ShearsLootTests extends BaseTestMod {
             player.gameMode.destroyBlock(helper.absolutePos(center));
 
             helper.assertItemEntityPresent(block.asItem(), center, 1.0);
+            helper.removeAllItemEntitiesInRange(center, 1.0);
         }
 
         helper.succeed();
-    }
-
-    private static final class ModdedShearsItem extends ShearsItem {
-        public ModdedShearsItem() {
-            super(new Item.Properties().setId(ITEMS.key("modded_shears")).component(DataComponents.TOOL, ShearsItem.createToolProperties()));
-        }
     }
 
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
@@ -26,58 +26,54 @@ import net.minecraftforge.test.BaseTestMod;
 @Mod(ShearsLootTests.MODID)
 @GameTestHolder("forge." + ShearsLootTests.MODID)
 public class ShearsLootTests extends BaseTestMod {
-    public static final String MODID = "shears_loot_test";
+    public static final String MODID = "shears_loot";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
     private static final RegistryObject<Item> MODDED_SHEARS = ITEMS.register("modded_shears", ModdedShearsItem::new);
 
-    private static final Block[] SHEARS_DROP_BLOCKS = {
-            //leaves
-            Blocks.ACACIA_LEAVES,
-            Blocks.AZALEA_LEAVES,
-            Blocks.BIRCH_LEAVES,
-            Blocks.CHERRY_LEAVES,
-            Blocks.DARK_OAK_LEAVES,
-            Blocks.FLOWERING_AZALEA_LEAVES,
-            Blocks.JUNGLE_LEAVES,
-            Blocks.MANGROVE_LEAVES,
-            Blocks.OAK_LEAVES,
-            Blocks.PALE_OAK_LEAVES,
-            Blocks.SPRUCE_LEAVES,
-            //misc
-            Blocks.COBWEB,
-            Blocks.DEAD_BUSH,
-            Blocks.FERN,
-            Blocks.HANGING_ROOTS,
-            Blocks.NETHER_SPROUTS,
-            Blocks.PALE_HANGING_MOSS,
-            Blocks.SEAGRASS,
-            Blocks.SHORT_GRASS,
-            Blocks.TWISTING_VINES,
-            Blocks.VINE,
-            Blocks.WEEPING_VINES
-    };
-
     public ShearsLootTests(FMLJavaModLoadingContext context) {
         super(context);
+        this.testItem(lookup -> MODDED_SHEARS.get().getDefaultInstance());
     }
 
     @GameTest(template = "forge:empty3x3x3")
     public static void test_shears_drop_blocks(GameTestHelper helper) {
+        Block[] shearsDropBlocks = {
+                //leaves
+                Blocks.ACACIA_LEAVES,
+                Blocks.AZALEA_LEAVES,
+                Blocks.BIRCH_LEAVES,
+                Blocks.CHERRY_LEAVES,
+                Blocks.DARK_OAK_LEAVES,
+                Blocks.FLOWERING_AZALEA_LEAVES,
+                Blocks.JUNGLE_LEAVES,
+                Blocks.MANGROVE_LEAVES,
+                Blocks.OAK_LEAVES,
+                Blocks.PALE_OAK_LEAVES,
+                Blocks.SPRUCE_LEAVES,
+                //misc
+                Blocks.COBWEB,
+                Blocks.DEAD_BUSH,
+                Blocks.FERN,
+                Blocks.HANGING_ROOTS,
+                Blocks.NETHER_SPROUTS,
+                Blocks.PALE_HANGING_MOSS,
+                Blocks.SEAGRASS,
+                Blocks.SHORT_GRASS,
+                Blocks.TWISTING_VINES,
+                Blocks.VINE,
+                Blocks.WEEPING_VINES
+        };
+
         var player = helper.makeMockServerPlayer();
-        var top = new BlockPos(1, 0, 1);
-        var bottom = new BlockPos(1, 2, 1);
         var center = new BlockPos(1, 1, 1);
 
         player.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(MODDED_SHEARS.get()));
-        helper.setBlock(top, Blocks.DIRT);
-        helper.assertBlock(top, b -> b == Blocks.DIRT, "Failed to set top dirt block");
-        helper.setBlock(bottom, Blocks.DIRT);
-        helper.assertBlock(bottom, b -> b == Blocks.DIRT, "Failed to set bottom dirt block");
+        helper.setAndAssertBlock(1, 0, 1, Blocks.DIRT); //top
+        helper.setAndAssertBlock(1, 2, 1, Blocks.DIRT); //bottom
 
-        for (Block block : SHEARS_DROP_BLOCKS) {
-            helper.setBlock(center, block);
-            helper.assertBlock(center, b -> b == block, "Failed to set block: " + block);
+        for (Block block : shearsDropBlocks) {
+            helper.setAndAssertBlock(center, block);
 
             player.gameMode.destroyBlock(helper.absolutePos(center));
 

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.gameplay.loot;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ShearsItem;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.test.BaseTestMod;
+
+@Mod(ShearsLootTests.MODID)
+@GameTestHolder("forge." + ShearsLootTests.MODID)
+public class ShearsLootTests extends BaseTestMod {
+    public static final String MODID = "shears_loot_test";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final RegistryObject<Item> MODDED_SHEARS = ITEMS.register("modded_shears", ModdedShearsItem::new);
+
+    private static final Block[] SHEARS_DROP_BLOCKS = {
+            //leaves
+            Blocks.ACACIA_LEAVES,
+            Blocks.AZALEA_LEAVES,
+            Blocks.BIRCH_LEAVES,
+            Blocks.CHERRY_LEAVES,
+            Blocks.DARK_OAK_LEAVES,
+            Blocks.FLOWERING_AZALEA_LEAVES,
+            Blocks.JUNGLE_LEAVES,
+            Blocks.MANGROVE_LEAVES,
+            Blocks.OAK_LEAVES,
+            Blocks.PALE_OAK_LEAVES,
+            Blocks.SPRUCE_LEAVES,
+            //misc
+            Blocks.COBWEB,
+            Blocks.DEAD_BUSH,
+            Blocks.FERN,
+            Blocks.HANGING_ROOTS,
+            Blocks.NETHER_SPROUTS,
+            Blocks.PALE_HANGING_MOSS,
+            Blocks.SEAGRASS,
+            Blocks.SHORT_GRASS,
+            Blocks.TWISTING_VINES,
+            Blocks.VINE,
+            Blocks.WEEPING_VINES
+    };
+
+    public ShearsLootTests(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+
+    @GameTest(template = "forge:empty3x3x3")
+    public static void test_shears_drop_blocks(GameTestHelper helper) {
+        var player = helper.makeMockServerPlayer();
+        var top = new BlockPos(1, 0, 1);
+        var bottom = new BlockPos(1, 2, 1);
+        var center = new BlockPos(1, 1, 1);
+
+        player.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(MODDED_SHEARS.get()));
+        helper.setBlock(top, Blocks.DIRT);
+        helper.assertBlock(top, b -> b == Blocks.DIRT, "Failed to set top dirt block");
+        helper.setBlock(bottom, Blocks.DIRT);
+        helper.assertBlock(bottom, b -> b == Blocks.DIRT, "Failed to set bottom dirt block");
+
+        for (Block block : SHEARS_DROP_BLOCKS) {
+            helper.setBlock(center, block);
+            helper.assertBlock(center, b -> b == block, "Failed to set block: " + block);
+
+            player.gameMode.destroyBlock(helper.absolutePos(center));
+
+            helper.assertItemEntityPresent(block.asItem(), center, 1.0);
+        }
+
+        helper.succeed();
+    }
+
+    private static final class ModdedShearsItem extends ShearsItem {
+        public ModdedShearsItem() {
+            super(new Item.Properties().setId(ITEMS.key("modded_shears")).component(DataComponents.TOOL, ShearsItem.createToolProperties()));
+        }
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.debug.gameplay.loot;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.gametest.framework.GameTest;
@@ -12,9 +14,14 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ShearsItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.DoublePlantBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;
@@ -41,48 +48,77 @@ public class ShearsLootTests extends BaseTestMod {
 
     @GameTest(template = "forge:empty3x3x3")
     public static void test_shears_drop_blocks(GameTestHelper helper) {
-        Block[] shearsDropBlocks = {
-                //leaves
-                Blocks.ACACIA_LEAVES,
-                Blocks.AZALEA_LEAVES,
-                Blocks.BIRCH_LEAVES,
-                Blocks.CHERRY_LEAVES,
-                Blocks.DARK_OAK_LEAVES,
-                Blocks.FLOWERING_AZALEA_LEAVES,
-                Blocks.JUNGLE_LEAVES,
-                Blocks.MANGROVE_LEAVES,
-                Blocks.OAK_LEAVES,
-                Blocks.PALE_OAK_LEAVES,
-                Blocks.SPRUCE_LEAVES,
-                //misc
-                Blocks.COBWEB,
-                Blocks.DEAD_BUSH,
-                Blocks.FERN,
-                Blocks.HANGING_ROOTS,
-                Blocks.NETHER_SPROUTS,
-                Blocks.PALE_HANGING_MOSS,
-                Blocks.SEAGRASS,
-                Blocks.SHORT_GRASS,
-                Blocks.TWISTING_VINES,
-                Blocks.VINE,
-                Blocks.WEEPING_VINES
+        Test[] tests = {
+            //leaves
+            Test.of(Blocks.ACACIA_LEAVES),
+            Test.of(Blocks.AZALEA_LEAVES),
+            Test.of(Blocks.BIRCH_LEAVES),
+            Test.of(Blocks.CHERRY_LEAVES),
+            Test.of(Blocks.DARK_OAK_LEAVES),
+            Test.of(Blocks.FLOWERING_AZALEA_LEAVES),
+            Test.of(Blocks.JUNGLE_LEAVES),
+            Test.of(Blocks.MANGROVE_LEAVES),
+            Test.of(Blocks.OAK_LEAVES),
+            Test.of(Blocks.PALE_OAK_LEAVES),
+            Test.of(Blocks.SPRUCE_LEAVES),
+
+            //misc
+            Test.of(Blocks.COBWEB),
+            Test.of(Blocks.DEAD_BUSH),
+            Test.of(Blocks.FERN),
+            Test.of(Blocks.HANGING_ROOTS),
+            Test.of(Blocks.NETHER_SPROUTS),
+            Test.of(Blocks.PALE_HANGING_MOSS),
+            Test.of(Blocks.SEAGRASS),
+            Test.of(Blocks.SHORT_GRASS),
+            Test.of(Blocks.TWISTING_VINES),
+            Test.of(Blocks.VINE),
+            Test.of(Blocks.WEEPING_VINES),
+
+            // Tall things that need surrounding blocks
+            Test.tall(Blocks.LARGE_FERN, Items.FERN),
+            Test.tall(Blocks.TALL_GRASS, Items.SHORT_GRASS),
+            Test.tall(Blocks.TALL_SEAGRASS, Items.SEAGRASS),
+
+            // Things that need a state different then default
+            Test.of(Blocks.GLOW_LICHEN.defaultBlockState().setValue(BlockStateProperties.NORTH, true), Items.GLOW_LICHEN),
         };
 
-        var player = helper.makeMockServerPlayer();
+        helper.makeFloor(); // Seagrass makes water
+        var player = helper.makeMockServerPlayer(false); // Plants prevent loot for creative players
         var center = new BlockPos(1, 1, 1);
 
         player.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(MODDED_SHEARS.get()));
 
-        for (Block block : shearsDropBlocks) {
-            helper.setAndAssertBlock(center, block);
+        for (Test test : tests) {
+            helper.setAndAssertBlock(center, test.state());
+            if (test.below() != null)
+                helper.setAndAssertBlock(center.below(), test.below());
 
             player.gameMode.destroyBlock(helper.absolutePos(center));
 
-            helper.assertItemEntityPresent(block.asItem(), center, 1.0);
+            helper.assertItemEntityPresent(test.item(), center, 1.0);
+
+            // Cleanup after ourselves
+            helper.setBlock(center, Blocks.AIR);
+            helper.setBlock(center.below(), Blocks.AIR);
+
             helper.removeAllItemEntitiesInRange(center, 1.0);
         }
 
         helper.succeed();
     }
 
+
+    private record Test(BlockState state, @Nullable BlockState below, Item item) {
+        private static Test of(Block block) {
+            return new Test(block.defaultBlockState(), null, block.asItem());
+        }
+        private static Test of(BlockState state, Item item) {
+            return new Test(state, null, item);
+        }
+        private static Test tall(Block block, Item item) {
+            return new Test(block.defaultBlockState().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER), block.defaultBlockState().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER), item);
+        }
+    }
 }


### PR DESCRIPTION
Pale Hanging Moss is not dropping when sheared with modded shears, because the loot table is not changed by the data generation.

This PR adds CompositeLootItemCondition to first level loot table condition detection to support pale hanging moss.