### PR TITLE
[1.20.1] Fix invalidly symlinked worlds crashing on level select

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/storage/LevelSummary.java.patch
@@ -1,13 +1,24 @@
 --- a/net/minecraft/world/level/storage/LevelSummary.java
 +++ b/net/minecraft/world/level/storage/LevelSummary.java
-@@ -193,6 +_,10 @@
-       }
-    }
+@@ -13,7 +_,7 @@
+ import net.minecraft.world.level.LevelSettings;
+ import org.apache.commons.lang3.StringUtils;
  
-+   public boolean isLifecycleExperimental() {
-+      return this.f_78344_.getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
+-public class LevelSummary implements Comparable<LevelSummary> {
++public class LevelSummary implements Comparable<LevelSummary>, net.minecraftforge.common.extensions.IForgeLevelSummary {
+    private final LevelSettings f_78344_;
+    private final LevelVersion f_78345_;
+    private final String f_78346_;
+@@ -191,6 +_,12 @@
+       public String m_164933_() {
+          return this.f_164922_;
+       }
 +   }
 +
++   // TODO Forge: Remove in 1.22. It is kept here for binary compatibility, but already exists in IForgeLevelSummary
++   @Deprecated(forRemoval = true, since = "1.21.4")
++   public boolean isLifecycleExperimental() {
++      return net.minecraftforge.common.extensions.IForgeLevelSummary.super.isLifecycleExperimental();
+    }
+ 
     public static class SymlinkLevelSummary extends LevelSummary {
-       public SymlinkLevelSummary(String p_289942_, Path p_289953_) {
-          super((LevelSettings)null, (LevelVersion)null, p_289942_, false, false, false, p_289953_);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeLevelSummary.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.world.level.storage.LevelSummary;
+
+public interface IForgeLevelSummary {
+    private LevelSummary self() {
+        return (LevelSummary) this;
+    }
+
+    /**
+     * Checks if the Forge lifecycle of this level is experimental. This is used to render the experimental warning
+     * tooltip on the level select screen.
+     *
+     * @return {@code true} if the level is experimental
+     */
+    default boolean isLifecycleExperimental() {
+        // NOTE: Because SymlinkLevelSummary can have null settings, we need to check it
+        var settings = this.self().getSettings();
+
+        return settings != null && settings.getLifecycle().equals(com.mojang.serialization.Lifecycle.experimental());
+    }
+}


### PR DESCRIPTION
- Backport of #10406 to 1.20.1.
- Fixes #9868 for 1.20.1.
- Corrupted worlds do not have this problem in this version.