### PR TITLE
[1.21.4] Add `#forge:chorus_grows_on`

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/ChorusFlowerBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/ChorusFlowerBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/ChorusFlowerBlock.java
 +++ b/net/minecraft/world/level/block/ChorusFlowerBlock.java
-@@ -66,7 +_,7 @@
+@@ -66,11 +_,12 @@
          BlockPos blockpos = p_220982_.above();
          if (p_220981_.isEmptyBlock(blockpos) && blockpos.getY() <= p_220981_.getMaxY()) {
              int i = p_220980_.getValue(AGE);
@@ -9,6 +9,22 @@
                  boolean flag = false;
                  boolean flag1 = false;
                  BlockState blockstate = p_220981_.getBlockState(p_220982_.below());
+-                if (blockstate.is(Blocks.END_STONE)) {
++                // Forge: check tag instead of end stone block
++                if (blockstate.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON)) {
+                     flag = true;
+                 } else if (blockstate.is(this.plant)) {
+                     int j = 1;
+@@ -78,7 +_,8 @@
+                     for (int k = 0; k < 4; k++) {
+                         BlockState blockstate1 = p_220981_.getBlockState(p_220982_.below(j + 1));
+                         if (!blockstate1.is(this.plant)) {
+-                            if (blockstate1.is(Blocks.END_STONE)) {
++                            // Forge: check tag instead of end stone block
++                            if (blockstate1.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON)) {
+                                 flag1 = true;
+                             }
+                             break;
 @@ -122,6 +_,7 @@
                  } else {
                      this.placeDeadFlower(p_220981_, p_220982_);
@@ -17,3 +33,13 @@
              }
          }
      }
+@@ -167,7 +_,8 @@
+     @Override
+     protected boolean canSurvive(BlockState p_51683_, LevelReader p_51684_, BlockPos p_51685_) {
+         BlockState blockstate = p_51684_.getBlockState(p_51685_.below());
+-        if (!blockstate.is(this.plant) && !blockstate.is(Blocks.END_STONE)) {
++        // Forge: check tag instead of end stone block
++        if (!blockstate.is(this.plant) && !blockstate.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON)) {
+             if (!blockstate.isAir()) {
+                 return false;
+             } else {

--- a/patches/minecraft/net/minecraft/world/level/block/ChorusPlantBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/ChorusPlantBlock.java.patch
@@ -1,0 +1,40 @@
+--- a/net/minecraft/world/level/block/ChorusPlantBlock.java
++++ b/net/minecraft/world/level/block/ChorusPlantBlock.java
+@@ -50,7 +_,8 @@
+         BlockState blockstate5 = p_51711_.getBlockState(p_51712_.west());
+         Block block = p_312378_.getBlock();
+         return p_312378_.trySetValue(
+-                DOWN, Boolean.valueOf(blockstate.is(block) || blockstate.is(Blocks.CHORUS_FLOWER) || blockstate.is(Blocks.END_STONE))
++                // Forge: check tag instead of end stone block
++                DOWN, Boolean.valueOf(blockstate.is(block) || blockstate.is(Blocks.CHORUS_FLOWER) || blockstate.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON))
+             )
+             .trySetValue(UP, Boolean.valueOf(blockstate1.is(block) || blockstate1.is(Blocks.CHORUS_FLOWER)))
+             .trySetValue(NORTH, Boolean.valueOf(blockstate2.is(block) || blockstate2.is(Blocks.CHORUS_FLOWER)))
+@@ -74,7 +_,8 @@
+             p_364837_.scheduleTick(p_51732_, this, 1);
+             return super.updateShape(p_51728_, p_369826_, p_364837_, p_51732_, p_51729_, p_51733_, p_51730_, p_368636_);
+         } else {
+-            boolean flag = p_51730_.is(this) || p_51730_.is(Blocks.CHORUS_FLOWER) || p_51729_ == Direction.DOWN && p_51730_.is(Blocks.END_STONE);
++            // Forge: check tag instead of end stone block
++            boolean flag = p_51730_.is(this) || p_51730_.is(Blocks.CHORUS_FLOWER) || p_51729_ == Direction.DOWN && p_51730_.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON);
+             return p_51728_.setValue(PROPERTY_BY_DIRECTION.get(p_51729_), Boolean.valueOf(flag));
+         }
+     }
+@@ -100,13 +_,15 @@
+                 }
+ 
+                 BlockState blockstate2 = p_51725_.getBlockState(blockpos.below());
+-                if (blockstate2.is(this) || blockstate2.is(Blocks.END_STONE)) {
++                // Forge: check tag instead of end stone block
++                if (blockstate2.is(this) || blockstate2.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON)) {
+                     return true;
+                 }
+             }
+         }
+ 
+-        return blockstate.is(this) || blockstate.is(Blocks.END_STONE);
++        // Forge: check tag instead of end stone block
++        return blockstate.is(this) || blockstate.is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON);
+     }
+ 
+     @Override

