### PR TITLE
[1.21.3] Account for ModelDiscovery using Item components early

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/ModelDiscovery.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelDiscovery.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/client/resources/model/ModelDiscovery.java
++++ b/net/minecraft/client/resources/model/ModelDiscovery.java
+@@ -37,7 +_,8 @@
+     private static Set<ModelResourceLocation> listMandatoryModels() {
+         Set<ModelResourceLocation> set = new HashSet<>();
+         BuiltInRegistries.ITEM.listElements().forEach(p_368638_ -> {
+-            ResourceLocation resourcelocation = p_368638_.value().components().get(DataComponents.ITEM_MODEL);
++            // Forge: Force use vanilla components without gathering mod components in the event
++            ResourceLocation resourcelocation = p_368638_.value().vanillaComponents().get(DataComponents.ITEM_MODEL);
+             if (resourcelocation != null) {
+                 set.add(ModelResourceLocation.inventory(resourcelocation));
+             }

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -28,7 +28,7 @@
      }
  
      @Deprecated
-@@ -123,17 +_,37 @@
+@@ -123,17 +_,35 @@
          return this.builtInRegistryHolder;
      }
  
@@ -48,10 +48,8 @@
 +     * Forge: Hack fix used in
 +     * {@link net.minecraft.client.resources.model.ModelDiscovery#listMandatoryModels ModelBakery.listMandatoryModels},
 +     * during mod loading, before the Forge event bus is ready.
-+     *
-+     * @deprecated <strong>INTERNAL ONLY! DO NOT USE THIS!</strong> Use {@link #components()}
 +     */
-+    @Deprecated(forRemoval = true, since = "1.21.3")
++    @org.jetbrains.annotations.ApiStatus.Internal
 +    public DataComponentMap vanillaComponents() {
 +        return components;
      }

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -28,7 +28,7 @@
      }
  
      @Deprecated
-@@ -123,17 +_,25 @@
+@@ -123,17 +_,37 @@
          return this.builtInRegistryHolder;
      }
  
@@ -42,6 +42,18 @@
 +        }
 +
 +        return builtComponents;
++    }
++
++    /**
++     * Forge: Hack fix used in
++     * {@link net.minecraft.client.resources.model.ModelDiscovery#listMandatoryModels ModelBakery.listMandatoryModels},
++     * during mod loading, before the Forge event bus is ready.
++     *
++     * @deprecated <strong>INTERNAL ONLY! DO NOT USE THIS!</strong> Use {@link #components()}
++     */
++    @Deprecated(forRemoval = true, since = "1.21.3")
++    public DataComponentMap vanillaComponents() {
++        return components;
      }
  
      public int getDefaultMaxStackSize() {


### PR DESCRIPTION
Forge uses `GatherComponentEvent.Item` as a way for modders to add their own components to items. Unfortunately, due to a 1.21.3-exclusive bug, components are not gathered lazily as expected. This is because `Item#components` is used in `ModelDiscovery#listMandatoryModels`, where all items are queried for `DataComponents.ITEM_MODEL`. This prompts the gathering of components, but ultimately fails because mods are still loading and the Forge event bus has not yet been started up.

This PR fixes this by creating a utility method, `Item#vanillaComponents`, to be used in model discovery in place of the original.

> [!NOTE]
> The bug that this PR fixes is exclusive to 1.21.3 and will not be backported older versions nor ported to future versions.