### PR TITLE
Add Pumpkin Block and Item Tags

### DIFF
--- a/src/main/generated/data/c/tags/block/pumpkins.json
+++ b/src/main/generated/data/c/tags/block/pumpkins.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#c:pumpkins/normal",
+    "#c:pumpkins/carved",
+    "#c:pumpkins/jack_o_lanterns"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/pumpkins/carved.json
+++ b/src/main/generated/data/c/tags/block/pumpkins/carved.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:carved_pumpkin"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/pumpkins/jack_o_lanterns.json
+++ b/src/main/generated/data/c/tags/block/pumpkins/jack_o_lanterns.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:jack_o_lantern"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/pumpkins/normal.json
+++ b/src/main/generated/data/c/tags/block/pumpkins/normal.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:pumpkin"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/pumpkins.json
+++ b/src/main/generated/data/c/tags/item/pumpkins.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#c:pumpkins/normal",
+    "#c:pumpkins/carved",
+    "#c:pumpkins/jack_o_lanterns"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/pumpkins/carved.json
+++ b/src/main/generated/data/c/tags/item/pumpkins/carved.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:carved_pumpkin"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/pumpkins/jack_o_lanterns.json
+++ b/src/main/generated/data/c/tags/item/pumpkins/jack_o_lanterns.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:jack_o_lantern"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/pumpkins/normal.json
+++ b/src/main/generated/data/c/tags/item/pumpkins/normal.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:pumpkin"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -210,18 +210,11 @@ public class Tags {
         public static final TagKey<Block> PLAYER_WORKSTATIONS_CRAFTING_TABLES = cTag("player_workstations/crafting_tables");
         public static final TagKey<Block> PLAYER_WORKSTATIONS_FURNACES = cTag("player_workstations/furnaces");
         public static final TagKey<Block> PUMPKINS = cTag("pumpkins");
-        /**
-         * For pumpkins that are not carved.
-         */
+        /** For pumpkins that are not carved. */
         public static final TagKey<Block> PUMPKINS_NORMAL = cTag("pumpkins/normal");
-        /**
-         * For pumpkins that are already carved but not a light source.
-         */
+        /** For pumpkins that are already carved but not a light source. */
         public static final TagKey<Block> PUMPKINS_CARVED = cTag("pumpkins/carved");
-
-        /**
-         * For pumpkins that are already carved and a light source.
-         */
+        /** For pumpkins that are already carved and a light source. */
         public static final TagKey<Block> PUMPKINS_JACK_O_LANTERNS = cTag("pumpkins/jack_o_lanterns");
         /**
          * Blocks should be included in this tag if their movement/relocation can cause serious issues such
@@ -762,18 +755,11 @@ public class Tags {
         public static final TagKey<Item> PLAYER_WORKSTATIONS_CRAFTING_TABLES = cTag("player_workstations/crafting_tables");
         public static final TagKey<Item> PLAYER_WORKSTATIONS_FURNACES = cTag("player_workstations/furnaces");
         public static final TagKey<Item> PUMPKINS = cTag("pumpkins");
-        /**
-         * For pumpkins that are not carved.
-         */
+        /** For pumpkins that are not carved. */
         public static final TagKey<Item> PUMPKINS_NORMAL = cTag("pumpkins/normal");
-        /**
-         * For pumpkins that are already carved but not a light source.
-         */
+        /** For pumpkins that are already carved but not a light source. */
         public static final TagKey<Item> PUMPKINS_CARVED = cTag("pumpkins/carved");
