### PR TITLE
[1.21.5] Fix Swords and Pickaxes not using ToolActions

### DIFF
--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -8,7 +8,6 @@ package net.minecraftforge.common;
 import com.google.common.collect.Sets;
 import net.minecraftforge.common.extensions.IForgeBlock;
 import net.minecraftforge.common.extensions.IForgeItem;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -113,15 +112,12 @@ public class ToolActions
     public static final Set<ToolAction> DEFAULT_AXE_ACTIONS = of(AXE_DIG, AXE_STRIP, AXE_SCRAPE, AXE_WAX_OFF);
     public static final Set<ToolAction> DEFAULT_HOE_ACTIONS = of(HOE_DIG, HOE_TILL);
     public static final Set<ToolAction> DEFAULT_SHOVEL_ACTIONS = of(SHOVEL_DIG, SHOVEL_FLATTEN);
-    /** @deprecated See {@link #PICKAXE_DIG} for details */
-    @Deprecated(forRemoval = true, since = "1.21.5")
+    @Deprecated(since = "1.21.5")
     public static final Set<ToolAction> DEFAULT_PICKAXE_ACTIONS = of(PICKAXE_DIG);
-    /** @deprecated See {@link #SWORD_DIG} and {@link #SWORD_SWEEP} for details */
-    @Deprecated(forRemoval = true, since = "1.21.5")
+    @Deprecated(since = "1.21.5")
     public static final Set<ToolAction> DEFAULT_SWORD_ACTIONS = of(SWORD_DIG, SWORD_SWEEP);
     public static final Set<ToolAction> DEFAULT_SHEARS_ACTIONS = of(SHEARS_DIG, SHEARS_HARVEST, SHEARS_CARVE, SHEARS_DISARM);
-    /** @deprecated See {@link #SHIELD_BLOCK} for details */
-    @Deprecated(forRemoval = true, since = "1.21.5")
+    @Deprecated(since = "1.21.5")
     public static final Set<ToolAction> DEFAULT_SHIELD_ACTIONS = of(SHIELD_BLOCK);
     public static final Set<ToolAction> DEFAULT_FISHING_ROD_ACTIONS = of(FISHING_ROD_CAST);
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -5,31 +5,31 @@
 
 package net.minecraftforge.common.extensions;
 
-import java.util.function.Consumer;
-
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.item.*;
-import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.monster.Monster;
-import net.minecraft.world.entity.monster.piglin.PiglinAi;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.entity.monster.piglin.PiglinAi;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
@@ -37,6 +37,8 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 // TODO systemic review of all extension functions. lots of unused -C
 public interface IForgeItem {
@@ -315,6 +317,11 @@ public interface IForgeItem {
      * @return True if the stack can perform the action
      */
     default boolean canPerformAction(ItemStack stack, ToolAction toolAction) {
+        if (stack.is(ItemTags.SWORDS))
+            return ToolActions.DEFAULT_SWORD_ACTIONS.contains(toolAction);
+        else if (stack.is(ItemTags.PICKAXES))
+            return ToolActions.DEFAULT_PICKAXE_ACTIONS.contains(toolAction);
+
         return false;
     }
 


### PR DESCRIPTION
Despite the 1.21.5 upgrade effectively obsoleting ToolActions, they are still used in some patches for now. Since SwordItem and PickaxeItem are gone, I forgot to check if those items still declared their tool actions. This PR fixes the related issues of swords not having sweeping damage by checking if the item is of `ItemTags.SWORDS`, and same for pickaxes.

- Fixes #10512.
- Fixes #10519.