### PR TITLE
Make Loot Function without builders Constructors public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -779,3 +779,12 @@ protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
+#group public net.minecraft.world.level.storage.loot.functions
+public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction simpleBuilder(Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$Builder; # simpleBuilder
+public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(Ljava/util/List;Lnet/minecraft/core/Holder;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # constructor

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -780,7 +780,7 @@ public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
 #group public net.minecraft.world.level.storage.loot.functions
-public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction simpleBuilder(Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$Builder; # simpleBuilder
+public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction m_80683_(Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$Builder; # simpleBuilder
 public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # constructor
@@ -788,3 +788,4 @@ public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(L
 public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # constructor
+#endgroup

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -779,13 +779,11 @@ protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls
-#group public net.minecraft.world.level.storage.loot.functions
-public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction m_80683_(Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$Builder; # simpleBuilder
 public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction m_80683_(Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$Builder; # simpleBuilder
 public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(Ljava/util/List;Lnet/minecraft/core/Holder;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # constructor
 public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # constructor
-#endgroup


### PR DESCRIPTION
along with LootItemConditionalFunction#simpleBuilder

Allows modders to not need AT entries to Datagen these