-
-        /**
-         * For pumpkins that are already carved and a light source.
-         */
+        /** For pumpkins that are already carved and a light source. */
         public static final TagKey<Item> PUMPKINS_JACK_O_LANTERNS = cTag("pumpkins/jack_o_lanterns");
         public static final TagKey<Item> RAW_MATERIALS = cTag("raw_materials");
         public static final TagKey<Item> RAW_MATERIALS_COPPER = cTag("raw_materials/copper");

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -209,6 +209,20 @@ public class Tags {
         public static final TagKey<Block> ORES_QUARTZ = cTag("ores/quartz");
         public static final TagKey<Block> PLAYER_WORKSTATIONS_CRAFTING_TABLES = cTag("player_workstations/crafting_tables");
         public static final TagKey<Block> PLAYER_WORKSTATIONS_FURNACES = cTag("player_workstations/furnaces");
+        public static final TagKey<Block> PUMPKINS = cTag("pumpkins");
+        /**
+         * For pumpkins that are not carved.
+         */
+        public static final TagKey<Block> PUMPKINS_NORMAL = cTag("pumpkins/normal");
+        /**
+         * For pumpkins that are already carved but not a light source.
+         */
+        public static final TagKey<Block> PUMPKINS_CARVED = cTag("pumpkins/carved");
+
+        /**
+         * For pumpkins that are already carved and a light source.
+         */
+        public static final TagKey<Block> PUMPKINS_JACK_O_LANTERNS = cTag("pumpkins/jack_o_lanterns");
         /**
          * Blocks should be included in this tag if their movement/relocation can cause serious issues such
          * as world corruption upon being moved or for balance reason where the block should not be able to be relocated.
@@ -747,6 +761,20 @@ public class Tags {
         public static final TagKey<Item> ORES_QUARTZ = cTag("ores/quartz");
         public static final TagKey<Item> PLAYER_WORKSTATIONS_CRAFTING_TABLES = cTag("player_workstations/crafting_tables");
         public static final TagKey<Item> PLAYER_WORKSTATIONS_FURNACES = cTag("player_workstations/furnaces");
+        public static final TagKey<Item> PUMPKINS = cTag("pumpkins");
+        /**
+         * For pumpkins that are not carved.
+         */
+        public static final TagKey<Item> PUMPKINS_NORMAL = cTag("pumpkins/normal");
+        /**
+         * For pumpkins that are already carved but not a light source.
+         */
+        public static final TagKey<Item> PUMPKINS_CARVED = cTag("pumpkins/carved");
+
+        /**
+         * For pumpkins that are already carved and a light source.
+         */
+        public static final TagKey<Item> PUMPKINS_JACK_O_LANTERNS = cTag("pumpkins/jack_o_lanterns");
         public static final TagKey<Item> RAW_MATERIALS = cTag("raw_materials");
         public static final TagKey<Item> RAW_MATERIALS_COPPER = cTag("raw_materials/copper");
         public static final TagKey<Item> RAW_MATERIALS_GOLD = cTag("raw_materials/gold");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -151,6 +151,10 @@ public final class ForgeBlockTagsProvider extends BlockTagsProvider {
         tag(ORES_IN_GROUND_STONE).add(Blocks.COAL_ORE, Blocks.COPPER_ORE, Blocks.DIAMOND_ORE, Blocks.EMERALD_ORE, Blocks.GOLD_ORE, Blocks.IRON_ORE, Blocks.LAPIS_ORE, Blocks.REDSTONE_ORE);
         tag(PLAYER_WORKSTATIONS_CRAFTING_TABLES).add(Blocks.CRAFTING_TABLE);
         tag(PLAYER_WORKSTATIONS_FURNACES).add(Blocks.FURNACE);
+        tag(PUMPKINS).addTags(PUMPKINS_NORMAL, PUMPKINS_CARVED, PUMPKINS_JACK_O_LANTERNS);
+        tag(PUMPKINS_NORMAL).add(Blocks.PUMPKIN);
+        tag(PUMPKINS_CARVED).add(Blocks.CARVED_PUMPKIN);
+        tag(PUMPKINS_JACK_O_LANTERNS).add(Blocks.JACK_O_LANTERN);
         tag(SAND).addTags(SAND_COLORLESS, SAND_RED); // forge:sand
         tag(RELOCATION_NOT_SUPPORTED);
         tag(ROPES);

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -257,6 +257,10 @@ public final class ForgeItemTagsProvider extends ItemTagsProvider {
         copy(Tags.Blocks.ORES_IN_GROUND_STONE, Tags.Items.ORES_IN_GROUND_STONE);
         copy(Tags.Blocks.PLAYER_WORKSTATIONS_CRAFTING_TABLES, Tags.Items.PLAYER_WORKSTATIONS_CRAFTING_TABLES);
         copy(Tags.Blocks.PLAYER_WORKSTATIONS_FURNACES, Tags.Items.PLAYER_WORKSTATIONS_FURNACES);
+        copy(Tags.Blocks.PUMPKINS, Tags.Items.PUMPKINS);
+        copy(Tags.Blocks.PUMPKINS_NORMAL, Tags.Items.PUMPKINS_NORMAL);
+        copy(Tags.Blocks.PUMPKINS_CARVED, Tags.Items.PUMPKINS_CARVED);
+        copy(Tags.Blocks.PUMPKINS_JACK_O_LANTERNS, Tags.Items.PUMPKINS_JACK_O_LANTERNS);
         tag(Tags.Items.RAW_MATERIALS)
                 .addTags(Tags.Items.RAW_MATERIALS_COPPER, Tags.Items.RAW_MATERIALS_GOLD, Tags.Items.RAW_MATERIALS_IRON)
                 .addOptionalTag(forgeItemTagKey("raw_materials"));


### PR DESCRIPTION
Pr aims to add Pumpkin Block and Item Tags to allow for checking for specific types of Pumpkin Blocks or all types of pumpkin blocks.

Blocks:
`c:pumpkins/normal` `c:pumpkins/carved` `c:pumpkins/jack_o_lantern`  `c:pumpkins`
Items:
`c:pumpkins/normal` `c:pumpkins/carved` `c:pumpkins/jack_o_lantern`  `c:pumpkins`

Fabric PR: https://github.com/FabricMC/fabric/pull/4476
NeoForge PR: https://github.com/neoforged/NeoForge/pull/1993