### PR TITLE
[1.19.2] Redstone updates

### DIFF
--- a/patches/minecraft/net/minecraft/core/Direction.java.patch
+++ b/patches/minecraft/net/minecraft/core/Direction.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/core/Direction.java
++++ b/net/minecraft/core/Direction.java
+@@ -42,6 +_,11 @@
+    private final Direction.AxisDirection f_122344_;
+    private final Vec3i f_122345_;
+    private static final Direction[] f_122346_ = values();
++   // In vanilla updates are notified only on the horizontal plane, in Forge we also notify up and down
++   private static final Direction[] UPDATE_ORDER = Stream.concat(Plane.HORIZONTAL.m_122557_(), Plane.VERTICAL.m_122557_()).toArray(Direction[]::new);
++   public static final Direction[] getUpdateOrder() {
++      return UPDATE_ORDER.clone();
++   }
+    private static final Direction[] f_122348_ = Arrays.stream(f_122346_).sorted(Comparator.comparingInt((p_235687_) -> {
+       return p_235687_.f_122339_;
+    })).toArray((p_235681_) -> {

--- a/patches/minecraft/net/minecraft/core/Direction.java.patch
+++ b/patches/minecraft/net/minecraft/core/Direction.java.patch
@@ -1,13 +1,17 @@
 --- a/net/minecraft/core/Direction.java
 +++ b/net/minecraft/core/Direction.java
-@@ -42,6 +_,11 @@
+@@ -42,6 +_,15 @@
     private final Direction.AxisDirection f_122344_;
     private final Vec3i f_122345_;
     private static final Direction[] f_122346_ = values();
++   private static final List<Direction> VALUES_VIEW = java.util.Collections.unmodifiableList(Arrays.asList(f_122346_));
++   public static final List<Direction> valuesView() {
++      return VALUES_VIEW;
++   }
 +   // In vanilla updates are notified only on the horizontal plane, in Forge we also notify up and down
-+   private static final Direction[] UPDATE_ORDER = Stream.concat(Plane.HORIZONTAL.m_122557_(), Plane.VERTICAL.m_122557_()).toArray(Direction[]::new);
-+   public static final Direction[] getUpdateOrder() {
-+      return UPDATE_ORDER.clone();
++   private static final List<Direction> UPDATE_ORDER = Stream.concat(Plane.HORIZONTAL.m_122557_(), Plane.VERTICAL.m_122557_()).toList();
++   public static final List<Direction> getUpdateOrder() {
++      return UPDATE_ORDER;
 +   }
     private static final Direction[] f_122348_ = Arrays.stream(f_122346_).sorted(Comparator.comparingInt((p_235687_) -> {
        return p_235687_.f_122339_;

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -212,7 +212,7 @@
     }
  
     public boolean m_46753_(BlockPos p_46754_) {
-@@ -769,17 +_,20 @@
+@@ -769,16 +_,19 @@
     public abstract Scoreboard m_6188_();
  
     public void m_46717_(BlockPos p_46718_, Block p_46719_) {
@@ -231,13 +231,12 @@
                 blockstate = this.m_8055_(blockpos);
 -               if (blockstate.m_60713_(Blocks.f_50328_)) {
 +               if (blockstate.getWeakChanges(this, blockpos)) {
-+                  // Forge: Replace Level#neighborChanged with BlockState#onNeighborChange. Boolean.valueOf(false) is used to account for problematic mixins (see #10402).
-+                  if (Boolean.valueOf(false))
-                   this.m_213960_(blockstate, blockpos, p_46719_, p_46718_, false);
++                  // Forge: Use IForgeBlockState#onNeighborChange, the default impl redirects to Level#neighborChanged
 +                  blockstate.onNeighborChange(this, blockpos, p_46718_);
++                  if (false)
+                   this.m_213960_(blockstate, blockpos, p_46719_, p_46718_, false);
                 }
              }
-          }
 @@ -863,6 +_,18 @@
  
     public BiomeManager m_7062_() {

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -217,7 +217,7 @@
  
     public void m_46717_(BlockPos p_46718_, Block p_46719_) {
 -      for(Direction direction : Direction.Plane.HORIZONTAL) {
-+      var updateOrder = net.minecraftforge.common.ForgeConfig.SERVER.fixNeighborUpdateOrder.get() ? Direction.getUpdateOrder() : Direction.values();
++      var updateOrder = net.minecraftforge.common.ForgeConfig.SERVER.fixNeighborUpdateOrder.get() ? Direction.getUpdateOrder() : Direction.valuesView();
 +      for(Direction direction : updateOrder) {
           BlockPos blockpos = p_46718_.m_121945_(direction);
           if (this.m_46805_(blockpos)) {

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -212,12 +212,13 @@
     }
  
     public boolean m_46753_(BlockPos p_46754_) {
-@@ -769,16 +_,15 @@
+@@ -769,17 +_,20 @@
     public abstract Scoreboard m_6188_();
  
     public void m_46717_(BlockPos p_46718_, Block p_46719_) {
 -      for(Direction direction : Direction.Plane.HORIZONTAL) {
-+      for(Direction direction : Direction.values()) {
++      var updateOrder = net.minecraftforge.common.ForgeConfig.SERVER.fixNeighborUpdateOrder.get() ? Direction.getUpdateOrder() : Direction.values();
++      for(Direction direction : updateOrder) {
           BlockPos blockpos = p_46718_.m_121945_(direction);
           if (this.m_46805_(blockpos)) {
              BlockState blockstate = this.m_8055_(blockpos);
@@ -230,9 +231,13 @@
                 blockstate = this.m_8055_(blockpos);
 -               if (blockstate.m_60713_(Blocks.f_50328_)) {
 +               if (blockstate.getWeakChanges(this, blockpos)) {
++                  // Forge: Replace Level#neighborChanged with BlockState#onNeighborChange. Boolean.valueOf(false) is used to account for problematic mixins (see #10402).
++                  if (Boolean.valueOf(false))
                    this.m_213960_(blockstate, blockpos, p_46719_, p_46718_, false);
++                  blockstate.onNeighborChange(this, blockpos, p_46718_);
                 }
              }
+          }
 @@ -863,6 +_,18 @@
  
     public BiomeManager m_7062_() {

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -212,7 +212,7 @@
     }
  
     public boolean m_46753_(BlockPos p_46754_) {
-@@ -769,16 +_,19 @@
+@@ -769,17 +_,18 @@
     public abstract Scoreboard m_6188_();
  
     public void m_46717_(BlockPos p_46718_, Block p_46719_) {
@@ -230,13 +230,13 @@
                 blockpos = blockpos.m_121945_(direction);
                 blockstate = this.m_8055_(blockpos);
 -               if (blockstate.m_60713_(Blocks.f_50328_)) {
+-                  this.m_213960_(blockstate, blockpos, p_46719_, p_46718_, false);
 +               if (blockstate.getWeakChanges(this, blockpos)) {
 +                  // Forge: Use IForgeBlockState#onNeighborChange, the default impl redirects to Level#neighborChanged
 +                  blockstate.onNeighborChange(this, blockpos, p_46718_);
-+                  if (false)
-                   this.m_213960_(blockstate, blockpos, p_46719_, p_46718_, false);
                 }
              }
+          }
 @@ -863,6 +_,18 @@
  
     public BiomeManager m_7062_() {

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -34,6 +34,8 @@ public class ForgeConfig {
 
         public final BooleanValue useItemWithDurationZero;
 
+        public final BooleanValue fixNeighborUpdateOrder;
+
         Server(ForgeConfigSpec.Builder builder) {
             builder.comment("Server configuration settings")
                    .push("server");
@@ -81,6 +83,11 @@ public class ForgeConfig {
                 .comment("Set this to true to enable living entities to use items with durations of 0. Fixes being able to use Eyes of Ender repeatedly by holding down the use button. Disabled by default as it could change interactions with items of existing mods.")
                 .translation("forge.configgui.useItemWithDurationZero")
                 .define("useItemWithDurationZero", false);
+
+            fixNeighborUpdateOrder = builder
+                .comment("Set this to true to fix the neighbor update order to match vanilla.")
+                .translation("forge.configgui.fixNeighborUpdateOrder")
+                .define("fixNeighborUpdateOrder", false);
 
             builder.pop();
         }

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -189,6 +189,8 @@
   "forge.configgui.showLoadWarnings": "Show Load Warnings",
   "forge.configgui.allowMipmapLowering.tooltip": "When enabled, Forge will allow mipmaps to be lowered in real-time. This is the default behavior in vanilla. Use this if you experience issues with resource packs that use textures lower than 8x8.",
   "forge.configgui.allowMipmapLowering": "Allow mipmap lowering",
+  "forge.configgui.fixNeighborUpdateOrder": "Fix Neighbor Update Order",
+  "forge.configgui.fixNeighborUpdateOrder.tooltip": "Set this to true to fix the neighbor update order to match vanilla.",
 
   "forge.configgui.disableVersionCheck.tooltip": "Set to true to disable Forge version check mechanics. Forge queries a small json file on our server for version information. For more details see the ForgeVersion class in our github.",
   "forge.configgui.disableVersionCheck": "Disable Forge Version Check",


### PR DESCRIPTION
- Backport of #10392 to 1.19.2.
- Backport of e69b07a to 1.19.2.
- Partially fixes #9973 for 1.19.2.
- Does not include game tests.

> [!IMPORTANT]
> **The new update order is gated behind a Forge server config.** The host world must have this config enabled to see the new update order take effect. This is to prevent breaking changes with redstone and neighbor updates since Forge for this version is already stable.