### PR TITLE
[1.20.1] Fix ForgeDev's test runs not working at all

### DIFF
--- a/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConstructorThrowTest.java
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-package net.minecraftforge.debug;
-
-import net.minecraftforge.fml.common.Mod;
-
-/**
- * Test that the mod loading error screen shows the cause of the crash when a mod constructor throws an exception.
- * <p>Enable or disable this test in the mods.toml</p>
- */
-@Mod("constructor_throw_test")
-public class ConstructorThrowTest {
-    public ConstructorThrowTest() {
-        throw new RuntimeException("Test");
-    }
-}
+//package net.minecraftforge.debug;
+//
+//import net.minecraftforge.fml.common.Mod;
+//
+///**
+// * Test that the mod loading error screen shows the cause of the crash when a mod constructor throws an exception.
+// * <p>Enable or disable this test in the mods.toml</p>
+// */
+//@Mod("constructor_throw_test")
+//public class ConstructorThrowTest {
+//    public ConstructorThrowTest() {
+//        throw new RuntimeException("Test");
+//    }
+//}


### PR DESCRIPTION
A bad test mod had its entry commented out in the mods.toml, but the annotation scanner still found the class. Since it wasn't then in the mods.toml, the game would kill itself. This PR comments out that file to fix this problem.

- Fixes #9629 for 1.20.1.