### PR TITLE
[1.21.3] Account for problematic mixins in patched-out code

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -4,7 +4,7 @@
          private final int villagerXp;
  
          public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
-+            if (false) // FORGE: Modders can add custom villager types, so remove this validation
++            if (Boolean.valueOf(false)) // FORGE: Modders can add custom villager types, so remove this validation, weird condition is to make the compiler not strip this dead code, breaking some mixins
              BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_327046_ -> {
                  throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_327046_));
              });

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -157,7 +157,7 @@
                      T t = p_261885_.tryCast(enderdragonpart);
                      if (t != null && p_261688_.test(t)) {
                          p_262071_.add(t);
-@@ -919,17 +_,16 @@
+@@ -919,17 +_,19 @@
      public abstract Scoreboard getScoreboard();
  
      public void updateNeighbourForOutputSignal(BlockPos p_46718_, Block p_46719_) {
@@ -174,8 +174,10 @@
                      blockpos = blockpos.relative(direction);
                      blockstate = this.getBlockState(blockpos);
 -                    if (blockstate.is(Blocks.COMPARATOR)) {
--                        this.neighborChanged(blockstate, blockpos, p_46719_, null, false);
 +                    if (blockstate.getWeakChanges(this, blockpos)) {
++                        // Forge: Replace Level#neighborChanged with BlockState#onNeighborChange. Boolean.valueOf(false) is used to account for problematic mixins (see #10402).
++                        if (Boolean.valueOf(false))
+                         this.neighborChanged(blockstate, blockpos, p_46719_, null, false);
 +                        blockstate.onNeighborChange(this, blockpos, p_46718_);
                      }
                  }


### PR DESCRIPTION
- Port of #10402 to 1.21.3.
  - Please see that PR for details. I am porting this to all versions for sake of consistency.
- Includes patch from #10422.