### PR TITLE
[1.20.1] Respect cancelled status of ProjectileImpactEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
@@ -18,7 +18,7 @@
           this.m_20095_();
        }
  
-@@ -186,9 +_,30 @@
+@@ -186,9 +_,35 @@
                 }
              }
  
@@ -27,7 +27,12 @@
 -               this.f_19812_ = true;
 +            if (hitresult != null && hitresult.m_6662_() != HitResult.Type.MISS && !flag) {
 +               var result = net.minecraftforge.event.ForgeEventFactory.onProjectileImpactResultNullable(this, hitresult);
-+               if (result == null) break;
++               if (result == null) {
++                  if (hitresult.m_6662_() != HitResult.Type.ENTITY)
++                     break;
++
++                  result = net.minecraftforge.event.entity.ProjectileImpactEvent.ImpactResult.SKIP_ENTITY;
++               }
 +               switch (result) {
 +                  case SKIP_ENTITY:
 +                     if (hitresult.m_6662_() != HitResult.Type.ENTITY) { // If there is no entity, we just return default behaviour

--- a/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
@@ -18,7 +18,7 @@
           this.m_20095_();
        }
  
-@@ -186,9 +_,28 @@
+@@ -186,9 +_,30 @@
                 }
              }
  
@@ -26,7 +26,9 @@
 -               this.m_6532_(hitresult);
 -               this.f_19812_ = true;
 +            if (hitresult != null && hitresult.m_6662_() != HitResult.Type.MISS && !flag) {
-+               switch (net.minecraftforge.event.ForgeEventFactory.onProjectileImpactResult(this, hitresult)) {
++               var result = net.minecraftforge.event.ForgeEventFactory.onProjectileImpactResultNullable(this, hitresult);
++               if (result == null) break;
++               switch (result) {
 +                  case SKIP_ENTITY:
 +                     if (hitresult.m_6662_() != HitResult.Type.ENTITY) { // If there is no entity, we just return default behaviour
 +                        this.m_6532_(hitresult);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -680,6 +680,31 @@ public class ForgeEventFactory
         return event.getImpactResult();
     }
 
+    /**
+     * This sister method exists due to an oversight in the original introduction of adding
+     * {@link ProjectileImpactEvent.ImpactResult ImpactResult} to {@link ProjectileImpactEvent}. Prior to its addition,
+     * the cancelling of this event would call <i>all</i> behavior within the if-clause of the while loop to stop and
+     * then break out of the loop early. When the result was added, the default cancellation was changed to
+     * {@link ProjectileImpactEvent.ImpactResult#SKIP_ENTITY}, breaking the ability to use
+     * {@link Event#setCanceled(boolean)} to actually cancel the event logic.
+     * <p>
+     * While not entirely ideal, this preserves compatibility with older 1.20.1 mods that rely on the cancellation of
+     * the projectile impact event.
+     *
+     * @return The result of the event, or {@code null} if it was cancelled.
+     * @see <a href="https://github.com/MinecraftForge/MinecraftForge/pull/10481">PR #10481</a>
+     */
+    public static @Nullable ProjectileImpactEvent.ImpactResult onProjectileImpactResultNullable(Projectile projectile, HitResult ray)
+    {
+        ProjectileImpactEvent event = new ProjectileImpactEvent(projectile, ray);
+
+        // Remove this when the event is no longer cancelable
+        if (MinecraftForge.EVENT_BUS.post(event))
+            return null;
+
+        return event.getImpactResult();
+    }
+
     public static boolean onProjectileImpact(Projectile projectile, HitResult ray)
     {
         return onProjectileImpactResult(projectile, ray) != ProjectileImpactEvent.ImpactResult.DEFAULT;

--- a/src/test/java/net/minecraftforge/debug/entity/ProjectileImpactEventLegacyCancelTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/ProjectileImpactEventLegacyCancelTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.entity;
+
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.ProjectileImpactEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(ProjectileImpactEventLegacyCancelTest.MOD_ID)
+public class ProjectileImpactEventLegacyCancelTest {
+    static final String MOD_ID = "projectile_impact_event_legacy_cancel";
+
+    private static final boolean ENABLED = false;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public ProjectileImpactEventLegacyCancelTest() {
+        if (ENABLED) {
+            LOGGER.warn("ProjectileImpactEvent Legacy Cancel test mod active! This will cancel all AbstractArrow impacts!");
+            MinecraftForge.EVENT_BUS.addListener(this::onProjectileImpact);
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private void onProjectileImpact(ProjectileImpactEvent event) {
+        event.setCanceled(event.getProjectile() instanceof AbstractArrow);
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -259,6 +259,8 @@ modId="hide_neighbor_face_test"
 [[mods]]
 modId="living_get_projectile_event_test"
 [[mods]]
+modId="projectile_impact_event_legacy_cancel"
+[[mods]]
 modId="server_world_creation_test"
 [[mods]]
 modId="valid_railshape_test"


### PR DESCRIPTION
This PR was made to address an oversight in the original introduction of adding `ImpactResult` to `ProjectileImpactEvent` in bf992fe. Prior to its addition, the cancelling of this event would cause *all* behavior within the if-clause of the while loop to stop and then break out of the loop early. When the result was added, the default cancellation was changed to `ImpactResult.SKIP_ENTITY`, breaking the ability to use `Event#setCanceled(boolean)` to actually cancel the event logic.

While not entirely ideal, this preserves compatibility with older 1.20.1 mods that rely on the cancellation of the projectile impact event.