### PR TITLE
[1.18.2] Ensure NetworkConstants is loaded before mod construction

### DIFF
--- a/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/server/Bootstrap.java.patch
@@ -1,10 +1,15 @@
 --- a/net/minecraft/server/Bootstrap.java
 +++ b/net/minecraft/server/Bootstrap.java
-@@ -55,6 +_,8 @@
+@@ -55,6 +_,13 @@
                 CauldronInteraction.m_175649_();
                 ArgumentTypes.m_121586_();
                 Registry.m_206101_();
 +               net.minecraftforge.registries.GameData.vanillaSnapshot();
++               // Forge: Hacky fix to ensure that NetworkConstants is loaded before mods are constructed.
++               // Many older mods use network internals that shouldn't be used, yet are exposed so they get used anyways.
++               // This can cause class-loading issues with ForgeMod loading NetworkConstants and HandshakeResolver.
++               // To ensure that doesn't happen, we load it here and now. This is not an issue in 1.20.2 and newer.
++               net.minecraftforge.network.NetworkHooks.init();
 +               if (false) // skip redirectOutputToLog, Forge already redirects stdout and stderr output to log so that they print with more context
                 m_135890_();
              }

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -148,7 +148,6 @@ public class ForgeMod
             return uuid.toString();
         });
 
-        LOGGER.debug(FORGEMOD, "Loading Network data for FML net version: {}", NetworkConstants.init());
         CrashReportCallables.registerCrashCallable("FML", ForgeVersion::getSpec);
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 

--- a/src/main/java/net/minecraftforge/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/network/NetworkHooks.java
@@ -47,6 +47,11 @@ public class NetworkHooks
 {
     private static final Logger LOGGER = LogManager.getLogger();
 
+    public static void init()
+    {
+        LOGGER.debug("Loading Network data for FML net version: {}", NetworkConstants.init());
+    }
+
     public static String getFMLVersion(final String ip)
     {
         return ip.contains("\0") ? Objects.equals(ip.split("\0")[1], NetworkConstants.NETVERSION) ? NetworkConstants.NETVERSION : ip.split("\0")[1] : NetworkConstants.NOVERSION;


### PR DESCRIPTION
- Backport of #10407 for 1.18.2.
- Fixes #9505 for 1.18.2.