--- a/patches/minecraft/net/minecraft/world/level/levelgen/feature/ChorusPlantFeature.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/levelgen/feature/ChorusPlantFeature.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/level/levelgen/feature/ChorusPlantFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/ChorusPlantFeature.java
+@@ -18,7 +_,8 @@
+         WorldGenLevel worldgenlevel = p_159521_.level();
+         BlockPos blockpos = p_159521_.origin();
+         RandomSource randomsource = p_159521_.random();
+-        if (worldgenlevel.isEmptyBlock(blockpos) && worldgenlevel.getBlockState(blockpos.below()).is(Blocks.END_STONE)) {
++        // Forge: check tag instead of end stone block
++        if (worldgenlevel.isEmptyBlock(blockpos) && worldgenlevel.getBlockState(blockpos.below()).is(net.minecraftforge.common.Tags.Blocks.CHORUS_GROWS_ON)) {
+             ChorusFlowerBlock.generatePlant(worldgenlevel, blockpos, randomsource, 8);
+             return true;
+         } else {

--- a/src/main/generated/data/forge/tags/block/chorus_grows_on.json
+++ b/src/main/generated/data/forge/tags/block/chorus_grows_on.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#forge:end_stones"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -53,6 +53,7 @@ public class Tags {
         public static final TagKey<Block> STORAGE_BLOCKS_AMETHYST = forgeTag("storage_blocks/amethyst");
         public static final TagKey<Block> STORAGE_BLOCKS_QUARTZ = forgeTag("storage_blocks/quartz");
 
+        public static final TagKey<Block> CHORUS_GROWS_ON = forgeTag("chorus_grows_on");
         public static final TagKey<Block> CHESTS_ENDER = forgeTag("chests/ender");
         public static final TagKey<Block> CHESTS_TRAPPED = forgeTag("chests/trapped");
         public static final TagKey<Block> COBBLESTONE_NORMAL = forgeTag("cobblestone/normal");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -55,6 +55,8 @@ public final class ForgeBlockTagsProvider extends BlockTagsProvider {
         tag(CHESTS_WOODEN)
                 .add(Blocks.CHEST, Blocks.TRAPPED_CHEST)
                 .addOptionalTag(forgeTagKey("chests/wooden"));
+        tag(CHORUS_GROWS_ON) // forge:chorus_grows_on
+                .addTags(END_STONES);
         tag(CLUSTERS).add(Blocks.AMETHYST_CLUSTER);
         tag(COBBLESTONES)
                 .addTags(COBBLESTONE_NORMAL, COBBLESTONE_INFESTED, COBBLESTONE_MOSSY, COBBLESTONE_DEEPSLATE)


### PR DESCRIPTION
Name entails. Chorus plants and fruits are hard-coded to only grow and sustain on `Blocks.END_STONE`. This tag allows modders to change that behavior, which is often done by modders who create new biomes for The End and have their own variations of the standard End Stone block. This PR made as a request from a fellow modder.

Vanilla has a tag similar to this, `#minecraft:azalea_grows_on`, for the Azalea flowers feature. This info is included in the commit this PR has.

> [!NOTE]
> The reason I decided to implement this as a tag instead of using a block extension is so that modders can change the behavior of the base-game chorus blocks themselves without hacks. The plant type system is garbage and has been effectively replaced by tags anyways.