### PR TITLE
Proof-of-concept of NovaBus in Forge

### DIFF
--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
     maven gradleutils.forgeMaven
     maven gradleutils.minecraftLibsMaven
-    //mavenLocal()
+    mavenLocal()
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.Event;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.fml.config;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.Event;
 import net.minecraftforge.fml.Bindings;
 
 import java.util.function.Function;

--- a/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event;
 
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
+
 /**
  * Marker interface for events dispatched on the ModLifecycle event bus instead of the primary event bus
  */
-public interface IModBusEvent {
-}
+@MarkerEvent
+public interface IModBusEvent extends InheritableEvent {}

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
@@ -5,26 +5,21 @@
 
 package net.minecraftforge.fml.javafmlmod;
 
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModLoadingContext;
 
 /**
  * Use the context provided by your language loader in your mod's constructor
  */
-public class FMLJavaModLoadingContext extends ModLoadingContext
-{
+public class FMLJavaModLoadingContext extends ModLoadingContext {
     private final FMLModContainer container;
 
     FMLJavaModLoadingContext(FMLModContainer container) {
         this.container = container;
     }
 
-    /**
-     * @return The mod's event bus, to allow subscription to Mod specific events
-     */
-    public IEventBus getModEventBus()
-    {
-        return container.getEventBus();
+    public BusGroup getModBusGroup() {
+        return container.getBusGroup();
     }
 
     /**

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -5,11 +5,10 @@
 
 package net.minecraftforge.fml.javafmlmod;
 
-import net.minecraftforge.eventbus.EventBusErrorMessage;
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.IEventListener;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.Event;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingException;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -36,7 +35,7 @@ public class FMLModContainer extends ModContainer {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker LOADING = MarkerManager.getMarker("LOADING");
     private final ModFileScanData scanResults;
-    private final IEventBus eventBus;
+    private final BusGroup busGroup;
     private Object modInstance;
     private final Class<?> modClass;
     private final FMLJavaModLoadingContext context = new FMLJavaModLoadingContext(this);
@@ -46,7 +45,7 @@ public class FMLModContainer extends ModContainer {
         LOGGER.debug(LOADING,"Creating FMLModContainer instance for {}", className);
         this.scanResults = modFileScanResults;
         activityMap.put(ModLoadingStage.CONSTRUCT, this::constructMod);
-        this.eventBus = BusBuilder.builder().setExceptionHandler(FMLModContainer::onEventFailed).setTrackPhases(false).markerType(IModBusEvent.class).useModLauncher().build();
+        this.busGroup = BusGroup.create(info.getModId(), IModBusEvent.class);
         this.contextExtension = () -> context;
         try {
             var moduleName = info.getOwningFile().moduleName();
@@ -128,10 +127,6 @@ public class FMLModContainer extends ModContainer {
         implAddExportsOrOpens.invoke(target, pkg, reader, open, /*syncVM*/true);
     }
 
-    private static void onEventFailed(IEventBus iEventBus, Event event, IEventListener[] iEventListeners, int i, Throwable throwable) {
-        LOGGER.error(new EventBusErrorMessage(event, i, iEventListeners, throwable));
-    }
-
     private void constructMod() {
         try {
             LOGGER.trace(LOADING, "Loading mod instance {} of type {}", getModId(), modClass.getName());
@@ -173,15 +168,17 @@ public class FMLModContainer extends ModContainer {
         return modInstance;
     }
 
-    public IEventBus getEventBus() {
-        return this.eventBus;
+    public BusGroup getBusGroup() {
+        return this.busGroup;
     }
 
     @Override
     protected <T extends Event & IModBusEvent> void acceptEvent(final T e) {
         try {
             LOGGER.trace(LOADING, "Firing event for modid {} : {}", this.getModId(), e);
-            this.eventBus.post(e);
+
+            getEventBus(e.getClass()).post(e);
+
             LOGGER.trace(LOADING, "Fired event for modid {} : {}", this.getModId(), e);
         } catch (Throwable t) {
             LOGGER.error(LOADING,"Caught exception during event {} dispatch for modid {}", e, this.getModId(), t);
@@ -191,11 +188,22 @@ public class FMLModContainer extends ModContainer {
 
     @Override
     public void dispatchConfigEvent(IConfigEvent event) {
-        this.eventBus.post(event.self());
+        getEventBus(event.self().getClass()).post(event.self());
     }
 
     @Override
     public String toString() {
         return "FMLModContainer[" + this.getModInfo().getModId() + ", " + this.getClass().getName() + "]";
+    }
+
+    /**
+     * A slow, hacky and temporary solution to get the EventBus for the event until FML is redesigned with the new EventBus in mind.
+     * <p>This may fail in a future EventBus release as it relies on an internal implementation detail.</p>
+     * <p>If you're trying to figure out how to add listeners to a mod bus event now, you need to use the BusGroup instead.</p>
+     * @see #getBusGroup()
+     */
+    @SuppressWarnings("unchecked")
+    public EventBus<Event> getEventBus(Class<? extends Event> eventClass) {
+        return (EventBus<Event>) EventBus.create(getBusGroup(), eventClass);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,8 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
+//            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
+            library('eventbus', 'net.minecraftforge:eventbus:7.0.0-SNAPSHOT')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.client.event;
 
 import com.google.common.base.Strings;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -21,15 +22,14 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
-@Cancelable
-public class ClientChatEvent extends Event
-{
+public final class ClientChatEvent extends MutableEvent implements Cancellable {
+    public static final EventBus<ClientChatEvent> BUS = EventBus.create(ClientChatEvent.class);
+
     private String message;
     private final String originalMessage;
 
     @ApiStatus.Internal
-    public ClientChatEvent(String message)
-    {
+    public ClientChatEvent(String message) {
         this.setMessage(message);
         this.originalMessage = Strings.nullToEmpty(message);
         this.message = this.originalMessage;
@@ -38,8 +38,7 @@ public class ClientChatEvent extends Event
     /**
      * {@return the message that will be sent to the server, if the event is not cancelled. This can be changed by mods}
      */
-    public String getMessage()
-    {
+    public String getMessage() {
         return this.message;
     }
 
@@ -48,16 +47,14 @@ public class ClientChatEvent extends Event
      *
      * @param message the new message to be sent
      */
-    public void setMessage(String message)
-    {
+    public void setMessage(String message) {
         this.message = Strings.nullToEmpty(message);
     }
 
     /**
      * {@return the original message that was to be sent to the server. This cannot be changed by mods}
      */
-    public String getOriginalMessage()
-    {
+    public String getOriginalMessage() {
         return this.originalMessage;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
@@ -6,10 +6,12 @@
 package net.minecraftforge.client.event;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 import net.minecraft.client.Minecraft;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -21,12 +23,8 @@ import net.minecraftforge.fml.LogicalSide;
  * @see ClientPauseChangeEvent.Pre
  * @see ClientPauseChangeEvent.Post
  */
-public abstract class ClientPauseChangeEvent extends Event {
-    private final boolean pause;
-
-    public ClientPauseChangeEvent(boolean pause) {
-        this.pause = pause;
-    }
+public sealed interface ClientPauseChangeEvent {
+    boolean isPaused();
 
     /**
      * Fired when {@linkplain Minecraft#pause pause} is going to change
@@ -37,12 +35,8 @@ public abstract class ClientPauseChangeEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends ClientPauseChangeEvent {
-
-        public Pre(boolean pause) {
-            super(pause);
-        }
+    record Pre(boolean isPaused) implements Cancellable, RecordEvent, ClientPauseChangeEvent {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
     }
 
     /**
@@ -53,17 +47,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends ClientPauseChangeEvent {
-
-        public Post(boolean pause) {
-            super(pause);
-        }
-    }
-
-    /**
-     * {@return game is paused}
-     */
-    public boolean isPaused() {
-        return pause;
+    record Post(boolean isPaused) implements RecordEvent, ClientPauseChangeEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
@@ -8,10 +8,9 @@ package net.minecraftforge.client.event;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when the client player is notified of a change of {@link GameType} from the server.
@@ -20,42 +19,12 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param info the client player information
+ * @param currentGameType the current game type of the player
+ * @param newGameType the new game type of the player
  */
-public class ClientPlayerChangeGameTypeEvent extends Event
-{
-    private final PlayerInfo info;
-    private final GameType currentGameType;
-    private final GameType newGameType;
-
-    @ApiStatus.Internal
-    public ClientPlayerChangeGameTypeEvent(PlayerInfo info, GameType currentGameType, GameType newGameType)
-    {
-        this.info = info;
-        this.currentGameType = currentGameType;
-        this.newGameType = newGameType;
-    }
-
-    /**
-     * {@return the client player information}
-     */
-    public PlayerInfo getInfo()
-    {
-        return info;
-    }
-
-    /**
-     * {@return the current game type of the player}
-     */
-    public GameType getCurrentGameType()
-    {
-        return currentGameType;
-    }
-
-    /**
-     * {@return the new game type of the player}
-     */
-    public GameType getNewGameType()
-    {
-        return newGameType;
-    }
+public record ClientPlayerChangeGameTypeEvent(PlayerInfo info, GameType currentGameType, GameType newGameType)
+        implements RecordEvent {
+    public static final EventBus<ClientPlayerChangeGameTypeEvent> BUS = EventBus.create(ClientPlayerChangeGameTypeEvent.class);
 }

--- a/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
@@ -5,12 +5,11 @@
 
 package net.minecraftforge.client.event;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -24,7 +23,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see ViewportEvent.ComputeFov
  */
-public class ComputeFovModifierEvent extends Event {
+public final class ComputeFovModifierEvent extends MutableEvent {
+    public static final EventBus<ComputeFovModifierEvent> BUS = EventBus.create(ComputeFovModifierEvent.class);
+
     private final Player player;
     private final float fovModifier;
     private final float scale;

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -8,10 +8,9 @@ package net.minecraftforge.client.event;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired for hooking into {@link AbstractContainerScreen} events.
@@ -23,20 +22,11 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Render.Foreground
  * @see Render.Background
  */
-public abstract class ContainerScreenEvent extends Event {
-    private final AbstractContainerScreen<?> containerScreen;
-
-    @ApiStatus.Internal
-    protected ContainerScreenEvent(AbstractContainerScreen<?> containerScreen) {
-        this.containerScreen = containerScreen;
-    }
-
+public sealed interface ContainerScreenEvent {
     /**
      * {@return the container screen}
      */
-    public AbstractContainerScreen<?> getContainerScreen() {
-        return containerScreen;
-    }
+    AbstractContainerScreen<?> containerScreen();
 
     /**
      * Fired every time an {@link AbstractContainerScreen} renders.
@@ -48,39 +38,21 @@ public abstract class ContainerScreenEvent extends Event {
      * @see Foreground
      * @see Background
      */
-    public static abstract class Render extends ContainerScreenEvent {
-        private final GuiGraphics guiGraphics;
-        private final int mouseX;
-        private final int mouseY;
-
-        @ApiStatus.Internal
-        protected Render(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
-            super(guiContainer);
-            this.guiGraphics = guiGraphics;
-            this.mouseX = mouseX;
-            this.mouseY = mouseY;
-        }
-
+    sealed interface Render extends ContainerScreenEvent {
         /**
          * {@return the gui graphics used for rendering}
          */
-        public GuiGraphics getGuiGraphics() {
-            return guiGraphics;
-        }
+        GuiGraphics guiGraphics();
 
         /**
          * {@return the X coordinate of the mouse pointer}
          */
-        public int getMouseX() {
-            return mouseX;
-        }
+        int mouseX();
 
         /**
          * {@return the Y coordinate of the mouse pointer}
          */
-        public int getMouseY() {
-            return mouseY;
-        }
+        int mouseY();
 
         /**
          * Fired after the container screen's foreground layer and elements are drawn, but
@@ -94,11 +66,9 @@ public abstract class ContainerScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Foreground extends Render {
-            @ApiStatus.Internal
-            public Foreground(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
-                super(guiContainer, guiGraphics, mouseX, mouseY);
-            }
+        record Foreground(AbstractContainerScreen<?> containerScreen, GuiGraphics guiGraphics, int mouseX, int mouseY)
+                implements Render, RecordEvent {
+            public static final EventBus<Foreground> BUS = EventBus.create(Foreground.class);
         }
 
         /**
@@ -110,11 +80,9 @@ public abstract class ContainerScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Background extends Render {
-            @ApiStatus.Internal
-            public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
-                super(guiContainer, guiGraphics, mouseX, mouseY);
-            }
+        record Background(AbstractContainerScreen<?> containerScreen, GuiGraphics guiGraphics, int mouseX, int mouseY)
+                implements Render, RecordEvent {
+            public static final EventBus<Background> BUS = EventBus.create(Background.class);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -9,8 +9,9 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -23,7 +24,7 @@ import java.util.List;
  * @see DebugText
  * @see Chat
  */
-public abstract class CustomizeGuiOverlayEvent extends Event {
+public sealed abstract class CustomizeGuiOverlayEvent extends MutableEvent {
     private final Window window;
     private final GuiGraphics guiGraphics;
     private final float partialTick;
@@ -56,8 +57,9 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class BossEventProgress extends CustomizeGuiOverlayEvent {
+    public static final class BossEventProgress extends CustomizeGuiOverlayEvent implements Cancellable {
+        public static final EventBus<BossEventProgress> BUS = EventBus.create(BossEventProgress.class);
+
         private final LerpingBossEvent bossEvent;
         private final int x;
         private final int y;
@@ -119,9 +121,10 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class DebugText extends CustomizeGuiOverlayEvent {
-        private final List<String> text;
+    public static final class DebugText extends CustomizeGuiOverlayEvent {
+        public static final EventBus<DebugText> BUS = EventBus.create(DebugText.class);
 
+        private final List<String> text;
         private final Side side;
 
         @ApiStatus.Internal
@@ -159,7 +162,9 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Chat extends CustomizeGuiOverlayEvent {
+    public static final class Chat extends CustomizeGuiOverlayEvent {
+        public static final EventBus<Chat> BUS = EventBus.create(Chat.class);
+
         private int posX;
         private int posY;
 

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -9,9 +9,13 @@ import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
+import org.intellij.lang.annotations.MagicConstant;
 import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.glfw.GLFW;
 
@@ -24,10 +28,7 @@ import org.lwjgl.glfw.GLFW;
  * @see Key
  * @see InteractionKeyMappingTriggered
  */
-public abstract class InputEvent extends Event {
-    @ApiStatus.Internal
-    protected InputEvent() {}
-
+public sealed interface InputEvent {
     /**
      * Fired when a mouse button is pressed/released. Sub-events get fired {@link Pre before} and {@link Post after} this happens.
      *
@@ -38,27 +39,14 @@ public abstract class InputEvent extends Event {
      * @see Pre
      * @see Post
      */
-    public static abstract class MouseButton extends InputEvent {
-        private final int button;
-        private final int action;
-        private final int modifiers;
-
-        @ApiStatus.Internal
-        protected MouseButton(int button, int action, int modifiers) {
-            this.button = button;
-            this.action = action;
-            this.modifiers = modifiers;
-        }
-
+    sealed interface MouseButton extends InputEvent {
         /**
          * {@return the mouse button's input code}
          *
          * @see GLFW mouse constants starting with 'GLFW_MOUSE_BUTTON_'
          * @see <a href="https://www.glfw.org/docs/latest/group__buttons.html" target="_top">the online GLFW documentation</a>
          */
-        public int getButton() {
-            return this.button;
-        }
+        int button();
 
         /**
          * {@return the mouse button's action}
@@ -66,9 +54,8 @@ public abstract class InputEvent extends Event {
          * @see InputConstants#PRESS
          * @see InputConstants#RELEASE
          */
-        public int getAction() {
-            return this.action;
-        }
+        @MagicConstant(intValues = { InputConstants.PRESS, InputConstants.RELEASE })
+        int action();
 
         /**
          * {@return a bit field representing the active modifier keys}
@@ -81,9 +68,7 @@ public abstract class InputEvent extends Event {
          * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
          * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
          */
-        public int getModifiers() {
-            return this.modifiers;
-        }
+        int modifiers();
 
         /**
          * Fired when a mouse button is pressed/released, <b>before</b> being processed by vanilla.
@@ -96,12 +81,8 @@ public abstract class InputEvent extends Event {
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
-        @Cancelable
-        public static class Pre extends MouseButton {
-            @ApiStatus.Internal
-            public Pre(int button, int action, int modifiers) {
-                super(button, action, modifiers);
-            }
+        record Pre(int button, int action, int modifiers) implements Cancellable, MouseButton, RecordEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
         }
 
         /**
@@ -114,11 +95,8 @@ public abstract class InputEvent extends Event {
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
-        public static class Post extends MouseButton {
-            @ApiStatus.Internal
-            public Post(int button, int action, int modifiers) {
-                super(button, action, modifiers);
-            }
+        record Post(int button, int action, int modifiers) implements Cancellable, MouseButton, RecordEvent {
+            public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
         }
     }
 
@@ -132,77 +110,26 @@ public abstract class InputEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
+     * @param deltaX the amount of change / delta of the mouse scroll in the vertical direction
+     * @param deltaY the amount of change / delta of the mouse scroll in the horizontal direction
+     * @param leftDown {@code true} if the left mouse button is pressed
+     * @param middleDown {@code true} if the right mouse button is pressed
+     * @param rightDown {@code true} if the middle mouse button is pressed
+     * @param mouseX the X position of the mouse cursor
+     * @param mouseY the Y position of the mouse cursor
+     *
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
-    @Cancelable
-    public static class MouseScrollingEvent extends InputEvent {
-        private final double deltaX;
-        private final double deltaY;
-        private final double mouseX;
-        private final double mouseY;
-        private final boolean leftDown;
-        private final boolean middleDown;
-        private final boolean rightDown;
-
-        @ApiStatus.Internal
-        public MouseScrollingEvent(double deltaX, double deltaY, boolean leftDown, boolean middleDown, boolean rightDown, double mouseX, double mouseY) {
-            this.deltaX = deltaX;
-            this.deltaY = deltaY;
-            this.leftDown = leftDown;
-            this.middleDown = middleDown;
-            this.rightDown = rightDown;
-            this.mouseX = mouseX;
-            this.mouseY = mouseY;
-        }
-
-        /**
-         * {@return the amount of change / delta of the mouse scroll in the vertical direction}
-         */
-        public double getDeltaX() {
-            return this.deltaX;
-        }
-
-        /**
-         * {@return the amount of change / delta of the mouse scroll in the horizontal direction}
-         */
-        public double getDeltaY() {
-            return this.deltaY;
-        }
-
-        /**
-         * {@return {@code true} if the left mouse button is pressed}
-         */
-        public boolean isLeftDown() {
-            return this.leftDown;
-        }
-
-        /**
-         * {@return {@code true} if the right mouse button is pressed}
-         */
-        public boolean isRightDown() {
-            return this.rightDown;
-        }
-
-        /**
-         * {@return  {@code true} if the middle mouse button is pressed}
-         */
-        public boolean isMiddleDown() {
-            return this.middleDown;
-        }
-
-        /**
-         * {@return the X position of the mouse cursor}
-         */
-        public double getMouseX() {
-            return this.mouseX;
-        }
-
-        /**
-         * {@return the Y position of the mouse cursor}
-         */
-        public double getMouseY() {
-            return this.mouseY;
-        }
+    record MouseScrollingEvent(
+            double deltaX,
+            double deltaY,
+            boolean leftDown,
+            boolean middleDown,
+            boolean rightDown,
+            double mouseX,
+            double mouseY
+    ) implements Cancellable, InputEvent, RecordEvent {
+        public static final CancellableEventBus<MouseScrollingEvent> BUS = CancellableEventBus.create(MouseScrollingEvent.class);
     }
 
     /**
@@ -213,19 +140,8 @@ public abstract class InputEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Key extends InputEvent {
-        private final int key;
-        private final int scanCode;
-        private final int action;
-        private final int modifiers;
-
-        @ApiStatus.Internal
-        public Key(int key, int scanCode, int action, int modifiers) {
-            this.key = key;
-            this.scanCode = scanCode;
-            this.action = action;
-            this.modifiers = modifiers;
-        }
+    record Key(int key, int scanCode, int action, int modifiers) implements InputEvent, RecordEvent {
+        public static final EventBus<Key> BUS = EventBus.create(Key.class);
 
         /**
          * {@return the {@code GLFW} (platform-agnostic) key code}
@@ -234,7 +150,7 @@ public abstract class InputEvent extends Event {
          * @see GLFW key constants starting with {@code GLFW_KEY_}
          * @see <a href="https://www.glfw.org/docs/latest/group__keys.html" target="_top">the online GLFW documentation</a>
          */
-        public int getKey() {
+        public int key() {
             return this.key;
         }
 
@@ -247,7 +163,7 @@ public abstract class InputEvent extends Event {
          *
          * @see InputConstants#getKey(int, int)
          */
-        public int getScanCode() {
+        public int scanCode() {
             return this.scanCode;
         }
 
@@ -258,7 +174,7 @@ public abstract class InputEvent extends Event {
          * @see InputConstants#RELEASE
          * @see InputConstants#REPEAT
          */
-        public int getAction() {
+        public int action() {
             return this.action;
         }
 
@@ -273,7 +189,7 @@ public abstract class InputEvent extends Event {
          * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
          * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
          */
-        public int getModifiers() {
+        public int modifiers() {
             return this.modifiers;
         }
     }
@@ -296,8 +212,9 @@ public abstract class InputEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     // TODO: Change the 'button' to sub events. - Lex 0422202
-    @Cancelable
-    public static class InteractionKeyMappingTriggered extends InputEvent {
+    final class InteractionKeyMappingTriggered extends MutableEvent implements Cancellable, InputEvent {
+        public static final CancellableEventBus<InteractionKeyMappingTriggered> BUS = CancellableEventBus.create(InteractionKeyMappingTriggered.class);
+
         private final int button;
         private final KeyMapping keyMapping;
         private final InteractionHand hand;

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -13,8 +13,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -28,10 +26,7 @@ import java.util.Map;
 /**
  * Houses events related to models.
  */
-public abstract class ModelEvent extends Event {
-    @ApiStatus.Internal
-    protected ModelEvent() { }
-
+public sealed interface ModelEvent {
     /**
      * Fired while the {@link ModelManager} is reloading models, after the model registry is set up, but before it's
      * passed to the {@link net.minecraft.client.renderer.block.BlockModelShaper} for caching.
@@ -47,31 +42,11 @@ public abstract class ModelEvent extends Event {
      *
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     *
+     * @param modelBakery the model loader
+     * @param results the modifiable registry map of models and their model names
      */
-    public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
-        private final ModelBakery modelBakery;
-        private final ModelBakery.BakingResult results;
-
-        @ApiStatus.Internal
-        public ModifyBakingResult(ModelBakery modelBakery, ModelBakery.BakingResult results) {
-            this.modelBakery = modelBakery;
-            this.results = results;
-        }
-
-        /**
-         * @return the modifiable registry map of models and their model names
-         */
-        public ModelBakery.BakingResult getResults() {
-            return results;
-        }
-
-        /**
-         * @return the model loader
-         */
-        public ModelBakery getModelBakery() {
-            return modelBakery;
-        }
-    }
+    record ModifyBakingResult(ModelBakery modelBakery, ModelBakery.BakingResult results) implements ModelEvent, IModBusEvent {}
 
     /**
      * Fired when the {@link ModelManager} is notified of the resource manager reloading.
@@ -84,30 +59,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BakingCompleted extends ModelEvent implements IModBusEvent {
-        private final ModelManager modelManager;
-        private final ModelBakery modelBakery;
-
-        @ApiStatus.Internal
-        public BakingCompleted(ModelManager modelManager, ModelBakery modelBakery) {
-            this.modelManager = modelManager;
-            this.modelBakery = modelBakery;
-        }
-
-        /**
-         * @return the model manager
-         */
-        public ModelManager getModelManager() {
-            return modelManager;
-        }
-
-        /**
-         * @return the model loader
-         */
-        public ModelBakery getModelBakery() {
-            return modelBakery;
-        }
-    }
+    record BakingCompleted(ModelManager modelManager, ModelBakery modelBakery) implements ModelEvent, IModBusEvent {}
 
     /**
      * Fired when the {@link net.minecraft.client.resources.model.BlockStateModelLoader BlockStateModelLoader} is notified of the resource manager reloading.
@@ -118,7 +70,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterModelStateDefinitions extends ModelEvent implements IModBusEvent {
+    final class RegisterModelStateDefinitions implements ModelEvent, IModBusEvent {
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> states = new HashMap<>();
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> view = Collections.unmodifiableMap(states);
 
@@ -148,7 +100,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent {
+    final class RegisterGeometryLoaders implements ModelEvent, IModBusEvent {
         private final Map<ResourceLocation, IGeometryLoader<?>> loaders;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -20,20 +22,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param input the player's movement inputs
  */
-public class MovementInputUpdateEvent extends PlayerEvent {
-    private final ClientInput input;
-
-    @ApiStatus.Internal
-    public MovementInputUpdateEvent(Player player, ClientInput input) {
-        super(player);
-        this.input = input;
-    }
-
-    /**
-     * {@return the player's movement inputs}
-     */
-    public ClientInput getInput() {
-        return input;
-    }
+public record MovementInputUpdateEvent(Player entity, ClientInput input) implements PlayerEvent, RecordEvent {
+    public static final EventBus<MovementInputUpdateEvent> BUS = EventBus.create(MovementInputUpdateEvent.class);
 }

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -6,12 +6,10 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.ClientRecipeBook;
-import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when the {@link ClientRecipeBook} has updated information about recipes from the server to the client.
@@ -20,19 +18,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param recipeBook the recipe manager
  */
-public class RecipesUpdatedEvent extends Event {
-    private final ClientRecipeBook recipeBook;
-
-    @ApiStatus.Internal
-    public RecipesUpdatedEvent(ClientRecipeBook recipeBook) {
-        this.recipeBook = recipeBook;
-    }
-
-    /**
-     * {@return the recipe manager}
-     */
-    public ClientRecipeBook getRecipeBook() {
-        return recipeBook;
-    }
+public record RecipesUpdatedEvent(ClientRecipeBook recipeBook) implements RecordEvent {
+    public static final EventBus<RecipesUpdatedEvent> BUS = EventBus.create(RecipesUpdatedEvent.class);
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -11,10 +11,9 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.ObjectiveArgument;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired to allow mods to register client commands.
@@ -32,33 +31,12 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
+ * @param dispatcher the command dispatcher for registering commands to be executed on the client
+ * @param context the context to build the commands for
+ *
  * @see net.minecraftforge.event.RegisterCommandsEvent
  */
-public class RegisterClientCommandsEvent extends Event
-{
-    private final CommandDispatcher<CommandSourceStack> dispatcher;
-    private final CommandBuildContext context;
-
-    @ApiStatus.Internal
-    public RegisterClientCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context)
-    {
-        this.dispatcher = dispatcher;
-        this.context = context;
-    }
-
-    /**
-     * {@return the command dispatcher for registering commands to be executed on the client}
-     */
-    public CommandDispatcher<CommandSourceStack> getDispatcher()
-    {
-        return dispatcher;
-    }
-
-    /**
-     * {@return the context to build the commands for}
-     */
-    public CommandBuildContext getBuildContext()
-    {
-        return context;
-    }
+public record RegisterClientCommandsEvent(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context)
+        implements RecordEvent {
+    public static final EventBus<RegisterClientCommandsEvent> BUS = EventBus.create(RegisterClientCommandsEvent.class);
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -10,8 +10,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -27,10 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RegisterColorHandlersEvent.Block
  * @see RegisterColorHandlersEvent.Item
  */
-public abstract class RegisterColorHandlersEvent extends Event implements IModBusEvent {
-    @ApiStatus.Internal
-    protected RegisterColorHandlersEvent() {}
-
+public sealed interface RegisterColorHandlersEvent extends IModBusEvent {
     /**
      * Fired for registering block color handlers.
      *
@@ -39,20 +35,15 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Block extends RegisterColorHandlersEvent {
-        private final BlockColors blockColors;
-
-        @ApiStatus.Internal
-        public Block(BlockColors blockColors) {
-            this.blockColors = blockColors;
-        }
+    record Block(BlockColors blockColors) implements RegisterColorHandlersEvent {
+        public static final EventBus<Block> BUS = EventBus.create(Block.class);
 
         /**
          * {@return the block colors registry}
          *
          * @see BlockColors#register(BlockColor, net.minecraft.world.level.block.Block...)
          */
-        public BlockColors getBlockColors() {
+        public BlockColors blockColors() {
             return blockColors;
         }
 
@@ -72,7 +63,9 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * Allows registration of custom {@link ColorResolver} implementations to be used with
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
-    public static class ColorResolvers extends RegisterColorHandlersEvent {
+    final class ColorResolvers implements RegisterColorHandlersEvent {
+        public static final EventBus<ColorResolvers> BUS = EventBus.create(ColorResolvers.class);
+
         private final ImmutableList.Builder<ColorResolver> builder;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -6,15 +6,14 @@
 package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired before the player's arm is rendered in first person. This is a more targeted version of {@link RenderHandEvent},
@@ -26,49 +25,22 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param poseStack the pose stack used for rendering
+ * @param multiBufferSource the source of rendering buffers
+ * @param arm the arm being rendered
  */
-@Cancelable
-public class RenderArmEvent extends Event {
-    private final PoseStack poseStack;
-    private final MultiBufferSource multiBufferSource;
-    private final int packedLight;
-    private final HumanoidArm arm;
-
-    @ApiStatus.Internal
-    public RenderArmEvent(PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight, HumanoidArm arm) {
-        this.poseStack = poseStack;
-        this.multiBufferSource = multiBufferSource;
-        this.packedLight = packedLight;
-        this.arm = arm;
-    }
-
-    /**
-     * {@return the arm being rendered}
-     */
-    public HumanoidArm getArm() {
-        return arm;
-    }
-
-    /**
-     * {@return the pose stack used for rendering}
-     */
-    public PoseStack getPoseStack() {
-        return poseStack;
-    }
-
-    /**
-     * {@return the source of rendering buffers}
-     */
-    public MultiBufferSource getMultiBufferSource() {
-        return multiBufferSource;
-    }
+public record RenderArmEvent(PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight, HumanoidArm arm)
+        implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<RenderArmEvent> BUS = CancellableEventBus.create(RenderArmEvent.class);
 
     /**
      * {@return the amount of packed (sky and block) light for rendering}
      *
      * @see LightTexture
      */
-    public int getPackedLight() {
+    @Override
+    public int packedLight() {
         return packedLight;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
@@ -10,10 +10,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired before a block texture will be overlaid on the player's view.
@@ -23,17 +23,28 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param player the player which the overlay will apply to
+ * @param poseStack the pose stack used for rendering
+ * @param overlayType the type of the overlay
+ * @param blockState the block state which the overlay is gotten from
+ * @param blockPos the position of the block which the overlay is gotten from
  */
-@Cancelable
-public class RenderBlockScreenEffectEvent extends Event
-{
+public record RenderBlockScreenEffectEvent(
+        Player player,
+        PoseStack poseStack,
+        OverlayType overlayType,
+        BlockState blockState,
+        BlockPos blockPos
+) implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<RenderBlockScreenEffectEvent> BUS = CancellableEventBus.create(RenderBlockScreenEffectEvent.class);
+
     /**
      * The type of the block overlay to be rendered.
      *
      * @see RenderBlockScreenEffectEvent
      */
-    public enum OverlayType
-    {
+    public enum OverlayType {
         /**
          * The type of the overlay when the player is burning / on fire.
          */
@@ -46,61 +57,5 @@ public class RenderBlockScreenEffectEvent extends Event
          * The type of overlay when the player is underwater.
          */
         WATER
-    }
-
-    private final Player player;
-    private final PoseStack poseStack;
-    private final OverlayType overlayType;
-    private final BlockState blockState;
-    private final BlockPos blockPos;
-
-    @ApiStatus.Internal
-    public RenderBlockScreenEffectEvent(Player player, PoseStack poseStack, OverlayType type, BlockState block, BlockPos blockPos)
-    {
-        this.player = player;
-        this.poseStack = poseStack;
-        this.overlayType = type;
-        this.blockState = block;
-        this.blockPos = blockPos;
-    }
-
-    /**
-     * {@return the player which the overlay will apply to}
-     */
-    public Player getPlayer()
-    {
-        return player;
-    }
-
-    /**
-     * {@return the pose stack used for rendering}
-     */
-    public PoseStack getPoseStack()
-    {
-        return poseStack;
-    }
-
-    /**
-     * {@return the type of the overlay}
-     */
-    public OverlayType getOverlayType()
-    {
-        return overlayType;
-    }
-
-    /**
-     * {@return the block which the overlay is gotten from}
-     */
-    public BlockState getBlockState()
-    {
-        return blockState;
-    }
-
-    /**
-     * {@return the position of the block which the overlay is gotten from}
-     */
-    public BlockPos getBlockPos()
-    {
-        return blockPos;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Forge Development LLC and contributors
+ * Copyright (stackrge Development LLC and contributors
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
@@ -11,10 +11,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired before a hand is rendered in the first person view.
@@ -25,108 +25,37 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
+ * @param hand the hand being rendered
+ * @param poseStack the pose stack used for rendering
+ * @param multiBufferSource the source of rendering buffers
+ * @param partialTick the partial tick
+ * @param interpolatedPitch the interpolated pitch of the player entity
+ * @param swingProgress the swing progress of the hand being rendered
+ * @param equipProgress the progress of the equip animation, from {@code 0.0} to {@code 1.0}
+ * @param itemStack the item stack to be rendered
+ *
  * @see RenderArmEvent
  */
-@Cancelable
-public class RenderHandEvent extends Event
-{
-    private final InteractionHand hand;
-    private final PoseStack poseStack;
-    private final MultiBufferSource multiBufferSource;
-    private final int packedLight;
-    private final float partialTick;
-    private final float interpolatedPitch;
-    private final float swingProgress;
-    private final float equipProgress;
-    private final ItemStack stack;
-
-    @ApiStatus.Internal
-    public RenderHandEvent(InteractionHand hand, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight,
-                           float partialTick, float interpolatedPitch,
-                           float swingProgress, float equipProgress, ItemStack stack)
-    {
-        this.hand = hand;
-        this.poseStack = poseStack;
-        this.multiBufferSource = multiBufferSource;
-        this.packedLight = packedLight;
-        this.partialTick = partialTick;
-        this.interpolatedPitch = interpolatedPitch;
-        this.swingProgress = swingProgress;
-        this.equipProgress = equipProgress;
-        this.stack = stack;
-    }
-
-    /**
-     * {@return the hand being rendered}
-     */
-    public InteractionHand getHand()
-    {
-        return hand;
-    }
-
-    /**
-     * {@return the pose stack used for rendering}
-     */
-    public PoseStack getPoseStack()
-    {
-        return poseStack;
-    }
-
-    /**
-     * {@return the source of rendering buffers}
-     */
-    public MultiBufferSource getMultiBufferSource()
-    {
-        return multiBufferSource;
-    }
+public record RenderHandEvent(
+        InteractionHand hand,
+        PoseStack poseStack,
+        MultiBufferSource multiBufferSource,
+        int packedLight,
+        float partialTick,
+        float interpolatedPitch,
+        float swingProgress,
+        float equipProgress,
+        ItemStack itemStack
+) implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<RenderHandEvent> BUS = CancellableEventBus.create(RenderHandEvent.class);
 
     /**
      * {@return the amount of packed (sky and block) light for rendering}
      *
      * @see LightTexture
      */
-    public int getPackedLight()
-    {
+    @Override
+    public int packedLight() {
         return packedLight;
-    }
-
-    /**
-     * {@return the partial tick}
-     */
-    public float getPartialTick()
-    {
-        return partialTick;
-    }
-
-    /**
-     * {@return the interpolated pitch of the player entity}
-     */
-    public float getInterpolatedPitch()
-    {
-        return interpolatedPitch;
-    }
-
-    /**
-     * {@return the swing progress of the hand being rendered}
-     */
-    public float getSwingProgress()
-    {
-        return swingProgress;
-    }
-
-    /**
-     * {@return the progress of the equip animation, from {@code 0.0} to {@code 1.0}}
-     */
-    public float getEquipProgress()
-    {
-        return equipProgress;
-    }
-
-    /**
-     * {@return the item stack to be rendered}
-     */
-    public ItemStack getItemStack()
-    {
-        return stack;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
@@ -13,10 +13,11 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired before a selection highlight is rendered.
@@ -25,74 +26,36 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Block
  * @see Entity
  */
-@Cancelable
-public abstract class RenderHighlightEvent extends Event
-{
-    private final LevelRenderer levelRenderer;
-    private final Camera camera;
-    private final HitResult target;
-    private final float partialTick;
-    private final PoseStack poseStack;
-    private final MultiBufferSource multiBufferSource;
-
-    @ApiStatus.Internal
-    protected RenderHighlightEvent(LevelRenderer levelRenderer, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource)
-    {
-        this.levelRenderer = levelRenderer;
-        this.camera = camera;
-        this.target = target;
-        this.partialTick = partialTick;
-        this.poseStack = poseStack;
-        this.multiBufferSource = multiBufferSource;
-    }
-
+public sealed interface RenderHighlightEvent {
     /**
      * {@return the level renderer}
      */
-    public LevelRenderer getLevelRenderer()
-    {
-        return levelRenderer;
-    }
+    LevelRenderer levelRenderer();
 
     /**
      * {@return the camera information}
      */
-    public Camera getCamera()
-    {
-        return camera;
-    }
+    Camera camera();
 
     /**
      * {@return the hit result which triggered the selection highlight}
      */
-    public HitResult getTarget()
-    {
-        return target;
-    }
+    HitResult target();
 
     /**
      * {@return the partial tick}
      */
-    public float getPartialTick()
-    {
-        return partialTick;
-    }
+    float partialTick();
 
     /**
      * {@return the pose stack used for rendering}
      */
-    public PoseStack getPoseStack()
-    {
-        return poseStack;
-    }
+    PoseStack poseStack();
 
     /**
      * {@return the source of rendering buffers}
      */
-    public MultiBufferSource getMultiBufferSource()
-    {
-        return multiBufferSource;
-    }
+    MultiBufferSource multiBufferSource();
 
     /**
      * Fired before a block's selection highlight is rendered.
@@ -103,22 +66,22 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Block extends RenderHighlightEvent
-    {
-        @ApiStatus.Internal
-        public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
-        {
-            super(levelRenderer, camera, target, partialTick, poseStack, bufferSource);
-        }
+    record Block(
+            LevelRenderer levelRenderer,
+            Camera camera,
+            BlockHitResult target,
+            float partialTick,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource
+    ) implements Cancellable, RecordEvent, RenderHighlightEvent {
+        public static final CancellableEventBus<Block> BUS = CancellableEventBus.create(Block.class);
 
         /**
          * {@return the block hit result}
          */
         @Override
-        public BlockHitResult getTarget()
-        {
-            return (BlockHitResult) super.target;
+        public BlockHitResult target() {
+            return target;
         }
     }
 
@@ -130,21 +93,22 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Entity extends RenderHighlightEvent
-    {
-        @ApiStatus.Internal
-        public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
-        {
-            super(levelRenderer, camera, target, partialTick, poseStack, bufferSource);
-        }
+    record Entity(
+            LevelRenderer levelRenderer,
+            Camera camera,
+            EntityHitResult target,
+            float partialTick,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource
+    ) implements RecordEvent, RenderHighlightEvent {
+        public static final EventBus<Entity> BUS = EventBus.create(Entity.class);
 
         /**
          * {@return the entity hit result}
          */
         @Override
-        public EntityHitResult getTarget()
-        {
-            return (EntityHitResult) super.target;
+        public EntityHitResult target() {
+            return target;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
@@ -11,10 +11,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.ItemFrameRenderer;
 import net.minecraft.client.renderer.entity.state.ItemFrameRenderState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired before an item stack is rendered in an item frame.
@@ -26,59 +26,29 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
+ * @param itemFrameState the item frame entity
+ * @param renderer the renderer for the item frame entity
+ * @param poseStack the pose stack used for rendering
+ * @param multiBufferSource the source of rendering buffers
+ *
  * @see ItemFrameRenderer
  */
-@Cancelable
-public class RenderItemInFrameEvent extends Event {
-    private final ItemFrameRenderState state;
-    private final ItemFrameRenderer<?> renderer;
-    private final PoseStack poseStack;
-    private final MultiBufferSource multiBufferSource;
-    private final int packedLight;
-
-    @ApiStatus.Internal
-    public RenderItemInFrameEvent(ItemFrameRenderState state, ItemFrameRenderer<?> renderItemFrame, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        this.state = state;
-        this.renderer = renderItemFrame;
-        this.poseStack = poseStack;
-        this.multiBufferSource = multiBufferSource;
-        this.packedLight = packedLight;
-    }
-
-    /**
-     * {@return the item frame entity}
-     */
-    public ItemFrameRenderState getItemFrameState() {
-        return state;
-    }
-
-    /**
-     * {@return the renderer for the item frame entity}
-     */
-    public ItemFrameRenderer<?> getRenderer() {
-        return renderer;
-    }
-
-    /**
-     * {@return the pose stack used for rendering}
-     */
-    public PoseStack getPoseStack() {
-        return poseStack;
-    }
-
-    /**
-     * {@return the source of rendering buffers}
-     */
-    public MultiBufferSource getMultiBufferSource() {
-        return multiBufferSource;
-    }
+public record RenderItemInFrameEvent(
+        ItemFrameRenderState itemFrameState,
+        ItemFrameRenderer<?> renderer,
+        PoseStack poseStack,
+        MultiBufferSource multiBufferSource,
+        int packedLight
+) implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<RenderItemInFrameEvent> BUS = CancellableEventBus.create(RenderItemInFrameEvent.class);
 
     /**
      * {@return the amount of packed (sky and block) light for rendering}
      *
      * @see LightTexture
      */
-    public int getPackedLight() {
+    @Override
+    public int packedLight() {
         return packedLight;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
@@ -11,10 +11,14 @@ import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Objects;
 
 /**
  * Fired before an entity renderer renders the nameplate of an entity.
@@ -31,8 +35,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see EntityRenderer
  */
-@Event.HasResult
-public class RenderNameTagEvent extends Event {
+public final class RenderNameTagEvent extends MutableEvent implements HasResult {
+    public static final EventBus<RenderNameTagEvent> BUS = EventBus.create(RenderNameTagEvent.class);
+
     private Component nameplateContent;
     private final EntityRenderState state;
     private final Component originalContent;
@@ -40,6 +45,7 @@ public class RenderNameTagEvent extends Event {
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;
     private final int packedLight;
+    private Result result = Result.DEFAULT;
 
     @ApiStatus.Internal
     public RenderNameTagEvent(EntityRenderState state, Component content, EntityRenderer<?, ?> entityRenderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
@@ -108,5 +114,16 @@ public class RenderNameTagEvent extends Event {
      */
     public int getPackedLight() {
         return this.packedLight;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        Objects.requireNonNull(result);
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -11,10 +11,11 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.client.renderer.entity.state.PlayerRenderState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when a player is being rendered.
@@ -24,55 +25,30 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent.Post
  * @see PlayerRenderer
  */
-public abstract class RenderPlayerEvent extends Event {
-    private final PlayerRenderState state;
-    private final PlayerRenderer renderer;
-    private final PoseStack poseStack;
-    private final MultiBufferSource multiBufferSource;
-    private final int packedLight;
-
-    @ApiStatus.Internal
-    protected RenderPlayerEvent(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        this.state = state;
-        this.renderer = renderer;
-        this.poseStack = poseStack;
-        this.multiBufferSource = multiBufferSource;
-        this.packedLight = packedLight;
-    }
-
-    public PlayerRenderState getState() {
-        return this.state;
-    }
+public sealed interface RenderPlayerEvent {
+    PlayerRenderState state();
 
     /**
      * {@return the player entity renderer}
      */
-    public PlayerRenderer getRenderer() {
-        return renderer;
-    }
+    PlayerRenderer renderer();
 
     /**
      * {@return the pose stack used for rendering}
      */
-    public PoseStack getPoseStack() {
-        return poseStack;
-    }
+    PoseStack poseStack();
 
     /**
      * {@return the source of rendering buffers}
      */
-    public MultiBufferSource getMultiBufferSource() {
-        return multiBufferSource;
-    }
+    MultiBufferSource multiBufferSource();
 
     /**
      * {@return the amount of packed (sky and block) light for rendering}
      *
      * @see LightTexture
      */
-    public int getPackedLight() {
-        return packedLight;
-    }
+    int packedLight();
 
     /**
      * Fired <b>before</b> the player is rendered.
@@ -85,12 +61,14 @@ public abstract class RenderPlayerEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends RenderPlayerEvent {
-        @ApiStatus.Internal
-        public Pre(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-            super(state, renderer, poseStack, multiBufferSource, packedLight);
-        }
+    record Pre(
+            PlayerRenderState state,
+            PlayerRenderer renderer,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource,
+            int packedLight
+    ) implements Cancellable, RecordEvent, RenderPlayerEvent {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
     }
 
     /**
@@ -101,10 +79,13 @@ public abstract class RenderPlayerEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends RenderPlayerEvent {
-        @ApiStatus.Internal
-        public Post(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-            super(state, renderer, poseStack, multiBufferSource, packedLight);
-        }
+    record Post(
+            PlayerRenderState state,
+            PlayerRenderer renderer,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource,
+            int packedLight
+    ) implements RecordEvent, RenderPlayerEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -16,8 +16,10 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -34,8 +36,7 @@ import java.util.List;
  * @see RenderTooltipEvent.Pre
  * @see RenderTooltipEvent.Background
  */
-public abstract class RenderTooltipEvent extends Event
-{
+public sealed abstract class RenderTooltipEvent extends MutableEvent {
     @NotNull
     protected final ItemStack itemStack;
     protected final GuiGraphics graphics;
@@ -120,9 +121,9 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class GatherComponents extends Event
-    {
+    public static final class GatherComponents extends MutableEvent implements Cancellable {
+        public static final CancellableEventBus<GatherComponents> BUS = CancellableEventBus.create(GatherComponents.class);
+
         private final ItemStack itemStack;
         private final int screenWidth;
         private final int screenHeight;
@@ -209,9 +210,9 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends RenderTooltipEvent
-    {
+    public static final class Pre extends RenderTooltipEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
         private final int screenWidth;
         private final int screenHeight;
         private final ClientTooltipPositioner positioner;
@@ -289,7 +290,9 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Background extends RenderTooltipEvent {
+    public static final class Background extends RenderTooltipEvent {
+        public static final EventBus<Background> BUS = EventBus.create(Background.class);
+
         private final ResourceLocation originalBackground;
         private ResourceLocation background;
 

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -10,8 +10,13 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -19,7 +24,6 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -35,20 +39,9 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-public abstract class ScreenEvent extends Event {
-    private final Screen screen;
-
-    @ApiStatus.Internal
-    protected ScreenEvent(Screen screen) {
-        this.screen = Objects.requireNonNull(screen);
-    }
-
-    /**
-     * {@return the screen that caused this event}
-     */
-    public Screen getScreen() {
-        return screen;
-    }
+public sealed interface ScreenEvent {
+    /** {@return the screen that caused this event} */
+    Screen screen();
 
     /**
      * Fired when a screen is being initialized.
@@ -61,34 +54,22 @@ public abstract class ScreenEvent extends Event {
      * @see Init.Pre
      * @see Init.Post
      */
-    public static abstract class Init extends ScreenEvent {
-        private final Consumer<GuiEventListener> add;
-        private final Consumer<GuiEventListener> remove;
-
-        private final List<GuiEventListener> listenerList;
-
-        @ApiStatus.Internal
-        protected Init(Screen screen, List<GuiEventListener> listenerList, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
-            super(screen);
-            this.listenerList = Collections.unmodifiableList(listenerList);
-            this.add = add;
-            this.remove = remove;
-        }
+    sealed interface Init extends ScreenEvent {
+        Consumer<GuiEventListener> adder();
+        Consumer<GuiEventListener> remover();
 
         /**
          * {@return unmodifiable view of list of event listeners on the screen}
          */
-        public List<GuiEventListener> getListenersList() {
-            return listenerList;
-        }
+        List<GuiEventListener> listenerList();
 
         /**
          * Adds the given {@link GuiEventListener} to the screen.
          *
          * @param listener the listener to add
          */
-        public void addListener(GuiEventListener listener) {
-            add.accept(listener);
+        default void addListener(GuiEventListener listener) {
+            adder().accept(listener);
         }
 
         /**
@@ -96,8 +77,8 @@ public abstract class ScreenEvent extends Event {
          *
          * @param listener the listener to remove
          */
-        public void removeListener(GuiEventListener listener) {
-            remove.accept(listener);
+        default void removeListener(GuiEventListener listener) {
+            remover().accept(listener);
         }
 
         /**
@@ -110,11 +91,16 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends Init {
-            @ApiStatus.Internal
-            public Pre(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
-                super(screen, list, add, remove);
+        record Pre(
+                Screen screen,
+                List<GuiEventListener> listenerList,
+                Consumer<GuiEventListener> adder,
+                Consumer<GuiEventListener> remover
+        ) implements Cancellable, Init, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
+            public Pre {
+                listenerList = Collections.unmodifiableList(listenerList);
             }
         }
 
@@ -126,10 +112,16 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Init {
-            @ApiStatus.Internal
-            public Post(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
-                super(screen, list, add, remove);
+        record Post(
+                Screen screen,
+                List<GuiEventListener> listenerList,
+                Consumer<GuiEventListener> adder,
+                Consumer<GuiEventListener> remover
+        ) implements Init, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
+            public Post {
+                listenerList = Collections.unmodifiableList(listenerList);
             }
         }
     }
@@ -141,48 +133,26 @@ public abstract class ScreenEvent extends Event {
      * @see Render.Pre
      * @see Render.Post
      */
-    public static abstract class Render extends ScreenEvent {
-        private final GuiGraphics guiGraphics;
-        private final int mouseX;
-        private final int mouseY;
-        private final float partialTick;
-
-        @ApiStatus.Internal
-        protected Render(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-            super(screen);
-            this.guiGraphics = guiGraphics;
-            this.mouseX = mouseX;
-            this.mouseY = mouseY;
-            this.partialTick = partialTick;
-        }
-
+    sealed interface Render extends ScreenEvent {
         /**
          * {@return the gui graphics used for rendering}
          */
-        public GuiGraphics getGuiGraphics() {
-            return guiGraphics;
-        }
+        GuiGraphics guiGraphics();
 
         /**
          * {@return the X coordinate of the mouse pointer}
          */
-        public int getMouseX() {
-            return mouseX;
-        }
+        int mouseX();
 
         /**
          * {@return the Y coordinate of the mouse pointer}
          */
-        public int getMouseY() {
-            return mouseY;
-        }
+        int mouseY();
 
         /**
          * {@return the partial tick}
          */
-        public float getPartialTick() {
-            return partialTick;
-        }
+        float partialTick();
 
         /**
          * Fired <b>before</b> the screen is drawn.
@@ -193,12 +163,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends Render {
-            @ApiStatus.Internal
-            public Pre(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-                super(screen, guiGraphics, mouseX, mouseY, partialTick);
-            }
+        record Pre(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
+                implements Cancellable, Render, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -209,11 +176,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Render {
-            @ApiStatus.Internal
-            public Post(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-                super(screen, guiGraphics, mouseX, mouseY, partialTick);
-            }
+        record Post(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
+                implements Render, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -225,22 +190,11 @@ public abstract class ScreenEvent extends Event {
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     *
+     * @param guiGraphics the gui graphics used for rendering
      */
-    public static class BackgroundRendered extends ScreenEvent {
-        private final GuiGraphics guiGraphics;
-
-        @ApiStatus.Internal
-        public BackgroundRendered(Screen screen, GuiGraphics guiGraphics) {
-            super(screen);
-            this.guiGraphics = guiGraphics;
-        }
-
-        /**
-         * {@return the gui graphics used for rendering}
-         */
-        public GuiGraphics getGuiGraphics() {
-            return guiGraphics;
-        }
+    record BackgroundRendered(Screen screen, GuiGraphics guiGraphics) implements RecordEvent, ScreenEvent {
+        public static final EventBus<BackgroundRendered> BUS = EventBus.create(BackgroundRendered.class);
     }
 
     /**
@@ -254,15 +208,17 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class RenderInventoryMobEffects extends ScreenEvent {
+    final class RenderInventoryMobEffects extends MutableEvent implements Cancellable, ScreenEvent {
+        public static final CancellableEventBus<RenderInventoryMobEffects> BUS = CancellableEventBus.create(RenderInventoryMobEffects.class);
+
+        private final Screen screen;
         private final int availableSpace;
         private boolean compact;
         private int horizontalOffset;
 
         @ApiStatus.Internal
         public RenderInventoryMobEffects(Screen screen, int availableSpace, boolean compact, int horizontalOffset) {
-            super(screen);
+            this.screen = screen;
             this.availableSpace = availableSpace;
             this.compact = compact;
             this.horizontalOffset = horizontalOffset;
@@ -309,6 +265,11 @@ public abstract class ScreenEvent extends Event {
         public void setCompact(boolean compact) {
             this.compact = compact;
         }
+
+        @Override
+        public Screen screen() {
+            return screen;
+        }
     }
 
     /**
@@ -320,30 +281,16 @@ public abstract class ScreenEvent extends Event {
      * @see MouseDragged
      * @see MouseScrolled
      */
-    private static abstract class MouseInput extends ScreenEvent {
-        private final double mouseX;
-        private final double mouseY;
-
-        @ApiStatus.Internal
-        protected MouseInput(Screen screen, double mouseX, double mouseY) {
-            super(screen);
-            this.mouseX = mouseX;
-            this.mouseY = mouseY;
-        }
-
+    sealed interface MouseInput extends ScreenEvent {
         /**
          * {@return the X position of the mouse cursor, relative to the screen}
          */
-        public double getMouseX() {
-            return mouseX;
-        }
+        double mouseX();
 
         /**
          * {@return the Y position of the mouse cursor, relative to the screen}
          */
-        public double getMouseY() {
-            return mouseY;
-        }
+        double mouseY();
     }
 
     /**
@@ -353,24 +300,14 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonPressed.Pre
      * @see MouseButtonPressed.Post
      */
-    public static abstract class MouseButtonPressed extends MouseInput {
-        private final int button;
-
-        @ApiStatus.Internal
-        public MouseButtonPressed(Screen screen, double mouseX, double mouseY, int button) {
-            super(screen, mouseX, mouseY);
-            this.button = button;
-        }
-
+    sealed interface MouseButtonPressed extends MouseInput {
         /**
          * {@return the mouse button's input code}
          *
          * @see GLFW mouse constants starting with 'GLFW_MOUSE_BUTTON_'
          * @see <a href="https://www.glfw.org/docs/latest/group__buttons.html" target="_top">the online GLFW documentation</a>
          */
-        public int getButton() {
-            return button;
-        }
+        int button();
 
         /**
          * Fired <b>before</b> the mouse click is handled by the screen.
@@ -382,12 +319,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseButtonPressed {
-            @ApiStatus.Internal
-            public Pre(Screen screen, double mouseX, double mouseY, int button) {
-                super(screen, mouseX, mouseY, button);
-            }
+        record Pre(Screen screen, double mouseX, double mouseY, int button)
+                implements Cancellable, MouseButtonPressed, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -404,23 +338,12 @@ public abstract class ScreenEvent extends Event {
          *
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         *
+         * @param wasHandled {@code true} if the mouse click was already handled by its screen
          */
-        @HasResult
-        public static class Post extends MouseButtonPressed {
-            private final boolean handled;
-
-            @ApiStatus.Internal
-            public Post(Screen screen, double mouseX, double mouseY, int button, boolean handled) {
-                super(screen, mouseX, mouseY, button);
-                this.handled = handled;
-            }
-
-            /**
-             * {@return {@code true} if the mouse click was already handled by its screen}
-             */
-            public boolean wasHandled() {
-                return handled;
-            }
+        record Post(Screen screen, double mouseX, double mouseY, int button, boolean wasHandled, Result.Holder resultHolder)
+                implements MouseButtonPressed, RecordEvent, HasResult.Record {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -431,24 +354,14 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonReleased.Pre
      * @see MouseButtonReleased.Post
      */
-    public static abstract class MouseButtonReleased extends MouseInput {
-        private final int button;
-
-        @ApiStatus.Internal
-        public MouseButtonReleased(Screen screen, double mouseX, double mouseY, int button) {
-            super(screen, mouseX, mouseY);
-            this.button = button;
-        }
-
+    sealed interface MouseButtonReleased extends MouseInput {
         /**
          * {@return the mouse button's input code}
          *
          * @see GLFW mouse constants starting with 'GLFW_MOUSE_BUTTON_'
          * @see <a href="https://www.glfw.org/docs/latest/group__buttons.html" target="_top">the online GLFW documentation</a>
          */
-        public int getButton() {
-            return button;
-        }
+        int button();
 
         /**
          * Fired <b>before</b> the mouse release is handled by the screen.
@@ -460,12 +373,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseButtonReleased {
-            @ApiStatus.Internal
-            public Pre(Screen screen, double mouseX, double mouseY, int button) {
-                super(screen, mouseX, mouseY, button);
-            }
+        record Pre(Screen screen, double mouseX, double mouseY, int button)
+                implements Cancellable, MouseButtonReleased, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -482,23 +392,12 @@ public abstract class ScreenEvent extends Event {
          *
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         *
+         * @param wasHandled {@code true} if the mouse release was already handled by its screen
          */
-        @HasResult
-        public static class Post extends MouseButtonReleased {
-            private final boolean handled;
-
-            @ApiStatus.Internal
-            public Post(Screen screen, double mouseX, double mouseY, int button, boolean handled) {
-                super(screen, mouseX, mouseY, button);
-                this.handled = handled;
-            }
-
-            /**
-             * @return {@code true} if the mouse release was already handled by its screen
-             */
-            public boolean wasHandled() {
-                return handled;
-            }
+        record Post(Screen screen, double mouseX, double mouseY, int button, boolean wasHandled, Result.Holder resultHolder)
+                implements MouseButtonReleased, RecordEvent, HasResult.Record {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -509,42 +408,24 @@ public abstract class ScreenEvent extends Event {
      * @see MouseDragged.Pre
      * @see MouseDragged.Post
      */
-    public static abstract class MouseDragged extends MouseInput {
-        private final int mouseButton;
-        private final double dragX;
-        private final double dragY;
-
-        @ApiStatus.Internal
-        public MouseDragged(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
-            super(screen, mouseX, mouseY);
-            this.mouseButton = mouseButton;
-            this.dragX = dragX;
-            this.dragY = dragY;
-        }
-
+    sealed interface MouseDragged extends MouseInput {
         /**
          * {@return the mouse button's input code}
          *
          * @see GLFW mouse constants starting with 'GLFW_MOUSE_BUTTON_'
          * @see <a href="https://www.glfw.org/docs/latest/group__buttons.html" target="_top">the online GLFW documentation</a>
          */
-        public int getMouseButton() {
-            return mouseButton;
-        }
+        int mouseButton();
 
         /**
          * {@return amount of mouse drag along the X axis}
          */
-        public double getDragX() {
-            return dragX;
-        }
+        double dragX();
 
         /**
          * {@return amount of mouse drag along the Y axis}
          */
-        public double getDragY() {
-            return dragY;
-        }
+        double dragY();
 
         /**
          * Fired <b>before</b> the mouse drag is handled by the screen.
@@ -556,12 +437,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseDragged {
-            @ApiStatus.Internal
-            public Pre(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
-                super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
-            }
+        record Pre(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY)
+                implements Cancellable, MouseDragged, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -574,11 +452,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseDragged {
-            @ApiStatus.Internal
-            public Post(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
-                super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
-            }
+        record Post(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY)
+                implements MouseDragged, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -589,30 +465,16 @@ public abstract class ScreenEvent extends Event {
      * @see MouseScrolled.Pre
      * @see MouseScrolled.Post
      */
-    public static abstract class MouseScrolled extends MouseInput {
-        private final double deltaX;
-        private final double deltaY;
-
-        @ApiStatus.Internal
-        public MouseScrolled(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
-            super(screen, mouseX, mouseY);
-            this.deltaX = deltaX;
-            this.deltaY = deltaY;
-        }
-
+    sealed interface MouseScrolled extends MouseInput {
         /**
          * {@return the amount of change / delta of the mouse scroll in the vertical direction}
          */
-        public double getDeltaX() {
-            return deltaX;
-        }
+        double deltaX();
 
         /**
          * {@return the amount of change / delta of the mouse scroll in the horizontal direction}
          */
-        public double getDeltaY() {
-            return deltaY;
-        }
+        double deltaY();
 
         /**
          * Fired <b>before</b> the mouse scroll is handled by the screen.
@@ -624,12 +486,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseScrolled {
-            @ApiStatus.Internal
-            public Pre(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
-                super(screen, mouseX, mouseY, deltaX, deltaY);
-            }
+        record Pre(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY)
+                implements Cancellable, MouseScrolled, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -642,11 +501,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseScrolled {
-            @ApiStatus.Internal
-            public Post(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
-                super(screen, mouseX, mouseY, deltaX, deltaY);
-            }
+        record Post(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY)
+                implements MouseScrolled, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -659,19 +516,7 @@ public abstract class ScreenEvent extends Event {
      * @see InputConstants
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_key" target="_top">the online GLFW documentation</a>
      */
-    private static abstract class KeyInput extends ScreenEvent {
-        private final int keyCode;
-        private final int scanCode;
-        private final int modifiers;
-
-        @ApiStatus.Internal
-        protected KeyInput(Screen screen, int keyCode, int scanCode, int modifiers) {
-            super(screen);
-            this.keyCode = keyCode;
-            this.scanCode = scanCode;
-            this.modifiers = modifiers;
-        }
-
+    sealed interface KeyInput extends ScreenEvent {
         /**
          * {@return the {@code GLFW} (platform-agnostic) key code}
          *
@@ -679,9 +524,7 @@ public abstract class ScreenEvent extends Event {
          * @see GLFW key constants starting with {@code GLFW_KEY_}
          * @see <a href="https://www.glfw.org/docs/latest/group__keys.html" target="_top">the online GLFW documentation</a>
          */
-        public int getKeyCode() {
-            return keyCode;
-        }
+        int keyCode();
 
         /**
          * {@return the platform-specific scan code}
@@ -692,9 +535,7 @@ public abstract class ScreenEvent extends Event {
          *
          * @see InputConstants#getKey(int, int)
          */
-        public int getScanCode() {
-            return scanCode;
-        }
+        int scanCode();
 
         /**
          * {@return a bit field representing the active modifier keys}
@@ -707,9 +548,7 @@ public abstract class ScreenEvent extends Event {
          * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
          * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
          */
-        public int getModifiers() {
-            return modifiers;
-        }
+        int modifiers();
     }
 
     /**
@@ -719,12 +558,7 @@ public abstract class ScreenEvent extends Event {
      * @see KeyPressed.Pre
      * @see KeyPressed.Post
      */
-    public static abstract class KeyPressed extends KeyInput {
-        @ApiStatus.Internal
-        public KeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {
-            super(screen, keyCode, scanCode, modifiers);
-        }
-
+    sealed interface KeyPressed extends KeyInput {
         /**
          * Fired <b>before</b> the key press is handled by the screen.
          *
@@ -735,12 +569,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends KeyPressed {
-            @ApiStatus.Internal
-            public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
-                super(screen, keyCode, scanCode, modifiers);
-            }
+        record Pre(Screen screen, int keyCode, int scanCode, int modifiers)
+                implements Cancellable, KeyPressed, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -753,12 +584,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Post extends KeyPressed {
-            @ApiStatus.Internal
-            public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
-                super(screen, keyCode, scanCode, modifiers);
-            }
+        record Post(Screen screen, int keyCode, int scanCode, int modifiers)
+                implements Cancellable, KeyPressed, RecordEvent {
+            public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
         }
     }
 
@@ -769,12 +597,7 @@ public abstract class ScreenEvent extends Event {
      * @see KeyReleased.Pre
      * @see KeyReleased.Post
      */
-    public static abstract class KeyReleased extends KeyInput {
-        @ApiStatus.Internal
-        public KeyReleased(Screen screen, int keyCode, int scanCode, int modifiers) {
-            super(screen, keyCode, scanCode, modifiers);
-        }
-
+    sealed interface KeyReleased extends KeyInput {
         /**
          * Fired <b>before</b> the key release is handled by the screen.
          *
@@ -785,12 +608,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends KeyReleased {
-            @ApiStatus.Internal
-            public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
-                super(screen, keyCode, scanCode, modifiers);
-            }
+        record Pre(Screen screen, int keyCode, int scanCode, int modifiers)
+                implements Cancellable, KeyReleased, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -803,12 +623,8 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Post extends KeyReleased {
-            @ApiStatus.Internal
-            public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
-                super(screen, keyCode, scanCode, modifiers);
-            }
+        record Post(Screen screen, int keyCode, int scanCode, int modifiers) implements KeyReleased, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -820,23 +636,11 @@ public abstract class ScreenEvent extends Event {
      * @see CharacterTyped.Post
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_char" target="_top">the online GLFW documentation</a>
      */
-    public static class CharacterTyped extends ScreenEvent {
-        private final char codePoint;
-        private final int modifiers;
-
-        @ApiStatus.Internal
-        public CharacterTyped(Screen screen, char codePoint, int modifiers) {
-            super(screen);
-            this.codePoint = codePoint;
-            this.modifiers = modifiers;
-        }
-
+    sealed interface CharacterTyped extends ScreenEvent {
         /**
          * {@return the character code point}
          */
-        public char getCodePoint() {
-            return codePoint;
-        }
+        char codePoint();
 
         /**
          * {@return a bit field representing the active modifier keys}
@@ -849,9 +653,7 @@ public abstract class ScreenEvent extends Event {
          * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
          * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
          */
-        public int getModifiers() {
-            return modifiers;
-        }
+        int modifiers();
 
         /**
          * Fired <b>before</b> the character input is handled by the screen.
@@ -863,12 +665,8 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends CharacterTyped {
-            @ApiStatus.Internal
-            public Pre(Screen screen, char codePoint, int modifiers) {
-                super(screen, codePoint, modifiers);
-            }
+        record Pre(Screen screen, char codePoint, int modifiers) implements Cancellable, CharacterTyped, RecordEvent {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
         }
 
         /**
@@ -881,11 +679,8 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends CharacterTyped {
-            @ApiStatus.Internal
-            public Post(Screen screen, char codePoint, int modifiers) {
-                super(screen, codePoint, modifiers);
-            }
+        record Post(Screen screen, char codePoint, int modifiers) implements Cancellable, CharacterTyped, RecordEvent {
+            public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
         }
     }
 
@@ -901,15 +696,17 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Opening extends ScreenEvent {
-        @Nullable
-        private final Screen currentScreen;
-        private Screen newScreen;
+    final class Opening extends MutableEvent implements Cancellable, ScreenEvent {
+        public static final CancellableEventBus<Opening> BUS = CancellableEventBus.create(Opening.class);
+
+        private final Screen screen;
+
+        private final @Nullable Screen currentScreen;
+        private @Nullable Screen newScreen;
 
         @ApiStatus.Internal
         public Opening(@Nullable Screen currentScreen, Screen screen) {
-            super(screen);
+            this.screen = screen;
             this.currentScreen = currentScreen;
             this.newScreen = screen;
         }
@@ -935,8 +732,13 @@ public abstract class ScreenEvent extends Event {
         /**
          * Sets the new screen to be opened if the event is not cancelled. May be null.
          */
-        public void setNewScreen(Screen newScreen) {
+        public void setNewScreen(@Nullable Screen newScreen) {
             this.newScreen = newScreen;
+        }
+
+        @Override
+        public Screen screen() {
+            return screen;
         }
     }
 
@@ -949,10 +751,7 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Closing extends ScreenEvent {
-        @ApiStatus.Internal
-        public Closing(Screen screen) {
-            super(screen);
-        }
+    record Closing(Screen screen) implements ScreenEvent, RecordEvent {
+        public static final EventBus<Closing> BUS = EventBus.create(Closing.class);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -9,10 +9,12 @@ import com.mojang.blaze3d.platform.NativeImage;
 import net.minecraft.client.Screenshot;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,42 +31,36 @@ import java.io.IOException;
  *
  * @see Screenshot
  */
-@Cancelable
-public class ScreenshotEvent extends Event
-{
+public final class ScreenshotEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ScreenshotEvent> BUS = CancellableEventBus.create(ScreenshotEvent.class);
+
     public static final Component DEFAULT_CANCEL_REASON = Component.literal("Screenshot canceled");
 
     private final NativeImage image;
     private File screenshotFile;
 
-    private Component resultMessage = null;
+    private @Nullable Component resultMessage = null;
 
     @ApiStatus.Internal
-    public ScreenshotEvent(NativeImage image, File screenshotFile)
-    {
+    public ScreenshotEvent(NativeImage image, File screenshotFile) {
         this.image = image;
         this.screenshotFile = screenshotFile;
-        try
-        {
+        try {
             this.screenshotFile = screenshotFile.getCanonicalFile(); // FORGE: Fix errors on Windows with paths that include \.\
-        } catch (IOException ignored)
-        {
-        }
+        } catch (IOException ignored) {}
     }
 
     /**
      * {@return the in-memory image of the screenshot}
      */
-    public NativeImage getImage()
-    {
+    public NativeImage getImage() {
         return image;
     }
 
     /**
      * @return the file where the screenshot will be saved to
      */
-    public File getScreenshotFile()
-    {
+    public File getScreenshotFile() {
         return screenshotFile;
     }
 
@@ -73,16 +69,14 @@ public class ScreenshotEvent extends Event
      *
      * @param screenshotFile the new filepath
      */
-    public void setScreenshotFile(File screenshotFile)
-    {
+    public void setScreenshotFile(File screenshotFile) {
         this.screenshotFile = screenshotFile;
     }
 
     /**
      * {@return the custom cancellation message, or {@code null} if no custom message is set}
      */
-    public Component getResultMessage()
-    {
+    public @Nullable Component getResultMessage() {
         return resultMessage;
     }
 
@@ -92,8 +86,7 @@ public class ScreenshotEvent extends Event
      *
      * @param resultMessage the new result message
      */
-    public void setResultMessage(Component resultMessage)
-    {
+    public void setResultMessage(Component resultMessage) {
         this.resultMessage = resultMessage;
     }
 
@@ -105,8 +98,7 @@ public class ScreenshotEvent extends Event
      *
      * @return the cancel message for the player
      */
-    public Component getCancelMessage()
-    {
+    public Component getCancelMessage() {
         return getResultMessage() != null ? getResultMessage() : DEFAULT_CANCEL_REASON;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
@@ -6,8 +6,9 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -17,8 +18,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>If the event is cancelled, the message is not displayed in the chat message window.</p>
  *
  */
-@Cancelable
-public class SystemMessageReceivedEvent extends Event {
+public final class SystemMessageReceivedEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<SystemMessageReceivedEvent> BUS = CancellableEventBus.create(SystemMessageReceivedEvent.class);
+
     private Component message;
     private final boolean overlay;
 

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -21,15 +22,6 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-@Cancelable
-public class ToastAddEvent extends Event {
-    private final Toast toast;
-
-    public ToastAddEvent(Toast toast) {
-        this.toast = toast;
-    }
-
-    public Toast getToast() {
-        return toast;
-    }
+public record ToastAddEvent(Toast toast) implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<ToastAddEvent> BUS = CancellableEventBus.create(ToastAddEvent.class);
 }

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -12,8 +12,9 @@ import net.minecraft.client.renderer.FogRenderer.FogMode;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.world.level.material.FogType;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ComputeCameraAngles
  * @see ComputeFov
  */
-public abstract class ViewportEvent extends Event {
+public sealed abstract class ViewportEvent extends MutableEvent {
     private final GameRenderer renderer;
     private final Camera camera;
     private final double partialTick;
@@ -72,8 +73,9 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class RenderFog extends ViewportEvent {
+    public static final class RenderFog extends ViewportEvent implements Cancellable {
+        public static final CancellableEventBus<RenderFog> BUS = CancellableEventBus.create(RenderFog.class);
+
         private final FogMode mode;
         private final FogType type;
         private float farPlaneDistance;
@@ -182,7 +184,9 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeFogColor extends ViewportEvent {
+    public static final class ComputeFogColor extends ViewportEvent implements Cancellable {
+        public static final CancellableEventBus<ComputeFogColor> BUS = CancellableEventBus.create(ComputeFogColor.class);
+
         private float red;
         private float green;
         private float blue;
@@ -254,7 +258,9 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeCameraAngles extends ViewportEvent {
+    public static final class ComputeCameraAngles extends ViewportEvent implements Cancellable {
+        public static final CancellableEventBus<ComputeCameraAngles> BUS = CancellableEventBus.create(ComputeCameraAngles.class);
+
         private float yaw;
         private float pitch;
         private float roll;
@@ -327,7 +333,9 @@ public abstract class ViewportEvent extends Event {
      *
      * @see ComputeFovModifierEvent
      */
-    public static class ComputeFov extends ViewportEvent {
+    public static final class ComputeFov extends ViewportEvent implements Cancellable {
+        public static final CancellableEventBus<ComputeFov> BUS = CancellableEventBus.create(ComputeFov.class);
+
         private final boolean usedConfiguredFov;
         private float fov;
 

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
@@ -9,6 +9,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -27,17 +28,16 @@ import org.jetbrains.annotations.Nullable;
  * @see PlaySoundSourceEvent
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundEvent extends SoundEvent
-{
+public final class PlaySoundEvent extends MutableEvent implements SoundEvent {
+    private final SoundEngine engine;
     private final String name;
     private final SoundInstance originalSound;
     @Nullable
     private SoundInstance sound;
 
     @ApiStatus.Internal
-    public PlaySoundEvent(SoundEngine manager, SoundInstance sound)
-    {
-        super(manager);
+    public PlaySoundEvent(SoundEngine manager, SoundInstance sound) {
+        this.engine = manager;
         this.originalSound = sound;
         this.name = sound.getLocation().getPath();
         this.setSound(sound);
@@ -76,5 +76,10 @@ public class PlaySoundEvent extends SoundEvent
     public void setSound(@Nullable SoundInstance newSound)
     {
         this.sound = newSound;
+    }
+
+    @Override
+    public SoundEngine engine() {
+        return engine;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -10,9 +10,8 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.client.event.sound.SoundEvent.SoundSourceEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when a <em>non-streaming</em> sound is being played. A non-streaming sound is loaded fully into memory
@@ -26,11 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundSourceEvent extends SoundSourceEvent
-{
-    @ApiStatus.Internal
-    public PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)
-    {
-        super(engine, sound, channel);
+public record PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel, String name)
+        implements RecordEvent, SoundSourceEvent {
+    public PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel) {
+        this(engine, sound, channel, sound.getLocation().getPath());
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -10,9 +10,8 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.client.event.sound.SoundEvent.SoundSourceEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when a <em>streaming</em> sound is being played. A streaming sound is streamed directly from its source
@@ -26,11 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlayStreamingSourceEvent extends SoundSourceEvent
-{
-    @ApiStatus.Internal
-    public PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)
-    {
-        super(engine, sound, channel);
+public record PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel, String name)
+        implements RecordEvent, SoundSourceEvent {
+    public PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel) {
+        this(engine, sound, channel, sound.getLocation().getPath());
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -6,11 +6,9 @@
 package net.minecraftforge.client.event.sound;
 
 import net.minecraft.client.sounds.SoundEngine;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when the {@link SoundEngine} is constructed or (re)loaded, such as during game initialization or when the sound
@@ -21,11 +19,4 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
-{
-    @ApiStatus.Internal
-    public SoundEngineLoadEvent(SoundEngine manager)
-    {
-        super(manager);
-    }
-}
+public record SoundEngineLoadEvent(SoundEngine engine) implements SoundEvent, IModBusEvent {}

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -9,9 +9,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import com.mojang.blaze3d.audio.Channel;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Superclass for sound related events.
@@ -23,23 +21,8 @@ import org.jetbrains.annotations.ApiStatus;
  * @see PlaySoundEvent
  * @see SoundEngineLoadEvent
  */
-public abstract class SoundEvent extends Event
-{
-    private final SoundEngine engine;
-
-    @ApiStatus.Internal
-    protected SoundEvent(SoundEngine engine)
-    {
-        this.engine = engine;
-    }
-
-    /**
-     * {@return the sound engine}
-     */
-    public SoundEngine getEngine()
-    {
-        return engine;
-    }
+public sealed interface SoundEvent permits PlaySoundEvent, SoundEngineLoadEvent, SoundEvent.SoundSourceEvent {
+    SoundEngine engine();
 
     /**
      * Superclass for when a sound has started to play on an audio channel.
@@ -50,43 +33,20 @@ public abstract class SoundEvent extends Event
      * @see PlaySoundSourceEvent
      * @see PlayStreamingSourceEvent
      */
-    public static abstract class SoundSourceEvent extends SoundEvent
-    {
-        private final SoundInstance sound;
-        private final Channel channel;
-        private final String name;
-
-        @ApiStatus.Internal
-        protected SoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)
-        {
-            super(engine);
-            this.name = sound.getLocation().getPath();
-            this.sound = sound;
-            this.channel = channel;
-        }
-
+    sealed interface SoundSourceEvent extends SoundEvent permits PlaySoundSourceEvent, PlayStreamingSourceEvent {
         /**
          * {@return the sound being played}
          */
-        public SoundInstance getSound()
-        {
-            return sound;
-        }
+        SoundInstance sound();
 
         /**
          * {@return the audio channel on which the sound is playing on}
          */
-        public Channel getChannel()
-        {
-            return channel;
-        }
+        Channel channel();
 
         /**
          * {@return the name of the sound being played} This is equivalent to the path of the location of the original sound.
          */
-        public String getName()
-        {
-            return name;
-        }
+        String name();
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -19,9 +19,10 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.event.network.ConnectionStartEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.event.TickEvent.ServerTickEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.network.filters.NetworkFilters;
 import net.minecraftforge.common.util.LogicalSidedProvider;
@@ -29,24 +30,31 @@ import net.minecraftforge.server.command.ForgeCommand;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import net.minecraftforge.server.command.ConfigCommand;
 
+import java.lang.invoke.MethodHandles;
+
 public class ForgeInternalHandler {
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onEntityJoinWorld(EntityJoinLevelEvent event) {
-        Entity entity = event.getEntity();
+    static void register() {
+        BusGroup.DEFAULT.register(MethodHandles.lookup(), new ForgeInternalHandler());
+    }
+
+    @SubscribeEvent(priority = Priority.HIGH)
+    public boolean onEntityJoinWorld(EntityJoinLevelEvent event) {
+        Entity entity = event.entity();
         if (entity.getClass().equals(ItemEntity.class)) {
             ItemStack stack = ((ItemEntity)entity).getItem();
             Item item = stack.getItem();
             if (item.hasCustomEntity(stack)) {
-                Entity newEntity = item.createEntity(event.getLevel(), entity, stack);
+                Entity newEntity = item.createEntity(event.level(), entity, stack);
                 if (newEntity != null) {
                     entity.discard();
-                    event.setCanceled(true);
                     @SuppressWarnings("resource")
-                    var executor = LogicalSidedProvider.WORKQUEUE.get(event.getLevel().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER);
-                    executor.schedule(new TickTask(0, () -> event.getLevel().addFreshEntity(newEntity)));
+                    var executor = LogicalSidedProvider.WORKQUEUE.get(event.level().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER);
+                    executor.schedule(new TickTask(0, () -> event.level().addFreshEntity(newEntity)));
+                    return true;
                 }
             }
         }
+        return false;
     }
 
     @SubscribeEvent
@@ -67,8 +75,8 @@ public class ForgeInternalHandler {
 
     @SubscribeEvent
     public void onChunkUnload(ChunkEvent.Unload event) {
-        if (!event.getLevel().isClientSide())
-            FarmlandWaterManager.removeTickets(event.getChunk());
+        if (!event.level().isClientSide())
+            FarmlandWaterManager.removeTickets(event.chunk());
     }
 
     /*
@@ -81,7 +89,7 @@ public class ForgeInternalHandler {
 
     @SubscribeEvent
     public void playerLogin(PlayerEvent.PlayerLoggedInEvent event) {
-        UsernameCache.setUsername(event.getEntity().getUUID(), event.getEntity().getGameProfile().getName());
+        UsernameCache.setUsername(event.entity().getUUID(), event.entity().getGameProfile().getName());
     }
 
     @SubscribeEvent
@@ -109,10 +117,9 @@ public class ForgeInternalHandler {
         event.addListener(CreativeModeTabRegistry.getReloadListener());
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public void builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
-        if(event.getEntity() instanceof Mob mob && mob.isSpawnCancelled())
-            event.setCanceled(true);
+    @SubscribeEvent(priority = Priority.HIGHEST)
+    public boolean builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
+        return event.entity() instanceof Mob mob && mob.isSpawnCancelled();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -61,8 +61,11 @@ import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveSpawnsBiomeModi
 import net.minecraftforge.common.world.NoneBiomeModifier;
 import net.minecraftforge.common.world.NoneStructureModifier;
 import net.minecraftforge.common.world.StructureModifier;
+import net.minecraftforge.event.network.GatherLoginConfigurationTasksEvent;
+import net.minecraftforge.event.server.ServerAboutToStartEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.*;
@@ -117,6 +120,7 @@ import com.mojang.serialization.MapCodec;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -381,13 +385,13 @@ public class ForgeMod {
         CrashReportCallables.registerCrashCallable("FML", ForgeVersion::getSpec);
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
-        final IEventBus modEventBus = context.getModEventBus();
+        var modEventBus = context.getModBusGroup();
         // Forge-provided datapack registries
         modEventBus.addListener((DataPackRegistryEvent.NewRegistry event) -> {
             event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
             event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
         });
-        modEventBus.addListener(this::preInit);
+        FMLCommonSetupEvent.BUS.apply(modEventBus).addListener(this::preInit);
         modEventBus.addListener(this::gatherData);
         modEventBus.addListener(this::registerFluids);
         modEventBus.addListener(this::registerVanillaDisplayContexts);
@@ -399,15 +403,15 @@ public class ForgeMod {
         context.registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
         context.registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
         context.registerConfig(ModConfig.Type.COMMON, ForgeConfig.commonSpec);
-        modEventBus.register(ForgeConfig.class);
+        modEventBus.register(MethodHandles.lookup(), ForgeConfig.class);
 
         // Forge does not display problems when the remote is not matching.
         context.registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);
         StartupMessageManager.addModMessage("Forge version "+ForgeVersion.getVersion());
 
-        MinecraftForge.EVENT_BUS.addListener(VillagerTradingManager::loadTrades);
-        MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
-        MinecraftForge.EVENT_BUS.register(new ForgeNetworkConfigurationHandler());
+        ServerAboutToStartEvent.BUS.addListener(VillagerTradingManager::loadTrades);
+        ForgeInternalHandler.register();
+        GatherLoginConfigurationTasksEvent.BUS.addListener(ForgeNetworkConfigurationHandler::gatherInit);
 
         ForgeRegistries.ITEMS.tags().addOptionalTagDefaults(Tags.Items.ENCHANTING_FUELS, Set.of(ForgeRegistries.ITEMS.getDelegateOrThrow(Items.LAPIS_LAZULI)));
 

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -10,8 +10,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.ConfigScreenHandler;
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
@@ -27,16 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class MinecraftForge {
-    /**
-     * The EventBus for all the Forge Events.
-     *
-     * Events marked with {@link net.minecraftforge.fml.event.IModBusEvent}
-     * belong on the ModBus and not this bus
-     */
-    public static final IEventBus EVENT_BUS = BusBuilder.builder().startShutdown().useModLauncher().build();
-
-    static final ForgeInternalHandler INTERNAL_HANDLER = new ForgeInternalHandler();
+public final class MinecraftForge {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker FORGE = MarkerManager.getMarker("FORGE");
 

--- a/src/main/java/net/minecraftforge/common/util/HasResult.java
+++ b/src/main/java/net/minecraftforge/common/util/HasResult.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.common.util;
+
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+
+public interface HasResult {
+    Result getResult();
+    void setResult(Result result);
+
+    /**
+     * A version of {@link HasResult} tailored for {@link RecordEvent}s.
+     */
+    interface Record extends HasResult {
+        Result.Holder resultHolder();
+
+        default Result getResult() {
+            return resultHolder().get();
+        }
+
+        default void setResult(Result result) {
+            resultHolder().set(result);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/util/Result.java
+++ b/src/main/java/net/minecraftforge/common/util/Result.java
@@ -1,0 +1,62 @@
+package net.minecraftforge.common.util;
+
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+
+import java.util.Objects;
+
+public enum Result {
+    ALLOW,
+    DEFAULT,
+    DENY;
+
+    public boolean isAllowed() {
+        return this == ALLOW;
+    }
+
+    public boolean isDefault() {
+        return this == DEFAULT;
+    }
+
+    public boolean isDenied() {
+        return this == DENY;
+    }
+
+    /**
+     * A mutable holder for a Result, useful for {@link RecordEvent}s combined with {@link HasResult.Record}
+     */
+    public static final class Holder {
+        private Result value;
+
+        public Holder() {
+            set(DEFAULT);
+        }
+
+        public Holder(Result value) {
+            set(value);
+        }
+
+        public Result get() {
+            return value;
+        }
+
+        public void set(Result value) {
+            Objects.requireNonNull(value);
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "Result.Holder{value=" + value + "\"}";
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            return this == that || (that instanceof Holder thatHolder && this.value == thatHolder.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
@@ -11,13 +11,14 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -29,7 +30,9 @@ import java.util.function.Supplier;
  * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
-public final class BuildCreativeModeTabContentsEvent extends Event implements IModBusEvent, CreativeModeTab.Output {
+public final class BuildCreativeModeTabContentsEvent implements IModBusEvent, CreativeModeTab.Output {
+    public static final Function<BusGroup, EventBus<BuildCreativeModeTabContentsEvent>> BUS = null; // todo
+
     private final CreativeModeTab tab;
     private final CreativeModeTab.ItemDisplayParameters parameters;
     private final MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility> entries;

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event;
 import net.minecraft.world.Difficulty;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 /**
  * DifficultyChangeEvent is fired when difficulty is changing. <br>
@@ -19,20 +20,6 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class DifficultyChangeEvent extends Event {
-    private final Difficulty difficulty;
-    private final Difficulty oldDifficulty;
-
-    public DifficultyChangeEvent(Difficulty difficulty, Difficulty oldDifficulty) {
-        this.difficulty = difficulty;
-        this.oldDifficulty = oldDifficulty;
-    }
-
-    public Difficulty getDifficulty() {
-        return difficulty;
-    }
-
-    public Difficulty getOldDifficulty() {
-        return oldDifficulty;
-    }
+public record DifficultyChangeEvent(Difficulty difficulty, Difficulty oldDifficulty) implements RecordEvent {
+    public static final EventBus<DifficultyChangeEvent> BUS = EventBus.create(DifficultyChangeEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
+++ b/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
@@ -5,7 +5,9 @@
 
 package net.minecraftforge.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 
 /**
  * A simple marker event that notifies when the game is about to close.
@@ -17,7 +19,6 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * @author Curle
  */
-public class GameShuttingDownEvent extends Event
-{
-    public GameShuttingDownEvent() {}
+public record GameShuttingDownEvent() implements SelfDestructing, RecordEvent {
+    public static final EventBus<GameShuttingDownEvent> BUS = EventBus.create(GameShuttingDownEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -12,8 +12,9 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -32,73 +33,21 @@ import org.jetbrains.annotations.ApiStatus;
  *  This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
  *  If the event is cancelled, the container's logic halts, the carried item and the slot will not be swapped, and handling is assumed to have been done by the mod.
  *  This also means that the two vanilla checks described above will not be called.
+ *
+ * @param carriedItem the stack being carried by the mouse. This may be empty!
+ * @param stackedOnItem the stack currently in the slot being clicked on. This may be empty!
+ * @param slot the slot being clicked on
+ * @param clickAction the click action being used. By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
+ * @param player the player doing the item swap attempt
+ * @param carriedSlotAccess a fake slot allowing the listener to see and change what item is being carried
  */
-@Cancelable
-public class ItemStackedOnOtherEvent extends Event
-{
-    private final ItemStack carriedItem;
-    private final ItemStack stackedOnItem;
-    private final Slot slot;
-    private final ClickAction action;
-    private final Player player;
-    private final SlotAccess carriedSlotAccess;
-
-    @ApiStatus.Internal
-    public ItemStackedOnOtherEvent(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess)
-    {
-        this.carriedItem = carriedItem;
-        this.stackedOnItem = stackedOnItem;
-        this.slot = slot;
-        this.action = action;
-        this.player = player;
-        this.carriedSlotAccess = carriedSlotAccess;
-    }
-
-    /**
-     * {@return the stack being carried by the mouse} This may be empty!
-     */
-    public ItemStack getCarriedItem()
-    {
-        return carriedItem;
-    }
-
-    /**
-     * {@return the stack currently in the slot being clicked on} This may be empty!
-     */
-    public ItemStack getStackedOnItem()
-    {
-        return stackedOnItem;
-    }
-
-    /**
-     * {@return the slot being clicked on}
-     */
-    public Slot getSlot()
-    {
-        return slot;
-    }
-
-    /**
-     * {@return the click action being used} By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
-     */
-    public ClickAction getClickAction()
-    {
-        return action;
-    }
-
-    /**
-     * {@return the player doing the item swap attempt}
-     */
-    public Player getPlayer()
-    {
-        return player;
-    }
-
-    /**
-     * {@return a fake slot allowing the listener to see and change what item is being carried}
-     */
-    public SlotAccess getCarriedSlotAccess()
-    {
-        return carriedSlotAccess;
-    }
+public record ItemStackedOnOtherEvent(
+        ItemStack carriedItem,
+        ItemStack stackedOnItem,
+        Slot slot,
+        ClickAction clickAction,
+        Player player,
+        SlotAccess carriedSlotAccess
+) implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<ItemStackedOnOtherEvent> BUS = CancellableEventBus.create(ItemStackedOnOtherEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -8,8 +8,9 @@ package net.minecraftforge.event;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -23,9 +24,9 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-@Cancelable
-public class LootTableLoadEvent extends Event
-{
+public final class LootTableLoadEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<LootTableLoadEvent> BUS = CancellableEventBus.create(LootTableLoadEvent.class);
+
     private final ResourceLocation name;
     private LootTable table;
 

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -7,7 +7,8 @@ package net.minecraftforge.event;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -16,39 +17,19 @@ import java.util.List;
  * Fires when a player joins the server or when the reload command is ran,
  * before tags and crafting recipes are sent to the client. Send datapack data
  * to clients when this event fires.
+ *
+ * @param playerList The server's player list to get a view of all players.
+ * @param player The player to sync datapacks to. Null when syncing for all players,
+ *               such as when the reload command runs.
  */
-public class OnDatapackSyncEvent extends Event {
-    private final PlayerList playerList;
-
-    @Nullable
-    private final ServerPlayer player;
-
-    public OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player) {
-        this.playerList = playerList;
-        this.player = player;
-    }
-
-    /**
-     * @return The server's player list to get a view of all players.
-     */
-    public PlayerList getPlayerList() {
-        return this.playerList;
-    }
-
-    /**
-     * @return The player to sync datapacks to. Null when syncing for all players,
-     *         such as when the reload command runs.
-     */
-    @Nullable
-    public ServerPlayer getPlayer() {
-        return this.player;
-    }
+public record OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player) implements RecordEvent {
+    public static final EventBus<OnDatapackSyncEvent> BUS = EventBus.create(OnDatapackSyncEvent.class);
 
     /**
      * @return A list of players that should receive data during this event, which is the specified player (if not null)
      *         or all players otherwise.
      */
-    public List<ServerPlayer> getPlayers() {
+    public List<ServerPlayer> players() {
         return this.player == null ? this.playerList.getPlayers() : List.of(this.player);
     }
 }

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -13,36 +13,30 @@ import java.util.function.BooleanSupplier;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfPosting;
 import net.minecraftforge.fml.LogicalSide;
 
-public class TickEvent extends Event {
-    public enum Type {
-        LEVEL, PLAYER, CLIENT, SERVER, RENDER;
+public sealed interface TickEvent {
+    enum Type {
+        LEVEL, PLAYER, CLIENT, SERVER, RENDER
     }
 
-    public enum Phase {
-        START, END;
-    }
+    Type type();
+    LogicalSide side();
 
-    public final Type type;
-    public final LogicalSide side;
-    public final Phase phase;
+    sealed interface ServerTickEvent extends TickEvent {
+        @Override
+        default Type type() {
+            return Type.SERVER;
+        }
 
-    public TickEvent(Type type, LogicalSide side, Phase phase) {
-        this.type = type;
-        this.side = side;
-        this.phase = phase;
-    }
-
-    public static class ServerTickEvent extends TickEvent {
-        private final BooleanSupplier haveTime;
-        private final MinecraftServer server;
-
-        protected ServerTickEvent(BooleanSupplier haveTime, MinecraftServer server, Phase phase) {
-            super(Type.SERVER, LogicalSide.SERVER, phase);
-            this.haveTime = haveTime;
-            this.server = server;
+        @Override
+        default LogicalSide side() {
+            return LogicalSide.SERVER;
         }
 
         /**
@@ -50,57 +44,69 @@ public class TickEvent extends Event {
          * additional tasks (usually IO related) during the current tick,
          * otherwise {@code false}
          */
-        public boolean haveTime() {
-            return this.haveTime.getAsBoolean();
+        default boolean haveTime() {
+            return haveTimeSupplier().getAsBoolean();
         }
+
+        BooleanSupplier haveTimeSupplier();
 
         /**
          * {@return the server instance}
          */
-        public MinecraftServer getServer() {
-            return server;
+        MinecraftServer server();
+
+        record Pre(BooleanSupplier haveTimeSupplier, MinecraftServer server) implements ServerTickEvent, RecordEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
         }
 
-        public static class Pre extends ServerTickEvent {
-            public Pre(BooleanSupplier haveTime, MinecraftServer server) {
-                super(haveTime, server, Phase.START);
+        record Post(BooleanSupplier haveTimeSupplier, MinecraftServer server) implements ServerTickEvent, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+        }
+    }
+
+    sealed interface ClientTickEvent<T extends Event> extends TickEvent, SelfPosting<T> {
+        @Override
+        default Type type() {
+            return Type.CLIENT;
+        }
+
+        @Override
+        default LogicalSide side() {
+            return LogicalSide.CLIENT;
+        }
+
+        final class Pre extends MutableEvent implements ClientTickEvent<Pre> {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+            public static final Pre INSTANCE = new Pre();
+
+            private Pre() {}
+
+            @Override
+            public EventBus<Pre> getDefaultBus() {
+                return BUS;
             }
         }
 
-        public static class Post extends ServerTickEvent {
-            public Post(BooleanSupplier haveTime, MinecraftServer server) {
-                super(haveTime, server, Phase.END);
+        final class Post extends MutableEvent implements ClientTickEvent<Post> {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+            public static final Post INSTANCE = new Post();
+            
+            private Post() {}
+
+            @Override
+            public EventBus<Post> getDefaultBus() {
+                return BUS;
             }
         }
     }
 
-    public static class ClientTickEvent extends TickEvent {
-        protected ClientTickEvent(Phase phase) {
-            super(Type.CLIENT, LogicalSide.CLIENT, phase);
+    sealed interface LevelTickEvent extends TickEvent {
+        @Override
+        default Type type() {
+            return Type.LEVEL;
         }
 
-        public static class Pre extends ClientTickEvent {
-            public Pre() {
-                super(Phase.START);
-            }
-        }
-
-        public static class Post extends ClientTickEvent {
-            public Post() {
-                super(Phase.END);
-            }
-        }
-    }
-
-    public static class LevelTickEvent extends TickEvent {
-        public final Level level;
-        private final BooleanSupplier haveTime;
-
-        protected LevelTickEvent(LogicalSide side, Level level, BooleanSupplier haveTime, Phase phase) {
-            super(Type.LEVEL, side, phase);
-            this.level = level;
-            this.haveTime = haveTime;
-        }
+        Level level();
 
         /**
          * @return {@code true} whether the server has enough time to perform any
@@ -108,67 +114,69 @@ public class TickEvent extends Event {
          * otherwise {@code false}
          * @see ServerTickEvent#haveTime()
          */
-        public boolean haveTime() {
-            return this.haveTime.getAsBoolean();
+        default boolean haveTime() {
+            return haveTimeSupplier().getAsBoolean();
         }
 
-        public static class Pre extends LevelTickEvent {
-            public Pre(LogicalSide side, Level level, BooleanSupplier haveTime) {
-                super(side, level, haveTime, Phase.START);
-            }
+        BooleanSupplier haveTimeSupplier();
+
+        record Pre(LogicalSide side, Level level, BooleanSupplier haveTimeSupplier) implements LevelTickEvent, RecordEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
         }
 
-        public static class Post extends LevelTickEvent {
-            public Post(LogicalSide side, Level level, BooleanSupplier haveTime) {
-                super(side, level, haveTime, Phase.END);
-            }
+        record Post(LogicalSide side, Level level, BooleanSupplier haveTimeSupplier) implements LevelTickEvent, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
-    public static class PlayerTickEvent extends TickEvent {
-        public final Player player;
-
-        protected PlayerTickEvent(Player player, Phase phase) {
-            super(Type.PLAYER, player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT, phase);
-            this.player = player;
+    sealed interface PlayerTickEvent extends TickEvent {
+        @Override
+        default Type type() {
+            return Type.PLAYER;
         }
 
-        public static class Pre extends PlayerTickEvent {
+        Player player();
+
+        record Pre(Player player, LogicalSide side) implements RecordEvent, PlayerTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(Player player) {
-                super(player, Phase.START);
+                this(player, getSide(player));
             }
         }
 
-        public static class Post extends PlayerTickEvent {
+        record Post(Player player, LogicalSide side) implements RecordEvent, PlayerTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post(Player player) {
-                super(player, Phase.END);
+                this(player, getSide(player));
             }
+        }
+
+        private static LogicalSide getSide(Player player) {
+            return player instanceof ServerPlayer ? LogicalSide.SERVER : LogicalSide.CLIENT;
         }
     }
 
-    public static class RenderTickEvent extends TickEvent {
-        private final DeltaTracker timer;
-
-        private RenderTickEvent(Phase phase, DeltaTracker timer) {
-            super(Type.RENDER, LogicalSide.CLIENT, phase);
-            this.timer = timer;
+    sealed interface RenderTickEvent extends TickEvent {
+        @Override
+        default Type type() {
+            return Type.RENDER;
         }
 
-        public DeltaTracker getTimer() {
-            return this.timer;
+        @Override
+        default LogicalSide side() {
+            return LogicalSide.CLIENT;
         }
 
-        public static class Pre extends RenderTickEvent {
-            public Pre(DeltaTracker timer) {
-                super(Phase.START, timer);
-            }
+        DeltaTracker timer();
+
+        record Pre(DeltaTracker timer) implements RenderTickEvent, RecordEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
         }
 
-        public static class Post extends RenderTickEvent {
-            public Post(DeltaTracker timer) {
-                super(Phase.END, timer);
-            }
+        record Post(DeltaTracker timer) implements RenderTickEvent, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
-
     }
 }

--- a/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
+++ b/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,30 +23,15 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}. <br>
  * <br>
  * Cancel this event to prevent Vanilla from posting the {@link GameEvent} to all nearby {@link net.minecraft.world.level.gameevent.GameEventListener GameEventListeners}.
+ *
+ * @param level The level the Vanilla {@link GameEvent} occurred.
+ * @param vanillaEvent The Vanilla event.
+ * @param position The position the event took place at.
+ * @param context the context of the vanilla event
  **/
-@Cancelable
-public class VanillaGameEvent extends Event
-{
-    private final Level level;
-    private final GameEvent vanillaEvent;
-    private final Vec3 position;
-    private final GameEvent.Context context;
-
-    public VanillaGameEvent(Level level, GameEvent vanillaEvent, Vec3 position, GameEvent.Context context)
-    {
-        this.level = level;
-        this.vanillaEvent = vanillaEvent;
-        this.position = position;
-        this.context = context;
-    }
-
-    /**
-     * @return The level the Vanilla {@link GameEvent} occurred.
-     */
-    public Level getLevel()
-    {
-        return level;
-    }
+public record VanillaGameEvent(Level level, GameEvent vanillaEvent, Vec3 position, GameEvent.Context context)
+        implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<VanillaGameEvent> BUS = CancellableEventBus.create(VanillaGameEvent.class);
 
     /**
      * @return The entity that was the source or "cause" of the {@link GameEvent}.
@@ -54,29 +40,5 @@ public class VanillaGameEvent extends Event
     public Entity getCause()
     {
         return context.sourceEntity();
-    }
-
-    /**
-     * @return The Vanilla event.
-     */
-    public GameEvent getVanillaEvent()
-    {
-        return vanillaEvent;
-    }
-
-    /**
-     * @return The position the event took place at.
-     */
-    public Vec3 getEventPosition()
-    {
-        return position;
-    }
-
-    /**
-     * @return the context of the vanilla event
-     */
-    public GameEvent.Context getContext()
-    {
-        return context;
     }
 }

--- a/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
@@ -5,7 +5,8 @@
 
 package net.minecraftforge.event.brewing;
 
-import org.jetbrains.annotations.ApiStatus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.ItemStack;
@@ -13,38 +14,19 @@ import net.minecraft.world.item.alchemy.PotionBrewing;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.brewing.BrewingRecipe;
 import net.minecraftforge.common.brewing.IBrewingRecipe;
-import net.minecraftforge.eventbus.api.Event;
 
-public class BrewingRecipeRegisterEvent extends Event {
-    private final PotionBrewing.Builder builder;
-    private final FeatureFlagSet features;
-
-    @ApiStatus.Internal
-    public BrewingRecipeRegisterEvent(PotionBrewing.Builder builder, FeatureFlagSet features) {
-        this.builder = builder;
-        this.features = features;
-    }
-
-    public PotionBrewing.Builder getBuilder() {
-        return this.builder;
-    }
-
-    public FeatureFlagSet getFeatures() {
-        return this.features;
-    }
+public record BrewingRecipeRegisterEvent(PotionBrewing.Builder builder, FeatureFlagSet features) implements RecordEvent {
+    public static final EventBus<BrewingRecipeRegisterEvent> BUS = EventBus.create(BrewingRecipeRegisterEvent.class);
 
     /**
      * Adds a recipe to the registry. Due to the nature of the brewing stand
      * inputs that stack (a.k.a max stack size > 1) are not allowed.
      *
-     * @param input
-     *            The Ingredient that goes in same slots as the water bottles
-     *            would.
-     * @param ingredient
-     *            The Ingredient that goes in the same slot as nether wart would.
-     * @param output
-     *            The ItemStack that will replace the input once the brewing is
-     *            done.
+     * @param input      The Ingredient that goes in same slots as the water bottles
+     *                   would.
+     * @param ingredient The Ingredient that goes in the same slot as nether wart would.
+     * @param output     The ItemStack that will replace the input once the brewing is
+     *                   done.
      */
     public void addRecipe(Ingredient input, Ingredient ingredient, ItemStack output) {
         addRecipe(new BrewingRecipe(input, ingredient, output));
@@ -55,6 +37,6 @@ public class BrewingRecipeRegisterEvent extends Event {
      * inputs that stack (a.k.a max stack size > 1) are not allowed.
      */
     public void addRecipe(IBrewingRecipe recipe) {
-        getBuilder().add(recipe);
+        builder().add(recipe);
     }
 }

--- a/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
@@ -8,27 +8,14 @@ package net.minecraftforge.event.brewing;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
-import org.jetbrains.annotations.NotNull;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 /**
  * This event is called when a player picks up a potion from a brewing stand.
+ *
+ * @param stack The item stack of the potion
  */
-public class PlayerBrewedPotionEvent extends PlayerEvent
-{
-    private final ItemStack stack;
-
-    public PlayerBrewedPotionEvent(Player player, @NotNull ItemStack stack)
-    {
-        super(player);
-        this.stack = stack;
-    }
-
-    /**
-     * The ItemStack of the potion.
-     */
-    @NotNull
-    public ItemStack getStack()
-    {
-        return stack;
-    }
+public record PlayerBrewedPotionEvent(Player entity, ItemStack stack) implements PlayerEvent, RecordEvent {
+    public static final EventBus<PlayerBrewedPotionEvent> BUS = EventBus.create(PlayerBrewedPotionEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event.enchanting;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -18,8 +20,9 @@ import org.jetbrains.annotations.NotNull;
  * from 0-15 and indicates how many bookshelves surround the enchanting table. The {@link #itemStack} representing the item being
  * enchanted is also available.
  */
-public class EnchantmentLevelSetEvent extends net.minecraftforge.eventbus.api.Event
-{
+public final class EnchantmentLevelSetEvent extends MutableEvent {
+    public static final EventBus<EnchantmentLevelSetEvent> BUS = EventBus.create(EnchantmentLevelSetEvent.class);
+
     private final Level level;
     private final BlockPos pos;
     private final int enchantRow;

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -8,7 +8,9 @@ package net.minecraftforge.event.entity;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 
 /**
  * EntityEvent is fired when an event involving any Entity occurs.<br>
@@ -19,16 +21,12 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class EntityEvent extends Event {
-    private final Entity entity;
-
-    public EntityEvent(Entity entity) {
-        this.entity = entity;
-    }
-
-    public Entity getEntity() {
-        return entity;
-    }
+@MarkerEvent
+public sealed interface EntityEvent extends InheritableEvent
+        permits EntityEvent.EnteringSection, EntityEvent.EntityConstructing, EntityJoinLevelEvent,
+                EntityLeaveLevelEvent, EntityMobGriefingEvent, EntityMountEvent, EntityStruckByLightningEvent,
+                EntityTeleportEvent, EntityTravelToDimensionEvent, ProjectileImpactEvent {
+    Entity entity();
 
     /**
      * EntityConstructing is fired when an Entity is being created. <br>
@@ -40,10 +38,8 @@ public class EntityEvent extends Event {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class EntityConstructing extends EntityEvent {
-        public EntityConstructing(Entity entity) {
-            super(entity);
-        }
+    record EntityConstructing(Entity entity) implements EntityEvent {
+        public static final EventBus<EntityConstructing> BUS = EventBus.create(EntityConstructing.class);
     }
 
     /**
@@ -58,15 +54,8 @@ public class EntityEvent extends Event {
      * <br>
      * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class EnteringSection extends EntityEvent {
-        private final long packedOldPos;
-        private final long packedNewPos;
-
-        public EnteringSection(Entity entity, long packedOldPos, long packedNewPos) {
-            super(entity);
-            this.packedOldPos = packedOldPos;
-            this.packedNewPos = packedNewPos;
-        }
+    record EnteringSection(Entity entity, long packedOldPos, long packedNewPos) implements EntityEvent {
+        public static final EventBus<EnteringSection> BUS = EventBus.create(EnteringSection.class);
 
         /**
          * A packed version of the old section's position. This is to be used with the various methods in {@link SectionPos},

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -25,34 +25,14 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * on both logical sides.
+ *
+ * @param level the level that the entity is set to join
+ * @param loadedFromDisk {@code true} if the entity was loaded from disk, {@code false} otherwise.<br>
+ *                       On the {@linkplain LogicalSide#CLIENT logical client}, this will always return {@code false}.
  **/
-@Cancelable
-public class EntityJoinLevelEvent extends EntityEvent {
-    private final Level level;
-    private final boolean loadedFromDisk;
-
+public record EntityJoinLevelEvent(Entity entity, Level level, boolean loadedFromDisk)
+        implements Cancellable, EntityEvent {
     public EntityJoinLevelEvent(Entity entity, Level level) {
         this(entity, level, false);
-    }
-
-    public EntityJoinLevelEvent(Entity entity, Level level, boolean loadedFromDisk) {
-        super(entity);
-        this.level = level;
-        this.loadedFromDisk = loadedFromDisk;
-    }
-
-    /**
-     * {@return the level that the entity is set to join}
-     */
-    public Level getLevel() {
-        return level;
-    }
-
-    /**
-     * @return {@code true} if the entity was loaded from disk, {@code false} otherwise.
-     * On the {@linkplain LogicalSide#CLIENT logical client}, this will always return {@code false}.
-     */
-    public boolean loadedFromDisk() {
-        return loadedFromDisk;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
@@ -9,7 +9,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.entity.LevelCallback;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * This event is fired whenever an {@link Entity} leaves a {@link Level}.
@@ -19,19 +18,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <p>
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * on both logical sides.
+ *
+ * @param level the level that the entity is set to leave
  **/
-public class EntityLeaveLevelEvent extends EntityEvent {
-    private final Level level;
-
-    public EntityLeaveLevelEvent(Entity entity, Level level) {
-        super(entity);
-        this.level = level;
-    }
-
-    /**
-     * {@return the level the entity is set to leave}
-     */
-    public Level getLevel() {
-        return level;
-    }
-}
+public record EntityLeaveLevelEvent(Entity entity, Level level) implements EntityEvent {}

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -7,7 +7,12 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+
+import java.util.Objects;
 
 /**
  * EntityMobGriefingEvent is fired when mob griefing is about to occur and allows an event listener to specify whether it should or not.<br>
@@ -21,11 +26,29 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * </ul>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@HasResult
-public class EntityMobGriefingEvent extends EntityEvent
-{
-    public EntityMobGriefingEvent(Entity entity)
-    {
-        super(entity);
+public final class EntityMobGriefingEvent implements EntityEvent, HasResult {
+    public static final EventBus<EntityMobGriefingEvent> BUS = EventBus.create(EntityMobGriefingEvent.class);
+
+    private final Entity entity;
+    private Result result = Result.DEFAULT;
+
+    public EntityMobGriefingEvent(Entity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public Entity entity() {
+        return entity;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        Objects.requireNonNull(result);
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.event.entity;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event gets fired whenever a entity mounts/dismounts another entity.<br>
@@ -23,48 +23,19 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  *
  */
-
-@Cancelable
-public class EntityMountEvent extends EntityEvent
-{
-
-    private final Entity entityMounting;
-    private final Entity entityBeingMounted;
-    private final Level level;
-
-    private final boolean isMounting;
-
-    public EntityMountEvent(Entity entityMounting, Entity entityBeingMounted, Level level, boolean isMounting)
-    {
-        super(entityMounting);
-        this.entityMounting = entityMounting;
-        this.entityBeingMounted = entityBeingMounted;
-        this.level = level;
-        this.isMounting = isMounting;
-    }
-
-    public boolean isMounting()
-    {
-        return isMounting;
+public record EntityMountEvent(
+        Entity entityMounting,
+        Entity entityBeingMounted,
+        Level level,
+        boolean isMounting
+) implements Cancellable, EntityEvent {
+    @Override
+    public Entity entity() {
+        return entityMounting;
     }
 
     public boolean isDismounting()
     {
         return !isMounting;
-    }
-
-    public Entity getEntityMounting()
-    {
-        return entityMounting;
-    }
-
-    public Entity getEntityBeingMounted()
-    {
-        return entityBeingMounted;
-    }
-
-    public Level getLevel()
-    {
-        return level;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * EntityStruckByLightningEvent is fired when an Entity is about to be struck by lightening.<br>
@@ -25,19 +25,5 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@net.minecraftforge.eventbus.api.Cancelable
-public class EntityStruckByLightningEvent extends EntityEvent
-{
-    private final LightningBolt lightning;
-
-    public EntityStruckByLightningEvent(Entity entity, LightningBolt lightning)
-    {
-        super(entity);
-        this.lightning = lightning;
-    }
-
-    public LightningBolt getLightning()
-    {
-        return lightning;
-    }
-}
+public record EntityStruckByLightningEvent(Entity entity, LightningBolt lightning)
+        implements Cancellable, EntityEvent {}

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -12,8 +12,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -28,18 +28,25 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@Cancelable
-public class EntityTeleportEvent extends EntityEvent
-{
+public sealed class EntityTeleportEvent implements Cancellable, EntityEvent {
+    public static final CancellableEventBus<EntityTeleportEvent> BUS = CancellableEventBus.create(EntityTeleportEvent.class);
+
+    private final Entity entity;
+
     protected double targetX;
     protected double targetY;
     protected double targetZ;
 
     public EntityTeleportEvent(Entity entity, double targetX, double targetY, double targetZ) {
-        super(entity);
+        this.entity = entity;
         this.targetX = targetX;
         this.targetY = targetY;
         this.targetZ = targetZ;
+    }
+
+    @Override
+    public Entity entity() {
+        return entity;
     }
 
     public double getTargetX() { return targetX; }
@@ -49,10 +56,10 @@ public class EntityTeleportEvent extends EntityEvent
     public double getTargetZ() { return targetZ; }
     public void setTargetZ(double targetZ) { this.targetZ = targetZ; }
     public Vec3 getTarget() { return new Vec3(this.targetX, this.targetY, this.targetZ); }
-    public double getPrevX() { return getEntity().getX(); }
-    public double getPrevY() { return getEntity().getY(); }
-    public double getPrevZ() { return getEntity().getZ(); }
-    public Vec3 getPrev() { return getEntity().position(); }
+    public double getPrevX() { return entity().getX(); }
+    public double getPrevY() { return entity().getY(); }
+    public double getPrevZ() { return entity().getZ(); }
+    public Vec3 getPrev() { return entity().position(); }
 
     /**
      * EntityTeleportEvent.TeleportCommand is fired before a living entity is teleported
@@ -69,11 +76,10 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class TeleportCommand extends EntityTeleportEvent
-    {
-        public TeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
-        {
+    public static final class TeleportCommand extends EntityTeleportEvent {
+        public static final CancellableEventBus<TeleportCommand> BUS = CancellableEventBus.create(TeleportCommand.class);
+
+        public TeleportCommand(Entity entity, double targetX, double targetY, double targetZ) {
             super(entity, targetX, targetY, targetZ);
         }
     }
@@ -93,11 +99,10 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class SpreadPlayersCommand extends EntityTeleportEvent
-    {
-        public SpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
-        {
+    public static final class SpreadPlayersCommand extends EntityTeleportEvent {
+        public static final CancellableEventBus<SpreadPlayersCommand> BUS = CancellableEventBus.create(SpreadPlayersCommand.class);
+
+        public SpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ) {
             super(entity, targetX, targetY, targetZ);
         }
     }
@@ -116,13 +121,12 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class EnderEntity extends EntityTeleportEvent
-    {
+    public static final class EnderEntity extends EntityTeleportEvent {
+        public static final CancellableEventBus<EnderEntity> BUS = CancellableEventBus.create(EnderEntity.class);
+
         private final LivingEntity entityLiving;
 
-        public EnderEntity(LivingEntity entity, double targetX, double targetY, double targetZ)
-        {
+        public EnderEntity(LivingEntity entity, double targetX, double targetY, double targetZ) {
             super(entity, targetX, targetY, targetZ);
             this.entityLiving = entity;
         }
@@ -147,17 +151,16 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class EnderPearl extends EntityTeleportEvent
-    {
+    public static final class EnderPearl extends EntityTeleportEvent {
+        public static final CancellableEventBus<EnderPearl> BUS = CancellableEventBus.create(EnderPearl.class);
+
         private final ServerPlayer player;
         private final ThrownEnderpearl pearlEntity;
         private float attackDamage;
         private final HitResult hitResult;
 
         @ApiStatus.Internal
-        public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, HitResult hitResult)
-        {
+        public EnderPearl(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, HitResult hitResult) {
             super(entity, targetX, targetY, targetZ);
             this.pearlEntity = pearlEntity;
             this.player = entity;
@@ -206,13 +209,12 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class ChorusFruit extends EntityTeleportEvent
-    {
+    public static final class ChorusFruit extends EntityTeleportEvent {
+        public static final CancellableEventBus<ChorusFruit> BUS = CancellableEventBus.create(ChorusFruit.class);
+
         private final LivingEntity entityLiving;
 
-        public ChorusFruit(LivingEntity entity, double targetX, double targetY, double targetZ)
-        {
+        public ChorusFruit(LivingEntity entity, double targetX, double targetY, double targetZ) {
             super(entity, targetX, targetY, targetZ);
             this.entityLiving = entity;
         }

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * EntityTravelToDimensionEvent is fired before an Entity travels to a dimension.<br>
@@ -23,19 +24,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@Cancelable
-public class EntityTravelToDimensionEvent extends EntityEvent
-{
-    private final ResourceKey<Level> dimension;
-
-    public EntityTravelToDimensionEvent(Entity entity, ResourceKey<Level> dimension)
-    {
-        super(entity);
-        this.dimension = dimension;
-    }
-
-    public ResourceKey<Level> getDimension()
-    {
-        return dimension;
-    }
+public record EntityTravelToDimensionEvent(Entity entity, ResourceKey<Level> dimension)
+        implements Cancellable, EntityEvent {
+    public static final CancellableEventBus<EntityTravelToDimensionEvent> BUS = CancellableEventBus.create(EntityTravelToDimensionEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -5,10 +5,12 @@
 
 package net.minecraftforge.event.entity;
 
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -22,14 +24,17 @@ import java.util.Objects;
  * You can also directly set the {@link ImpactResult} to change the impact behaviour.
  * @see #setImpactResult(ImpactResult)
  */
-public class ProjectileImpactEvent extends EntityEvent {
+public final class ProjectileImpactEvent implements EntityEvent {
+    public static final EventBus<ProjectileImpactEvent> BUS = EventBus.create(ProjectileImpactEvent.class);
+
+    private final Entity entity;
     private final HitResult ray;
     private final Projectile projectile;
 
     private ImpactResult result = ImpactResult.DEFAULT;
 
     public ProjectileImpactEvent(Projectile projectile, HitResult ray) {
-        super(projectile);
+        this.entity = projectile;
         this.ray = ray;
         this.projectile = projectile;
     }
@@ -48,6 +53,11 @@ public class ProjectileImpactEvent extends EntityEvent {
 
     public ImpactResult getImpactResult() {
         return result;
+    }
+
+    @Override
+    public Entity entity() {
+        return entity;
     }
 
     public enum ImpactResult {

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.item;
 
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 
 /**
  * Base class for all {@link ItemEntity} events. Contains a reference to the
@@ -14,27 +15,7 @@ import net.minecraftforge.event.entity.EntityEvent;
  * additional useful data from the firing method that isn't already contained
  * within the ItemEntity instance.
  */
-public class ItemEvent extends EntityEvent
-{
-    private final ItemEntity itemEntity;
-
-    /**
-     * Creates a new event for an {@link ItemEntity}.
-     *
-     * @param itemEntity The ItemEntity for this event
-     */
-    public ItemEvent(ItemEntity itemEntity)
-    {
-        super(itemEntity);
-        this.itemEntity = itemEntity;
-    }
-
-    /**
-     * The relevant {@link ItemEntity} for this event.
-     */
-    @Override
-    public ItemEntity getEntity()
-    {
-        return itemEntity;
-    }
+@MarkerEvent
+public sealed interface ItemEvent extends EntityEvent permits ItemExpireEvent, ItemTossEvent {
+    ItemEntity entity();
 }

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -5,8 +5,9 @@
 
 package net.minecraftforge.event.entity.item;
 
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Event that is fired when an EntityItem's age has reached its maximum
@@ -14,10 +15,10 @@ import net.minecraft.world.entity.item.ItemEntity;
  * flagged as dead, thus staying it's removal from the world. If canceled
  * it will add more time to the entities life equal to extraLife.
  */
-@Cancelable
-public class ItemExpireEvent extends ItemEvent
-{
+public final class ItemExpireEvent implements Cancellable, ItemEvent {
+    public static final CancellableEventBus<ItemExpireEvent> BUS = CancellableEventBus.create(ItemExpireEvent.class);
 
+    private final ItemEntity entity;
     private int extraLife;
 
     /**
@@ -26,9 +27,8 @@ public class ItemExpireEvent extends ItemEvent
      * @param entityItem The EntityItem being deleted.
      * @param extraLife The amount of time to be added to this entities lifespan if the event is canceled.
      */
-    public ItemExpireEvent(ItemEntity entityItem, int extraLife)
-    {
-        super(entityItem);
+    public ItemExpireEvent(ItemEntity entityItem, int extraLife) {
+        this.entity = entityItem;
         this.setExtraLife(extraLife);
     }
 
@@ -40,5 +40,10 @@ public class ItemExpireEvent extends ItemEvent
     public void setExtraLife(int extraLife)
     {
         this.extraLife = extraLife;
+    }
+
+    @Override
+    public ItemEntity entity() {
+        return entity;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
@@ -5,9 +5,10 @@
 
 package net.minecraftforge.event.entity.item;
 
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Event that is fired whenever a player tosses (Q) an item or drag-n-drops a
@@ -15,10 +16,10 @@ import net.minecraft.world.entity.player.Player;
  * stop the items from entering the world, but will not prevent them being
  * removed from the inventory - and thus removed from the system.
  */
-@Cancelable
-public class ItemTossEvent extends ItemEvent
-{
+public final class ItemTossEvent implements Cancellable, ItemEvent {
+    public static final CancellableEventBus<ItemTossEvent> BUS = CancellableEventBus.create(ItemTossEvent.class);
 
+    private final ItemEntity entity;
     private final Player player;
 
     /**
@@ -29,7 +30,7 @@ public class ItemTossEvent extends ItemEvent
      */
     public ItemTossEvent(ItemEntity entityItem, Player player)
     {
-        super(entityItem);
+        this.entity = entityItem;
         this.player = player;
     }
 
@@ -39,5 +40,10 @@ public class ItemTossEvent extends ItemEvent
     public Player getPlayer()
     {
         return player;
+    }
+
+    @Override
+    public ItemEntity entity() {
+        return entity;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -5,11 +5,13 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event is fired when an {@link Animal} is tamed. <br>
@@ -18,26 +20,11 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}. If canceled, taming the animal will fail.
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class AnimalTameEvent extends LivingEvent
-{
-    private final Animal animal;
-    private final Player tamer;
+public record AnimalTameEvent(Animal animal, Player tamer) implements Cancellable, LivingEvent {
+    public static final CancellableEventBus<AnimalTameEvent> BUS = CancellableEventBus.create(AnimalTameEvent.class);
 
-    public AnimalTameEvent(Animal animal, Player tamer)
-    {
-        super(animal);
-        this.animal = animal;
-        this.tamer = tamer;
-    }
-
-    public Animal getAnimal()
-    {
+    @Override
+    public LivingEntity entity() {
         return animal;
-    }
-
-    public Player getTamer()
-    {
-        return tamer;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingAttackEvent is fired when a living Entity is attacked. <br>
@@ -30,18 +31,5 @@ import net.minecraft.world.entity.LivingEntity;
  *<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingAttackEvent extends LivingEvent
-{
-    private final DamageSource source;
-    private final float amount;
-    public LivingAttackEvent(LivingEntity entity, DamageSource source, float amount)
-    {
-        super(entity);
-        this.source = source;
-        this.amount = amount;
-    }
-
-    public DamageSource getSource() { return source; }
-    public float getAmount() { return amount; }
-}
+public record LivingAttackEvent(LivingEntity entity, DamageSource source, float amount)
+        implements Cancellable, LivingEvent {}

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -5,12 +5,12 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingBreatheEvent is fired whenever a living entity ticks.<br>
@@ -23,7 +23,11 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  */
-public class LivingBreatheEvent extends LivingEvent {
+public final class LivingBreatheEvent implements LivingEvent {
+    public static final EventBus<LivingBreatheEvent> BUS = EventBus.create(LivingBreatheEvent.class);
+
+    private final LivingEntity entity;
+
     private boolean canBreathe;
     private boolean canRefillAir;
     private int consumeAirAmount;
@@ -31,7 +35,7 @@ public class LivingBreatheEvent extends LivingEvent {
 
     @ApiStatus.Internal
     public LivingBreatheEvent(LivingEntity entity, boolean canBreathe, int consumeAirAmount, int refillAirAmount, boolean canRefillAir) {
-        super(entity);
+        this.entity = entity;
         this.canBreathe = canBreathe;
         this.canRefillAir = canRefillAir;
         this.consumeAirAmount = Math.max(consumeAirAmount, 0);
@@ -103,5 +107,10 @@ public class LivingBreatheEvent extends LivingEvent {
      */
     public void setRefillAirAmount(int refillAirAmount) {
         this.refillAirAmount = Math.max(refillAirAmount, 0);
+    }
+
+    @Override
+    public LivingEntity entity() {
+        return entity;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -9,9 +9,10 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingDeathEvent is fired when an Entity dies. <br>
@@ -31,18 +32,7 @@ import net.minecraft.world.entity.LivingEntity;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingDeathEvent extends LivingEvent
-{
-    private final DamageSource source;
-    public LivingDeathEvent(LivingEntity entity, DamageSource source)
-    {
-        super(entity);
-        this.source = source;
-    }
-
-    public DamageSource getSource()
-    {
-        return source;
-    }
+public record LivingDeathEvent(LivingEntity entity, DamageSource source)
+        implements Cancellable, LivingEvent {
+    public static final CancellableEventBus<LivingDeathEvent> BUS = CancellableEventBus.create(LivingDeathEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -9,10 +9,12 @@ import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,21 +24,13 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class LivingEvent extends EntityEvent
-{
-    private final LivingEntity livingEntity;
-
-    public LivingEvent(LivingEntity entity)
-    {
-        super(entity);
-        livingEntity = entity;
-    }
-
+@MarkerEvent
+public sealed interface LivingEvent extends EntityEvent
+        permits AnimalTameEvent, LivingAttackEvent, LivingDeathEvent, LivingEvent.LivingJumpEvent,
+                LivingEvent.LivingTickEvent, LivingEvent.LivingVisibilityEvent, LivingHealEvent, LivingPackSizeEvent,
+                LivingUseTotemEvent {
     @Override
-    public LivingEntity getEntity()
-    {
-        return livingEntity;
-    }
+    LivingEntity entity();
 
     /**
      * LivingUpdateEvent is fired when a LivingEntity is ticked in {@link LivingEntity#tick()}. <br>
@@ -50,10 +44,8 @@ public class LivingEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    @Cancelable
-    public static class LivingTickEvent extends LivingEvent
-    {
-        public LivingTickEvent(LivingEntity e){ super(e); }
+    record LivingTickEvent(LivingEntity entity) implements Cancellable, LivingEvent {
+        public static final CancellableEventBus<LivingTickEvent> BUS = CancellableEventBus.create(LivingTickEvent.class);
     }
 
     /**
@@ -70,20 +62,21 @@ public class LivingEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class LivingJumpEvent extends LivingEvent
-    {
-        public LivingJumpEvent(LivingEntity e){ super(e); }
+    record LivingJumpEvent(LivingEntity entity) implements LivingEvent {
+        public static final EventBus<LivingJumpEvent> BUS = EventBus.create(LivingJumpEvent.class);
     }
 
-    public static class LivingVisibilityEvent extends LivingEvent
-    {
+    final class LivingVisibilityEvent implements LivingEvent {
+        public static final EventBus<LivingVisibilityEvent> BUS = EventBus.create(LivingVisibilityEvent.class);
+
+        private final LivingEntity entity;
         private double visibilityModifier;
         @Nullable
         private final Entity lookingEntity;
 
         public LivingVisibilityEvent(LivingEntity livingEntity, @Nullable Entity lookingEntity, double originalMultiplier)
         {
-            super(livingEntity);
+            this.entity = livingEntity;
             this.visibilityModifier = originalMultiplier;
             this.lookingEntity = lookingEntity;
         }
@@ -111,6 +104,11 @@ public class LivingEvent extends EntityEvent
         public Entity getLookingEntity()
         {
             return lookingEntity;
+        }
+
+        @Override
+        public LivingEntity entity() {
+            return entity;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingHealEvent is fired when an Entity is set to be healed. <br>
@@ -25,13 +26,14 @@ import net.minecraft.world.entity.LivingEntity;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingHealEvent extends LivingEvent
-{
+public final class LivingHealEvent implements Cancellable, LivingEvent {
+    public static final CancellableEventBus<LivingHealEvent> BUS = CancellableEventBus.create(LivingHealEvent.class);
+
+    private final LivingEntity entity;
     private float amount;
-    public LivingHealEvent(LivingEntity entity, float amount)
-    {
-        super(entity);
+
+    public LivingHealEvent(LivingEntity entity, float amount) {
+        this.entity = entity;
         this.setAmount(amount);
     }
 
@@ -43,5 +45,10 @@ public class LivingHealEvent extends LivingEvent
     public void setAmount(float amount)
     {
         this.amount = amount;
+    }
+
+    @Override
+    public LivingEntity entity() {
+        return entity;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
@@ -5,17 +5,24 @@
 
 package net.minecraftforge.event.entity.living;
 
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraft.world.entity.Mob;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
-@HasResult
-public class LivingPackSizeEvent extends LivingEvent
-{
+import java.util.Objects;
+
+public final class LivingPackSizeEvent extends MutableEvent implements LivingEvent, HasResult {
+    public static final EventBus<LivingPackSizeEvent> BUS = EventBus.create(LivingPackSizeEvent.class);
+
+    private final Mob entity;
+    private Result result = Result.DEFAULT;
     private int maxPackSize;
     
-    public LivingPackSizeEvent(Mob entity)
-    {
-        super(entity);
+    public LivingPackSizeEvent(Mob entity) {
+        this.entity = entity;
     }
 
     /**
@@ -34,5 +41,21 @@ public class LivingPackSizeEvent extends LivingEvent
     public void setMaxPackSize(int maxPackSize)
     {
         this.maxPackSize = maxPackSize;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        Objects.requireNonNull(result);
+        this.result = result;
+    }
+
+    @Override
+    public LivingEntity entity() {
+        return null;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
@@ -10,7 +10,8 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -21,43 +22,16 @@ import net.minecraftforge.fml.LogicalSide;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
+ *
+ * @param source the damage source that caused the entity to die
+ * @param totem the totem of undying being used from the entity's inventory
+ * @param handHolding the hand holding the totem
  */
-@Cancelable
-public class LivingUseTotemEvent extends LivingEvent
-{
-    private final DamageSource source;
-    private final ItemStack totem;
-    private final InteractionHand hand;
-
-    public LivingUseTotemEvent(LivingEntity entity, DamageSource source, ItemStack totem, InteractionHand hand)
-    {
-        super(entity);
-        this.source = source;
-        this.totem = totem;
-        this.hand = hand;
-    }
-
-    /**
-     * {@return the damage source that caused the entity to die}
-     */
-    public DamageSource getSource()
-    {
-        return source;
-    }
-
-    /**
-     * {@return the totem of undying being used from the entity's inventory}
-     */
-    public ItemStack getTotem()
-    {
-        return totem;
-    }
-
-    /**
-     * {@return the hand holding the totem}
-     */
-    public InteractionHand getHandHolding()
-    {
-        return hand;
-    }
+public record LivingUseTotemEvent(
+        LivingEntity entity,
+        DamageSource source,
+        ItemStack totem,
+        InteractionHand handHolding
+) implements Cancellable, LivingEvent {
+    public static final CancellableEventBus<LivingUseTotemEvent> BUS = CancellableEventBus.create(LivingUseTotemEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -6,6 +6,10 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.*;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,53 +40,29 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * {@link AllowDespawn} is not related to the mob spawn event flow, as it fires when a despawn is attempted.
  */
-public abstract class MobSpawnEvent extends EntityEvent {
-    private final ServerLevelAccessor level;
-    private final double x;
-    private final double y;
-    private final double z;
-
-    @ApiStatus.Internal
-    protected MobSpawnEvent(Mob mob, ServerLevelAccessor level, double x, double y, double z) {
-        super(mob);
-        this.level = level;
-        this.x = x;
-        this.y = y;
-        this.z = z;
-    }
-
-    @Override
-    public Mob getEntity() {
-        return (Mob)super.getEntity();
-    }
+@MarkerEvent
+public sealed interface MobSpawnEvent implements EntityEvent {
+    Mob entity();
 
     /**
      * @return The level relating to the mob spawn action
      */
-    public ServerLevelAccessor getLevel() {
-        return this.level;
-    }
+    ServerLevelAccessor getLevel();
 
     /**
      * @return The x-coordinate relating to the mob spawn action
      */
-    public double getX() {
-        return this.x;
-    }
+    double getX();
 
     /**
      * @return The y-coordinate relating to the mob spawn action
      */
-    public double getY() {
-        return this.y;
-    }
+    double getY();
 
     /**
      * @return The z-coordinate relating to the mob spawn action
      */
-    public double getZ() {
-        return this.z;
-    }
+    double getZ();
 
     /**
      * This event is fired {@linkplain SpawnPlacements#checkSpawnRules when Spawn Placements (aka Spawn Rules) are checked}, before a mob attempts to spawn.<br>
@@ -100,45 +80,29 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      * <p>
      * This event is not fired for mob spawners which utilize {@link CustomSpawnRules}, as they do not check spawn placements.
+     *
+     * @param entityType The type of entity that checks are being performed for.
+     * @param level The level relating to the mob spawn action
+     * @param pos The position where checks are being evaluated.
+     *
      * @apiNote If your modifications are for a single entity, and do not vary at runtime, use {@link SpawnPlacementRegisterEvent}.
      * @see SpawnPlacementRegisterEvent
      */
-    @HasResult
-    public static class SpawnPlacementCheck extends Event {
-        private final EntityType<?> entityType;
-        private final ServerLevelAccessor level;
-        private final EntitySpawnReason spawnReason;
-        private final BlockPos pos;
-        private final RandomSource random;
-        private final boolean defaultResult;
-
+    record SpawnPlacementCheck(
+            EntityType<?> entityType,
+            ServerLevelAccessor level,
+            EntitySpawnReason spawnReason,
+            BlockPos pos,
+            RandomSource random,
+            boolean defaultResult,
+            Result.Holder resultHolder
+    ) implements RecordEvent, HasResult.Record {
         /**
          * Internal.
          * @see {@link SpawnPlacements#checkSpawnRules} for the single call site of this event.
          */
         @ApiStatus.Internal
-        public SpawnPlacementCheck(EntityType<?> entityType, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random, boolean defaultResult) {
-            this.entityType = entityType;
-            this.level = level;
-            this.spawnReason = spawnReason;
-            this.pos = pos;
-            this.random = random;
-            this.defaultResult = defaultResult;
-        }
-
-        /**
-         * @return The type of entity that checks are being performed for.
-         */
-        public EntityType<?> getEntityType() {
-            return this.entityType;
-        }
-
-        /**
-         * @return The level relating to the mob spawn action
-         */
-        public ServerLevelAccessor getLevel() {
-            return this.level;
-        }
+        public SpawnPlacementCheck {}
 
         /**
          * Retrieves the type of mob spawn that is happening.
@@ -147,13 +111,6 @@ public abstract class MobSpawnEvent extends EntityEvent {
          */
         public EntitySpawnReason getSpawnReason() {
             return this.spawnReason;
-        }
-
-        /**
-         * @return The position where checks are being evaluated.
-         */
-        public BlockPos getPos() {
-            return this.pos;
         }
 
         /**

--- a/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * The ShieldBlockEvent is fired when an entity successfully blocks with a shield.<br>
@@ -17,17 +19,17 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * Note: The shield item stack "should" be available from {@link LivingEntity#getUseItem()}
  * at least for players.
  */
-@Cancelable
-public class ShieldBlockEvent extends LivingEvent
-{
+public final class ShieldBlockEvent implements Cancellable, LivingEvent {
+    public static final CancellableEventBus<ShieldBlockEvent> BUS = CancelableEventBus.create(ShieldBlockEvent.class);
+
+    private final LivingEntity blocker;
     private final DamageSource source;
     private final float originalBlocked;
     private float dmgBlocked;
     private boolean shieldTakesDamage = true;
 
-    public ShieldBlockEvent(LivingEntity blocker, DamageSource source, float blocked)
-    {
-        super(blocker);
+    public ShieldBlockEvent(LivingEntity blocker, DamageSource source, float blocked) {
+        this.blocker = blocker;
         this.source = source;
         this.originalBlocked = blocked;
         this.dmgBlocked = blocked;
@@ -84,4 +86,8 @@ public class ShieldBlockEvent extends LivingEvent
         this.shieldTakesDamage = damage;
     }
 
+    @Override
+    public LivingEntity entity() {
+        return blocker;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -20,17 +20,15 @@ import net.minecraftforge.eventbus.api.Cancelable;
  *
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class ZombieEvent extends EntityEvent {
+public sealed class ZombieEvent implements EntityEvent {
     private final Zombie zombie;
 
-    public ZombieEvent(Zombie zombie)
-    {
-        super(zombie);
+    public ZombieEvent(Zombie zombie) {
         this.zombie = zombie;
     }
 
     @Override
-    public Zombie getEntity()
+    public Zombie entity()
     {
         return this.zombie;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
@@ -10,23 +10,17 @@ import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 
 /**
  * Base class used for advancement-related events. Should not be used directly.
  * @see AdvancementEarnEvent
  * @see AdvancementProgressEvent
  */
-public class AdvancementEvent extends PlayerEvent {
-    private final AdvancementHolder advancement;
-
-    public AdvancementEvent(Player player, AdvancementHolder advancement) {
-        super(player);
-        this.advancement = advancement;
-    }
-
-    public AdvancementHolder getAdvancement() {
-        return advancement;
-    }
+@MarkerEvent
+public sealed interface AdvancementEvent extends PlayerEvent {
+    AdvancementHolder advancement();
 
     /**
      * Fired when the player earns an advancement. An advancement is earned once its requirements are complete.
@@ -41,10 +35,8 @@ public class AdvancementEvent extends PlayerEvent {
      *
      * @see AdvancementProgress#isDone()
      */
-    public static class AdvancementEarnEvent extends AdvancementEvent {
-        public AdvancementEarnEvent(Player player, AdvancementHolder earned) {
-            super(player, earned);
-        }
+    record AdvancementEarnEvent(Player entity, AdvancementHolder advancement) implements AdvancementEvent {
+        public static final EventBus<AdvancementEarnEvent> BUS = EventBus.create(AdvancementEarnEvent.class);
     }
 
     /**
@@ -55,42 +47,22 @@ public class AdvancementEvent extends PlayerEvent {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.</p>
      *
+     * @param advancementProgress the progress of the advancement
+     * @param criterionName name of the criterion that was progressed
+     * @param progressType The type of progress for the criterion in this event
+     *
      * @see AdvancementEarnEvent
      * @see net.minecraft.server.PlayerAdvancements#award(Advancement, String)
      * @see net.minecraft.server.PlayerAdvancements#revoke(Advancement, String)
      */
-    public static class AdvancementProgressEvent extends AdvancementEvent {
-        private final AdvancementProgress advancementProgress;
-        private final String criterionName;
-        private final AdvancementEvent.AdvancementProgressEvent.ProgressType progressType;
-
-        public AdvancementProgressEvent(Player player, AdvancementHolder progressed, AdvancementProgress advancementProgress, String criterionName, AdvancementEvent.AdvancementProgressEvent.ProgressType progressType) {
-            super(player, progressed);
-            this.advancementProgress = advancementProgress;
-            this.criterionName = criterionName;
-            this.progressType = progressType;
-        }
-
-        /**
-         * {@return the progress of the advancement}
-         */
-        public AdvancementProgress getAdvancementProgress() {
-            return advancementProgress;
-        }
-
-        /**
-         * {@return name of the criterion that was progressed}
-         */
-        public String getCriterionName() {
-            return criterionName;
-        }
-
-        /**
-         * {@return The type of progress for the criterion in this event}
-         */
-        public ProgressType getProgressType() {
-            return progressType;
-        }
+    record AdvancementProgressEvent(
+            Player entity,
+            AdvancementHolder advancement,
+            AdvancementProgress advancementProgress,
+            String criterionName,
+            AdvancementEvent.AdvancementProgressEvent.ProgressType progressType
+    ) implements AdvancementEvent {
+        public static final EventBus<AdvancementProgressEvent> BUS = EventBus.create(AdvancementProgressEvent.class);
 
         public enum ProgressType {
             GRANT, REVOKE

--- a/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -16,8 +17,11 @@ import org.jetbrains.annotations.NotNull;
  *
  * ItemStacks are the inputs/output from the anvil. They cannot be edited.
  */
-public class AnvilRepairEvent extends PlayerEvent
-{
+public final class AnvilRepairEvent implements PlayerEvent {
+    public static final EventBus<AnvilRepairEvent> BUS = EventBus.create(AnvilRepairEvent.class);
+
+    private final Player player;
+
     @NotNull
     private final ItemStack left; // The left side of the input
     @NotNull
@@ -26,9 +30,8 @@ public class AnvilRepairEvent extends PlayerEvent
     private final ItemStack output; // Set this to set the output stack
     private float breakChance; // Anvil's chance to break (reduced by 1 durability) when this is complete. Default is 12% (0.12f)
 
-    public AnvilRepairEvent(Player player, @NotNull ItemStack left, @NotNull ItemStack right, @NotNull ItemStack output)
-    {
-        super(player);
+    public AnvilRepairEvent(Player player, @NotNull ItemStack left, @NotNull ItemStack right, @NotNull ItemStack output) {
+        this.player = player;
         this.output = output;
         this.left = left;
         this.right = right;
@@ -58,4 +61,9 @@ public class AnvilRepairEvent extends PlayerEvent
 
     public float getBreakChance() { return breakChance; }
     public void setBreakChance(float breakChance) { this.breakChance = breakChance; }
+
+    @Override
+    public Player entity() {
+        return player;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -12,6 +12,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -30,17 +32,17 @@ import org.jetbrains.annotations.NotNull;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class ArrowLooseEvent extends PlayerEvent
-{
+public final class ArrowLooseEvent implements Cancellable, PlayerEvent {
+    public static final CancellableEventBus<ArrowLooseEvent> BUS = CancellableEventBus.create(ArrowLooseEvent.class);
+
+    private final Player player;
     private final ItemStack bow;
     private final Level level;
     private final boolean hasAmmo;
     private int charge;
 
-    public ArrowLooseEvent(Player player, @NotNull ItemStack bow, Level level, int charge, boolean hasAmmo)
-    {
-        super(player);
+    public ArrowLooseEvent(Player player, @NotNull ItemStack bow, Level level, int charge, boolean hasAmmo) {
+        this.player = player;
         this.bow = bow;
         this.level = level;
         this.charge = charge;
@@ -53,4 +55,9 @@ public class ArrowLooseEvent extends PlayerEvent
     public boolean hasAmmo() { return this.hasAmmo; }
     public int getCharge() { return this.charge; }
     public void setCharge(int charge) { this.charge = charge; }
+
+    @Override
+    public Player entity() {
+        return player;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
@@ -12,6 +12,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -21,7 +22,10 @@ import org.jetbrains.annotations.NotNull;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class ArrowNockEvent extends PlayerEvent {
+public final class ArrowNockEvent implements PlayerEvent {
+    public static final EventBus<ArrowNockEvent> BUS = EventBus.create(ArrowNockEvent.class);
+
+    private final Player player;
     private final ItemStack bow;
     private final InteractionHand hand;
     private final Level level;
@@ -29,7 +33,7 @@ public class ArrowNockEvent extends PlayerEvent {
     private InteractionResult action;
 
     public ArrowNockEvent(Player player, @NotNull ItemStack item, InteractionHand hand, Level level, boolean hasAmmo) {
-        super(player);
+        this.player = player;
         this.bow = item;
         this.hand = hand;
         this.level = level;
@@ -47,5 +51,10 @@ public class ArrowNockEvent extends PlayerEvent {
 
     public void setAction(InteractionResult action) {
         this.action = action;
+    }
+
+    @Override
+    public Player entity() {
+        return player;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
@@ -9,6 +9,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * AttackEntityEvent is fired when a player attacks an Entity.<br>
@@ -24,18 +26,6 @@ import net.minecraft.world.entity.player.Player;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class AttackEntityEvent extends PlayerEvent
-{
-    private final Entity target;
-    public AttackEntityEvent(Player player, Entity target)
-    {
-        super(player);
-        this.target = target;
-    }
-
-    public Entity getTarget()
-    {
-        return target;
-    }
+public record AttackEntityEvent(Player entity, Entity target) implements Cancellable, PlayerEvent {
+    public static final CancellableEventBus<AttackEntityEvent> BUS = CancellableEventBus.create(AttackEntityEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -6,10 +6,14 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+
+import java.util.Objects;
 
 /**
  * This event is fired whenever a player attacks an Entity in
@@ -24,17 +28,19 @@ import net.minecraft.world.entity.player.Player;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@HasResult
-public class CriticalHitEvent extends PlayerEvent
-{
+public final class CriticalHitEvent extends MutableEvent implements PlayerEvent, HasResult {
+    public static final EventBus<CriticalHitEvent> BUS = EventBus.create(CriticalHitEvent.class);
+
+    private final Player player;
     private float damageModifier;
     private final float oldDamageModifier;
     private final Entity target;
     private final boolean vanillaCritical;
+    private Result result = Result.DEFAULT;
     
     public CriticalHitEvent(Player player, Entity target, float damageModifier, boolean vanillaCritical)
     {
-        super(player);
+        this.player = player;
         this.target = target;
         this.damageModifier = damageModifier;
         this.oldDamageModifier = damageModifier;
@@ -82,5 +88,21 @@ public class CriticalHitEvent extends PlayerEvent
     public boolean isVanillaCritical()
     {
         return vanillaCritical;
+    }
+
+    @Override
+    public Player entity() {
+        return player;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        Objects.requireNonNull(result);
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
@@ -5,10 +5,12 @@
 
 package net.minecraftforge.event.entity.player;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event is called when a player collides with a EntityItem on the ground.
@@ -20,20 +22,7 @@ import net.minecraft.world.entity.player.Player;
  *
  *  setResult(ALLOW) is the same as the old setHandled()
  */
-@Cancelable
-@Event.HasResult
-public class EntityItemPickupEvent extends PlayerEvent
-{
-    private final ItemEntity item;
-
-    public EntityItemPickupEvent(Player player, ItemEntity item)
-    {
-        super(player);
-        this.item = item;
-    }
-
-    public ItemEntity getItem()
-    {
-        return item;
-    }
+public record EntityItemPickupEvent(Player entity, ItemEntity item, Result.Holder resultHolder)
+        implements Cancellable, PlayerEvent, HasResult.Record {
+    public static final CancellableEventBus<EntityItemPickupEvent> BUS = CancellableEventBus.create(EntityItemPickupEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -6,10 +6,12 @@
 package net.minecraftforge.event.entity.player;
 
 import com.google.common.base.Preconditions;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 import javax.annotation.Nonnegative;
 import java.util.List;
@@ -21,14 +23,15 @@ import java.util.List;
  * Canceling the event will cause the player to receive no items at all.
  * The hook will still take the damage specified
  */
-@Cancelable
-public class ItemFishedEvent extends PlayerEvent {
+public final class ItemFishedEvent implements Cancellable, PlayerEvent {
+    private final Player player;
+
     private final NonNullList<ItemStack> stacks = NonNullList.create();
     private final FishingHook hook;
     private int rodDamage;
 
     public ItemFishedEvent(List<ItemStack> stacks, int rodDamage, FishingHook hook) {
-        super(hook.getPlayerOwner());
+        this.player = hook.getPlayerOwner();
         this.stacks.addAll(stacks);
         this.rodDamage = rodDamage;
         this.hook = hook;
@@ -66,5 +69,10 @@ public class ItemFishedEvent extends PlayerEvent {
      */
     public FishingHook getHookEntity() {
         return hook;
+    }
+
+    @Override
+    public Player entity() {
+        return player;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
@@ -5,39 +5,18 @@
 
 package net.minecraftforge.event.entity.player;
 
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event will fire when the player is opped or deopped.
  * <p>
  * This event is cancelable which will stop the op or deop from happening.
+ *
+ * @param newLevel The new permission level of the player
+ * @param oldLevel The old permission level of the player
  */
-@Cancelable
-public class PermissionsChangedEvent extends PlayerEvent
-{
-    private final int newLevel;
-    private final int oldLevel;
-
-    public PermissionsChangedEvent(ServerPlayer player, int newLevel, int oldLevel)
-    {
-        super(player);
-        this.oldLevel = oldLevel;
-        this.newLevel = newLevel;
-    }
-
-    /**
-     * @return The new permission level.
-     */
-    public int getNewLevel()
-    {
-        return newLevel;
-    }
-    /**
-     * @return The old permission level.
-     */
-    public int getOldLevel()
-    {
-        return oldLevel;
-    }
+public record PermissionsChangedEvent(Player entity, int newLevel, int oldLevel) implements Cancellable, PlayerEvent {
+    public static final CancellableEventBus<PermissionsChangedEvent> BUS = CancellableEventBus.create(PermissionsChangedEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
@@ -7,33 +7,18 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 
-public class PlayerContainerEvent extends PlayerEvent
-{
-    private final AbstractContainerMenu container;
-    public PlayerContainerEvent(Player player, AbstractContainerMenu container)
-    {
-        super(player);
-        this.container = container;
+@MarkerEvent
+public sealed interface PlayerContainerEvent extends PlayerEvent {
+    AbstractContainerMenu container();
+
+    record Open(Player entity, AbstractContainerMenu container) implements PlayerContainerEvent {
+        public static final EventBus<Open> BUS = EventBus.create(Open.class);
     }
 
-    public static class Open extends PlayerContainerEvent
-    {
-        public Open(Player player, AbstractContainerMenu container)
-        {
-            super(player, container);
-        }
-    }
-    public static class Close extends PlayerContainerEvent
-    {
-        public Close(Player player, AbstractContainerMenu container)
-        {
-            super(player, container);
-        }
-    }
-
-    public AbstractContainerMenu getContainer()
-    {
-        return container;
+    record Close(Player entity, AbstractContainerMenu container) implements PlayerContainerEvent {
+        public static final EventBus<Close> BUS = EventBus.create(Close.class);
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -21,6 +21,7 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,27 +48,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * This event is fired from {@link ForgeEventFactory#onPlayerDestroyItem(Player, ItemStack, InteractionHand)}.<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ *
+ * @param slot May be null if this player destroys the item by any use besides holding it.
  **/
-public class PlayerDestroyItemEvent extends PlayerEvent {
-    @NotNull
-    private final ItemStack original;
-    @Nullable
-    private final EquipmentSlot slot; // May be null if this player destroys the item by any use besides holding it.
-
-    public PlayerDestroyItemEvent(Player player, @NotNull ItemStack original, @Nullable EquipmentSlot slot) {
-        super(player);
-        this.original = original;
-        this.slot = slot;
-    }
-
-    @NotNull
-    public ItemStack getOriginal() {
-        return this.original;
-    }
-
-    @Nullable
-    public EquipmentSlot getSlot() {
-        return this.slot;
-    }
-
+public record PlayerDestroyItemEvent(Player entity, ItemStack original, @Nullable EquipmentSlot slot) implements PlayerEvent {
+    public static final EventBus<PlayerDestroyItemEvent> BUS = EventBus.create(PlayerDestroyItemEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -17,14 +17,16 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.event.entity.living.LivingEvent;
-import org.jetbrains.annotations.NotNull;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -34,21 +36,19 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerEvent extends LivingEvent
-{
-    private final Player player;
-
-    public PlayerEvent(Player player)
-    {
-        super(player);
-        this.player = player;
-    }
-
+@MarkerEvent
+public sealed interface PlayerEvent extends LivingEvent
+        permits AdvancementEvent, AnvilRepairEvent, ArrowLooseEvent, AttackEntityEvent, CriticalHitEvent,
+                EntityItemPickupEvent, PermissionsChangedEvent, PlayerContainerEvent, PlayerDestroyItemEvent,
+                PlayerEvent.BreakSpeed, PlayerEvent.Clone, PlayerEvent.HarvestCheck, PlayerEvent.ItemCraftedEvent,
+                PlayerEvent.ItemPickupEvent, PlayerEvent.ItemSmeltedEvent, PlayerEvent.LoadFromFile,
+                PlayerEvent.NameFormat, PlayerEvent.PlayerChangeGameModeEvent, PlayerEvent.PlayerChangedDimensionEvent,
+                PlayerEvent.PlayerLoggedInEvent, PlayerEvent.PlayerLoggedOutEvent, PlayerEvent.PlayerRespawnEvent,
+                PlayerEvent.SaveToFile, PlayerEvent.StartTracking, PlayerEvent.StopTracking,
+                PlayerEvent.TabListNameFormat, PlayerSleepInBedEvent, PlayerWakeUpEvent, PlayerXpEvent,
+                TradeWithVillagerEvent {
     @Override
-    public Player getEntity()
-    {
-        return player;
-    }
+    Player entity();
 
     /**
      * HarvestCheck is fired when a player attempts to harvest a block.<br>
@@ -66,14 +66,15 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class HarvestCheck extends PlayerEvent
-    {
+    final class HarvestCheck implements PlayerEvent {
+        public static final EventBus<HarvestCheck> BUS = EventBus.create(HarvestCheck.class);
+
+        private final Player player;
         private final BlockState state;
         private boolean success;
 
-        public HarvestCheck(Player player, BlockState state, boolean success)
-        {
-            super(player);
+        public HarvestCheck(Player player, BlockState state, boolean success) {
+            this.player = player;
             this.state = state;
             this.success = success;
         }
@@ -81,6 +82,9 @@ public class PlayerEvent extends LivingEvent
         public BlockState getTargetBlock() { return this.state; }
         public boolean canHarvest() { return this.success; }
         public void setCanHarvest(boolean success){ this.success = success; }
+
+        @Override
+        public Player entity() { return player; }
     }
 
     /**
@@ -102,18 +106,18 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    @Cancelable
-    public static class BreakSpeed extends PlayerEvent
-    {
+    final class BreakSpeed implements Cancellable, PlayerEvent {
+        public static final CancellableEventBus<BreakSpeed> BUS = CancellableEventBus.create(BreakSpeed.class);
+
+        private final Player player;
         private static final BlockPos LEGACY_UNKNOWN = new BlockPos(0, -1, 0);
         private final BlockState state;
         private final float originalSpeed;
         private float newSpeed = 0.0f;
         private final Optional<BlockPos> pos; // Y position of -1 notes unknown location
 
-        public BreakSpeed(Player player, BlockState state, float original, @Nullable BlockPos pos)
-        {
-            super(player);
+        public BreakSpeed(Player player, BlockState state, float original, @Nullable BlockPos pos) {
+            this.player = player;
             this.state = state;
             this.originalSpeed = original;
             this.setNewSpeed(original);
@@ -125,6 +129,9 @@ public class PlayerEvent extends LivingEvent
         public float getNewSpeed() { return newSpeed; }
         public void setNewSpeed(float newSpeed) { this.newSpeed = newSpeed; }
         public Optional<BlockPos> getPosition() { return this.pos; }
+
+        @Override
+        public Player entity() { return player; }
     }
 
     /**
@@ -143,14 +150,15 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class NameFormat extends PlayerEvent
-    {
+    final class NameFormat implements PlayerEvent {
+        public static final EventBus<NameFormat> BUS = EventBus.create(NameFormat.class);
+
+        private final Player player;
         private final Component username;
         private Component displayname;
 
-        public NameFormat(Player player, Component username)
-        {
-            super(player);
+        public NameFormat(Player player, Component username) {
+            this.player = player;
             this.username = username;
             this.setDisplayname(username);
         }
@@ -169,6 +177,9 @@ public class PlayerEvent extends LivingEvent
         {
             this.displayname = displayname;
         }
+
+        @Override
+        public Player entity() { return player; }
     }
 
     /**
@@ -186,14 +197,16 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class TabListNameFormat extends PlayerEvent
-    {
+    final class TabListNameFormat implements PlayerEvent {
+        public static final EventBus<TabListNameFormat> BUS = EventBus.create(TabListNameFormat.class);
+
+        private final Player player;
+
         @Nullable
         private Component displayName;
 
-        public TabListNameFormat(Player player)
-        {
-            super(player);
+        public TabListNameFormat(Player player) {
+            this.player = player;
         }
 
         @Nullable
@@ -206,86 +219,38 @@ public class PlayerEvent extends LivingEvent
         {
             this.displayName = displayName;
         }
+
+        @Override
+        public Player entity() { return player; }
     }
 
     /**
      * Fired when the EntityPlayer is cloned, typically caused by the impl sending a RESPAWN_PLAYER event.
      * Either caused by death, or by traveling from the End to the overworld.
+     *
+     * @param original The old player that this new entity is a clone of.
+     * @param isWasDeath True if this event was fired because the player died. False if it was fired because the entity switched dimensions.
      */
-    public static class Clone extends PlayerEvent
-    {
-        private final Player original;
-        private final boolean wasDeath;
-
-        public Clone(Player _new, Player oldPlayer, boolean wasDeath)
-        {
-            super(_new);
-            this.original = oldPlayer;
-            this.wasDeath = wasDeath;
-        }
-
-        /**
-         * The old EntityPlayer that this new entity is a clone of.
-         */
-        public Player getOriginal()
-        {
-            return original;
-        }
-
-        /**
-         * True if this event was fired because the player died.
-         * False if it was fired because the entity switched dimensions.
-         */
-        public boolean isWasDeath()
-        {
-            return wasDeath;
-        }
+    record Clone(Player entity, Player original, boolean isWasDeath) implements PlayerEvent {
+        public static final EventBus<Clone> BUS = EventBus.create(Clone.class);
     }
 
     /**
      * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
      *
+     * @param target The Entity now being tracked.
      */
-    public static class StartTracking extends PlayerEvent {
-
-        private final Entity target;
-
-        public StartTracking(Player player, Entity target)
-        {
-            super(player);
-            this.target = target;
-        }
-
-        /**
-         * The Entity now being tracked.
-         */
-        public Entity getTarget()
-        {
-            return target;
-        }
+    record StartTracking(Player entity, Entity target) implements PlayerEvent {
+        public static final EventBus<StartTracking> BUS = EventBus.create(StartTracking.class);
     }
 
     /**
      * Fired when an Entity is stopped to be "tracked" by this player (the player no longer receives updates about this entity, e.g. motion).
      *
+     * @param target The Entity no longer being tracked.
      */
-    public static class StopTracking extends PlayerEvent {
-
-        private final Entity target;
-
-        public StopTracking(Player player, Entity target)
-        {
-            super(player);
-            this.target = target;
-        }
-
-        /**
-         * The Entity no longer being tracked.
-         */
-        public Entity getTarget()
-        {
-            return target;
-        }
+    record StopTracking(Player entity, Entity target) implements PlayerEvent {
+        public static final EventBus<StopTracking> BUS = EventBus.create(StopTracking.class);
     }
 
     /**
@@ -293,44 +258,20 @@ public class PlayerEvent extends LivingEvent
      * player won't have been added to the world yet. Intended to
      * allow mods to load an additional file from the players directory
      * containing additional mod related player data.
+     *
+     * @param playerDirectory The directory where player data is being stored. Use this to locate your mod additional file.
+     * @param playerUUID The UUID is the standard for player related file storage. It is broken out here for convenience for quick file generation.
      */
-    public static class LoadFromFile extends PlayerEvent {
-        private final File playerDirectory;
-        private final String playerUUID;
-
-        public LoadFromFile(Player player, File originDirectory, String playerUUID)
-        {
-            super(player);
-            this.playerDirectory = originDirectory;
-            this.playerUUID = playerUUID;
-        }
+    record LoadFromFile(Player entity, File playerDirectory, String playerUUID) implements PlayerEvent {
+        public static final EventBus<LoadFromFile> BUS = EventBus.create(LoadFromFile.class);
 
         /**
          * Construct and return a recommended file for the supplied suffix
          * @param suffix The suffix to use.
          */
-        public File getPlayerFile(String suffix)
-        {
+        public File getPlayerFile(String suffix) {
             if ("dat".equals(suffix)) throw new IllegalArgumentException("The suffix 'dat' is reserved");
-            return new File(this.getPlayerDirectory(), this.getPlayerUUID() +"."+suffix);
-        }
-
-        /**
-         * The directory where player data is being stored. Use this
-         * to locate your mod additional file.
-         */
-        public File getPlayerDirectory()
-        {
-            return playerDirectory;
-        }
-
-        /**
-         * The UUID is the standard for player related file storage.
-         * It is broken out here for convenience for quick file generation.
-         */
-        public String getPlayerUUID()
-        {
-            return playerUUID;
+            return new File(playerDirectory(), playerUUID() + "." +suffix);
         }
     }
     /**
@@ -345,180 +286,69 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * <em>WARNING</em>: Do not overwrite the player's .dat file here. You will
      * corrupt the world state.
+     *
+     * @param playerDirectory The directory where player data is being stored. Use this to locate your mod additional file.
+     * @param playerUUID The UUID is the standard for player related file storage. It is broken out here for convenience for quick file generation.
      */
-    public static class SaveToFile extends PlayerEvent {
-        private final File playerDirectory;
-        private final String playerUUID;
-
-        public SaveToFile(Player player, File originDirectory, String playerUUID)
-        {
-            super(player);
-            this.playerDirectory = originDirectory;
-            this.playerUUID = playerUUID;
-        }
-
+    record SaveToFile(Player entity, File playerDirectory, String playerUUID) implements PlayerEvent {
         /**
          * Construct and return a recommended file for the supplied suffix
          * @param suffix The suffix to use.
          */
-        public File getPlayerFile(String suffix)
-        {
+        public File getPlayerFile(String suffix) {
             if ("dat".equals(suffix)) throw new IllegalArgumentException("The suffix 'dat' is reserved");
-            return new File(this.getPlayerDirectory(), this.getPlayerUUID() +"."+suffix);
-        }
-
-        /**
-         * The directory where player data is being stored. Use this
-         * to locate your mod additional file.
-         */
-        public File getPlayerDirectory()
-        {
-            return playerDirectory;
-        }
-
-        /**
-         * The UUID is the standard for player related file storage.
-         * It is broken out here for convenience for quick file generation.
-         */
-        public String getPlayerUUID()
-        {
-            return playerUUID;
+            return new File(playerDirectory(), playerUUID() + "." + suffix);
         }
     }
 
-    public static class ItemPickupEvent extends PlayerEvent {
-        /**
-         * Original EntityItem with current remaining stack size
-         */
-        private final ItemEntity originalEntity;
-        /**
-         * Clone item stack, containing the item and amount picked up
-         */
-        private final ItemStack stack;
-        public ItemPickupEvent(Player player, ItemEntity entPickedUp, ItemStack stack)
-        {
-            super(player);
-            this.originalEntity = entPickedUp;
-            this.stack = stack;
-        }
-
-        public ItemStack getStack() {
-            return stack;
-        }
-
-        public ItemEntity getOriginalEntity() {
-            return originalEntity;
-        }
+    /**
+     * @param originalEntity The original item entity with the current remaining stack size
+     * @param stack The clone item stack, containing the item and amount picked up
+     */
+    record ItemPickupEvent(Player entity, ItemEntity originalEntity, ItemStack stack) implements PlayerEvent {
+        public static final EventBus<ItemPickupEvent> BUS = EventBus.create(ItemPickupEvent.class);
     }
 
-    public static class ItemCraftedEvent extends PlayerEvent {
-        @NotNull
-        private final ItemStack crafting;
-        private final Container craftMatrix;
-        public ItemCraftedEvent(Player player, @NotNull ItemStack crafting, Container craftMatrix)
-        {
-            super(player);
-            this.crafting = crafting;
-            this.craftMatrix = craftMatrix;
-        }
-
-        @NotNull
-        public ItemStack getCrafting()
-        {
-            return this.crafting;
-        }
-
-        public Container getInventory()
-        {
-            return this.craftMatrix;
-        }
+    record ItemCraftedEvent(Player entity, ItemStack crafting, Container inventory) implements PlayerEvent {
+        public static final EventBus<ItemCraftedEvent> BUS = EventBus.create(ItemCraftedEvent.class);
     }
 
-    public static class ItemSmeltedEvent extends PlayerEvent {
-        @NotNull
-        private final ItemStack smelting;
-        public ItemSmeltedEvent(Player player, @NotNull ItemStack crafting)
-        {
-            super(player);
-            this.smelting = crafting;
-        }
-
-        @NotNull
-        public ItemStack getSmelting()
-        {
-            return this.smelting;
-        }
+    record ItemSmeltedEvent(Player entity, ItemStack smelting) implements PlayerEvent {
+        public static final EventBus<ItemSmeltedEvent> BUS = EventBus.create(ItemSmeltedEvent.class);
     }
 
-    public static class PlayerLoggedInEvent extends PlayerEvent {
-        public PlayerLoggedInEvent(Player player)
-        {
-            super(player);
-        }
+    record PlayerLoggedInEvent(Player entity) implements PlayerEvent {
+        public static final EventBus<PlayerLoggedInEvent> BUS = EventBus.create(PlayerLoggedInEvent.class);
     }
 
-    public static class PlayerLoggedOutEvent extends PlayerEvent {
-        public PlayerLoggedOutEvent(Player player)
-        {
-            super(player);
-        }
+    record PlayerLoggedOutEvent(Player entity) implements PlayerEvent {
+        public static final EventBus<PlayerLoggedOutEvent> BUS = EventBus.create(PlayerLoggedOutEvent.class);
     }
 
-    public static class PlayerRespawnEvent extends PlayerEvent {
-        private final boolean endConquered;
-
-        public PlayerRespawnEvent(Player player, boolean endConquered)
-        {
-            super(player);
-            this.endConquered = endConquered;
-        }
-
-        /**
-         * Did this respawn event come from the player conquering the end?
-         * @return if this respawn was because the player conquered the end
-         */
-        public boolean isEndConquered()
-        {
-            return this.endConquered;
-        }
-
-
+    /**
+     * @param isEndConquered True if the respawn event came from the player conquering the end
+     */
+    record PlayerRespawnEvent(Player entity, boolean isEndConquered) implements PlayerEvent {
+        public static final EventBus<PlayerRespawnEvent> BUS = EventBus.create(PlayerRespawnEvent.class);
     }
 
-    public static class PlayerChangedDimensionEvent extends PlayerEvent {
-        private final ResourceKey<Level> fromDim;
-        private final ResourceKey<Level> toDim;
-        public PlayerChangedDimensionEvent(Player player, ResourceKey<Level> fromDim, ResourceKey<Level> toDim)
-        {
-            super(player);
-            this.fromDim = fromDim;
-            this.toDim = toDim;
-        }
-
-        public ResourceKey<Level> getFrom()
-        {
-            return this.fromDim;
-        }
-
-        public ResourceKey<Level> getTo()
-        {
-            return this.toDim;
-        }
+    record PlayerChangedDimensionEvent(Player entity, ResourceKey<Level> from, ResourceKey<Level> to) implements PlayerEvent {
+        public static final EventBus<PlayerChangedDimensionEvent> BUS = EventBus.create(PlayerChangedDimensionEvent.class);
     }
 
     /**
      * Fired when the game type of a server player is changed to a different value than what it was previously. Eg Creative to Survival, not Survival to Survival.
      * If the event is cancelled the game mode of the player is not changed and the value of <code>newGameMode</code> is ignored.
      */
-    @Cancelable
-    public static class PlayerChangeGameModeEvent extends PlayerEvent
-    {
+    final class PlayerChangeGameModeEvent implements Cancellable, PlayerEvent {
+        public static final CancellableEventBus<PlayerChangeGameModeEvent> BUS = CancellableEventBus.create(PlayerChangeGameModeEvent.class);
+
+        private final Player player;
         private final GameType currentGameMode;
         private GameType newGameMode;
 
-        public PlayerChangeGameModeEvent(Player player, GameType currentGameMode, GameType newGameMode)
-        {
-            super(player);
+        public PlayerChangeGameModeEvent(Player player, GameType currentGameMode, GameType newGameMode) {
+            this.player = player;
             this.currentGameMode = currentGameMode;
             this.newGameMode = newGameMode;
         }
@@ -540,5 +370,8 @@ public class PlayerEvent extends LivingEvent
         {
             this.newGameMode = newGameMode;
         }
+
+        @Override
+        public Player entity() { return player; }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
@@ -6,26 +6,32 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Occurs when a player falls, but is able to fly.  Doesn't need to be cancelable, this is mainly for notification purposes.
  * @author Mithion
  *
  */
-public class PlayerFlyableFallEvent extends PlayerEvent
-{
+public final class PlayerFlyableFallEvent implements PlayerEvent {
+    public static final EventBus<PlayerFlyableFallEvent> BUS = EventBus.create(PlayerFlyableFallEvent.class);
+
+    private final Player player;
+
     private float distance;
     private float multiplier;
 
-    public PlayerFlyableFallEvent(Player player, float distance, float multiplier)
-    {
-        super(player);
+    public PlayerFlyableFallEvent(Player player, float distance, float multiplier) {
+        this.player = player;
         this.distance = distance;
         this.multiplier = multiplier;
     }
 
-    public float getDistance() { return distance;}
+    public float getDistance() { return distance; }
     public void setDistance(float distance) { this.distance = distance; }
     public float getMultiplier() { return multiplier; }
     public void setMultiplier(float multiplier) { this.multiplier = multiplier; }
+
+    @Override
+    public Player entity() { return player; }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Player.BedSleepingProblem;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 import java.util.Optional;
 
@@ -24,14 +26,15 @@ import java.util.Optional;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerSleepInBedEvent extends PlayerEvent
-{
+public final class PlayerSleepInBedEvent extends MutableEvent implements PlayerEvent {
+    public static final EventBus<PlayerSleepInBedEvent> BUS = EventBus.create(PlayerSleepInBedEvent.class);
+
+    private final Player player;
     private BedSleepingProblem result = null;
     private final Optional<BlockPos> pos;
 
-    public PlayerSleepInBedEvent(Player player, Optional<BlockPos> pos)
-    {
-        super(player);
+    public PlayerSleepInBedEvent(Player player, Optional<BlockPos> pos) {
+        this.player = player;
         this.pos = pos;
     }
 
@@ -54,4 +57,8 @@ public class PlayerSleepInBedEvent extends PlayerEvent
         return pos;
     }
 
+    @Override
+    public Player entity() {
+        return player;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
@@ -6,34 +6,18 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired when the player is waking up.<br/>
  * This is merely for purposes of listening for this to happen.<br/>
  * There is nothing that can be manipulated with this event.
+ *
+ * @param wakeImmediately Used for the 'wake up animation'.
+ *                        This is false if the player is considered 'sleepy' and the overlay should slowly fade away.
+ * @param updateLevel Indicates if the server should be notified of sleeping changes.
+ *                    This will only be false if the server is considered 'up to date' already, because, for example, it initiated the call.
  */
-public class PlayerWakeUpEvent extends PlayerEvent
-{
-    private final boolean wakeImmediately;
-
-    private final boolean updateLevel;
-
-    public PlayerWakeUpEvent(Player player, boolean wakeImmediately, boolean updateLevel)
-    {
-        super(player);
-        this.wakeImmediately = wakeImmediately;
-        this.updateLevel = updateLevel;
-    }
-
-    /**
-     * Used for the 'wake up animation'.
-     * This is false if the player is considered 'sleepy' and the overlay should slowly fade away.
-     */
-    public boolean wakeImmediately() { return wakeImmediately; }
-
-    /**
-     * Indicates if the server should be notified of sleeping changes.
-     * This will only be false if the server is considered 'up to date' already, because, for example, it initiated the call.
-     */
-    public boolean updateLevel() { return updateLevel; }
+public record PlayerWakeUpEvent(Player entity, boolean wakeImmediately, boolean updateLevel) implements PlayerEvent {
+    public static final EventBus<PlayerWakeUpEvent> BUS = EventBus.create(PlayerWakeUpEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * PlayerXpEvent is fired whenever an event involving player experience occurs. <br>
@@ -17,39 +19,27 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-public class PlayerXpEvent extends PlayerEvent {
-    public PlayerXpEvent(Player player) {
-        super(player);
-    }
-
+public sealed interface PlayerXpEvent extends PlayerEvent {
     /**
      * This event is fired after the player collides with an experience orb, but before the player has been given the experience.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class PickupXp extends PlayerXpEvent {
-        private final ExperienceOrb orb;
-
-        public PickupXp(Player player, ExperienceOrb orb) {
-            super(player);
-            this.orb = orb;
-        }
-
-        public ExperienceOrb getOrb() {
-            return orb;
-        }
+    record PickupXp(Player entity, ExperienceOrb orb) implements Cancellable, PlayerXpEvent {
+        public static final CancellableEventBus<PickupXp> BUS = CancellableEventBus.create(PickupXp.class);
     }
 
     /**
      * This event is fired when the player's experience changes through the {@link Player#giveExperiencePoints(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class XpChange extends PlayerXpEvent {
+    final class XpChange implements Cancellable, PlayerXpEvent {
+        public static final CancellableEventBus<XpChange> BUS = CancellableEventBus.create(XpChange.class);
+
+        private final Player entity;
         private int amount;
 
         public XpChange(Player player, int amount) {
-            super(player);
+            this.entity = player;
             this.amount = amount;
         }
 
@@ -60,18 +50,25 @@ public class PlayerXpEvent extends PlayerEvent {
         public void setAmount(int amount) {
             this.amount = amount;
         }
+
+        @Override
+        public Player entity() {
+            return this.entity;
+        }
     }
 
     /**
      * This event is fired when the player's experience level changes through the {@link Player#giveExperienceLevels(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class LevelChange extends PlayerXpEvent {
+    final class LevelChange implements Cancellable, PlayerXpEvent {
+        public static final CancellableEventBus<LevelChange> BUS = CancellableEventBus.create(LevelChange.class);
+
+        private final Player entity;
         private int levels;
 
         public LevelChange(Player player, int levels) {
-            super(player);
+            this.entity = player;
             this.levels = levels;
         }
 
@@ -81,6 +78,11 @@ public class PlayerXpEvent extends PlayerEvent {
 
         public void setLevels(int levels) {
             this.levels = levels;
+        }
+
+        @Override
+        public Player entity() {
+            return this.entity;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
@@ -9,8 +9,7 @@ import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import org.jetbrains.annotations.ApiStatus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Fired when a player trades with an {@link AbstractVillager}.
@@ -19,33 +18,11 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
+ *
+ * @param merchantOffer the {@link MerchantOffer} selected by the player to trade with
+ * @param abstractVillager the villager the player traded with
  */
-public class TradeWithVillagerEvent extends PlayerEvent
-{
-    private final MerchantOffer offer;
-    private final AbstractVillager abstractVillager;
-
-    @ApiStatus.Internal
-    public TradeWithVillagerEvent(Player player, MerchantOffer offer, AbstractVillager abstractVillager)
-    {
-        super(player);
-        this.offer = offer;
-        this.abstractVillager = abstractVillager;
-    }
-
-    /**
-     * {@return the {@link MerchantOffer} selected by the player to trade with}
-     */
-    public MerchantOffer getMerchantOffer()
-    {
-        return offer;
-    }
-
-    /**
-     * {@return the villager the player traded with}
-     */
-    public AbstractVillager getAbstractVillager()
-    {
-        return abstractVillager;
-    }
+public record TradeWithVillagerEvent(Player entity, MerchantOffer merchantOffer, AbstractVillager abstractVillager)
+        implements PlayerEvent {
+    public static final EventBus<TradeWithVillagerEvent> BUS = EventBus.create(TradeWithVillagerEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,17 +29,16 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class FurnaceFuelBurnTimeEvent extends Event
-{
+public final class FurnaceFuelBurnTimeEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<FurnaceFuelBurnTimeEvent> BUS = CancellableEventBus.create(FurnaceFuelBurnTimeEvent.class);
+
     @NotNull
     private final ItemStack itemStack;
     @Nullable
     private final RecipeType<?> recipeType;
     private int burnTime;
 
-    public FurnaceFuelBurnTimeEvent(@NotNull ItemStack itemStack, int burnTime, @Nullable RecipeType<?> recipeType)
-    {
+    public FurnaceFuelBurnTimeEvent(@NotNull ItemStack itemStack, int burnTime, @Nullable RecipeType<?> recipeType) {
         this.itemStack = itemStack;
         this.burnTime = burnTime;
         this.recipeType = recipeType;
@@ -72,7 +72,7 @@ public class FurnaceFuelBurnTimeEvent extends Event
         if (burnTime >= 0)
         {
             this.burnTime = burnTime;
-            setCanceled(true);
+            setCanceled(true); // Uh oh... only listeners can cancel the event, so this no longer works
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -11,8 +11,8 @@ import net.minecraft.world.level.LevelSimulatedReader;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecorator;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
-public class AlterGroundEvent extends Event {
+public final class AlterGroundEvent extends MutableEvent {
+    public static final EventBus<AlterGroundEvent> BUS = EventBus.create(AlterGroundEvent.class);
+
     private final LevelSimulatedReader level;
     private final RandomSource random;
     private final BlockPos pos;
@@ -33,7 +35,6 @@ public class AlterGroundEvent extends Event {
 
     @ApiStatus.Internal
     public AlterGroundEvent(LevelSimulatedReader level, RandomSource random, BlockPos pos, BlockState altered) {
-        super();
         this.level = level;
         this.random = random;
         this.pos = pos;

--- a/src/main/java/net/minecraftforge/event/level/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/BlockEvent.java
@@ -9,7 +9,6 @@ import java.util.EnumSet;
 import java.util.List;
 
 import net.minecraft.core.registries.Registries;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -27,50 +26,47 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class BlockEvent extends Event {
-    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("forge.debugBlockEvent", "false"));
+public sealed interface BlockEvent
+        permits BlockEvent.BlockToolModificationEvent, BlockEvent.BreakEvent, BlockEvent.CropGrowEvent,
+                BlockEvent.EntityPlaceEvent, BlockEvent.FarmlandTrampleEvent, BlockEvent.FluidPlaceBlockEvent,
+                BlockEvent.NeighborNotifyEvent, BlockEvent.PortalSpawnEvent, NoteBlockEvent, PistonEvent {
+    boolean DEBUG = Boolean.parseBoolean(System.getProperty("forge.debugBlockEvent", "false"));
 
-    private final LevelAccessor level;
-    private final BlockPos pos;
-    private final BlockState state;
-
-    public BlockEvent(LevelAccessor level, BlockPos pos, BlockState state) {
-        this.pos = pos;
-        this.level = level;
-        this.state = state;
-    }
-
-    public LevelAccessor getLevel() {
-        return level;
-    }
-
-    public BlockPos getPos() {
-        return pos;
-    }
-
-    public BlockState getState() {
-        return state;
-    }
+    LevelAccessor level();
+    BlockPos pos();
+    BlockState state();
 
     /**
      * Event that is fired when an Block is about to be broken by a player
      * Canceling this event will prevent the Block from being broken.
      */
-    @Cancelable
-    public static class BreakEvent extends BlockEvent {
+    final class BreakEvent extends MutableEvent implements Cancellable, BlockEvent {
+        public static final CancellableEventBus<BreakEvent> BUS = CancellableEventBus.create(BreakEvent.class);
+
+        private final LevelAccessor level;
+        private final BlockPos pos;
+        private final BlockState state;
+
         /** Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer */
         private final Player player;
         private int exp;
 
         public BreakEvent(Level level, BlockPos pos, BlockState state, Player player) {
-            super(level, pos, state);
+            this.level = level;
+            this.pos = pos;
+            this.state = state;
             this.player = player;
 
             if (state == null || !ForgeHooks.isCorrectToolForDrops(state, player)) { // Handle empty block or player unable to break block scenario
@@ -82,6 +78,21 @@ public class BlockEvent extends Event {
                 int silkTouchLevel = EnchantmentHelper.getItemEnchantmentLevel(lookup.getOrThrow(Enchantments.SILK_TOUCH), player.getMainHandItem());
                 this.exp = state.getExpDrop(level, level.random, pos, fortuneLevel, silkTouchLevel);
             }
+        }
+
+        @Override
+        public LevelAccessor level() {
+            return level;
+        }
+
+        @Override
+        public BlockPos pos() {
+            return pos;
+        }
+
+        @Override
+        public BlockState state() {
+            return state;
         }
 
         public Player getPlayer() {
@@ -112,30 +123,25 @@ public class BlockEvent extends Event {
      *
      * If a Block Place event is cancelled, the block will not be placed.
      */
-    @Cancelable
-    public static class EntityPlaceEvent extends BlockEvent {
-        private final Entity entity;
-        private final BlockSnapshot blockSnapshot;
-        private final BlockState placedBlock;
-        private final BlockState placedAgainst;
+    record EntityPlaceEvent(
+            LevelAccessor level,
+            BlockPos pos,
+            BlockState state,
+            Entity entity,
+            BlockSnapshot blockSnapshot,
+            BlockState placedBlock,
+            BlockState placedAgainst
+    ) implements Cancellable, BlockEvent, RecordEvent {
+        public static final CancellableEventBus<EntityPlaceEvent> BUS = CancellableEventBus.create(EntityPlaceEvent.class);
 
-        public EntityPlaceEvent(@NotNull BlockSnapshot blockSnapshot, @NotNull BlockState placedAgainst, @Nullable Entity entity) {
-            super(blockSnapshot.getLevel(), blockSnapshot.getPos(), !(entity instanceof Player) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock());
-            this.entity = entity;
-            this.blockSnapshot = blockSnapshot;
-            this.placedBlock = !(entity instanceof Player) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock();
-            this.placedAgainst = placedAgainst;
+        public static EntityPlaceEvent of(BlockSnapshot blockSnapshot, BlockState placedAgainst, Entity entity) {
+            var placedBlock = !(entity instanceof Player) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock();
+            var ret = new EntityPlaceEvent(blockSnapshot.getLevel(), blockSnapshot.getPos(), placedBlock, entity, blockSnapshot, placedBlock, placedAgainst);
+            if (DEBUG)
+                System.out.printf("Created EntityPlaceEvent - [PlacedBlock: %s ][PlacedAgainst: %s ][Entity: %s ]\n", placedBlock, placedAgainst, entity);
 
-            if (DEBUG) {
-                System.out.printf("Created EntityPlaceEvent - [PlacedBlock: %s ][PlacedAgainst: %s ][Entity: %s ]\n", getPlacedBlock(), placedAgainst, entity);
-            }
+            return ret;
         }
-
-        @Nullable
-        public Entity getEntity() { return entity; }
-        public BlockSnapshot getBlockSnapshot() { return blockSnapshot; }
-        public BlockState getPlacedBlock() { return placedBlock; }
-        public BlockState getPlacedAgainst() { return placedAgainst; }
     }
 
     /**
@@ -172,34 +178,18 @@ public class BlockEvent extends Event {
      * Fired when a physics update occurs on a block. This event acts as
      * a way for mods to detect physics updates, in the same way a BUD switch
      * does. This event is only called on the server.
+     *
+     * @param notifiedSides A list of directions from the base block that updates will occur upon.
+     * @param forceRedstoneUpdate If redstone update was forced during setBlock call (0x16 to flags)
      */
-    @Cancelable
-    public static class NeighborNotifyEvent extends BlockEvent {
-        private final EnumSet<Direction> notifiedSides;
-        private final boolean forceRedstoneUpdate;
-
-        public NeighborNotifyEvent(Level level, BlockPos pos, BlockState state, EnumSet<Direction> notifiedSides, boolean forceRedstoneUpdate) {
-            super(level, pos, state);
-            this.notifiedSides = notifiedSides;
-            this.forceRedstoneUpdate = forceRedstoneUpdate;
-        }
-
-        /**
-         * Gets a list of directions from the base block that updates will occur upon.
-         *
-         * @return list of notified directions
-         */
-        public EnumSet<Direction> getNotifiedSides() {
-            return notifiedSides;
-        }
-
-        /**
-         * Get if redstone update was forced during setBlock call (0x16 to flags)
-         * @return if the flag was set
-         */
-        public boolean getForceRedstoneUpdate() {
-            return forceRedstoneUpdate;
-        }
+    record NeighborNotifyEvent(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            EnumSet<Direction> notifiedSides,
+            boolean forceRedstoneUpdate
+    ) implements Cancellable, BlockEvent, RecordEvent {
+        public static final CancellableEventBus<NeighborNotifyEvent> BUS = CancellableEventBus.create(NeighborNotifyEvent.class);
     }
 
     /**
@@ -208,29 +198,9 @@ public class BlockEvent extends Event {
      * usually doesn't do that (like lava), and a result of DENY prevents creation
      * even if the liquid usually does do that (like water).
      */
-    @HasResult
-    public static class CreateFluidSourceEvent extends Event {
-        private final Level level;
-        private final BlockPos pos;
-        private final BlockState state;
-
-        public CreateFluidSourceEvent(Level level, BlockPos pos, BlockState state) {
-            this.level = level;
-            this.pos = pos;
-            this.state = state;
-        }
-
-        public Level getLevel() {
-            return level;
-        }
-
-        public BlockPos getPos() {
-            return pos;
-        }
-
-        public BlockState getState() {
-            return state;
-        }
+    record CreateFluidSourceEvent(Level level, BlockPos pos, BlockState state, Result.Holder resultHolder)
+            implements RecordEvent, HasResult.Record {
+        public static final EventBus<CreateFluidSourceEvent> BUS = EventBus.create(CreateFluidSourceEvent.class);
     }
 
     /**
@@ -241,14 +211,22 @@ public class BlockEvent extends Event {
      * {@link #getState()} will return the block that was originally going to be placed.
      * {@link #getPos()} will return the position of the block to be changed.
      */
-    @Cancelable
-    public static class FluidPlaceBlockEvent extends BlockEvent {
+    final class FluidPlaceBlockEvent extends MutableEvent implements Cancellable, BlockEvent {
+        public static final CancellableEventBus<FluidPlaceBlockEvent> BUS = CancellableEventBus.create(FluidPlaceBlockEvent.class);
+
+        private final LevelAccessor level;
+        private final BlockPos pos;
+        private final BlockState state;
+
         private final BlockPos liquidPos;
         private BlockState newState;
         private BlockState origState;
 
         public FluidPlaceBlockEvent(LevelAccessor level, BlockPos pos, BlockPos liquidPos, BlockState state) {
-            super(level, pos, state);
+            this.level = level;
+            this.pos = pos;
+            this.state = state;
+
             this.liquidPos = liquidPos;
             this.newState = state;
             this.origState = level.getBlockState(pos);
@@ -278,17 +256,29 @@ public class BlockEvent extends Event {
         public BlockState getOriginalState() {
             return origState;
         }
+
+        @Override
+        public LevelAccessor level() {
+            return level;
+        }
+
+        @Override
+        public BlockPos pos() {
+            return pos;
+        }
+
+        @Override
+        public BlockState state() {
+            return state;
+        }
     }
 
     /**
-     * Fired when a crop block grows.  See subevents.
-     *
+     * Fired when a crop block grows.
+     * @see CropGrowEvent.Pre
+     * @see CropGrowEvent.Post
      */
-    public static class CropGrowEvent extends BlockEvent {
-        public CropGrowEvent(Level level, BlockPos pos, BlockState state) {
-            super(level, pos, state);
-        }
-
+    sealed interface CropGrowEvent extends BlockEvent {
         /**
          * Fired when any "growing age" blocks (for example cacti, chorus plants, or crops
          * in vanilla) attempt to advance to the next growth age state during a random tick.<br>
@@ -300,11 +290,9 @@ public class BlockEvent extends Event {
          * This event is not {@link Cancelable}.<br>
          * <br>
          */
-        @HasResult
-        public static class Pre extends CropGrowEvent {
-            public Pre(Level level, BlockPos pos, BlockState state) {
-                super(level, pos, state);
-            }
+        record Pre(Level level, BlockPos pos, BlockState state, Result.Holder resultHolder)
+                implements CropGrowEvent, RecordEvent, HasResult.Record {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
         }
 
         /**
@@ -316,17 +304,8 @@ public class BlockEvent extends Event {
          * <br>
          * This event does not have a result. {@link HasResult}<br>
          */
-        public static class Post extends CropGrowEvent {
-            private final BlockState originalState;
-
-            public Post(Level level, BlockPos pos, BlockState original, BlockState state) {
-                super(level, pos, state);
-                originalState = original;
-            }
-
-            public BlockState getOriginalState() {
-                return originalState;
-            }
+        record Post(Level level, BlockPos pos, BlockState originalState, BlockState state) implements CropGrowEvent, RecordEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
         }
     }
 
@@ -334,44 +313,28 @@ public class BlockEvent extends Event {
      * Fired when when farmland gets trampled
      * This event is {@link Cancelable}
      */
-    @Cancelable
-    public static class FarmlandTrampleEvent extends BlockEvent {
-        private final Entity entity;
-        private final float fallDistance;
-
-        public FarmlandTrampleEvent(ServerLevel level, BlockPos pos, BlockState state, float fallDistance, Entity entity) {
-            super(level, pos, state);
-            this.entity = entity;
-            this.fallDistance = fallDistance;
-        }
-
-        public Entity getEntity() {
-            return entity;
-        }
-
-        public float getFallDistance() {
-            return fallDistance;
-        }
-
+    record FarmlandTrampleEvent(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            float fallDistance,
+            Entity entity
+    ) implements Cancellable, BlockEvent, RecordEvent {
+        public static final CancellableEventBus<FarmlandTrampleEvent> BUS = CancellableEventBus.create(FarmlandTrampleEvent.class);
     }
 
     /** Fired when an attempt is made to spawn a nether portal from
      * {@link BaseFireBlock#onPlace(BlockState, Level, BlockPos, BlockState, boolean)}.
-     *
+     * <br>
      * If cancelled, the portal will not be spawned.
      */
-    @Cancelable
-    public static class PortalSpawnEvent extends BlockEvent {
-        private final PortalShape size;
-
-        public PortalSpawnEvent(LevelAccessor level, BlockPos pos, BlockState state, PortalShape size) {
-            super(level, pos, state);
-            this.size = size;
-        }
-
-        public PortalShape getPortalSize() {
-            return size;
-        }
+    record PortalSpawnEvent(
+            LevelAccessor level,
+            BlockPos pos,
+            BlockState state,
+            PortalShape portalSize
+    ) implements Cancellable, BlockEvent, RecordEvent {
+        public static final CancellableEventBus<PortalSpawnEvent> BUS = CancellableEventBus.create(PortalSpawnEvent.class);
     }
 
     /**
@@ -384,8 +347,9 @@ public class BlockEvent extends Event {
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      */
-    @Cancelable
-    public static class BlockToolModificationEvent extends BlockEvent {
+    final class BlockToolModificationEvent extends MutableEvent implements Cancellable, BlockEvent {
+        public static final CancellableEventBus<BlockToolModificationEvent> BUS = CancellableEventBus.create(BlockToolModificationEvent.class);
+
         private final UseOnContext context;
         private final ToolAction toolAction;
         private final boolean simulate;

--- a/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
@@ -13,8 +13,8 @@ import net.minecraft.world.level.chunk.status.ChunkType;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * ChunkDataEvent is fired when an event involving chunk data occurs.<br>
@@ -25,17 +25,33 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkDataEvent extends ChunkEvent {
+public sealed class ChunkDataEvent extends MutableEvent implements ChunkEvent {
+    public static final EventBus<ChunkDataEvent> BUS = EventBus.create(ChunkDataEvent.class);
+
+    private final LevelAccessor level;
+    private final ChunkAccess chunk;
     private final SerializableChunkData data;
 
     public ChunkDataEvent(ChunkAccess chunk, SerializableChunkData data) {
-        super(chunk);
+        this.level = chunk.getWorldForge();
+        this.chunk = chunk;
         this.data = data;
     }
 
     public ChunkDataEvent(ChunkAccess chunk, LevelAccessor world, SerializableChunkData data) {
-        super(chunk, world);
+        this.level = world;
+        this.chunk = chunk;
         this.data = data;
+    }
+
+    @Override
+    public LevelAccessor level() {
+        return level;
+    }
+
+    @Override
+    public ChunkAccess chunk() {
+        return chunk;
     }
 
     public SerializableChunkData getData() {
@@ -53,8 +69,10 @@ public class ChunkDataEvent extends ChunkEvent {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkDataEvent {
-        private ChunkType status;
+    public static final class Load extends ChunkDataEvent {
+        public static final EventBus<ChunkDataEvent.Load> BUS = EventBus.create(ChunkDataEvent.Load.class);
+
+        private final ChunkType status;
 
         public Load(ChunkAccess chunk, SerializableChunkData data, ChunkType status) {
             super(chunk, data);
@@ -77,7 +95,9 @@ public class ChunkDataEvent extends ChunkEvent {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Save extends ChunkDataEvent {
+    public static final class Save extends ChunkDataEvent {
+        public static final EventBus<ChunkDataEvent.Save> BUS = EventBus.create(ChunkDataEvent.Save.class);
+
         public Save(ChunkAccess chunk, LevelAccessor world, SerializableChunkData data) {
             super(chunk, world, data);
         }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -9,9 +9,8 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
-import org.jetbrains.annotations.ApiStatus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 /**
  * ChunkEvent is fired when an event involving a chunk occurs.<br>
@@ -22,26 +21,8 @@ import org.jetbrains.annotations.ApiStatus;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkEvent extends LevelEvent
-{
-    private final ChunkAccess chunk;
-
-    public ChunkEvent(ChunkAccess chunk)
-    {
-        super(chunk.getWorldForge());
-        this.chunk = chunk;
-    }
-
-    public ChunkEvent(ChunkAccess chunk, LevelAccessor level)
-    {
-        super(level);
-        this.chunk = chunk;
-    }
-
-    public ChunkAccess getChunk()
-    {
-        return chunk;
-    }
+public sealed interface ChunkEvent extends LevelEvent permits ChunkDataEvent, ChunkEvent.Load, ChunkEvent.Unload {
+    ChunkAccess chunk();
 
     /**
      * ChunkEvent.Load is fired when vanilla Minecraft attempts to load a Chunk into the level.<br>
@@ -56,15 +37,11 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkEvent
-    {
-        private final boolean newChunk;
+    record Load(LevelAccessor level, ChunkAccess chunk, boolean isNewChunk) implements ChunkEvent, RecordEvent {
+        public static final EventBus<ChunkEvent.Load> BUS = EventBus.create(ChunkEvent.Load.class);
 
-        @ApiStatus.Internal
-        public Load(ChunkAccess chunk, boolean newChunk)
-        {
-            super(chunk);
-            this.newChunk = newChunk;
+        public Load(ChunkAccess chunk, boolean newChunk) {
+            this(chunk.getWorldForge(), chunk, newChunk);
         }
 
         /**
@@ -74,9 +51,8 @@ public class ChunkEvent extends LevelEvent
          *
          * @return whether the Chunk is newly generated
          */
-        public boolean isNewChunk()
-        {
-            return newChunk;
+        public boolean isNewChunk() {
+            return isNewChunk;
         }
     }
 
@@ -91,11 +67,11 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Unload extends ChunkEvent
-    {
-        public Unload(ChunkAccess chunk)
-        {
-            super(chunk);
+    record Unload(LevelAccessor level, ChunkAccess chunk) implements ChunkEvent, RecordEvent {
+        public static final EventBus<ChunkEvent.Unload> BUS = EventBus.create(ChunkEvent.Unload.class);
+
+        public Unload(ChunkAccess chunk) {
+            this(chunk.getWorldForge(), chunk);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.event.level;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,63 +28,19 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
+ *
+ * @param level the server level containing the chunk
+ * @param chunkPos the long representation of the chunk position the ticket level changed for
+ * @param oldTicketLevel the previous ticket level the chunk had
+ * @param newTicketLevel the new ticket level for the chunk
+ * @param chunkHolder chunk that had its ticket level updated
  **/
-public class ChunkTicketLevelUpdatedEvent extends Event
-{
-    private final ServerLevel level;
-    private final long chunkPos;
-    private final int oldTicketLevel;
-    private final int newTicketLevel;
-    @Nullable
-    private final ChunkHolder chunkHolder;
-
-    public ChunkTicketLevelUpdatedEvent(ServerLevel level, long chunkPos, int oldTicketLevel, int newTicketLevel, @Nullable ChunkHolder chunkHolder)
-    {
-        this.level = level;
-        this.chunkPos = chunkPos;
-        this.oldTicketLevel = oldTicketLevel;
-        this.newTicketLevel = newTicketLevel;
-        this.chunkHolder = chunkHolder;
-    }
-
-    /**
-     * {@return the server level containing the chunk}
-     */
-    public ServerLevel getLevel()
-    {
-        return this.level;
-    }
-
-    /**
-     * {@return the long representation of the chunk position the ticket level changed for}
-     */
-    public long getChunkPos()
-    {
-        return this.chunkPos;
-    }
-
-    /**
-     * {@return the previous ticket level the chunk had}
-     */
-    public int getOldTicketLevel()
-    {
-        return this.oldTicketLevel;
-    }
-
-    /**
-     * {@return the new ticket level for the chunk}
-     */
-    public int getNewTicketLevel()
-    {
-        return this.newTicketLevel;
-    }
-
-    /**
-     * {@return chunk that had its ticket level updated}
-     */
-    @Nullable
-    public ChunkHolder getChunkHolder()
-    {
-        return this.chunkHolder;
-    }
+public record ChunkTicketLevelUpdatedEvent(
+        ServerLevel level,
+        long chunkPos,
+        int oldTicketLevel,
+        int newTicketLevel,
+        @Nullable ChunkHolder chunkHolder
+) implements RecordEvent {
+    public static final EventBus<ChunkTicketLevelUpdatedEvent> BUS = EventBus.create(ChunkTicketLevelUpdatedEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -10,8 +10,8 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -25,37 +25,21 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkWatchEvent extends Event {
-    private final ServerLevel level;
-    private final ServerPlayer player;
-    private final ChunkPos pos;
-
-    public ChunkWatchEvent(ServerPlayer player, ChunkPos pos, ServerLevel level) {
-        this.player = player;
-        this.pos = pos;
-        this.level = level;
-    }
-
+public sealed interface ChunkWatchEvent {
     /**
      * {@return the server player involved with the watch action}
      */
-    public ServerPlayer getPlayer() {
-        return this.player;
-    }
+    ServerPlayer player();
 
     /**
      * {@return the chunk position this watch event is affecting}
      */
-    public ChunkPos getPos() {
-        return this.pos;
-    }
+    ChunkPos pos();
 
     /**
      * {@return the server level containing the chunk}
      */
-    public ServerLevel getLevel() {
-        return this.level;
-    }
+    ServerLevel level();
 
     /**
      * This event is fired when chunk data is sent to the {@link ServerPlayer} (see {@link net.minecraft.server.network.PlayerChunkSender}).
@@ -67,16 +51,11 @@ public class ChunkWatchEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Watch extends ChunkWatchEvent {
-        private final LevelChunk chunk;
+    record Watch(ServerPlayer player, ChunkPos pos, ServerLevel level, LevelChunk chunk) implements ChunkWatchEvent, RecordEvent {
+        public static final EventBus<Watch> BUS = EventBus.create(Watch.class);
 
         public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel level) {
-            super(player, chunk.getPos(), level);
-            this.chunk = chunk;
-        }
-
-        public LevelChunk getChunk() {
-            return this.chunk;
+            this(player, chunk.getPos(), level, chunk);
         }
     }
 
@@ -88,9 +67,7 @@ public class ChunkWatchEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class UnWatch extends ChunkWatchEvent {
-        public UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) {
-            super(player, pos, level);
-        }
+    record UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) implements ChunkWatchEvent, RecordEvent {
+        public static final EventBus<UnWatch> BUS = EventBus.create(UnWatch.class);
     }
 }

--- a/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
@@ -8,12 +8,14 @@ package net.minecraftforge.event.level;
 import java.util.List;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /** ExplosionEvent triggers when an explosion happens in the level.<br>
  * <br>
@@ -25,22 +27,9 @@ import net.minecraft.world.level.Level;
  * Children do not use {@link HasResult}.<br>
  * Children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  */
-public class ExplosionEvent extends Event {
-    private final Level level;
-    private final Explosion explosion;
-
-    public ExplosionEvent(Level level, Explosion explosion) {
-        this.level = level;
-        this.explosion = explosion;
-    }
-
-    public Level getLevel() {
-        return level;
-    }
-
-    public Explosion getExplosion() {
-        return explosion;
-    }
+public sealed interface ExplosionEvent {
+    Level level();
+    Explosion explosion();
 
     /** ExplosionEvent.Start is fired before the explosion actually occurs.  Canceling this event will stop the explosion.<br>
      * <br>
@@ -48,11 +37,8 @@ public class ExplosionEvent extends Event {
      * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      */
-    @Cancelable
-    public static class Start extends ExplosionEvent {
-        public Start(Level level, Explosion explosion) {
-            super(level, explosion);
-        }
+    record Start(Level level, Explosion explosion) implements Cancellable, ExplosionEvent, RecordEvent {
+        public static final CancellableEventBus<ExplosionEvent.Start> BUS = CancellableEventBus.create(ExplosionEvent.Start.class);
     }
 
     /** ExplosionEvent.Detonate is fired once the explosion has a list of affected blocks and entities.  These lists can be modified to change the outcome.<br>
@@ -60,25 +46,12 @@ public class ExplosionEvent extends Event {
      * This event is not {@link Cancelable}.<br>
      * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     *
+     * @param affectedBlocks the list of blocks affected by the explosion.
+     * @param affectedEntities the list of entities affected by the explosion.
      */
-    public static class Detonate extends ExplosionEvent {
-        private final List<BlockPos> blocks;
-        private final List<Entity> entityList;
-
-        public Detonate(Level level, Explosion explosion, List<BlockPos> blocks, List<Entity> entityList) {
-            super(level, explosion);
-            this.blocks = blocks;
-            this.entityList = entityList;
-        }
-
-        /** return the list of blocks affected by the explosion. */
-        public List<BlockPos> getAffectedBlocks() {
-            return blocks;
-        }
-
-        /** return the list of entities affected by the explosion. */
-        public List<Entity> getAffectedEntities() {
-            return entityList;
-        }
+    record Detonate(Level level, Explosion explosion, List<BlockPos> affectedBlocks, List<Entity> affectedEntities)
+            implements ExplosionEvent, RecordEvent {
+        public static final EventBus<Detonate> BUS = EventBus.create(ExplosionEvent.Detonate.class);
     }
 }

--- a/src/main/java/net/minecraftforge/event/level/LevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/LevelEvent.java
@@ -23,8 +23,11 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.storage.ServerLevelData;
 import net.minecraftforge.common.ForgeInternalHandler;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -32,22 +35,13 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * All children of this event are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}.
  */
-public class LevelEvent extends Event
-{
-    private final LevelAccessor level;
-
-    public LevelEvent(LevelAccessor level)
-    {
-        this.level = level;
-    }
-
+public sealed interface LevelEvent
+        permits LevelEvent.Load, LevelEvent.Unload, LevelEvent.Save, LevelEvent.CreateSpawnPosition,
+                LevelEvent.PotentialSpawns, ChunkEvent, SaplingGrowTreeEvent, SleepFinishedTimeEvent {
     /**
      * {@return the level this event is affecting}
      */
-    public LevelAccessor getLevel()
-    {
-        return level;
-    }
+    LevelAccessor level();
 
     /**
      * This event is fired whenever a level loads.
@@ -59,9 +53,8 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Load extends LevelEvent
-    {
-        public Load(LevelAccessor level) { super(level); }
+    record Load(LevelAccessor level) implements LevelEvent, RecordEvent {
+        public static final EventBus<LevelEvent.Load> BUS = EventBus.create(LevelEvent.Load.class);
     }
 
     /**
@@ -77,9 +70,8 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Unload extends LevelEvent
-    {
-        public Unload(LevelAccessor level) { super(level); }
+    record Unload(LevelAccessor level) implements LevelEvent, RecordEvent {
+        public static final EventBus<LevelEvent.Unload> BUS = EventBus.create(LevelEvent.Unload.class);
     }
 
     /**
@@ -92,9 +84,8 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Save extends LevelEvent
-    {
-        public Save(LevelAccessor level) { super(level); }
+    record Save(LevelAccessor level) implements LevelEvent, RecordEvent {
+        public static final EventBus<LevelEvent.Save> BUS = EventBus.create(LevelEvent.Save.class);
     }
 
     /**
@@ -109,21 +100,8 @@ public class LevelEvent extends Event
      *
      * @see ServerLevelData#isInitialized()
      */
-    @Cancelable
-    public static class CreateSpawnPosition extends LevelEvent
-    {
-        private final ServerLevelData settings;
-
-        public CreateSpawnPosition(LevelAccessor level, ServerLevelData settings)
-        {
-            super(level);
-            this.settings = settings;
-        }
-
-        public ServerLevelData getSettings()
-        {
-            return settings;
-        }
+    record CreateSpawnPosition(LevelAccessor level, ServerLevelData settings) implements Cancellable, LevelEvent, RecordEvent {
+        public static final CancellableEventBus<CreateSpawnPosition> BUS = CancellableEventBus.create(LevelEvent.CreateSpawnPosition.class);
     }
 
     /**
@@ -137,17 +115,17 @@ public class LevelEvent extends Event
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
      * Canceling the event will result in an empty list, meaning no entity will be spawned.</p>
      */
-    @Cancelable
-    public static class PotentialSpawns extends LevelEvent
-    {
+    final class PotentialSpawns extends MutableEvent implements Cancellable, LevelEvent {
+        public static final CancellableEventBus<PotentialSpawns> BUS = CancellableEventBus.create(PotentialSpawns.class);
+
+        private final LevelAccessor level;
         private final MobCategory mobcategory;
         private final BlockPos pos;
         private final List<MobSpawnSettings.SpawnerData> list;
         private final List<MobSpawnSettings.SpawnerData> view;
 
-        public PotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedRandomList<MobSpawnSettings.SpawnerData> oldList)
-        {
-            super(level);
+        public PotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedRandomList<MobSpawnSettings.SpawnerData> oldList) {
+            this.level = level;
             this.pos = pos;
             this.mobcategory = category;
             if (!oldList.isEmpty())
@@ -156,6 +134,11 @@ public class LevelEvent extends Event
                 this.list = new ArrayList<>();
 
             this.view = Collections.unmodifiableList(list);
+        }
+
+        @Override
+        public LevelAccessor level() {
+            return level;
         }
 
         /**

--- a/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
@@ -9,19 +9,41 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 import com.google.common.base.Preconditions;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Base class for Noteblock Events
  *
  */
-public class NoteBlockEvent extends BlockEvent {
+public sealed class NoteBlockEvent extends MutableEvent implements BlockEvent {
+    private final Level level;
+    private final BlockPos pos;
+    private final BlockState state;
     private int noteId;
 
-    protected NoteBlockEvent(Level world, BlockPos pos, BlockState state, int note) {
-        super(world, pos, state);
+    @Override
+    public Level level() {
+        return level;
+    }
+
+    @Override
+    public BlockPos pos() {
+        return pos;
+    }
+
+    @Override
+    public BlockState state() {
+        return state;
+    }
+
+    protected NoteBlockEvent(Level level, BlockPos pos, BlockState state, int note) {
+        this.level = level;
+        this.pos = pos;
+        this.state = state;
         this.noteId = note;
     }
 
@@ -64,8 +86,9 @@ public class NoteBlockEvent extends BlockEvent {
      * Fired when a Noteblock plays it's note. You can override the note and instrument
      * Canceling this event will stop the note from playing.
      */
-    @Cancelable
-    public static class Play extends NoteBlockEvent {
+    public static final class Play extends NoteBlockEvent implements Cancellable {
+        public static final CancellableEventBus<NoteBlockEvent.Play> BUS = CancellableEventBus.create(NoteBlockEvent.Play.class);
+
         private NoteBlockInstrument instrument;
 
         public Play(Level world, BlockPos pos, BlockState state, int note, NoteBlockInstrument instrument) {
@@ -86,8 +109,9 @@ public class NoteBlockEvent extends BlockEvent {
      * Fired when a Noteblock is changed. You can adjust the note it will change to via {@link #setNote(Note, Octave)}.
      * Canceling this event will not change the note and also stop the Noteblock from playing it's note.
      */
-    @Cancelable
-    public static class Change extends NoteBlockEvent {
+    public static final class Change extends NoteBlockEvent implements Cancellable {
+        public static final CancellableEventBus<NoteBlockEvent.Change> BUS = CancellableEventBus.create(NoteBlockEvent.Change.class);
+
         private final Note oldNote;
         private final Octave oldOctave;
 
@@ -111,7 +135,7 @@ public class NoteBlockEvent extends BlockEvent {
      * For altered notes such as G-Sharp / A-Flat the Sharp variant is used here.
      *
      */
-    public static enum Note {
+    public enum Note {
         F_SHARP,
         G,
         G_SHARP,
@@ -137,7 +161,7 @@ public class NoteBlockEvent extends BlockEvent {
      * Together with {@link Note} it fully describes the note.
      *
      */
-    public static enum Octave {
+    public enum Octave {
         LOW,
         MID,
         HIGH; // only valid for F_SHARP

--- a/src/main/java/net/minecraftforge/event/level/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/PistonEvent.java
@@ -9,95 +9,17 @@ import net.minecraft.world.level.block.piston.PistonStructureResolver;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
-public abstract class PistonEvent extends BlockEvent
-{
-
-    private final Direction direction;
-    private final PistonMoveType moveType;
-
-    /**
-     * @param pos - The position of the piston
-     * @param direction - The move direction of the piston
-     */
-    public PistonEvent(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
-    {
-        super(world, pos, world.getBlockState(pos));
-        this.direction = direction;
-        this.moveType = moveType;
-    }
-
-    /**
-     * @return The direction of the piston block
-     */
-    public Direction getDirection()
-    {
-        return this.direction;
-    }
-
-    /**
-     * Helper method that gets the piston position offset by its facing
-     */
-    public BlockPos getFaceOffsetPos()
-    {
-        return this.getPos().relative(direction);
-    }
-
-    /**
-     * @return The movement type of the piston (extension, retraction)
-     */
-    public PistonMoveType getPistonMoveType()
-    {
-        return moveType;
-    }
-
-    /**
-     * @return A piston structure helper for this movement. Returns null if the world stored is not a {@link Level}
-     */
-    @Nullable
-    public PistonStructureResolver getStructureHelper()
-    {
-        if(this.getLevel() instanceof Level) {
-            return new PistonStructureResolver((Level) this.getLevel(), this.getPos(), this.getDirection(), this.getPistonMoveType().isExtend);
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
-     */
-    public static class Post extends PistonEvent
-    {
-
-        public Post(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
-        {
-            super(world, pos, direction, moveType);
-        }
-
-    }
-
-    /**
-     * Fires before the piston has updated block states. Cancellation prevents movement.
-     */
-    @Cancelable
-    public static class Pre extends PistonEvent
-    {
-
-        public Pre(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
-        {
-            super(world, pos, direction, moveType);
-        }
-
-    }
-
-    public static enum PistonMoveType
-    {
+public sealed interface PistonEvent extends BlockEvent {
+    enum PistonMoveType {
         EXTEND(true), RETRACT(false);
 
         public final boolean isExtend;
@@ -108,4 +30,66 @@ public abstract class PistonEvent extends BlockEvent
         }
     }
 
+    /**
+     * @return The direction of the piston block
+     */
+    Direction direction();
+
+    /**
+     * Helper method that gets the piston position offset by its facing
+     */
+    default BlockPos faceOffsetPos() {
+        return pos().relative(direction());
+    }
+
+    /**
+     * @return The movement type of the piston (extension, retraction)
+     */
+    PistonMoveType pistonMoveType();
+
+    /**
+     * @return A piston structure helper for this movement. Returns null if the world stored is not a {@link Level}
+     */
+    @Nullable
+    default PistonStructureResolver structureHelper() {
+        if (level() instanceof Level) {
+            return new PistonStructureResolver((Level) level(), pos(), direction(), pistonMoveType().isExtend);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
+     */
+    record Post(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            Direction direction,
+            PistonMoveType pistonMoveType
+    ) implements PistonEvent, RecordEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
+        public Post(Level world, BlockPos pos, Direction direction, PistonMoveType moveType) {
+            this(world, pos, world.getBlockState(pos), direction, moveType);
+        }
+    }
+
+    /**
+     * Fires before the piston has updated block states. Cancellation prevents movement.
+     */
+    record Pre(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            Direction direction,
+            PistonMoveType pistonMoveType
+    ) implements Cancellable, PistonEvent, RecordEvent {
+        public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
+        public Pre(Level world, BlockPos pos, Direction direction, PistonMoveType moveType) {
+            this(world, pos, world.getBlockState(pos), direction, moveType);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
@@ -6,20 +6,24 @@
 package net.minecraftforge.event.level;
 
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * This event is fired when all players are asleep and the time should be set to day.<br>
  *
  * setWakeUpTime(wakeUpTime) sets a new time that will be added to the dayTime.<br>
  */
-public class SleepFinishedTimeEvent extends LevelEvent
-{
+public final class SleepFinishedTimeEvent extends MutableEvent implements LevelEvent {
+    public static final EventBus<SleepFinishedTimeEvent> BUS = EventBus.create(SleepFinishedTimeEvent.class);
+
+    private final ServerLevel level;
     private long newTime;
     private final long minTime;
 
-    public SleepFinishedTimeEvent(ServerLevel level, long newTime, long minTime)
-    {
-        super(level);
+    public SleepFinishedTimeEvent(ServerLevel level, long newTime, long minTime) {
+        this.level = level;
         this.newTime = newTime;
         this.minTime = minTime;
     }
@@ -43,5 +47,10 @@ public class SleepFinishedTimeEvent extends LevelEvent
             return false;
         this.newTime = newTimeIn;
         return true;
+    }
+
+    @Override
+    public LevelAccessor level() {
+        return level;
     }
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 
 /**
@@ -15,10 +16,6 @@ import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
  * You can obtain a reference to the server with this event.
  * @author cpw
  */
-public class ServerAboutToStartEvent extends ServerLifecycleEvent {
-
-    public ServerAboutToStartEvent(MinecraftServer server)
-    {
-        super(server);
-    }
+public record ServerAboutToStartEvent(MinecraftServer server) implements ServerLifecycleEvent {
+    public static final EventBus<ServerAboutToStartEvent> BUS = EventBus.create(ServerAboutToStartEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
@@ -6,20 +6,11 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 
-public class ServerLifecycleEvent extends Event
-{
-
-    protected final MinecraftServer server;
-
-    public ServerLifecycleEvent(MinecraftServer server)
-    {
-        this.server = server;
-    }
-
-    public MinecraftServer getServer()
-    {
-        return server;
-    }
+@MarkerEvent
+public sealed interface ServerLifecycleEvent extends InheritableEvent
+        permits ServerAboutToStartEvent, ServerStartingEvent, ServerStartedEvent, ServerStoppingEvent, ServerStoppedEvent {
+    MinecraftServer server();
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
@@ -6,17 +6,13 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerStartingEvent} when the server is available and ready to play.
  *
  * @author cpw
  */
-public class ServerStartedEvent extends ServerLifecycleEvent
-{
-
-    public ServerStartedEvent(final MinecraftServer server)
-    {
-        super(server);
-    }
+public record ServerStartedEvent(MinecraftServer server) implements ServerLifecycleEvent {
+    public static final EventBus<ServerStartedEvent> BUS = EventBus.create(ServerStartedEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerAboutToStartEvent} and before {@link ServerStartedEvent}.
@@ -15,11 +16,6 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStartingEvent extends ServerLifecycleEvent
-{
-    public ServerStartingEvent(final MinecraftServer server)
-    {
-        super(server);
-    }
-
+public record ServerStartingEvent(MinecraftServer server) implements ServerLifecycleEvent {
+    public static final EventBus<ServerStartingEvent> BUS = EventBus.create(ServerStartingEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerStoppingEvent} when the server has completely shut down.
@@ -14,9 +15,6 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStoppedEvent extends ServerLifecycleEvent {
-    public ServerStoppedEvent(MinecraftServer server)
-    {
-        super(server);
-    }
+public record ServerStoppedEvent(MinecraftServer server) implements ServerLifecycleEvent {
+    public static final EventBus<ServerStoppedEvent> BUS = EventBus.create(ServerStoppedEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
@@ -6,16 +6,13 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called when the server begins an orderly shutdown, before {@link ServerStoppedEvent}.
  *
  * @author cpw
  */
-public class ServerStoppingEvent extends ServerLifecycleEvent
-{
-    public ServerStoppingEvent(MinecraftServer server)
-    {
-        super(server);
-    }
+public record ServerStoppingEvent(MinecraftServer server) implements ServerLifecycleEvent {
+    public static final EventBus<ServerStoppingEvent> BUS = EventBus.create(ServerStoppingEvent.class);
 }

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.ai.village.VillageSiege;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 /**
  * VillageSiegeEvent is fired just before a zombie siege finds a successful location in
@@ -23,39 +24,7 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class VillageSiegeEvent extends Event
-{
-    private final VillageSiege siege;
-    private final Level level;
-    private final Player player;
-    private final Vec3 attemptedSpawnPos;
-
-    public VillageSiegeEvent(VillageSiege siege, Level level, Player player, Vec3 attemptedSpawnPos)
-    {
-       this.siege = siege;
-       this.level = level;
-       this.player = player;
-       this.attemptedSpawnPos = attemptedSpawnPos;
-    }
-
-    public VillageSiege getSiege()
-    {
-        return siege;
-    }
-
-    public Level getLevel()
-    {
-        return level;
-    }
-
-    public Player getPlayer()
-    {
-        return player;
-    }
-
-    public Vec3 getAttemptedSpawnPos()
-    {
-        return attemptedSpawnPos;
-    }
+public record VillageSiegeEvent(VillageSiege siege, Level level, Player player, Vec3 attemptedSpawnPos)
+        implements Cancellable, RecordEvent {
+    public static final CancellableEventBus<VillageSiegeEvent> BUS = CancellableEventBus.create(VillageSiegeEvent.class);
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
@@ -5,9 +5,13 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
 
+import java.util.function.Function;
 
 /**
  * This is the second of four commonly called events during mod lifecycle startup.
@@ -23,7 +27,10 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class FMLClientSetupEvent extends ParallelDispatchEvent {
+public final class FMLClientSetupEvent extends ParallelDispatchEvent implements SelfDestructing {
+    public static final Function<BusGroup, EventBus<FMLClientSetupEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, FMLClientSetupEvent.class);
+
     public FMLClientSetupEvent(ModContainer container, ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -5,11 +5,15 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModLoadingStage;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * This is the first of four commonly called events during mod initialization.
@@ -27,10 +31,11 @@ import java.util.function.Consumer;
  * @see DeferredWorkQueue to enqueue work to run on the main game thread after this event has
  * completed dispatch
  */
-public class FMLCommonSetupEvent extends ParallelDispatchEvent
-{
-    public FMLCommonSetupEvent(final ModContainer container, final ModLoadingStage stage)
-    {
+public final class FMLCommonSetupEvent extends ParallelDispatchEvent implements SelfDestructing {
+    public static final Function<BusGroup, EventBus<FMLCommonSetupEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, FMLCommonSetupEvent.class);
+
+    public FMLCommonSetupEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
@@ -5,14 +5,22 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+
+import java.util.function.Function;
 
 /**
  * Supplied as a param to your mod's constructor to get access
  * to the mod EventBus and various mod-specific objects.
  */
-public class FMLConstructModEvent extends ParallelDispatchEvent {
+public final class FMLConstructModEvent extends ParallelDispatchEvent implements SelfDestructing {
+    public static final Function<BusGroup, EventBus<FMLConstructModEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, FMLConstructModEvent.class);
+
     public FMLConstructModEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -5,8 +5,13 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+
+import java.util.function.Function;
 
 /**
  * This is the second of four commonly called events during mod core startup.
@@ -26,8 +31,10 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent
-{
+public final class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent implements SelfDestructing {
+    public static final Function<BusGroup, EventBus<FMLDedicatedServerSetupEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, FMLDedicatedServerSetupEvent.class);
+
     public FMLDedicatedServerSetupEvent(ModContainer container, ModLoadingStage stage)
     {
         super(container, stage);

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
@@ -5,8 +5,13 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+
+import java.util.function.Function;
 
 /**
  * This is a mostly internal event fired to mod containers that indicates that loading is complete. Mods should not
@@ -14,10 +19,11 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * @author cpw
  */
-public class FMLLoadCompleteEvent extends ParallelDispatchEvent
-{
-    public FMLLoadCompleteEvent(final ModContainer container, final ModLoadingStage stage)
-    {
+public final class FMLLoadCompleteEvent extends ParallelDispatchEvent implements SelfDestructing {
+    public static final Function<BusGroup, EventBus<FMLLoadCompleteEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, FMLLoadCompleteEvent.class);
+
+    public FMLLoadCompleteEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
@@ -5,8 +5,12 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+
+import java.util.function.Function;
 
 /**
  * This is the third of four commonly called events during mod core startup.
@@ -19,11 +23,11 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class InterModEnqueueEvent extends ParallelDispatchEvent
-{
+public final class InterModEnqueueEvent extends ParallelDispatchEvent {
+    public static final Function<BusGroup, EventBus<InterModEnqueueEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, InterModEnqueueEvent.class);
 
-    public InterModEnqueueEvent(final ModContainer container, final ModLoadingStage stage)
-    {
+    public InterModEnqueueEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
@@ -5,9 +5,12 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -23,10 +26,11 @@ import java.util.function.Predicate;
  * @see #getIMCStream()
  * @see #getIMCStream(Predicate)
  */
-public class InterModProcessEvent extends ParallelDispatchEvent
-{
-    public InterModProcessEvent(final ModContainer container, final ModLoadingStage stage)
-    {
+public final class InterModProcessEvent extends ParallelDispatchEvent {
+    public static final Function<BusGroup, EventBus<InterModProcessEvent>> BUS =
+            busGroup -> ParallelDispatchEvent.busSupplier(busGroup, InterModProcessEvent.class);
+
+    public InterModProcessEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -17,35 +17,20 @@ import java.util.stream.Stream;
  * Parent type to all ModLifecycle events. This is based on Forge EventBus. They fire through the
  * ModContainer's eventbus instance.
  */
-public class ModLifecycleEvent extends Event implements IModBusEvent
-{
-    private final ModContainer container;
-
-    public ModLifecycleEvent(ModContainer container)
-    {
-        this.container = container;
-    }
-
-    public final String description()
-    {
+@MarkerEvent
+public sealed interface ModLifecycleEvent extends IModBusEvent permits ParallelDispatchEvent {
+    default String description() {
        String cn = getClass().getName();
-       return cn.substring(cn.lastIndexOf('.')+1);
+       return cn.substring(cn.lastIndexOf('.') + 1);
     }
 
-    public Stream<InterModComms.IMCMessage> getIMCStream() {
-        return InterModComms.getMessages(this.container.getModId());
+    default Stream<InterModComms.IMCMessage> getIMCStream() {
+        return InterModComms.getMessages(container().getModId());
     }
 
-    public Stream<InterModComms.IMCMessage> getIMCStream(Predicate<String> methodFilter) {
-        return InterModComms.getMessages(this.container.getModId(), methodFilter);
+    default Stream<InterModComms.IMCMessage> getIMCStream(Predicate<String> methodFilter) {
+        return InterModComms.getMessages(container().getModId(), methodFilter);
     }
 
-    ModContainer getContainer() {
-        return this.container;
-    }
-
-    @Override
-    public String toString() {
-        return description();
-    }
+    ModContainer container();
 }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
@@ -5,6 +5,10 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.Event;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -13,11 +17,15 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-public class ParallelDispatchEvent extends ModLifecycleEvent {
+@MarkerEvent
+public sealed class ParallelDispatchEvent implements ModLifecycleEvent
+        permits FMLClientSetupEvent, FMLCommonSetupEvent, FMLConstructModEvent, FMLDedicatedServerSetupEvent,
+                FMLLoadCompleteEvent, InterModEnqueueEvent, InterModProcessEvent {
+    private final ModContainer container;
     private final ModLoadingStage modLoadingStage;
 
     public ParallelDispatchEvent(final ModContainer container, final ModLoadingStage stage) {
-        super(container);
+        this.container = container;
         this.modLoadingStage = stage;
     }
 
@@ -26,10 +34,24 @@ public class ParallelDispatchEvent extends ModLifecycleEvent {
     }
 
     public CompletableFuture<Void> enqueueWork(Runnable work) {
-        return getQueue().map(q->q.enqueueWork(getContainer(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
+        return getQueue().map(q->q.enqueueWork(container(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
     }
 
     public <T> CompletableFuture<T> enqueueWork(Supplier<T> work) {
-        return getQueue().map(q->q.enqueueWork(getContainer(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
+        return getQueue().map(q->q.enqueueWork(container(), work)).orElseThrow(()->new RuntimeException("No work queue found!"));
+    }
+
+    @Override
+    public ModContainer container() {
+        return container;
+    }
+
+    @Override
+    public String toString() {
+        return description();
+    }
+
+    protected static <T extends Event> EventBus<T> busSupplier(BusGroup busGroup, Class<T> eventType) {
+        return EventBus.create(busGroup, eventType);
     }
 }

--- a/src/main/java/net/minecraftforge/network/tasks/ForgeNetworkConfigurationHandler.java
+++ b/src/main/java/net/minecraftforge/network/tasks/ForgeNetworkConfigurationHandler.java
@@ -14,8 +14,7 @@ import net.minecraftforge.network.NetworkContext;
 
 @ApiStatus.Internal
 public class ForgeNetworkConfigurationHandler {
-    @SubscribeEvent
-    public void gatherInit(GatherLoginConfigurationTasksEvent event) {
+    public static void gatherInit(GatherLoginConfigurationTasksEvent event) {
         var ctx = NetworkContext.get(event.getConnection());
         if (ctx.getType() != ConnectionType.MODDED)
             return;

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -14,11 +14,13 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.registries.tags.ITagManager;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -318,8 +320,8 @@ public class DeferredRegister<T> {
      *
      * @param bus The Mod Specific event bus.
      */
-    public void register(IEventBus bus) {
-        bus.register(new EventDispatcher());
+    public void register(BusGroup busGroup) {
+        busGroup.register(MethodHandles.lookup(), new EventDispatcher());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/registries/ForgeDeferredRegistriesSetup.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeDeferredRegistriesSetup.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.registries;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -16,7 +17,7 @@ public class ForgeDeferredRegistriesSetup {
     /**
      * Internal forge method. Modders do not call.
      */
-    public static void setup(IEventBus modEventBus) {
+    public static void setup(BusGroup modEventBus) {
         synchronized (ForgeDeferredRegistriesSetup.class) {
             if (setup)
                 throw new IllegalStateException("Setup has already been called!");

--- a/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
+++ b/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
@@ -8,6 +8,9 @@ package net.minecraftforge.server.permission.events;
 import com.google.common.base.Preconditions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+import net.minecraftforge.eventbus.api.event.MarkerEvent;
 import net.minecraftforge.server.permission.handler.DefaultPermissionHandler;
 import net.minecraftforge.server.permission.handler.IPermissionHandler;
 import net.minecraftforge.server.permission.handler.IPermissionHandlerFactory;
@@ -25,33 +28,31 @@ import java.util.function.Function;
  *
  * <p><strong>Note:</strong> All PermissionNodes that you want to use, <strong>must</strong> be registered!</p>
  */
-public class PermissionGatherEvent extends Event
-{
-
+@MarkerEvent
+public sealed interface PermissionGatherEvent extends InheritableEvent {
     /**
      * Used to register a new PermissionHandler, a server config value exists to choose which one to use.
      * <p>Note: Create a new instance when registering a PermissionHandler.
      * If you cache it, make sure that your PermissionHandler is actually used after this event.</p>
      */
-    public static class Handler extends PermissionGatherEvent
-    {
-        private Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
+    final class Handler implements PermissionGatherEvent {
+        public static final EventBus<Handler> BUS = EventBus.create(Handler.class);
+
+        private final Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
 
         public Handler()
         {
             availableHandlers.put(DefaultPermissionHandler.IDENTIFIER, DefaultPermissionHandler::new);
         }
 
-        public Map<ResourceLocation, IPermissionHandlerFactory> getAvailablePermissionHandlerFactories()
-        {
+        public Map<ResourceLocation, IPermissionHandlerFactory> getAvailablePermissionHandlerFactories() {
             return Collections.unmodifiableMap(availableHandlers);
         }
 
-        public void addPermissionHandler(ResourceLocation identifier, IPermissionHandlerFactory handlerFactory)
-        {
+        public void addPermissionHandler(ResourceLocation identifier, IPermissionHandlerFactory handlerFactory) {
             Preconditions.checkNotNull(identifier, "Permission handler identifier cannot be null!");
             Preconditions.checkNotNull(handlerFactory, "Permission handler cannot be null!");
-            if(this.availableHandlers.containsKey(identifier))
+            if (this.availableHandlers.containsKey(identifier))
                 throw new IllegalArgumentException("Attempted to overwrite permission handler " + identifier + ", this is not allowed.");
             this.availableHandlers.put(identifier, handlerFactory);
         }
@@ -61,32 +62,26 @@ public class PermissionGatherEvent extends Event
     /**
      * Used to register your PermissionNodes, <strong>every node that you want to use, must be registered!</strong>
      */
-    public static class Nodes extends PermissionGatherEvent
-    {
+    final class Nodes implements PermissionGatherEvent {
+        public static final EventBus<Nodes> BUS = EventBus.create(Nodes.class);
+
         private final Set<PermissionNode<?>> nodes = new HashSet<>();
 
-        public Nodes()
-        {
-        }
+        public Nodes() {}
 
-        public Collection<PermissionNode<?>> getNodes()
-        {
+        public Collection<PermissionNode<?>> getNodes() {
             return Collections.unmodifiableCollection(this.nodes);
         }
 
-        public void addNodes(PermissionNode<?>... nodes)
-        {
-            for (PermissionNode<?> node : nodes)
-            {
+        public void addNodes(PermissionNode<?>... nodes) {
+            for (PermissionNode<?> node : nodes) {
                 if (!this.nodes.add(node))
                     throw new IllegalArgumentException("Tried to register duplicate PermissionNode '" + node.getNodeName() + "'");
             }
         }
 
-        public void addNodes(Iterable<PermissionNode<?>> nodes)
-        {
-            for (PermissionNode<?> node : nodes)
-            {
+        public void addNodes(Iterable<PermissionNode<?>> nodes) {
+            for (PermissionNode<?> node : nodes) {
                 if (!this.nodes.add(node))
                     throw new IllegalArgumentException("Tried to register duplicate PermissionNode '" + node.getNodeName() + "'");
             }

--- a/src/test/java/com/example/examplemod/ExampleMod.java
+++ b/src/test/java/com/example/examplemod/ExampleMod.java
@@ -13,11 +13,11 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -27,6 +27,8 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.slf4j.Logger;
+
+import java.lang.invoke.MethodHandles;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(ExampleMod.MODID)
@@ -76,20 +78,20 @@ public class ExampleMod {
             }).build());
 
     public ExampleMod(FMLJavaModLoadingContext context) {
-        IEventBus modEventBus = context.getModEventBus();
+        BusGroup modEventBusGroup = context.getModBusGroup();
 
         // Register the commonSetup method for modloading
-        modEventBus.addListener(this::commonSetup);
+        FMLCommonSetupEvent.BUS.apply(modEventBusGroup).addListener(this::commonSetup);
 
         // Register the Deferred Register to the mod event bus so blocks get registered
-        BLOCKS.register(modEventBus);
+        BLOCKS.register(modEventBusGroup);
         // Register the Deferred Register to the mod event bus so items get registered
-        ITEMS.register(modEventBus);
+        ITEMS.register(modEventBusGroup);
         // Register the Deferred Register to the mod event bus so tabs get registered
-        CREATIVE_MODE_TABS.register(modEventBus);
+        CREATIVE_MODE_TABS.register(modEventBusGroup);
 
         // Register ourselves for server and other game events we are interested in
-        MinecraftForge.EVENT_BUS.register(this);
+        BusGroup.DEFAULT.register(MethodHandles.lookup(), this);
 
         // Register the item to a creative tab
         modEventBus.addListener(this::addCreative);


### PR DESCRIPTION
This proof-of-concept RFC accompanies the EventBus rewrite PR, which offers new API design opportunities for Forge's
extensive collection of events (roughly 400 of them!). This PR isn't meant to be merged, but rather to start a
discussion on how we want to approach this.

## Approaches
There are multiple ways we could go about it...
1) Minimal changes: Port the events over to the new system as-is, with minimal changes to the event classes themselves.
   Basically most changes become replacing the `@Cancelable` annotation and `extends Event` with the new API equivalents.
2) Refactor: All of 1, but also use sealed types, records and rename methods to better fit records. **This PR's code
   shows roughly what that might look like.**
3) Full rewrite: All of 1 and 2, but also restructure the package layout with a full separation of API spec and internal
   implementation.

Whichever way we go, I'd be happy to help implement it. We could do it in stages if it makes things more manageable.

## Things to consider
### Breaking changes
The new EventBus is a full rewrite, so it's a major breaking change anyway. In my opinion we should take advantage of
this opportunity to lump in related breaking changes so that we don't annoy mod devs from lots of staggered breakages,
but also be careful with scope creep considering the amount of work involved and MC's frequent updates.

Maybe we should go with a mix of approaches 1 and 2 at first, with the full rewrite later? For instance, minimal changes
but also make events final and sealed, without the method renames and interfaces.

### Inheritance
The old system always supported inheritance with no way to opt-out. There are some cases where it's unclear if
supporting adding listeners to abstract events is intentionally supported/realistic. In the new system, it's opt-in with
`implements InheritableEvent` and then opt-out on a per-child-basis with `@MarkerEvent`. We need to decide where we want
to explicitly support inheritance and where we don't.

There's also some events where they're technically static inner classes of another event, but not inheriting from it.
Should these be made top-level classes?

### Internals and encapsulation
Currently we mark a bunch of constructors and public methods inside events as `@ApiStatus.Internal`, but we could
instead opt for a separate API spec interface and have the implementation classes in another package, wired together
nicely with the Java module system and sealed types.

Forge's bundled events are currently spread out across multiple package roots:
- `net.minecraftforge.client.event`
- `net.minecraftforge.common.capabilities`
- `net.minecraftforge.data.event`
- `net.minecraftforge.event`
- `net.minecraftforge.fml.event`
- `net.minecraftforge.registries`
- `net.minecraftforge.server.permission.events`

Separate packages for client and FML events makes sense, but the package structure seems inconsistent. If do split it
up, we need to decide on a new package structure - ideally one that allows for future modularisation efforts.

However, I don't think we should use interfaces for all events. Some may be better off being simple `RecordEvent`s, to
avoid code duplication for simple data carrier events.

Something that seems to have been overlooked in the past is the use of `final` on event classes, I think we should adopt
it now to reduce API surface area (i.e. changing a `protected` field name would no longer be a breaking change if
`sealed`/`final`). The new EventBus has optimisations for sealed types and final as well to reduce memory usage. If a
mod dev has a good use-case for extending an event, they can PR a non-sealed custom inner interface to the event class,
or we can unseal it altogether.

### EventBusSubscriber
This might not play nicely with `BusGroup.DEFAULT.register()` because it requires a `MethodHandles.Lookup` for the
underlying `LambdaMetaFactory` usages to create direct method calls. One solution for now is a transformer that adds a
synthetic method to the class that does the actual registration and then call that from where EventBusSubscriber would
usually do the it. Someone needs to investigate if this is actually necessary though - maybe having the mod's module
`opens` or `exports` to Forge's module is enough for public methods?

On the bright side, it'll now be straightforward to have EBS support a mix of static and instance methods in the same
class, as that artificial restriction is gone and the performance gap between the two is now negligible for most events.

### FML
The mod loading infrastructure needs a rewrite as well and doesn't play nicely with the new EventBus architecture at all.

#### Option 1
A slow, hacky and temporary solution is to call EventBus#create(String, BusGroup) to grab the instance on every post for
mod bus events. I think this should suffice for now until we rewrite FML to use a simple interface instead of separate
BusGroups for each mod. Technically, this violates the API spec of EventBus#create as it may throw in future if the
EventBus already exists on that BusGroup, but FML should be redesigned before then anyway.

#### Option 2
Another option is to add a new record to FML's API that contains all the EventBus instances for the mod's BusGroup.
More work, but would be a cleaner solution that doesn't force mod devs to use bulk registration, like this:

```java
import com.mojang.logging.LogUtils;
import net.minecraftforge.eventbus.api.bus.BusGroup;
import net.minecraftforge.eventbus.api.bus.EventBus;
import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
import org.slf4j.Logger;

public final class ExampleMod {
    private static final Logger LOGGER = LogUtils.getLogger();

    public ExampleMod(FMLJavaModLoadingContext context) {
        context.getModEventBuses().commonSetup().addListener(ExampleMod::onCommonSetup);
    }

    private static void onCommonSetup(FMLCommonSetupEvent event) {
        LOGGER.info("Hello from common setup!");
    }
}

public record ModEventBuses(BusGroup busGroup, EventBus<FMLCommonSetupEvent> commonSetup) {
    public ModEventBuses(BusGroup busGroup) {
        this(busGroup, EventBus.create(FMLCommonSetupEvent.class, busGroup));
    }
}
```

...the catch is there are about 50 mod bus events, that would be a big record.

#### Option 3
A third option is to combine option 1 with a static method in each of the mod bus events, like so:
```java
import com.mojang.logging.LogUtils;
import net.minecraftforge.eventbus.api.bus.BusGroup;
import net.minecraftforge.eventbus.api.bus.EventBus;
import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
import org.slf4j.Logger;

public final class ExampleMod {
    private static final Logger LOGGER = LogUtils.getLogger();

    public ExampleMod(FMLJavaModLoadingContext context) {
        FMLCommonSetupEvent.getBus(context.getModBusGroup()).addListener(ExampleMod::onCommonSetup);
    }

    private static void onCommonSetup(FMLCommonSetupEvent event) {
        LOGGER.info("Hello from common setup!");
    }
}

public final class FMLCommonSetupEvent extends ParallelDispatchEvent implements SelfDestructing {
    public static EventBus<FMLCommonSetupEvent> getBus(BusGroup modBusGroup) {
        return ParallelDispatchEvent.busSupplier(modBusGroup, FMLCommonSetupEvent.class);
    }

    // (...)
}

public sealed class ParallelDispatchEvent permits FMLCommonSetupEvent {
    // (...)
   
    protected static <T extends ParallelDispatchEvent> EventBus<T> busSupplier(BusGroup busGroup, Class<T> eventType) {
        // Do not copy! Temporary solution until the FML rewrite is complete. May throw in future
        // without prior notice.
        // 
        // Mods creating their own events should directly assign the result of the create method to a
        // static final field in their event class, without wrapping or calling multiple times.
        //
        // Mods using existing events should instead use the existing static final BUS field in the
        // event class (for most events) or getBus(BusGroup) method (for mod bus events).
        return EventBus.create(busGroup, eventType);
    }
}
```

This avoids eager creation of EventBus instances and is a bit closer to Forge/Game/Default event
usage where you'd do `DifficultyChangeEvent.BUS.addListener(this::onDifficultyChange)`.

I think the third option is the best compromise for now.

### Capabilities

These currently rely on generic events, which are not supported in the new EventBus. For now, we can provide the class
that would usually be the event generic as part of the event instance and have mod devs check the class in their
listeners, casting and bouncing to the appropriate generic method when applicable.
