### PR TITLE
[1.21.5] Seal most event hierarchies

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
 @Cancelable
-public class ClientChatEvent extends Event
+public final class ClientChatEvent extends Event
 {
     private String message;
     private final String originalMessage;

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * @see ChatType
  */
 @Cancelable
-public class ClientChatReceivedEvent extends Event {
+public sealed class ClientChatReceivedEvent extends Event {
     private Component message;
     private final ChatType.Bound boundChatType;
     private final UUID sender;
@@ -94,7 +94,7 @@ public class ClientChatReceivedEvent extends Event {
      *
      * @see ChatType
      */
-    public static class Player extends ClientChatReceivedEvent {
+    public static final class Player extends ClientChatReceivedEvent {
         private final PlayerChatMessage playerChatMessage;
 
         @ApiStatus.Internal
@@ -119,7 +119,7 @@ public class ClientChatReceivedEvent extends Event {
      * So moved to it's own event. {@link SystemMessageReceivedEvent}
      */
     @Deprecated(forRemoval = true, since = "1.21.1")
-    public static class System extends ClientChatReceivedEvent {
+    public static final class System extends ClientChatReceivedEvent {
         private final boolean overlay;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.LogicalSide;
  * @see ClientPauseChangeEvent.Pre
  * @see ClientPauseChangeEvent.Post
  */
-public abstract class ClientPauseChangeEvent extends Event {
+public abstract sealed class ClientPauseChangeEvent extends Event {
     private final boolean pause;
 
     public ClientPauseChangeEvent(boolean pause) {
@@ -38,7 +38,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Pre extends ClientPauseChangeEvent {
+    public static final class Pre extends ClientPauseChangeEvent {
 
         public Pre(boolean pause) {
             super(pause);
@@ -53,7 +53,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends ClientPauseChangeEvent {
+    public static final class Post extends ClientPauseChangeEvent {
 
         public Post(boolean pause) {
             super(pause);

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class ClientPlayerChangeGameTypeEvent extends Event
+public final class ClientPlayerChangeGameTypeEvent extends Event
 {
     private final PlayerInfo info;
     private final GameType currentGameType;

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
  * @see LoggingOut
  * @see Clone
  **/
-public abstract class ClientPlayerNetworkEvent extends Event {
+public abstract sealed class ClientPlayerNetworkEvent extends Event {
     private final MultiPlayerGameMode multiPlayerGameMode;
     private final LocalPlayer player;
     private final Connection connection;
@@ -67,7 +67,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class LoggingIn extends ClientPlayerNetworkEvent {
+    public static final class LoggingIn extends ClientPlayerNetworkEvent {
         @ApiStatus.Internal
         public LoggingIn(final MultiPlayerGameMode controller, final LocalPlayer player, final Connection networkManager) {
             super(controller, player, networkManager);
@@ -84,7 +84,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      */
     @SuppressWarnings("NullableProblems")
     // Shush IntelliJ, we override non-nullables as nullables in this specific event; see later comment
-    public static class LoggingOut extends ClientPlayerNetworkEvent {
+    public static final class LoggingOut extends ClientPlayerNetworkEvent {
         @ApiStatus.Internal
         public LoggingOut(@Nullable final MultiPlayerGameMode controller, @Nullable final LocalPlayer player, @Nullable final Connection networkManager) {
             //noinspection ConstantConditions we know these are nullable, but we don't want to annotate the super as nullable since this is the only event with nullables
@@ -133,7 +133,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Clone extends ClientPlayerNetworkEvent {
+    public static final class Clone extends ClientPlayerNetworkEvent {
         private final LocalPlayer oldPlayer;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see ViewportEvent.ComputeFov
  */
-public class ComputeFovModifierEvent extends Event {
+public final class ComputeFovModifierEvent extends Event {
     private final Player player;
     private final float fovModifier;
     private final float scale;

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Render.Foreground
  * @see Render.Background
  */
-public abstract class ContainerScreenEvent extends Event {
+public abstract sealed class ContainerScreenEvent extends Event {
     private final AbstractContainerScreen<?> containerScreen;
 
     @ApiStatus.Internal
@@ -48,7 +48,7 @@ public abstract class ContainerScreenEvent extends Event {
      * @see Foreground
      * @see Background
      */
-    public static abstract class Render extends ContainerScreenEvent {
+    public static abstract sealed class Render extends ContainerScreenEvent {
         private final GuiGraphics guiGraphics;
         private final int mouseX;
         private final int mouseY;
@@ -94,7 +94,7 @@ public abstract class ContainerScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Foreground extends Render {
+        public static final class Foreground extends Render {
             @ApiStatus.Internal
             public Foreground(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
                 super(guiContainer, guiGraphics, mouseX, mouseY);
@@ -110,7 +110,7 @@ public abstract class ContainerScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Background extends Render {
+        public static final class Background extends Render {
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
                 super(guiContainer, guiGraphics, mouseX, mouseY);

--- a/src/main/java/net/minecraftforge/client/event/CreateSpecialBlockRendererEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CreateSpecialBlockRendererEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.special.SpecialModelRenderer;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.eventbus.api.Event;
 
-public class CreateSpecialBlockRendererEvent extends Event {
+public final class CreateSpecialBlockRendererEvent extends Event {
     private final Map<Block, SpecialModelRenderer.Unbaked> map;
 
     public CreateSpecialBlockRendererEvent(Map<Block, SpecialModelRenderer.Unbaked> map) {

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -23,7 +23,7 @@ import java.util.List;
  * @see DebugText
  * @see Chat
  */
-public abstract class CustomizeGuiOverlayEvent extends Event {
+public abstract sealed class CustomizeGuiOverlayEvent extends Event {
     private final Window window;
     private final GuiGraphics guiGraphics;
     private final float partialTick;
@@ -57,7 +57,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class BossEventProgress extends CustomizeGuiOverlayEvent {
+    public static final class BossEventProgress extends CustomizeGuiOverlayEvent {
         private final LerpingBossEvent bossEvent;
         private final int x;
         private final int y;
@@ -119,7 +119,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class DebugText extends CustomizeGuiOverlayEvent {
+    public static final class DebugText extends CustomizeGuiOverlayEvent {
         private final List<String> text;
 
         private final Side side;
@@ -159,7 +159,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Chat extends CustomizeGuiOverlayEvent {
+    public static final class Chat extends CustomizeGuiOverlayEvent {
         private int posX;
         private int posY;
 

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -53,7 +53,7 @@ import java.util.function.Supplier;
  * @see EntityRenderersEvent.RegisterRenderers
  * @see EntityRenderersEvent.AddLayers
  */
-public abstract class EntityRenderersEvent extends Event implements IModBusEvent {
+public abstract sealed class EntityRenderersEvent extends Event implements IModBusEvent {
     @ApiStatus.Internal
     protected EntityRenderersEvent() {}
 
@@ -65,7 +65,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterLayerDefinitions extends EntityRenderersEvent {
+    public static final class RegisterLayerDefinitions extends EntityRenderersEvent {
         @ApiStatus.Internal
         public RegisterLayerDefinitions() {}
 
@@ -93,7 +93,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterRenderers extends EntityRenderersEvent {
+    public static final class RegisterRenderers extends EntityRenderersEvent {
         @ApiStatus.Internal
         public RegisterRenderers() {}
 
@@ -127,7 +127,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class AddLayers extends EntityRenderersEvent {
+    public static final class AddLayers extends EntityRenderersEvent {
         private final Map<EntityType<?>, EntityRenderer<?, ?>> renderers;
         private final Map<PlayerSkin.Model, EntityRenderer<? extends Player, ?>> skinMap;
         private final EntityRendererProvider.Context context;
@@ -201,7 +201,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class CreateSkullModels extends EntityRenderersEvent {
+    public static final class CreateSkullModels extends EntityRenderersEvent {
         private final ImmutableMap.Builder<Type, Function<EntityModelSet, SkullModelBase>> builder;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -24,7 +24,7 @@ import org.lwjgl.glfw.GLFW;
  * @see Key
  * @see InteractionKeyMappingTriggered
  */
-public abstract class InputEvent extends Event {
+public abstract sealed class InputEvent extends Event {
     @ApiStatus.Internal
     protected InputEvent() {}
 
@@ -38,7 +38,7 @@ public abstract class InputEvent extends Event {
      * @see Pre
      * @see Post
      */
-    public static abstract class MouseButton extends InputEvent {
+    public static abstract sealed class MouseButton extends InputEvent {
         private final int button;
         private final int action;
         private final int modifiers;
@@ -97,7 +97,7 @@ public abstract class InputEvent extends Event {
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
         @Cancelable
-        public static class Pre extends MouseButton {
+        public static final class Pre extends MouseButton {
             @ApiStatus.Internal
             public Pre(int button, int action, int modifiers) {
                 super(button, action, modifiers);
@@ -114,7 +114,7 @@ public abstract class InputEvent extends Event {
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
-        public static class Post extends MouseButton {
+        public static final class Post extends MouseButton {
             @ApiStatus.Internal
             public Post(int button, int action, int modifiers) {
                 super(button, action, modifiers);
@@ -135,7 +135,7 @@ public abstract class InputEvent extends Event {
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
     @Cancelable
-    public static class MouseScrollingEvent extends InputEvent {
+    public static final class MouseScrollingEvent extends InputEvent {
         private final double deltaX;
         private final double deltaY;
         private final double mouseX;
@@ -213,7 +213,7 @@ public abstract class InputEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Key extends InputEvent {
+    public static final class Key extends InputEvent {
         private final int key;
         private final int scanCode;
         private final int action;
@@ -297,7 +297,7 @@ public abstract class InputEvent extends Event {
      */
     // TODO: Change the 'button' to sub events. - Lex 0422202
     @Cancelable
-    public static class InteractionKeyMappingTriggered extends InputEvent {
+    public static final class InteractionKeyMappingTriggered extends InputEvent {
         private final int button;
         private final KeyMapping keyMapping;
         private final InteractionHand hand;

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Houses events related to models.
  */
-public abstract class ModelEvent extends Event {
+public abstract sealed class ModelEvent extends Event {
     @ApiStatus.Internal
     protected ModelEvent() { }
 
@@ -48,7 +48,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
+    public static final class ModifyBakingResult extends ModelEvent implements IModBusEvent {
         private final ModelBakery modelBakery;
         private final ModelBakery.BakingResult results;
 
@@ -84,7 +84,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BakingCompleted extends ModelEvent implements IModBusEvent {
+    public static final class BakingCompleted extends ModelEvent implements IModBusEvent {
         private final ModelManager modelManager;
         private final ModelBakery modelBakery;
 
@@ -118,7 +118,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterModelStateDefinitions extends ModelEvent implements IModBusEvent {
+    public static final class RegisterModelStateDefinitions extends ModelEvent implements IModBusEvent {
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> states = new HashMap<>();
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> view = Collections.unmodifiableMap(states);
 
@@ -148,7 +148,7 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent {
+    public static final class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent {
         private final Map<ResourceLocation, IGeometryLoader> loaders;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class MovementInputUpdateEvent extends PlayerEvent {
+public final class MovementInputUpdateEvent extends PlayerEvent {
     private final ClientInput input;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RecipesUpdatedEvent extends Event {
+public final class RecipesUpdatedEvent extends Event {
     private final ClientRecipeBook recipeBook;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see net.minecraftforge.event.RegisterCommandsEvent
  */
-public class RegisterClientCommandsEvent extends Event
+public final class RegisterClientCommandsEvent extends Event
 {
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final CommandBuildContext context;

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientReloadListenersEvent extends Event implements IModBusEvent
+public final class RegisterClientReloadListenersEvent extends Event implements IModBusEvent
 {
     private final ReloadableResourceManager resourceManager;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientTooltipComponentFactoriesEvent extends Event implements IModBusEvent
+public final class RegisterClientTooltipComponentFactoriesEvent extends Event implements IModBusEvent
 {
     private final Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> factories;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RegisterColorHandlersEvent.Block
  * @see RegisterColorHandlersEvent.Item
  */
-public abstract class RegisterColorHandlersEvent extends Event implements IModBusEvent {
+public abstract sealed class RegisterColorHandlersEvent extends Event implements IModBusEvent {
     @ApiStatus.Internal
     protected RegisterColorHandlersEvent() {}
 
@@ -39,7 +39,7 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Block extends RegisterColorHandlersEvent {
+    public static final class Block extends RegisterColorHandlersEvent {
         private final BlockColors blockColors;
 
         @ApiStatus.Internal
@@ -72,7 +72,7 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * Allows registration of custom {@link ColorResolver} implementations to be used with
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
-    public static class ColorResolvers extends RegisterColorHandlersEvent {
+    public static final class ColorResolvers extends RegisterColorHandlersEvent {
         private final ImmutableList.Builder<ColorResolver> builder;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterDimensionSpecialEffectsEvent extends Event implements IModBusEvent
+public final class RegisterDimensionSpecialEffectsEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, DimensionSpecialEffects> effects;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterEntitySpectatorShadersEvent extends Event implements IModBusEvent
+public final class RegisterEntitySpectatorShadersEvent extends Event implements IModBusEvent
 {
     private final Map<EntityType<?>, ResourceLocation> shaders;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterItemDecorationsEvent extends Event implements IModBusEvent
+public final class RegisterItemDecorationsEvent extends Event implements IModBusEvent
 {
 
     private final Map<Item, List<IItemDecorator>> decorators;

--- a/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterKeyMappingsEvent extends Event implements IModBusEvent
+public final class RegisterKeyMappingsEvent extends Event implements IModBusEvent
 {
     private final Options options;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
+public final class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, RenderTypeGroup> renderTypes;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterParticleProvidersEvent extends Event implements IModBusEvent
+public final class RegisterParticleProvidersEvent extends Event implements IModBusEvent
 {
     private final ParticleEngine particleEngine;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterPresetEditorsEvent extends Event implements IModBusEvent
+public final class RegisterPresetEditorsEvent extends Event implements IModBusEvent
 {
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IModBusEvent {
+public final class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IModBusEvent {
     private final BiMap<ResourceLocation, ITextureAtlasSpriteLoader> loaders;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @Cancelable
-public class RenderArmEvent extends Event {
+public final class RenderArmEvent extends Event {
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;
     private final int packedLight;

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @Cancelable
-public class RenderBlockScreenEffectEvent extends Event
+public final class RenderBlockScreenEffectEvent extends Event
 {
     /**
      * The type of the block overlay to be rendered.

--- a/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderArmEvent
  */
 @Cancelable
-public class RenderHandEvent extends Event
+public final class RenderHandEvent extends Event
 {
     private final InteractionHand hand;
     private final PoseStack poseStack;

--- a/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Entity
  */
 @Cancelable
-public abstract class RenderHighlightEvent extends Event
+public abstract sealed class RenderHighlightEvent extends Event
 {
     private final LevelRenderer levelRenderer;
     private final Camera camera;
@@ -104,7 +104,7 @@ public abstract class RenderHighlightEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Block extends RenderHighlightEvent
+    public static final class Block extends RenderHighlightEvent
     {
         @ApiStatus.Internal
         public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
@@ -130,7 +130,7 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Entity extends RenderHighlightEvent
+    public static final class Entity extends RenderHighlightEvent
     {
         @ApiStatus.Internal
         public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)

--- a/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ItemFrameRenderer
  */
 @Cancelable
-public class RenderItemInFrameEvent extends Event {
+public final class RenderItemInFrameEvent extends Event {
     private final ItemFrameRenderState state;
     private final ItemFrameRenderer<?> renderer;
     private final PoseStack poseStack;

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent
  * @see LivingEntityRenderer
  */
-public abstract class RenderLivingEvent<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends Event {
+public abstract sealed class RenderLivingEvent<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends Event {
     private final S state;
     private final LivingEntityRenderer<T, S, M> renderer;
     private final PoseStack poseStack;
@@ -100,7 +100,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     @Cancelable
-    public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
+    public static final class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
         @ApiStatus.Internal
         public Pre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);
@@ -118,7 +118,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <T> the living entity that was rendered
      * @param <M> the model for the living entity
      */
-    public static class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
+    public static final class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
         @ApiStatus.Internal
         public Post(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);

--- a/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see EntityRenderer
  */
 @Event.HasResult
-public class RenderNameTagEvent extends Event {
+public final class RenderNameTagEvent extends Event {
     private Component nameplateContent;
     private final EntityRenderState state;
     private final Component originalContent;

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent.Post
  * @see PlayerRenderer
  */
-public abstract class RenderPlayerEvent extends Event {
+public abstract sealed class RenderPlayerEvent extends Event {
     private final PlayerRenderState state;
     private final PlayerRenderer renderer;
     private final PoseStack poseStack;
@@ -86,7 +86,7 @@ public abstract class RenderPlayerEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Pre extends RenderPlayerEvent {
+    public static final class Pre extends RenderPlayerEvent {
         @ApiStatus.Internal
         public Pre(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);
@@ -101,7 +101,7 @@ public abstract class RenderPlayerEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends RenderPlayerEvent {
+    public static final class Post extends RenderPlayerEvent {
         @ApiStatus.Internal
         public Post(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @see RenderTooltipEvent.Pre
  * @see RenderTooltipEvent.Background
  */
-public abstract class RenderTooltipEvent extends Event
+public abstract sealed class RenderTooltipEvent extends Event
 {
     @NotNull
     protected final ItemStack itemStack;
@@ -121,7 +121,7 @@ public abstract class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class GatherComponents extends Event
+    public static final class GatherComponents extends Event
     {
         private final ItemStack itemStack;
         private final int screenWidth;
@@ -210,7 +210,7 @@ public abstract class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Pre extends RenderTooltipEvent
+    public static final class Pre extends RenderTooltipEvent
     {
         private final int screenWidth;
         private final int screenHeight;
@@ -289,7 +289,7 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Background extends RenderTooltipEvent {
+    public static final class Background extends RenderTooltipEvent {
         private final ResourceLocation originalBackground;
         private ResourceLocation background;
 

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-public abstract class ScreenEvent extends Event {
+public abstract sealed class ScreenEvent extends Event {
     private final Screen screen;
 
     @ApiStatus.Internal
@@ -61,7 +61,7 @@ public abstract class ScreenEvent extends Event {
      * @see Init.Pre
      * @see Init.Post
      */
-    public static abstract class Init extends ScreenEvent {
+    public static abstract sealed class Init extends ScreenEvent {
         private final Consumer<GuiEventListener> add;
         private final Consumer<GuiEventListener> remove;
 
@@ -111,7 +111,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends Init {
+        public static final class Pre extends Init {
             @ApiStatus.Internal
             public Pre(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
                 super(screen, list, add, remove);
@@ -126,7 +126,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Init {
+        public static final class Post extends Init {
             @ApiStatus.Internal
             public Post(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
                 super(screen, list, add, remove);
@@ -141,7 +141,7 @@ public abstract class ScreenEvent extends Event {
      * @see Render.Pre
      * @see Render.Post
      */
-    public static abstract class Render extends ScreenEvent {
+    public static abstract sealed class Render extends ScreenEvent {
         private final GuiGraphics guiGraphics;
         private final int mouseX;
         private final int mouseY;
@@ -194,7 +194,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends Render {
+        public static final class Pre extends Render {
             @ApiStatus.Internal
             public Pre(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
                 super(screen, guiGraphics, mouseX, mouseY, partialTick);
@@ -209,7 +209,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Render {
+        public static final class Post extends Render {
             @ApiStatus.Internal
             public Post(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
                 super(screen, guiGraphics, mouseX, mouseY, partialTick);
@@ -226,7 +226,7 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BackgroundRendered extends ScreenEvent {
+    public static final class BackgroundRendered extends ScreenEvent {
         private final GuiGraphics guiGraphics;
 
         @ApiStatus.Internal
@@ -255,7 +255,7 @@ public abstract class ScreenEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class RenderInventoryMobEffects extends ScreenEvent {
+    public static final class RenderInventoryMobEffects extends ScreenEvent {
         private final int availableSpace;
         private boolean compact;
         private int horizontalOffset;
@@ -320,7 +320,7 @@ public abstract class ScreenEvent extends Event {
      * @see MouseDragged
      * @see MouseScrolled
      */
-    private static abstract class MouseInput extends ScreenEvent {
+    private static abstract sealed class MouseInput extends ScreenEvent {
         private final double mouseX;
         private final double mouseY;
 
@@ -353,7 +353,7 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonPressed.Pre
      * @see MouseButtonPressed.Post
      */
-    public static abstract class MouseButtonPressed extends MouseInput {
+    public static abstract sealed class MouseButtonPressed extends MouseInput {
         private final int button;
 
         @ApiStatus.Internal
@@ -383,7 +383,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseButtonPressed {
+        public static final class Pre extends MouseButtonPressed {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button) {
                 super(screen, mouseX, mouseY, button);
@@ -406,7 +406,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @HasResult
-        public static class Post extends MouseButtonPressed {
+        public static final class Post extends MouseButtonPressed {
             private final boolean handled;
 
             @ApiStatus.Internal
@@ -431,7 +431,7 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonReleased.Pre
      * @see MouseButtonReleased.Post
      */
-    public static abstract class MouseButtonReleased extends MouseInput {
+    public static abstract sealed class MouseButtonReleased extends MouseInput {
         private final int button;
 
         @ApiStatus.Internal
@@ -461,7 +461,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseButtonReleased {
+        public static final class Pre extends MouseButtonReleased {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button) {
                 super(screen, mouseX, mouseY, button);
@@ -484,7 +484,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @HasResult
-        public static class Post extends MouseButtonReleased {
+        public static final class Post extends MouseButtonReleased {
             private final boolean handled;
 
             @ApiStatus.Internal
@@ -509,7 +509,7 @@ public abstract class ScreenEvent extends Event {
      * @see MouseDragged.Pre
      * @see MouseDragged.Post
      */
-    public static abstract class MouseDragged extends MouseInput {
+    public static abstract sealed class MouseDragged extends MouseInput {
         private final int mouseButton;
         private final double dragX;
         private final double dragY;
@@ -557,7 +557,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseDragged {
+        public static final class Pre extends MouseDragged {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
                 super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
@@ -574,7 +574,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseDragged {
+        public static final class Post extends MouseDragged {
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
                 super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
@@ -589,7 +589,7 @@ public abstract class ScreenEvent extends Event {
      * @see MouseScrolled.Pre
      * @see MouseScrolled.Post
      */
-    public static abstract class MouseScrolled extends MouseInput {
+    public static abstract sealed class MouseScrolled extends MouseInput {
         private final double deltaX;
         private final double deltaY;
 
@@ -625,7 +625,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseScrolled {
+        public static final class Pre extends MouseScrolled {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
                 super(screen, mouseX, mouseY, deltaX, deltaY);
@@ -642,7 +642,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseScrolled {
+        public static final class Post extends MouseScrolled {
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
                 super(screen, mouseX, mouseY, deltaX, deltaY);
@@ -659,7 +659,7 @@ public abstract class ScreenEvent extends Event {
      * @see InputConstants
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_key" target="_top">the online GLFW documentation</a>
      */
-    private static abstract class KeyInput extends ScreenEvent {
+    private static abstract sealed class KeyInput extends ScreenEvent {
         private final int keyCode;
         private final int scanCode;
         private final int modifiers;
@@ -719,7 +719,7 @@ public abstract class ScreenEvent extends Event {
      * @see KeyPressed.Pre
      * @see KeyPressed.Post
      */
-    public static abstract class KeyPressed extends KeyInput {
+    public static abstract sealed class KeyPressed extends KeyInput {
         @ApiStatus.Internal
         public KeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {
             super(screen, keyCode, scanCode, modifiers);
@@ -736,7 +736,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends KeyPressed {
+        public static final class Pre extends KeyPressed {
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -754,7 +754,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Post extends KeyPressed {
+        public static final class Post extends KeyPressed {
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -769,7 +769,7 @@ public abstract class ScreenEvent extends Event {
      * @see KeyReleased.Pre
      * @see KeyReleased.Post
      */
-    public static abstract class KeyReleased extends KeyInput {
+    public static abstract sealed class KeyReleased extends KeyInput {
         @ApiStatus.Internal
         public KeyReleased(Screen screen, int keyCode, int scanCode, int modifiers) {
             super(screen, keyCode, scanCode, modifiers);
@@ -786,7 +786,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends KeyReleased {
+        public static final class Pre extends KeyReleased {
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -804,7 +804,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Post extends KeyReleased {
+        public static final class Post extends KeyReleased {
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -820,7 +820,7 @@ public abstract class ScreenEvent extends Event {
      * @see CharacterTyped.Post
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_char" target="_top">the online GLFW documentation</a>
      */
-    public static class CharacterTyped extends ScreenEvent {
+    public static sealed class CharacterTyped extends ScreenEvent {
         private final char codePoint;
         private final int modifiers;
 
@@ -864,7 +864,7 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends CharacterTyped {
+        public static final class Pre extends CharacterTyped {
             @ApiStatus.Internal
             public Pre(Screen screen, char codePoint, int modifiers) {
                 super(screen, codePoint, modifiers);
@@ -881,7 +881,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends CharacterTyped {
+        public static final class Post extends CharacterTyped {
             @ApiStatus.Internal
             public Post(Screen screen, char codePoint, int modifiers) {
                 super(screen, codePoint, modifiers);
@@ -902,7 +902,7 @@ public abstract class ScreenEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Opening extends ScreenEvent {
+    public static final class Opening extends ScreenEvent {
         @Nullable
         private final Screen currentScreen;
         private Screen newScreen;
@@ -949,7 +949,7 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Closing extends ScreenEvent {
+    public static final class Closing extends ScreenEvent {
         @ApiStatus.Internal
         public Closing(Screen screen) {
             super(screen);

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @see Screenshot
  */
 @Cancelable
-public class ScreenshotEvent extends Event {
+public final class ScreenshotEvent extends Event {
     public static final Component DEFAULT_CANCEL_REASON = Component.literal("Screenshot canceled");
 
     private final NativeImage image;

--- a/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  */
 @Cancelable
-public class SystemMessageReceivedEvent extends Event {
+public final class SystemMessageReceivedEvent extends Event {
     private Component message;
     private final boolean overlay;
 

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see TextureStitchEvent.Post
  * @see TextureAtlas
  */
-public class TextureStitchEvent extends Event implements IModBusEvent
+public sealed class TextureStitchEvent extends Event implements IModBusEvent
 {
     private final TextureAtlas atlas;
 
@@ -80,7 +80,7 @@ public class TextureStitchEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus()} mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends TextureStitchEvent
+    public static final class Post extends TextureStitchEvent
     {
         @ApiStatus.Internal
         public Post(TextureAtlas map)

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fml.LogicalSide;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @Cancelable
-public class ToastAddEvent extends Event {
+public final class ToastAddEvent extends Event {
     private final Toast toast;
 
     public ToastAddEvent(Toast toast) {

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ComputeCameraAngles
  * @see ComputeFov
  */
-public abstract class ViewportEvent extends Event {
+public abstract sealed class ViewportEvent extends Event {
     private final GameRenderer renderer;
     private final Camera camera;
     private final double partialTick;
@@ -73,7 +73,7 @@ public abstract class ViewportEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class RenderFog extends ViewportEvent {
+    public static final class RenderFog extends ViewportEvent {
         private final FogMode mode;
         private final FogType type;
         private float farPlaneDistance;
@@ -182,7 +182,7 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeFogColor extends ViewportEvent {
+    public static final class ComputeFogColor extends ViewportEvent {
         private float red;
         private float green;
         private float blue;
@@ -254,7 +254,7 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeCameraAngles extends ViewportEvent {
+    public static final class ComputeCameraAngles extends ViewportEvent {
         private float yaw;
         private float pitch;
         private float roll;
@@ -327,7 +327,7 @@ public abstract class ViewportEvent extends Event {
      *
      * @see ComputeFovModifierEvent
      */
-    public static class ComputeFov extends ViewportEvent {
+    public static final class ComputeFov extends ViewportEvent {
         private final boolean usedConfiguredFov;
         private float fov;
 

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * @see PlaySoundSourceEvent
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundEvent extends SoundEvent
+public final class PlaySoundEvent extends SoundEvent
 {
     private final String name;
     private final SoundInstance originalSound;

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundSourceEvent extends SoundSourceEvent
+public final class PlaySoundSourceEvent extends SoundSourceEvent
 {
     @ApiStatus.Internal
     public PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlayStreamingSourceEvent extends SoundSourceEvent
+public final class PlayStreamingSourceEvent extends SoundSourceEvent
 {
     @ApiStatus.Internal
     public PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
+public final class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
 {
     @ApiStatus.Internal
     public SoundEngineLoadEvent(SoundEngine manager)

--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class GatherDataEvent extends Event implements IModBusEvent
+public final class GatherDataEvent extends Event implements IModBusEvent
 {
     private final DataGenerator dataGenerator;
     private final DataGeneratorConfig config;
@@ -54,7 +54,7 @@ public class GatherDataEvent extends Event implements IModBusEvent
     public boolean includeReports() { return this.config.reports; }
     public boolean validate() { return this.config.validate; }
 
-    public static class DataGeneratorConfig {
+    public static final class DataGeneratorConfig {
         private final Set<String> mods;
         private final Path path;
         private final Collection<Path> inputs;

--- a/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 /**
  * Fired on {@link PackRepository} creation to allow mods to add new pack finders.
  */
-public class AddPackFindersEvent extends Event implements IModBusEvent {
+public final class AddPackFindersEvent extends Event implements IModBusEvent {
     private final PackType packType;
     private final Consumer<RepositorySource> sources;
 

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executor;
  * The event is fired on each reload and lets modders add their own ReloadListeners, for server-side resources.
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}
  */
-public class AddReloadListenerEvent extends Event {
+public final class AddReloadListenerEvent extends Event {
     private final List<PreparableReloadListener> listeners = new ArrayList<>();
     private final ReloadableServerResources serverResources;
 

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
 @Cancelable
-public class AnvilUpdateEvent extends Event {
+public final class AnvilUpdateEvent extends Event {
     private final ItemStack left;
     private final ItemStack right;
     private final String name;

--- a/src/main/java/net/minecraftforge/event/CommandEvent.java
+++ b/src/main/java/net/minecraftforge/event/CommandEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 @Cancelable
-public class CommandEvent extends Event
+public final class CommandEvent extends Event
 {
     private ParseResults<CommandSourceStack> parse;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class DifficultyChangeEvent extends Event {
+public final class DifficultyChangeEvent extends Event {
     private final Difficulty difficulty;
     private final Difficulty oldDifficulty;
 

--- a/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
+++ b/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
@@ -17,7 +17,7 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * @author Curle
  */
-public class GameShuttingDownEvent extends Event
+public final class GameShuttingDownEvent extends Event
 {
     public GameShuttingDownEvent() {}
 }

--- a/src/main/java/net/minecraftforge/event/GatherComponentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/GatherComponentsEvent.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  Where all the events fore Gathering Components will exist.
  */
 
-public abstract class GatherComponentsEvent extends Event {
+public abstract sealed class GatherComponentsEvent extends Event {
     private final DataComponentMap.Builder components = DataComponentMap.builder();
     private final DataComponentMap originalComponents;
     private final Object owner;
@@ -54,7 +54,7 @@ public abstract class GatherComponentsEvent extends Event {
      *
      * References in {@link net.minecraft.world.item.Items} may not be valid at the current time.
      */
-    public static class Item extends GatherComponentsEvent {
+    public static final class Item extends GatherComponentsEvent {
         public Item(net.minecraft.world.item.Item item, DataComponentMap dataComponents) {
             super(item, dataComponents);
         }

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
-public abstract class GrindstoneEvent extends Event
+public abstract sealed class GrindstoneEvent extends Event
 {
     private final ItemStack top;
     private final ItemStack bottom;
@@ -79,7 +79,7 @@ public abstract class GrindstoneEvent extends Event
      * </ul>
      */
     @Cancelable
-    public static class OnPlaceItem extends GrindstoneEvent
+    public static final class OnPlaceItem extends GrindstoneEvent
     {
         private ItemStack output;
 
@@ -119,7 +119,7 @@ public abstract class GrindstoneEvent extends Event
      * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
      */
     @Cancelable
-    public static class OnTakeItem extends GrindstoneEvent
+    public static final class OnTakeItem extends GrindstoneEvent
     {
         private ItemStack newTop = ItemStack.EMPTY;
         private ItemStack newBottom = ItemStack.EMPTY;

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.ApiStatus;
  *  This also means that the two vanilla checks described above will not be called.
  */
 @Cancelable
-public class ItemStackedOnOtherEvent extends Event
+public final class ItemStackedOnOtherEvent extends Event
 {
     private final ItemStack carriedItem;
     private final ItemStack stackedOnItem;

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -24,7 +24,7 @@ import net.minecraftforge.fml.LogicalSide;
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
 @Cancelable
-public class LootTableLoadEvent extends Event
+public final class LootTableLoadEvent extends Event
 {
     private final ResourceLocation name;
     private LootTable table;

--- a/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * on both {@linkplain LogicalSide logical sides}.</p>
  */
-public class ModMismatchEvent extends Event implements IModBusEvent
+public final class ModMismatchEvent extends Event implements IModBusEvent
 {
     /**
      * The level being loaded. Useful for things like {@link net.minecraft.world.level.storage.DimensionDataStorage}

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -17,7 +17,7 @@ import java.util.List;
  * before tags and crafting recipes are sent to the client. Send datapack data
  * to clients when this event fires.
  */
-public class OnDatapackSyncEvent extends Event {
+public final class OnDatapackSyncEvent extends Event {
     private final PlayerList playerList;
 
     @Nullable

--- a/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
+++ b/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @Cancelable
-public class PlayLevelSoundEvent extends Event {
+public sealed class PlayLevelSoundEvent extends Event {
     private final Level level;
     private final float originalVolume;
     private final float originalPitch;
@@ -149,7 +149,7 @@ public class PlayLevelSoundEvent extends Event {
      * <p>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
-    public static class AtEntity extends PlayLevelSoundEvent {
+    public static final class AtEntity extends PlayLevelSoundEvent {
         private final Entity entity;
 
         public AtEntity(Entity entity, Holder<SoundEvent> sound, SoundSource source, float volume, float pitch) {
@@ -176,7 +176,7 @@ public class PlayLevelSoundEvent extends Event {
      * <p>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
-    public static class AtPosition extends PlayLevelSoundEvent {
+    public static final class AtPosition extends PlayLevelSoundEvent {
         private final Vec3 position;
 
         public AtPosition(Level level, Vec3 position, Holder<SoundEvent> sound, SoundSource source, float volume, float pitch) {

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -21,7 +21,7 @@ import net.minecraft.commands.Commands;
  *
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}
  */
-public class RegisterCommandsEvent extends Event
+public final class RegisterCommandsEvent extends Event
 {
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final Commands.CommandSelection environment;

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -35,7 +35,7 @@ import com.google.common.base.Preconditions;
  * @see StructuresBecomeConfiguredFix
  * @see #register(String, StructuresBecomeConfiguredFix.Conversion)
  */
-public class RegisterStructureConversionsEvent extends Event
+public final class RegisterStructureConversionsEvent extends Event
 {
     private final Map<String, StructuresBecomeConfiguredFix.Conversion> map;
 

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 @Cancelable
-public class ServerChatEvent extends Event {
+public final class ServerChatEvent extends Event {
     private final ServerPlayer player;
     private final String username;
     private final String rawText;

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -11,7 +11,7 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
  */
-public class TagsUpdatedEvent extends Event
+public final class TagsUpdatedEvent extends Event
 {
     private final RegistryAccess registryAccess;
     private final UpdateCause updateCause;

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -16,13 +16,13 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
-public class TickEvent extends Event {
+public sealed class TickEvent extends Event {
     public enum Type {
-        LEVEL, PLAYER, CLIENT, SERVER, RENDER;
+        LEVEL, PLAYER, CLIENT, SERVER, RENDER
     }
 
     public enum Phase {
-        START, END;
+        START, END
     }
 
     public final Type type;
@@ -35,7 +35,7 @@ public class TickEvent extends Event {
         this.phase = phase;
     }
 
-    public static class ServerTickEvent extends TickEvent {
+    public static sealed class ServerTickEvent extends TickEvent {
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
@@ -61,38 +61,38 @@ public class TickEvent extends Event {
             return server;
         }
 
-        public static class Pre extends ServerTickEvent {
+        public static final class Pre extends ServerTickEvent {
             public Pre(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server, Phase.START);
             }
         }
 
-        public static class Post extends ServerTickEvent {
+        public static final class Post extends ServerTickEvent {
             public Post(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server, Phase.END);
             }
         }
     }
 
-    public static class ClientTickEvent extends TickEvent {
+    public static sealed class ClientTickEvent extends TickEvent {
         protected ClientTickEvent(Phase phase) {
             super(Type.CLIENT, LogicalSide.CLIENT, phase);
         }
 
-        public static class Pre extends ClientTickEvent {
+        public static final class Pre extends ClientTickEvent {
             public Pre() {
                 super(Phase.START);
             }
         }
 
-        public static class Post extends ClientTickEvent {
+        public static final class Post extends ClientTickEvent {
             public Post() {
                 super(Phase.END);
             }
         }
     }
 
-    public static class LevelTickEvent extends TickEvent {
+    public static sealed class LevelTickEvent extends TickEvent {
         public final Level level;
         private final BooleanSupplier haveTime;
 
@@ -112,20 +112,20 @@ public class TickEvent extends Event {
             return this.haveTime.getAsBoolean();
         }
 
-        public static class Pre extends LevelTickEvent {
+        public static final class Pre extends LevelTickEvent {
             public Pre(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime, Phase.START);
             }
         }
 
-        public static class Post extends LevelTickEvent {
+        public static final class Post extends LevelTickEvent {
             public Post(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime, Phase.END);
             }
         }
     }
 
-    public static class PlayerTickEvent extends TickEvent {
+    public static sealed class PlayerTickEvent extends TickEvent {
         public final Player player;
 
         protected PlayerTickEvent(Player player, Phase phase) {
@@ -133,20 +133,20 @@ public class TickEvent extends Event {
             this.player = player;
         }
 
-        public static class Pre extends PlayerTickEvent {
+        public static final class Pre extends PlayerTickEvent {
             public Pre(Player player) {
                 super(player, Phase.START);
             }
         }
 
-        public static class Post extends PlayerTickEvent {
+        public static final class Post extends PlayerTickEvent {
             public Post(Player player) {
                 super(player, Phase.END);
             }
         }
     }
 
-    public static class RenderTickEvent extends TickEvent {
+    public static sealed class RenderTickEvent extends TickEvent {
         private final DeltaTracker timer;
 
         private RenderTickEvent(Phase phase, DeltaTracker timer) {
@@ -158,13 +158,13 @@ public class TickEvent extends Event {
             return this.timer;
         }
 
-        public static class Pre extends RenderTickEvent {
+        public static final class Pre extends RenderTickEvent {
             public Pre(DeltaTracker timer) {
                 super(Phase.START, timer);
             }
         }
 
-        public static class Post extends RenderTickEvent {
+        public static final class Post extends RenderTickEvent {
             public Post(DeltaTracker timer) {
                 super(Phase.END, timer);
             }

--- a/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
+++ b/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
  * Cancel this event to prevent Vanilla from posting the {@link GameEvent} to all nearby {@link net.minecraft.world.level.gameevent.GameEventListener GameEventListeners}.
  **/
 @Cancelable
-public class VanillaGameEvent extends Event
+public final class VanillaGameEvent extends Event
 {
     private final Level level;
     private final GameEvent vanillaEvent;

--- a/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
@@ -15,7 +15,7 @@ import net.minecraftforge.common.brewing.BrewingRecipe;
 import net.minecraftforge.common.brewing.IBrewingRecipe;
 import net.minecraftforge.eventbus.api.Event;
 
-public class BrewingRecipeRegisterEvent extends Event {
+public final class BrewingRecipeRegisterEvent extends Event {
     private final PotionBrewing.Builder builder;
     private final FeatureFlagSet features;
 

--- a/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * This event is called when a player picks up a potion from a brewing stand.
  */
-public class PlayerBrewedPotionEvent extends PlayerEvent
+public final class PlayerBrewedPotionEvent extends PlayerEvent
 {
     private final ItemStack stack;
 

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -12,9 +12,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import org.jetbrains.annotations.NotNull;
 
-public class PotionBrewEvent extends Event
+public sealed class PotionBrewEvent extends Event
 {
-    private NonNullList<ItemStack> stacks;
+    private final NonNullList<ItemStack> stacks;
 
     protected PotionBrewEvent(NonNullList<ItemStack> stacks)
     {
@@ -59,7 +59,7 @@ public class PotionBrewEvent extends Event
      * If this event is canceled, and items have been modified, PotionBrewEvent.Post will automatically be fired.
      **/
     @Cancelable
-    public static class Pre extends PotionBrewEvent
+    public static final class Pre extends PotionBrewEvent
     {
         public Pre(NonNullList<ItemStack> stacks)
         {
@@ -80,7 +80,7 @@ public class PotionBrewEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Post extends PotionBrewEvent
+    public static final class Post extends PotionBrewEvent
     {
         public Post(NonNullList<ItemStack> stacks)
         {

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
  * from 0-15 and indicates how many bookshelves surround the enchanting table. The {@link #itemStack} representing the item being
  * enchanted is also available.
  */
-public class EnchantmentLevelSetEvent extends net.minecraftforge.eventbus.api.Event
+public final class EnchantmentLevelSetEvent extends net.minecraftforge.eventbus.api.Event
 {
     private final Level level;
     private final BlockPos pos;

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.event.IModBusEvent;
  * <br>
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public class EntityAttributeCreationEvent extends Event implements IModBusEvent {
+public final class EntityAttributeCreationEvent extends Event implements IModBusEvent {
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier> map;
 
     public EntityAttributeCreationEvent(Map<EntityType<? extends LivingEntity>, AttributeSupplier> map) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  * <br>
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public class EntityAttributeModificationEvent extends Event implements IModBusEvent {
+public final class EntityAttributeModificationEvent extends Event implements IModBusEvent {
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> entityAttributes;
     private final List<EntityType<? extends LivingEntity>> entityTypes;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -40,7 +40,7 @@ public class EntityEvent extends Event {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class EntityConstructing extends EntityEvent {
+    public static final class EntityConstructing extends EntityEvent {
         public EntityConstructing(Entity entity) {
             super(entity);
         }
@@ -58,7 +58,7 @@ public class EntityEvent extends Event {
      * <br>
      * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class EnteringSection extends EntityEvent {
+    public static final class EnteringSection extends EntityEvent {
         private final long packedOldPos;
         private final long packedNewPos;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
@@ -27,7 +27,7 @@ import net.minecraftforge.fml.LogicalSide;
  * on both logical sides.
  **/
 @Cancelable
-public class EntityJoinLevelEvent extends EntityEvent {
+public final class EntityJoinLevelEvent extends EntityEvent {
     private final Level level;
     private final boolean loadedFromDisk;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * on both logical sides.
  **/
-public class EntityLeaveLevelEvent extends EntityEvent {
+public final class EntityLeaveLevelEvent extends EntityEvent {
     private final Level level;
 
     public EntityLeaveLevelEvent(Entity entity, Level level) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -22,7 +22,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @HasResult
-public class EntityMobGriefingEvent extends EntityEvent
+public final class EntityMobGriefingEvent extends EntityEvent
 {
     public EntityMobGriefingEvent(Entity entity)
     {

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  */
 
 @Cancelable
-public class EntityMountEvent extends EntityEvent
+public final class EntityMountEvent extends EntityEvent
 {
 
     private final Entity entityMounting;

--- a/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
 @net.minecraftforge.eventbus.api.Cancelable
-public class EntityStruckByLightningEvent extends EntityEvent
+public final class EntityStruckByLightningEvent extends EntityEvent
 {
     private final LightningBolt lightning;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
 @Cancelable
-public class EntityTeleportEvent extends EntityEvent
+public sealed class EntityTeleportEvent extends EntityEvent
 {
     protected double targetX;
     protected double targetY;
@@ -70,7 +70,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class TeleportCommand extends EntityTeleportEvent
+    public static final class TeleportCommand extends EntityTeleportEvent
     {
         public TeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
         {
@@ -94,7 +94,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class SpreadPlayersCommand extends EntityTeleportEvent
+    public static final class SpreadPlayersCommand extends EntityTeleportEvent
     {
         public SpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
         {
@@ -117,7 +117,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class EnderEntity extends EntityTeleportEvent
+    public static final class EnderEntity extends EntityTeleportEvent
     {
         private final LivingEntity entityLiving;
 
@@ -148,7 +148,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class EnderPearl extends EntityTeleportEvent
+    public static final class EnderPearl extends EntityTeleportEvent
     {
         private final ServerPlayer player;
         private final ThrownEnderpearl pearlEntity;
@@ -207,7 +207,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class ChorusFruit extends EntityTeleportEvent
+    public static final class ChorusFruit extends EntityTeleportEvent
     {
         private final LivingEntity entityLiving;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -24,7 +24,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
 @Cancelable
-public class EntityTravelToDimensionEvent extends EntityEvent
+public final class EntityTravelToDimensionEvent extends EntityEvent
 {
     private final ResourceKey<Level> dimension;
 

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  * You can also directly set the {@link ImpactResult} to change the impact behaviour.
  * @see #setImpactResult(ImpactResult)
  */
-public class ProjectileImpactEvent extends EntityEvent {
+public final class ProjectileImpactEvent extends EntityEvent {
     private final HitResult ray;
     private final Projectile projectile;
 

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -42,7 +42,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  *  Fired on the Mod bus {@link IModBusEvent}.<br>
  */
-public class SpawnPlacementRegisterEvent extends Event implements IModBusEvent {
+public final class SpawnPlacementRegisterEvent extends Event implements IModBusEvent {
     private final Map<EntityType<?>, MergedSpawnPredicate<?>> map;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -15,7 +15,7 @@ import net.minecraft.world.entity.item.ItemEntity;
  * it will add more time to the entities life equal to extraLife.
  */
 @Cancelable
-public class ItemExpireEvent extends ItemEvent
+public final class ItemExpireEvent extends ItemEvent
 {
 
     private int extraLife;

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
@@ -16,7 +16,7 @@ import net.minecraft.world.entity.player.Player;
  * removed from the inventory - and thus removed from the system.
  */
 @Cancelable
-public class ItemTossEvent extends ItemEvent
+public final class ItemTossEvent extends ItemEvent
 {
 
     private final Player player;

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @Cancelable
-public class AnimalTameEvent extends LivingEvent
+public final class AnimalTameEvent extends LivingEvent
 {
     private final Animal animal;
     private final Player tamer;

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class BabyEntitySpawnEvent extends Event {
+public final class BabyEntitySpawnEvent extends Event {
     private final Mob parentA;
     private final Mob parentB;
     private final Player causedByPlayer;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -31,7 +31,7 @@ import net.minecraft.world.entity.LivingEntity;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class LivingAttackEvent extends LivingEvent
+public final class LivingAttackEvent extends LivingEvent
 {
     private final DamageSource source;
     private final float amount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -23,7 +23,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  */
-public class LivingBreatheEvent extends LivingEvent {
+public final class LivingBreatheEvent extends LivingEvent {
     private boolean canBreathe;
     private boolean canRefillAir;
     private int consumeAirAmount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
@@ -34,7 +34,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @Cancelable
-public class LivingChangeTargetEvent extends LivingEvent {
+public final class LivingChangeTargetEvent extends LivingEvent {
     private final ILivingTargetType targetType;
     private final LivingEntity originalTarget;
     private LivingEntity newTarget;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
  *   Tadpole -> Frog when it grows up
  *   Mushroom Cow -> Cow when sheared
  */
-public class LivingConversionEvent extends LivingEvent {
+public sealed class LivingConversionEvent extends LivingEvent {
     public LivingConversionEvent(LivingEntity entity) {
         super(entity);
     }
@@ -42,7 +42,7 @@ public class LivingConversionEvent extends LivingEvent {
      * If cancelled, the replacement will not occur
      */
     @Cancelable
-    public static class Pre extends LivingConversionEvent {
+    public static final class Pre extends LivingConversionEvent {
         private final EntityType<? extends LivingEntity> outcome;
         private final Consumer<Integer> timer;
 
@@ -79,7 +79,7 @@ public class LivingConversionEvent extends LivingEvent {
      * itself with another entity.
      * The old living entity is likely to be removed right after this event.
      */
-    public static class Post extends LivingConversionEvent {
+    public static final class Post extends LivingConversionEvent {
         private final LivingEntity outcome;
 
         public Post(LivingEntity entity, LivingEntity outcome) {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -30,7 +30,7 @@ import net.minecraft.world.entity.LivingEntity;
  * @see LivingHurtEvent
  **/
 @Cancelable
-public class LivingDamageEvent extends LivingEvent
+public final class LivingDamageEvent extends LivingEvent
 {
     private final DamageSource source;
     private float amount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -32,7 +32,7 @@ import net.minecraft.world.entity.LivingEntity;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class LivingDeathEvent extends LivingEvent
+public final class LivingDeathEvent extends LivingEvent
 {
     private final DamageSource source;
     public LivingDeathEvent(LivingEntity entity, DamageSource source)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class LivingDestroyBlockEvent extends LivingEvent
+public final class LivingDestroyBlockEvent extends LivingEvent
 {
     private final BlockPos pos;
     private final BlockState state;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -34,7 +34,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @net.minecraftforge.eventbus.api.Cancelable
-public class LivingDropsEvent extends LivingEvent {
+public final class LivingDropsEvent extends LivingEvent {
     private final DamageSource source;
     private final Collection<ItemEntity> drops;
     private final boolean recentlyHit;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  **/
 @Cancelable
-public class LivingDrownEvent extends LivingEvent {
+public final class LivingDrownEvent extends LivingEvent {
     private boolean isDrowning;
     private float damageAmount;
     private int bubbleCount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import org.jetbrains.annotations.NotNull;
 
-public class LivingEntityUseItemEvent extends LivingEvent
+public sealed class LivingEntityUseItemEvent extends LivingEvent
 {
     private final ItemStack item;
     private int duration;
@@ -50,7 +50,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      *
      */
     @Cancelable
-    public static class Start extends LivingEntityUseItemEvent
+    public static final class Start extends LivingEntityUseItemEvent
     {
         public Start(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
@@ -65,7 +65,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      *
      */
     @Cancelable
-    public static class Tick extends LivingEntityUseItemEvent
+    public static final class Tick extends LivingEntityUseItemEvent
     {
         public Tick(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
@@ -86,7 +86,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * The only vanilla item this would effect are bows, and it would cause them NOT to fire there arrow.
      */
     @Cancelable
-    public static class Stop extends LivingEntityUseItemEvent
+    public static final class Stop extends LivingEntityUseItemEvent
     {
         public Stop(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
@@ -106,7 +106,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * The result item stack is the stack that is placed in the player's inventory in replacement of the stack that is currently being used.
      *
      */
-    public static class Finish extends LivingEntityUseItemEvent
+    public static final class Finish extends LivingEntityUseItemEvent
     {
         private ItemStack result;
         public Finish(LivingEntity entity, @NotNull ItemStack item, int duration, @NotNull ItemStack result)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class LivingEquipmentChangeEvent extends LivingEvent {
+public final class LivingEquipmentChangeEvent extends LivingEvent {
     private final EquipmentSlot slot;
     private final ItemStack from;
     private final ItemStack to;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -51,7 +51,7 @@ public class LivingEvent extends EntityEvent
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
     @Cancelable
-    public static class LivingTickEvent extends LivingEvent
+    public static final class LivingTickEvent extends LivingEvent
     {
         public LivingTickEvent(LivingEntity e){ super(e); }
     }
@@ -70,12 +70,12 @@ public class LivingEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class LivingJumpEvent extends LivingEvent
+    public static final class LivingJumpEvent extends LivingEvent
     {
         public LivingJumpEvent(LivingEntity e){ super(e); }
     }
 
-    public static class LivingVisibilityEvent extends LivingEvent
+    public static final class LivingVisibilityEvent extends LivingEvent
     {
         private double visibilityModifier;
         @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
  * by canceling the event.
  */
 @Cancelable
-public class LivingExperienceDropEvent extends LivingEvent
+public final class LivingExperienceDropEvent extends LivingEvent
 {
     @Nullable private final Player attackingPlayer;
     private final int originalExperiencePoints;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
@@ -28,7 +28,7 @@ import net.minecraft.world.entity.LivingEntity;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class LivingFallEvent extends LivingEvent {
+public final class LivingFallEvent extends LivingEvent {
     private double distance;
     private float damageMultiplier;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingGetProjectileEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingGetProjectileEvent.java
@@ -20,7 +20,7 @@ import net.minecraft.world.item.ItemStack;
  * <p>
  * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
  */
-public class LivingGetProjectileEvent extends LivingEvent
+public final class LivingGetProjectileEvent extends LivingEvent
 {
     private final ItemStack projectileWeaponItemStack;
     private ItemStack projectileItemStack;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
@@ -26,7 +26,7 @@ import net.minecraft.world.entity.LivingEntity;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class LivingHealEvent extends LivingEvent
+public final class LivingHealEvent extends LivingEvent
 {
     private float amount;
     public LivingHealEvent(LivingEntity entity, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
@@ -31,7 +31,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * @see LivingDamageEvent
  **/
 @net.minecraftforge.eventbus.api.Cancelable
-public class LivingHurtEvent extends LivingEvent
+public final class LivingHurtEvent extends LivingEvent
 {
     private final DamageSource source;
     private float amount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingMakeBrainEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingMakeBrainEvent.java
@@ -31,7 +31,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class LivingMakeBrainEvent extends LivingEvent
+public final class LivingMakeBrainEvent extends LivingEvent
 {
     private final BrainBuilder<?> brainBuilder;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
@@ -9,7 +9,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraft.world.entity.Mob;
 
 @HasResult
-public class LivingPackSizeEvent extends LivingEvent
+public final class LivingPackSizeEvent extends LivingEvent
 {
     private int maxPackSize;
     

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import org.jetbrains.annotations.ApiStatus;
 
-public class LivingSwapItemsEvent extends LivingEvent
+public sealed class LivingSwapItemsEvent extends LivingEvent
 {
 
     @ApiStatus.Internal
@@ -27,7 +27,7 @@ public class LivingSwapItemsEvent extends LivingEvent
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
      */
     @Cancelable
-    public static class Hands extends LivingSwapItemsEvent
+    public static final class Hands extends LivingSwapItemsEvent
     {
         private ItemStack toMainHand;
         private ItemStack toOffHand;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.LogicalSide;
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
 @Cancelable
-public class LivingUseTotemEvent extends LivingEvent
+public final class LivingUseTotemEvent extends LivingEvent
 {
     private final DamageSource source;
     private final ItemStack totem;

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.damagesource.DamageSource;
 import org.jetbrains.annotations.Nullable;
 
-public class LootingLevelEvent extends LivingEvent {
+public final class LootingLevelEvent extends LivingEvent {
 
     @Nullable
     private final DamageSource damageSource;

--- a/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-public class MobEffectEvent extends LivingEvent {
+public sealed class MobEffectEvent extends LivingEvent {
     @Nullable
     protected final MobEffectInstance effectInstance;
 
@@ -40,7 +40,7 @@ public class MobEffectEvent extends LivingEvent {
      * This Event does not have a result.
      */
     @Cancelable
-    public static class Remove extends MobEffectEvent {
+    public static final class Remove extends MobEffectEvent {
         private final MobEffect effect;
 
         public Remove(LivingEntity living, MobEffect effect) {
@@ -80,7 +80,7 @@ public class MobEffectEvent extends LivingEvent {
      * {@link Result#DEFAULT DEFAULT} will run vanilla logic to determine if this mob effect is applicable in {@link LivingEntity#canBeAffected}.
      */
     @HasResult
-    public static class Applicable extends MobEffectEvent {
+    public static final class Applicable extends MobEffectEvent {
         public Applicable(LivingEntity living, @NotNull MobEffectInstance effectInstance) {
             super(living, effectInstance);
         }
@@ -98,7 +98,7 @@ public class MobEffectEvent extends LivingEvent {
      * This event is not {@link Cancelable}.
      * This event does not have a result.
      */
-    public static class Added extends MobEffectEvent {
+    public static final class Added extends MobEffectEvent {
         private final MobEffectInstance oldEffectInstance;
         private final Entity source;
 
@@ -139,7 +139,7 @@ public class MobEffectEvent extends LivingEvent {
      * This event is not {@link Cancelable}.
      * This event does not have a result.
      */
-    public static class Expired extends MobEffectEvent {
+    public static final class Expired extends MobEffectEvent {
         public Expired(LivingEntity living, MobEffectInstance effect) {
             super(living, effect);
         }

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -36,7 +36,7 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * {@link AllowDespawn} is not related to the mob spawn event flow, as it fires when a despawn is attempted.
  */
-public abstract class MobSpawnEvent extends EntityEvent {
+public abstract sealed class MobSpawnEvent extends EntityEvent {
     private final ServerLevelAccessor level;
     private final double x;
     private final double y;
@@ -104,7 +104,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see SpawnPlacementRegisterEvent
      */
     @HasResult
-    public static class SpawnPlacementCheck extends Event {
+    public static final class SpawnPlacementCheck extends Event {
         private final EntityType<?> entityType;
         private final ServerLevelAccessor level;
         private final EntitySpawnReason spawnReason;
@@ -201,7 +201,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see {@link SpawnPlacementCheck} To modify the result of spawn placements at runtime.
      */
     @HasResult
-    public static class PositionCheck extends MobSpawnEvent {
+    public static final class PositionCheck extends MobSpawnEvent {
         @Nullable
         private final BaseSpawner spawner;
         private final EntitySpawnReason spawnReason;
@@ -245,7 +245,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
     @Cancelable
-    public static class FinalizeSpawn extends MobSpawnEvent {
+    public static final class FinalizeSpawn extends MobSpawnEvent {
         private final EntitySpawnReason spawnReason;
         @Nullable
         private final BaseSpawner spawner;
@@ -383,7 +383,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
     // TODO: 1.20 Move to standalone class, as it is unrelated to the complex mob spawning flow.
     // Such a refactor will allow the BaseSpawner and MobSpawnType params to be hoisted to MobSpawnEvent.
     @HasResult
-    public static class AllowDespawn extends MobSpawnEvent {
+    public static final class AllowDespawn extends MobSpawnEvent {
         public AllowDespawn(Mob mob, ServerLevelAccessor level) {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());
         }

--- a/src/main/java/net/minecraftforge/event/entity/living/MonsterDisguiseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MonsterDisguiseEvent.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event does not have a {@link Result}.
  */
 @Cancelable
-public class MonsterDisguiseEvent extends LivingEvent {
+public final class MonsterDisguiseEvent extends LivingEvent {
     private final Player player;
 
     public MonsterDisguiseEvent(Monster monster, Player player) {

--- a/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * at least for players.
  */
 @Cancelable
-public class ShieldBlockEvent extends LivingEvent {
+public final class ShieldBlockEvent extends LivingEvent {
     private final DamageSource source;
     private final float originalBlocked;
     private float dmgBlocked;

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  *
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class ZombieEvent extends EntityEvent {
+public sealed class ZombieEvent extends EntityEvent {
     private final Zombie zombie;
 
     public ZombieEvent(Zombie zombie)
@@ -59,7 +59,7 @@ public class ZombieEvent extends EntityEvent {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
     @HasResult
-    public static class SummonAidEvent extends ZombieEvent {
+    public static final class SummonAidEvent extends ZombieEvent {
         private Zombie customSummonedAid;
 
         private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
@@ -16,7 +16,7 @@ import net.minecraftforge.common.MinecraftForge;
  * @see AdvancementEarnEvent
  * @see AdvancementProgressEvent
  */
-public class AdvancementEvent extends PlayerEvent {
+public sealed class AdvancementEvent extends PlayerEvent {
     private final AdvancementHolder advancement;
 
     public AdvancementEvent(Player player, AdvancementHolder advancement) {
@@ -41,7 +41,7 @@ public class AdvancementEvent extends PlayerEvent {
      *
      * @see AdvancementProgress#isDone()
      */
-    public static class AdvancementEarnEvent extends AdvancementEvent {
+    public static final class AdvancementEarnEvent extends AdvancementEvent {
         public AdvancementEarnEvent(Player player, AdvancementHolder earned) {
             super(player, earned);
         }
@@ -59,7 +59,7 @@ public class AdvancementEvent extends PlayerEvent {
      * @see net.minecraft.server.PlayerAdvancements#award(Advancement, String)
      * @see net.minecraft.server.PlayerAdvancements#revoke(Advancement, String)
      */
-    public static class AdvancementProgressEvent extends AdvancementEvent {
+    public static final class AdvancementProgressEvent extends AdvancementEvent {
         private final AdvancementProgress advancementProgress;
         private final String criterionName;
         private final AdvancementEvent.AdvancementProgressEvent.ProgressType progressType;

--- a/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * ItemStacks are the inputs/output from the anvil. They cannot be edited.
  */
-public class AnvilRepairEvent extends PlayerEvent
+public final class AnvilRepairEvent extends PlayerEvent
 {
     @NotNull
     private final ItemStack left; // The left side of the input

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class ArrowLooseEvent extends PlayerEvent
+public final class ArrowLooseEvent extends PlayerEvent
 {
     private final ItemStack bow;
     private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class ArrowNockEvent extends PlayerEvent {
+public final class ArrowNockEvent extends PlayerEvent {
     private final ItemStack bow;
     private final InteractionHand hand;
     private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
@@ -25,7 +25,7 @@ import net.minecraft.world.entity.player.Player;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class AttackEntityEvent extends PlayerEvent
+public final class AttackEntityEvent extends PlayerEvent
 {
     private final Entity target;
     public AttackEntityEvent(Player player, Entity target)

--- a/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 @Cancelable
 @HasResult
 // TODO: Redesign BonemealEvent the whole thing, it doens't make sense.
-public class BonemealEvent extends PlayerEvent {
+public final class BonemealEvent extends PlayerEvent {
     private final Level level;
     private final BlockPos pos;
     private final BlockState block;

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -25,7 +25,7 @@ import net.minecraft.world.entity.player.Player;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @HasResult
-public class CriticalHitEvent extends PlayerEvent
+public final class CriticalHitEvent extends PlayerEvent
 {
     private float damageModifier;
     private final float oldDamageModifier;

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
@@ -22,7 +22,7 @@ import net.minecraft.world.entity.player.Player;
  */
 @Cancelable
 @Event.HasResult
-public class EntityItemPickupEvent extends PlayerEvent
+public final class EntityItemPickupEvent extends PlayerEvent
 {
     private final ItemEntity item;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
  */
 @Cancelable
 @Event.HasResult
-public class FillBucketEvent extends PlayerEvent
+public final class FillBucketEvent extends PlayerEvent
 {
 
     private final ItemStack current;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -22,7 +22,7 @@ import java.util.List;
  * The hook will still take the damage specified
  */
 @Cancelable
-public class ItemFishedEvent extends PlayerEvent {
+public final class ItemFishedEvent extends PlayerEvent {
     private final NonNullList<ItemStack> stacks = NonNullList.create();
     private final FishingHook hook;
     private int rodDamage;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -15,7 +15,7 @@ import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ItemTooltipEvent extends PlayerEvent
+public final class ItemTooltipEvent extends PlayerEvent
 {
     private final TooltipFlag flags;
     @NotNull

--- a/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
@@ -14,7 +14,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is cancelable which will stop the op or deop from happening.
  */
 @Cancelable
-public class PermissionsChangedEvent extends PlayerEvent
+public final class PermissionsChangedEvent extends PlayerEvent
 {
     private final int newLevel;
     private final int oldLevel;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 
-public class PlayerContainerEvent extends PlayerEvent
+public sealed class PlayerContainerEvent extends PlayerEvent
 {
     private final AbstractContainerMenu container;
     public PlayerContainerEvent(Player player, AbstractContainerMenu container)
@@ -17,14 +17,14 @@ public class PlayerContainerEvent extends PlayerEvent
         this.container = container;
     }
 
-    public static class Open extends PlayerContainerEvent
+    public static final class Open extends PlayerContainerEvent
     {
         public Open(Player player, AbstractContainerMenu container)
         {
             super(player, container);
         }
     }
-    public static class Close extends PlayerContainerEvent
+    public static final class Close extends PlayerContainerEvent
     {
         public Close(Player player, AbstractContainerMenu container)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -48,7 +48,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired from {@link ForgeEventFactory#onPlayerDestroyItem(Player, ItemStack, InteractionHand)}.<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerDestroyItemEvent extends PlayerEvent {
+public final class PlayerDestroyItemEvent extends PlayerEvent {
     @NotNull
     private final ItemStack original;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -66,7 +66,7 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class HarvestCheck extends PlayerEvent
+    public static final class HarvestCheck extends PlayerEvent
     {
         private final BlockState state;
         private boolean success;
@@ -103,7 +103,7 @@ public class PlayerEvent extends LivingEvent
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
     @Cancelable
-    public static class BreakSpeed extends PlayerEvent
+    public static final class BreakSpeed extends PlayerEvent
     {
         private static final BlockPos LEGACY_UNKNOWN = new BlockPos(0, -1, 0);
         private final BlockState state;
@@ -143,7 +143,7 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class NameFormat extends PlayerEvent
+    public static final class NameFormat extends PlayerEvent
     {
         private final Component username;
         private Component displayname;
@@ -186,7 +186,7 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class TabListNameFormat extends PlayerEvent
+    public static final class TabListNameFormat extends PlayerEvent
     {
         @Nullable
         private Component displayName;
@@ -212,7 +212,7 @@ public class PlayerEvent extends LivingEvent
      * Fired when the EntityPlayer is cloned, typically caused by the impl sending a RESPAWN_PLAYER event.
      * Either caused by death, or by traveling from the End to the overworld.
      */
-    public static class Clone extends PlayerEvent
+    public static final class Clone extends PlayerEvent
     {
         private final Player original;
         private final boolean wasDeath;
@@ -246,7 +246,7 @@ public class PlayerEvent extends LivingEvent
      * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
      *
      */
-    public static class StartTracking extends PlayerEvent {
+    public static final class StartTracking extends PlayerEvent {
 
         private final Entity target;
 
@@ -269,7 +269,7 @@ public class PlayerEvent extends LivingEvent
      * Fired when an Entity is stopped to be "tracked" by this player (the player no longer receives updates about this entity, e.g. motion).
      *
      */
-    public static class StopTracking extends PlayerEvent {
+    public static final class StopTracking extends PlayerEvent {
 
         private final Entity target;
 
@@ -294,7 +294,7 @@ public class PlayerEvent extends LivingEvent
      * allow mods to load an additional file from the players directory
      * containing additional mod related player data.
      */
-    public static class LoadFromFile extends PlayerEvent {
+    public static final class LoadFromFile extends PlayerEvent {
         private final File playerDirectory;
         private final String playerUUID;
 
@@ -346,7 +346,7 @@ public class PlayerEvent extends LivingEvent
      * <em>WARNING</em>: Do not overwrite the player's .dat file here. You will
      * corrupt the world state.
      */
-    public static class SaveToFile extends PlayerEvent {
+    public static final class SaveToFile extends PlayerEvent {
         private final File playerDirectory;
         private final String playerUUID;
 
@@ -386,7 +386,7 @@ public class PlayerEvent extends LivingEvent
         }
     }
 
-    public static class ItemPickupEvent extends PlayerEvent {
+    public static final class ItemPickupEvent extends PlayerEvent {
         /**
          * Original EntityItem with current remaining stack size
          */
@@ -411,7 +411,7 @@ public class PlayerEvent extends LivingEvent
         }
     }
 
-    public static class ItemCraftedEvent extends PlayerEvent {
+    public static final class ItemCraftedEvent extends PlayerEvent {
         @NotNull
         private final ItemStack crafting;
         private final Container craftMatrix;
@@ -434,7 +434,7 @@ public class PlayerEvent extends LivingEvent
         }
     }
 
-    public static class ItemSmeltedEvent extends PlayerEvent {
+    public static final class ItemSmeltedEvent extends PlayerEvent {
         @NotNull
         private final ItemStack smelting;
         public ItemSmeltedEvent(Player player, @NotNull ItemStack crafting)
@@ -450,21 +450,21 @@ public class PlayerEvent extends LivingEvent
         }
     }
 
-    public static class PlayerLoggedInEvent extends PlayerEvent {
+    public static final class PlayerLoggedInEvent extends PlayerEvent {
         public PlayerLoggedInEvent(Player player)
         {
             super(player);
         }
     }
 
-    public static class PlayerLoggedOutEvent extends PlayerEvent {
+    public static final class PlayerLoggedOutEvent extends PlayerEvent {
         public PlayerLoggedOutEvent(Player player)
         {
             super(player);
         }
     }
 
-    public static class PlayerRespawnEvent extends PlayerEvent {
+    public static final class PlayerRespawnEvent extends PlayerEvent {
         private final boolean endConquered;
 
         public PlayerRespawnEvent(Player player, boolean endConquered)
@@ -485,7 +485,7 @@ public class PlayerEvent extends LivingEvent
 
     }
 
-    public static class PlayerChangedDimensionEvent extends PlayerEvent {
+    public static final class PlayerChangedDimensionEvent extends PlayerEvent {
         private final ResourceKey<Level> fromDim;
         private final ResourceKey<Level> toDim;
         public PlayerChangedDimensionEvent(Player player, ResourceKey<Level> fromDim, ResourceKey<Level> toDim)
@@ -511,7 +511,7 @@ public class PlayerEvent extends LivingEvent
      * If the event is cancelled the game mode of the player is not changed and the value of <code>newGameMode</code> is ignored.
      */
     @Cancelable
-    public static class PlayerChangeGameModeEvent extends PlayerEvent
+    public static final class PlayerChangeGameModeEvent extends PlayerEvent
     {
         private final GameType currentGameMode;
         private GameType newGameMode;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.world.entity.player.Player;
  * @author Mithion
  *
  */
-public class PlayerFlyableFallEvent extends PlayerEvent
+public final class PlayerFlyableFallEvent extends PlayerEvent
 {
     private float distance;
     private float multiplier;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * All subclasses are fired on {@link MinecraftForge#EVENT_BUS}.
  * See the individual documentation on each subevent for more details.
  **/
-public class PlayerInteractEvent extends PlayerEvent {
+public sealed class PlayerInteractEvent extends PlayerEvent {
     private final InteractionHand hand;
     private final BlockPos pos;
     @Nullable
@@ -61,7 +61,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link EntityInteract}.
      */
     @Cancelable
-    public static class EntityInteractSpecific extends PlayerInteractEvent {
+    public static final class EntityInteractSpecific extends PlayerInteractEvent {
         private final Vec3 localPos;
         private final Entity target;
 
@@ -100,7 +100,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link RightClickItem}.
      */
     @Cancelable
-    public static class EntityInteract extends PlayerInteractEvent {
+    public static final class EntityInteract extends PlayerInteractEvent {
         private final Entity target;
 
         public EntityInteract(Player player, InteractionHand hand, Entity target) {
@@ -127,10 +127,10 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Note that handling things differently on the client vs server may cause desynchronizations!
      */
     @Cancelable
-    public static class RightClickBlock extends PlayerInteractEvent {
+    public static final class RightClickBlock extends PlayerInteractEvent {
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
-        private BlockHitResult hitVec;
+        private final BlockHitResult hitVec;
 
         public RightClickBlock(Player player, InteractionHand hand, BlockPos pos, BlockHitResult hitVec) {
             super(player, hand, pos, hitVec.getDirection());
@@ -195,7 +195,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then continue to other hands.
      */
     @Cancelable
-    public static class RightClickItem extends PlayerInteractEvent {
+    public static final class RightClickItem extends PlayerInteractEvent {
         public RightClickItem(Player player, InteractionHand hand) {
             super(player, hand, player.blockPosition(), null);
         }
@@ -206,7 +206,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * The server is not aware of when the client right clicks empty space with an empty hand, you will need to tell the server yourself.
      * This event cannot be canceled.
      */
-    public static class RightClickEmpty extends PlayerInteractEvent {
+    public static final class RightClickEmpty extends PlayerInteractEvent {
         public RightClickEmpty(Player player, InteractionHand hand) {
             super(player, hand, player.blockPosition(), null);
         }
@@ -228,7 +228,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Therefore, in creative mode, {@link #setUseBlock} and {@link #setUseItem} have no effect.
      */
     @Cancelable
-    public static class LeftClickBlock extends PlayerInteractEvent {
+    public static final class LeftClickBlock extends PlayerInteractEvent {
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
         private final Action action;
@@ -313,7 +313,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * The server is not aware of when the client left clicks empty space, you will need to tell the server yourself.
      * This event cannot be canceled.
      */
-    public static class LeftClickEmpty extends PlayerInteractEvent {
+    public static final class LeftClickEmpty extends PlayerInteractEvent {
         public LeftClickEmpty(Player player) {
             super(player, InteractionHand.MAIN_HAND, player.blockPosition(), null);
         }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
  * The event can be canceled, which will prevent the spawn point from being changed.
  */
 @Cancelable
-public class PlayerSetSpawnEvent extends PlayerEvent {
+public final class PlayerSetSpawnEvent extends PlayerEvent {
     private final @Nullable ServerPlayer.RespawnConfig config;
 
     @Deprecated(forRemoval = true, since = "1.21.5")

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerSleepInBedEvent extends PlayerEvent
+public final class PlayerSleepInBedEvent extends PlayerEvent
 {
     private BedSleepingProblem result = null;
     private final Optional<BlockPos> pos;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * @see PlayerSpawnPhantomsEvent#setResult for the effects of each result.
  */
 @Event.HasResult
-public class PlayerSpawnPhantomsEvent extends PlayerEvent {
+public final class PlayerSpawnPhantomsEvent extends PlayerEvent {
     private int phantomsToSpawn;
 
     public PlayerSpawnPhantomsEvent(Player player, int phantomsToSpawn) {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.world.entity.player.Player;
  * This is merely for purposes of listening for this to happen.<br/>
  * There is nothing that can be manipulated with this event.
  */
-public class PlayerWakeUpEvent extends PlayerEvent
+public final class PlayerWakeUpEvent extends PlayerEvent
 {
     private final boolean wakeImmediately;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -17,7 +17,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-public class PlayerXpEvent extends PlayerEvent {
+public sealed class PlayerXpEvent extends PlayerEvent {
     public PlayerXpEvent(Player player) {
         super(player);
     }
@@ -27,7 +27,7 @@ public class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     @Cancelable
-    public static class PickupXp extends PlayerXpEvent {
+    public static final class PickupXp extends PlayerXpEvent {
         private final ExperienceOrb orb;
 
         public PickupXp(Player player, ExperienceOrb orb) {
@@ -45,7 +45,7 @@ public class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     @Cancelable
-    public static class XpChange extends PlayerXpEvent {
+    public static final class XpChange extends PlayerXpEvent {
         private int amount;
 
         public XpChange(Player player, int amount) {
@@ -67,7 +67,7 @@ public class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     @Cancelable
-    public static class LevelChange extends PlayerXpEvent {
+    public static final class LevelChange extends PlayerXpEvent {
         private int levels;
 
         public LevelChange(Player player, int levels) {

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -24,7 +24,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * setResult(DEFAULT) causes game to check {@link Block#isBed(BlockState, BlockGetter, BlockPos, Entity)} instead
  */
 @HasResult
-public class SleepingLocationCheckEvent extends LivingEvent
+public final class SleepingLocationCheckEvent extends LivingEvent
 {
 
     private final BlockPos sleepingLocation;

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * setResult(DEFAULT) causes game to check !{@link Level#isDay()} instead.
  */
 @HasResult
-public class SleepingTimeCheckEvent extends PlayerEvent
+public final class SleepingTimeCheckEvent extends PlayerEvent
 {
     private final Optional<BlockPos> sleepingLocation;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-public class TradeWithVillagerEvent extends PlayerEvent
+public final class TradeWithVillagerEvent extends PlayerEvent
 {
     private final MerchantOffer offer;
     private final AbstractVillager abstractVillager;

--- a/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class FurnaceFuelBurnTimeEvent extends Event
+public final class FurnaceFuelBurnTimeEvent extends Event
 {
     @NotNull
     private final ItemStack itemStack;

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
-public class AlterGroundEvent extends Event {
+public final class AlterGroundEvent extends Event {
     private final LevelSimulatedReader level;
     private final RandomSource random;
     private final BlockPos pos;

--- a/src/main/java/net/minecraftforge/event/level/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/BlockEvent.java
@@ -64,7 +64,7 @@ public class BlockEvent extends Event {
      * Canceling this event will prevent the Block from being broken.
      */
     @Cancelable
-    public static class BreakEvent extends BlockEvent {
+    public static final class BreakEvent extends BlockEvent {
         /** Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer */
         private final Player player;
         private int exp;
@@ -113,7 +113,7 @@ public class BlockEvent extends Event {
      * If a Block Place event is cancelled, the block will not be placed.
      */
     @Cancelable
-    public static class EntityPlaceEvent extends BlockEvent {
+    public static sealed class EntityPlaceEvent extends BlockEvent {
         private final Entity entity;
         private final BlockSnapshot blockSnapshot;
         private final BlockState placedBlock;
@@ -146,7 +146,7 @@ public class BlockEvent extends Event {
      * block.
      */
     @Cancelable
-    public static class EntityMultiPlaceEvent extends EntityPlaceEvent {
+    public static final class EntityMultiPlaceEvent extends EntityPlaceEvent {
         private final List<BlockSnapshot> blockSnapshots;
 
         public EntityMultiPlaceEvent(@NotNull List<BlockSnapshot> blockSnapshots, @NotNull BlockState placedAgainst, @Nullable Entity entity) {
@@ -174,7 +174,7 @@ public class BlockEvent extends Event {
      * does. This event is only called on the server.
      */
     @Cancelable
-    public static class NeighborNotifyEvent extends BlockEvent {
+    public static final class NeighborNotifyEvent extends BlockEvent {
         private final EnumSet<Direction> notifiedSides;
         private final boolean forceRedstoneUpdate;
 
@@ -209,7 +209,7 @@ public class BlockEvent extends Event {
      * even if the liquid usually does do that (like water).
      */
     @HasResult
-    public static class CreateFluidSourceEvent extends Event {
+    public static final class CreateFluidSourceEvent extends Event {
         private final Level level;
         private final BlockPos pos;
         private final BlockState state;
@@ -242,10 +242,10 @@ public class BlockEvent extends Event {
      * {@link #getPos()} will return the position of the block to be changed.
      */
     @Cancelable
-    public static class FluidPlaceBlockEvent extends BlockEvent {
+    public static final class FluidPlaceBlockEvent extends BlockEvent {
         private final BlockPos liquidPos;
         private BlockState newState;
-        private BlockState origState;
+        private final BlockState origState;
 
         public FluidPlaceBlockEvent(LevelAccessor level, BlockPos pos, BlockPos liquidPos, BlockState state) {
             super(level, pos, state);
@@ -284,7 +284,7 @@ public class BlockEvent extends Event {
      * Fired when a crop block grows.  See subevents.
      *
      */
-    public static class CropGrowEvent extends BlockEvent {
+    public static sealed class CropGrowEvent extends BlockEvent {
         public CropGrowEvent(Level level, BlockPos pos, BlockState state) {
             super(level, pos, state);
         }
@@ -301,7 +301,7 @@ public class BlockEvent extends Event {
          * <br>
          */
         @HasResult
-        public static class Pre extends CropGrowEvent {
+        public static final class Pre extends CropGrowEvent {
             public Pre(Level level, BlockPos pos, BlockState state) {
                 super(level, pos, state);
             }
@@ -316,7 +316,7 @@ public class BlockEvent extends Event {
          * <br>
          * This event does not have a result. {@link HasResult}<br>
          */
-        public static class Post extends CropGrowEvent {
+        public static final class Post extends CropGrowEvent {
             private final BlockState originalState;
 
             public Post(Level level, BlockPos pos, BlockState original, BlockState state) {
@@ -335,7 +335,7 @@ public class BlockEvent extends Event {
      * This event is {@link Cancelable}
      */
     @Cancelable
-    public static class FarmlandTrampleEvent extends BlockEvent {
+    public static final class FarmlandTrampleEvent extends BlockEvent {
         private final Entity entity;
         private final double fallDistance;
 
@@ -361,7 +361,7 @@ public class BlockEvent extends Event {
      * If cancelled, the portal will not be spawned.
      */
     @Cancelable
-    public static class PortalSpawnEvent extends BlockEvent {
+    public static final class PortalSpawnEvent extends BlockEvent {
         private final PortalShape size;
 
         public PortalSpawnEvent(LevelAccessor level, BlockPos pos, BlockState state, PortalShape size) {
@@ -385,7 +385,7 @@ public class BlockEvent extends Event {
      * from changing the block's state.
      */
     @Cancelable
-    public static class BlockToolModificationEvent extends BlockEvent {
+    public static final class BlockToolModificationEvent extends BlockEvent {
         private final UseOnContext context;
         private final ToolAction toolAction;
         private final boolean simulate;

--- a/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkDataEvent extends ChunkEvent {
+public sealed class ChunkDataEvent extends ChunkEvent {
     private final SerializableChunkData data;
 
     public ChunkDataEvent(ChunkAccess chunk, SerializableChunkData data) {
@@ -53,8 +53,8 @@ public class ChunkDataEvent extends ChunkEvent {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkDataEvent {
-        private ChunkType status;
+    public static final class Load extends ChunkDataEvent {
+        private final ChunkType status;
 
         public Load(ChunkAccess chunk, SerializableChunkData data, ChunkType status) {
             super(chunk, data);
@@ -77,7 +77,7 @@ public class ChunkDataEvent extends ChunkEvent {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Save extends ChunkDataEvent {
+    public static final class Save extends ChunkDataEvent {
         public Save(ChunkAccess chunk, LevelAccessor world, SerializableChunkData data) {
             super(chunk, world, data);
         }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -56,7 +56,7 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkEvent
+    public static final class Load extends ChunkEvent
     {
         private final boolean newChunk;
 
@@ -91,7 +91,7 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Unload extends ChunkEvent
+    public static final class Unload extends ChunkEvent
     {
         public Unload(ChunkAccess chunk)
         {

--- a/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkTicketLevelUpdatedEvent extends Event
+public final class ChunkTicketLevelUpdatedEvent extends Event
 {
     private final ServerLevel level;
     private final long chunkPos;

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkWatchEvent extends Event {
+public sealed class ChunkWatchEvent extends Event {
     private final ServerLevel level;
     private final ServerPlayer player;
     private final ChunkPos pos;
@@ -67,7 +67,7 @@ public class ChunkWatchEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Watch extends ChunkWatchEvent {
+    public static final class Watch extends ChunkWatchEvent {
         private final LevelChunk chunk;
 
         public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel level) {
@@ -88,7 +88,7 @@ public class ChunkWatchEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class UnWatch extends ChunkWatchEvent {
+    public static final class UnWatch extends ChunkWatchEvent {
         public UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) {
             super(player, pos, level);
         }

--- a/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
@@ -25,7 +25,7 @@ import net.minecraft.world.level.Level;
  * Children do not use {@link HasResult}.<br>
  * Children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  */
-public class ExplosionEvent extends Event {
+public sealed class ExplosionEvent extends Event {
     private final Level level;
     private final Explosion explosion;
 
@@ -49,7 +49,7 @@ public class ExplosionEvent extends Event {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      */
     @Cancelable
-    public static class Start extends ExplosionEvent {
+    public static final class Start extends ExplosionEvent {
         public Start(Level level, Explosion explosion) {
             super(level, explosion);
         }
@@ -61,7 +61,7 @@ public class ExplosionEvent extends Event {
      * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      */
-    public static class Detonate extends ExplosionEvent {
+    public static final class Detonate extends ExplosionEvent {
         private final List<BlockPos> blocks;
         private final List<Entity> entityList;
 

--- a/src/main/java/net/minecraftforge/event/level/LevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/LevelEvent.java
@@ -61,7 +61,7 @@ public class LevelEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Load extends LevelEvent {
+    public static final class Load extends LevelEvent {
         public Load(LevelAccessor level) { super(level); }
     }
 
@@ -77,7 +77,7 @@ public class LevelEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Unload extends LevelEvent {
+    public static final class Unload extends LevelEvent {
         public Unload(LevelAccessor level) { super(level); }
     }
 
@@ -91,7 +91,7 @@ public class LevelEvent extends Event {
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Save extends LevelEvent {
+    public static final class Save extends LevelEvent {
         public Save(LevelAccessor level) { super(level); }
     }
 
@@ -108,7 +108,7 @@ public class LevelEvent extends Event {
      * @see ServerLevelData#isInitialized()
      */
     @Cancelable
-    public static class CreateSpawnPosition extends LevelEvent {
+    public static final class CreateSpawnPosition extends LevelEvent {
         private final ServerLevelData settings;
 
         public CreateSpawnPosition(LevelAccessor level, ServerLevelData settings) {
@@ -133,7 +133,7 @@ public class LevelEvent extends Event {
      * Canceling the event will result in an empty list, meaning no entity will be spawned.</p>
      */
     @Cancelable
-    public static class PotentialSpawns extends LevelEvent {
+    public static final class PotentialSpawns extends LevelEvent {
         private final MobCategory mobcategory;
         private final BlockPos pos;
         private final List<Weighted<MobSpawnSettings.SpawnerData>> list;

--- a/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
@@ -17,7 +17,7 @@ import com.google.common.base.Preconditions;
  * Base class for Noteblock Events
  *
  */
-public class NoteBlockEvent extends BlockEvent {
+public sealed class NoteBlockEvent extends BlockEvent {
     private int noteId;
 
     protected NoteBlockEvent(Level world, BlockPos pos, BlockState state, int note) {
@@ -65,7 +65,7 @@ public class NoteBlockEvent extends BlockEvent {
      * Canceling this event will stop the note from playing.
      */
     @Cancelable
-    public static class Play extends NoteBlockEvent {
+    public static final class Play extends NoteBlockEvent {
         private NoteBlockInstrument instrument;
 
         public Play(Level world, BlockPos pos, BlockState state, int note, NoteBlockInstrument instrument) {
@@ -87,7 +87,7 @@ public class NoteBlockEvent extends BlockEvent {
      * Canceling this event will not change the note and also stop the Noteblock from playing it's note.
      */
     @Cancelable
-    public static class Change extends NoteBlockEvent {
+    public static final class Change extends NoteBlockEvent {
         private final Note oldNote;
         private final Octave oldOctave;
 
@@ -111,7 +111,7 @@ public class NoteBlockEvent extends BlockEvent {
      * For altered notes such as G-Sharp / A-Flat the Sharp variant is used here.
      *
      */
-    public static enum Note {
+    public enum Note {
         F_SHARP,
         G,
         G_SHARP,
@@ -137,7 +137,7 @@ public class NoteBlockEvent extends BlockEvent {
      * Together with {@link Note} it fully describes the note.
      *
      */
-    public static enum Octave {
+    public enum Octave {
         LOW,
         MID,
         HIGH; // only valid for F_SHARP

--- a/src/main/java/net/minecraftforge/event/level/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/PistonEvent.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
-public abstract class PistonEvent extends BlockEvent
+public abstract sealed class PistonEvent extends BlockEvent
 {
 
     private final Direction direction;
@@ -72,7 +72,7 @@ public abstract class PistonEvent extends BlockEvent
     /**
      * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
      */
-    public static class Post extends PistonEvent
+    public static final class Post extends PistonEvent
     {
 
         public Post(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
@@ -86,7 +86,7 @@ public abstract class PistonEvent extends BlockEvent
      * Fires before the piston has updated block states. Cancellation prevents movement.
      */
     @Cancelable
-    public static class Pre extends PistonEvent
+    public static final class Pre extends PistonEvent
     {
 
         public Pre(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)

--- a/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 // TODO: Rename to BlockFeatureGrowEvent in 1.20
 @HasResult
 @Deprecated(forRemoval = true, since = "1.21.1") // Dont remove, rename
-public class SaplingGrowTreeEvent extends LevelEvent {
+public final class SaplingGrowTreeEvent extends LevelEvent {
     private final RandomSource randomSource;
     private final BlockPos pos;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.server.level.ServerLevel;
  *
  * setWakeUpTime(wakeUpTime) sets a new time that will be added to the dayTime.<br>
  */
-public class SleepFinishedTimeEvent extends LevelEvent
+public final class SleepFinishedTimeEvent extends LevelEvent
 {
     private long newTime;
     private final long minTime;

--- a/src/main/java/net/minecraftforge/event/network/ChannelRegistrationChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/ChannelRegistrationChangeEvent.java
@@ -18,9 +18,9 @@ import net.minecraftforge.eventbus.api.Event;
  * It seems plausible that this will fire multiple times for the same state, depending on what the server is doing.
  * It just directly dispatches upon receipt.
  */
-public class ChannelRegistrationChangeEvent extends Event {
+public final class ChannelRegistrationChangeEvent extends Event {
     public enum Type {
-        REGISTER, UNREGISTER;
+        REGISTER, UNREGISTER
     }
 
     private final Connection source;

--- a/src/main/java/net/minecraftforge/event/network/ConnectionStartEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/ConnectionStartEvent.java
@@ -18,7 +18,7 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * As this is a blocking event modders can also do things like load data. Need some example uses.
  */
-public class ConnectionStartEvent extends Event {
+public final class ConnectionStartEvent extends Event {
     private final Connection connection;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/network/GatherLoginConfigurationTasksEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/GatherLoginConfigurationTasksEvent.java
@@ -15,7 +15,7 @@ import net.minecraftforge.eventbus.api.Event;
  * Gathers tasks that need to be run during the initial login configuration.
  * @see net.minecraft.server.network.ServerConfigurationPacketListenerImpl#startConfiguration() startConfiguration
  */
-public class GatherLoginConfigurationTasksEvent extends Event {
+public final class GatherLoginConfigurationTasksEvent extends Event {
     private final Connection connection;
     private final Consumer<ConfigurationTask> add;
 

--- a/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
  * You can obtain a reference to the server with this event.
  * @author cpw
  */
-public class ServerAboutToStartEvent extends ServerLifecycleEvent {
+public final class ServerAboutToStartEvent extends ServerLifecycleEvent {
 
     public ServerAboutToStartEvent(MinecraftServer server)
     {

--- a/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.event.server;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.eventbus.api.Event;
 
-public class ServerLifecycleEvent extends Event
-{
+public sealed class ServerLifecycleEvent extends Event
+        permits ServerAboutToStartEvent, ServerStartedEvent, ServerStartingEvent, ServerStoppedEvent, ServerStoppingEvent {
 
     protected final MinecraftServer server;
 

--- a/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStartedEvent extends ServerLifecycleEvent
+public final class ServerStartedEvent extends ServerLifecycleEvent
 {
 
     public ServerStartedEvent(final MinecraftServer server)

--- a/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
@@ -15,7 +15,7 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStartingEvent extends ServerLifecycleEvent
+public final class ServerStartingEvent extends ServerLifecycleEvent
 {
     public ServerStartingEvent(final MinecraftServer server)
     {

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
@@ -14,7 +14,7 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStoppedEvent extends ServerLifecycleEvent {
+public final class ServerStoppedEvent extends ServerLifecycleEvent {
     public ServerStoppedEvent(MinecraftServer server)
     {
         super(server);

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStoppingEvent extends ServerLifecycleEvent
+public final class ServerStoppingEvent extends ServerLifecycleEvent
 {
     public ServerStoppingEvent(MinecraftServer server)
     {

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -24,7 +24,7 @@ import net.minecraftforge.eventbus.api.Event;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @Cancelable
-public class VillageSiegeEvent extends Event
+public final class VillageSiegeEvent extends Event
 {
     private final VillageSiege siege;
     private final Level level;

--- a/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
@@ -36,7 +36,7 @@ public class WandererTradesEvent extends Event {
 
     public static class Pool {
         private int rolls;
-        private List<ItemListing> entries;
+        private final List<ItemListing> entries;
 
         public Pool(Pair<ItemListing[], Integer> data) {
             this.rolls = data.getRight();

--- a/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;
 
-public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent {
+public sealed class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent {
     private final ModConfig config;
 
     ModConfigEvent(final ModConfig config) {
@@ -26,7 +26,7 @@ public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent 
      * Fired during mod and server loading, depending on {@link ModConfig.Type} of config file.
      * Any Config objects associated with this will be valid and can be queried directly.
      */
-    public static class Loading extends ModConfigEvent {
+    public static final class Loading extends ModConfigEvent {
         public Loading(final ModConfig config) {
             super(config);
         }
@@ -38,7 +38,7 @@ public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent 
      * and may not even be on the server or client threads. Ensure you properly synchronize
      * any resultant changes.
      */
-    public static class Reloading extends ModConfigEvent {
+    public static final class Reloading extends ModConfigEvent {
         public Reloading(final ModConfig config) {
             super(config);
         }
@@ -50,7 +50,7 @@ public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent 
      * server goes away, though it will fire on the dedicated server as well.
      * The config file will be saved after this event has fired.
      */
-    public static class Unloading extends ModConfigEvent {
+    public static final class Unloading extends ModConfigEvent {
         public Unloading(final ModConfig config) {
             super(config);
         }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class FMLClientSetupEvent extends ParallelDispatchEvent {
+public final class FMLClientSetupEvent extends ParallelDispatchEvent {
     public FMLClientSetupEvent(ModContainer container, ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  * @see DeferredWorkQueue to enqueue work to run on the main game thread after this event has
  * completed dispatch
  */
-public class FMLCommonSetupEvent extends ParallelDispatchEvent
+public final class FMLCommonSetupEvent extends ParallelDispatchEvent
 {
     public FMLCommonSetupEvent(final ModContainer container, final ModLoadingStage stage)
     {

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  * Supplied as a param to your mod's constructor to get access
  * to the mod EventBus and various mod-specific objects.
  */
-public class FMLConstructModEvent extends ParallelDispatchEvent {
+public final class FMLConstructModEvent extends ParallelDispatchEvent {
     public FMLConstructModEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent
+public final class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent
 {
     public FMLDedicatedServerSetupEvent(ModContainer container, ModLoadingStage stage)
     {

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * @author cpw
  */
-public class FMLLoadCompleteEvent extends ParallelDispatchEvent
+public final class FMLLoadCompleteEvent extends ParallelDispatchEvent
 {
     public FMLLoadCompleteEvent(final ModContainer container, final ModLoadingStage stage)
     {

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class InterModEnqueueEvent extends ParallelDispatchEvent
+public final class InterModEnqueueEvent extends ParallelDispatchEvent
 {
 
     public InterModEnqueueEvent(final ModContainer container, final ModLoadingStage stage)

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  * @see #getIMCStream()
  * @see #getIMCStream(Predicate)
  */
-public class InterModProcessEvent extends ParallelDispatchEvent
+public final class InterModProcessEvent extends ParallelDispatchEvent
 {
     public InterModProcessEvent(final ModContainer container, final ModLoadingStage stage)
     {

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class DataPackRegistryEvent extends Event implements IModBusEvent
+public sealed class DataPackRegistryEvent extends Event implements IModBusEvent
 {
     @ApiStatus.Internal
     public DataPackRegistryEvent() {}

--- a/src/main/java/net/minecraftforge/registries/IdMappingEvent.java
+++ b/src/main/java/net/minecraftforge/registries/IdMappingEvent.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * <p>
  * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS forge bus}.
  */
-public class IdMappingEvent extends Event
+public final class IdMappingEvent extends Event
 {
-    public static class ModRemapping
+    public static final class ModRemapping
     {
         public final ResourceLocation registry;
         public final ResourceLocation key;

--- a/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
@@ -18,7 +18,7 @@ import java.util.Locale;
 /**
  * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS forge bus}.
  */
-public class MissingMappingsEvent extends Event
+public final class MissingMappingsEvent extends Event
 {
     private final ResourceKey<? extends Registry<?>> key;
     private final IForgeRegistry<?> registry;

--- a/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 /**
  * Register new registries when you receive this event through {@link RegistryBuilder} and {@link #create(RegistryBuilder)}.
  */
-public class NewRegistryEvent extends Event implements IModBusEvent {
+public final class NewRegistryEvent extends Event implements IModBusEvent {
     private static final Logger LOGGER = LogUtils.getLogger();
     private final List<RegistryData<?>> registries = new ArrayList<>();
 
@@ -97,7 +97,7 @@ public class NewRegistryEvent extends Event implements IModBusEvent {
             Consumer<IForgeRegistry<V>> onFill
     ) {}
 
-    private static class RegistryHolder<V> implements Supplier<IForgeRegistry<V>> {
+    private static final class RegistryHolder<V> implements Supplier<IForgeRegistry<V>> {
         IForgeRegistry<V> registry = null;
 
         @Override

--- a/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
+++ b/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
@@ -24,7 +24,7 @@ import java.util.*;
  *
  * <p><strong>Note:</strong> All PermissionNodes that you want to use, <strong>must</strong> be registered!</p>
  */
-public class PermissionGatherEvent extends Event
+public sealed class PermissionGatherEvent extends Event
 {
 
     /**
@@ -32,9 +32,9 @@ public class PermissionGatherEvent extends Event
      * <p>Note: Create a new instance when registering a PermissionHandler.
      * If you cache it, make sure that your PermissionHandler is actually used after this event.</p>
      */
-    public static class Handler extends PermissionGatherEvent
+    public static final class Handler extends PermissionGatherEvent
     {
-        private Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
+        private final Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
 
         public Handler()
         {
@@ -60,7 +60,7 @@ public class PermissionGatherEvent extends Event
     /**
      * Used to register your PermissionNodes, <strong>every node that you want to use, must be registered!</strong>
      */
-    public static class Nodes extends PermissionGatherEvent
+    public static final class Nodes extends PermissionGatherEvent
     {
         private final Set<PermissionNode<?>> nodes = new HashSet<>();
 


### PR DESCRIPTION
There's a few reasons I think this is useful:
- Many events in Forge have internal constructors, but still technically permit extending due to the lack of a `final` or `sealed` modifier on the class. Sealing these classes helps modders avoid accidentally running into breaking changes and unsupported behaviour.
- Newer versions of EventBus use the `final` and `sealed`/`permits` information to improve memory usage.
- Giving the JVM more static guarantees logically would help it warmup faster.

Important: this isn't about preventing mod devs from extending Forge events altogether, it's about preventing breaking changes for those that do. If you need to extend a Forge event, please let us know and we'll design it with extending in mind (such as by making fields protected instead of private).