### PR TITLE
[1.21.5] Add ChunkEvent.LightingCalculated

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ThreadedLevelLightEngine.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ThreadedLevelLightEngine.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/level/ThreadedLevelLightEngine.java
++++ b/net/minecraft/server/level/ThreadedLevelLightEngine.java
+@@ -171,6 +_,7 @@
+         }, () -> "lightChunk " + chunkpos + " " + p_9355_));
+         return CompletableFuture.supplyAsync(() -> {
+             p_9354_.setLightCorrect(true);
++            net.minecraftforge.common.ForgeHooks.fireLightingCalculatedEvent(p_9354_);
+             return p_9354_;
+         }, p_280982_ -> this.addTask(chunkpos.x, chunkpos.z, ThreadedLevelLightEngine.TaskType.POST_UPDATE, p_280982_));
+     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -153,6 +153,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.living.LivingGetProjectileEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.NoteBlockEvent;
+import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.event.network.CustomPayloadEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fluids.FluidType;
@@ -188,6 +189,7 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.jetbrains.annotations.ApiStatus;
@@ -204,6 +206,10 @@ public final class ForgeHooks {
 
     private ForgeHooks() {}
 
+    public static void fireLightingCalculatedEvent(ChunkAccess chunk) {
+        MinecraftForge.EVENT_BUS.post(new ChunkEvent.LightingCalculated(chunk));
+    }
+    
     public static boolean canContinueUsing(@NotNull ItemStack from, @NotNull ItemStack to) {
         if (!from.isEmpty() && !to.isEmpty()) {
             return from.getItem().canContinueUsing(from, to);

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -102,7 +102,7 @@ public class ChunkEvent extends LevelEvent {
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class LightingCalculated extends ChunkEvent {
+    public static final class LightingCalculated extends ChunkEvent {
         public LightingCalculated(ChunkAccess chunk) {
             super(chunk);
         }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -92,7 +92,7 @@ public class ChunkEvent extends LevelEvent {
     
     /**
      * ChunkEvent.LightingCalculated is fired when MinecraftForge flags that lighting is correct in a chunk.<br>
-     * This event is fired during light propagation in ThreadedLightEngine.CompletableFuture(), specifically upon setting 
+     * This event is fired during light propagation in ThreadedLevelLightEngine.CompletableFuture(), specifically upon setting 
      * the ChunkAccess isLightCorrect to true.<br>
      *
      * ThreadedLevelLightEngine.CompletableFuture(). <br>

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -98,4 +98,23 @@ public class ChunkEvent extends LevelEvent
             super(chunk);
         }
     }
+    
+    /**
+     * ChunkEvent.LightingCalculated is fired when MinecraftForge flags that lighting is correct in a chunk.<br>
+     * This event is fired during light propagation in <br>
+     *
+     * ThreadedLevelLightEngine.CompletableFuture(). <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class LightingCalculated extends ChunkEvent
+    {
+        public LightingCalculated(ChunkAccess chunk)
+        {
+            super(chunk);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -22,24 +22,20 @@ import org.jetbrains.annotations.ApiStatus;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkEvent extends LevelEvent
-{
+public class ChunkEvent extends LevelEvent {
     private final ChunkAccess chunk;
 
-    public ChunkEvent(ChunkAccess chunk)
-    {
+    public ChunkEvent(ChunkAccess chunk) {
         super(chunk.getWorldForge());
         this.chunk = chunk;
     }
 
-    public ChunkEvent(ChunkAccess chunk, LevelAccessor level)
-    {
+    public ChunkEvent(ChunkAccess chunk, LevelAccessor level) {
         super(level);
         this.chunk = chunk;
     }
 
-    public ChunkAccess getChunk()
-    {
+    public ChunkAccess getChunk() {
         return chunk;
     }
 
@@ -56,13 +52,11 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkEvent
-    {
+    public static class Load extends ChunkEvent {
         private final boolean newChunk;
 
         @ApiStatus.Internal
-        public Load(ChunkAccess chunk, boolean newChunk)
-        {
+        public Load(ChunkAccess chunk, boolean newChunk) {
             super(chunk);
             this.newChunk = newChunk;
         }
@@ -74,8 +68,7 @@ public class ChunkEvent extends LevelEvent
          *
          * @return whether the Chunk is newly generated
          */
-        public boolean isNewChunk()
-        {
+        public boolean isNewChunk() {
             return newChunk;
         }
     }
@@ -91,17 +84,16 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Unload extends ChunkEvent
-    {
-        public Unload(ChunkAccess chunk)
-        {
+    public static class Unload extends ChunkEvent {
+        public Unload(ChunkAccess chunk) {
             super(chunk);
         }
     }
     
     /**
      * ChunkEvent.LightingCalculated is fired when MinecraftForge flags that lighting is correct in a chunk.<br>
-     * This event is fired during light propagation in <br>
+     * This event is fired during light propagation in ThreadedLightEngine.CompletableFuture(), specifically upon setting 
+     * the ChunkAccess isLightCorrect to true.<br>
      *
      * ThreadedLevelLightEngine.CompletableFuture(). <br>
      * This event is not {@link Cancelable}.<br>
@@ -110,10 +102,8 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class LightingCalculated extends ChunkEvent
-    {
-        public LightingCalculated(ChunkAccess chunk)
-        {
+    public static class LightingCalculated extends ChunkEvent {
+        public LightingCalculated(ChunkAccess chunk) {
             super(chunk);
         }
     }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -94,8 +94,9 @@ public class ChunkEvent extends LevelEvent {
      * ChunkEvent.LightingCalculated is fired when MinecraftForge flags that lighting is correct in a chunk.<br>
      * This event is fired during light propagation in ThreadedLevelLightEngine.CompletableFuture(), specifically upon setting 
      * the ChunkAccess isLightCorrect to true.<br>
-     *
-     * ThreadedLevelLightEngine.CompletableFuture(). <br>
+     * <br>
+     * The game test for this event is lighting_event_test in net.minecraftforge.debug.chunk<br>
+     * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
      * This event does not have a result. {@link HasResult} <br>

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,13 +5,13 @@ logoFile="forge_logo.png"
 license="LGPL v2.1"
 
 [[mods]]
-    modId="forge"
-    version="${global.forgeVersion}"
-    updateJSONURL="https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json"
-    displayURL="https://minecraftforge.net/"
-    displayName="Forge"
-    credits="Anyone who has contributed on Github and supports our development"
-    authors="LexManos,cpw"
-    description='''
-    Forge, a broad compatibility API.
-    '''
+modId="forge"
+version="${global.forgeVersion}"
+updateJSONURL="https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json"
+displayURL="https://minecraftforge.net/"
+displayName="Forge"
+credits="Anyone who has contributed on Github and supports our development"
+authors="LexManos,cpw"
+description='''
+Forge, a broad compatibility API.
+'''

--- a/src/test/generated/lighting_event_test/data/forge/test_instance/lighting_event_test/test_lighting_event_fires.json
+++ b/src/test/generated/lighting_event_test/data/forge/test_instance/lighting_event_test/test_lighting_event_fires.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:lighting_event_test/test_lighting_event_fires",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
@@ -1,7 +1,11 @@
 package net.minecraftforge.debug.chunk;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -17,6 +21,8 @@ import net.minecraftforge.test.BaseTestMod;
 public class LightingEventTest extends BaseTestMod {
     public static final String MODID = "lighting_event_test";
 
+    private static final int MAX_CHUNK_LOCATION_ATTEMPTS = 5;
+
     public LightingEventTest(FMLJavaModLoadingContext context) {
         super(context);
     }
@@ -26,8 +32,29 @@ public class LightingEventTest extends BaseTestMod {
         var eventFired = helper.boolFlag("eventFired");
         helper.<ChunkEvent.LightingCalculated>addEventListener(event -> eventFired.set(true));
 
-        BlockPos pos = helper.absolutePos(BlockPos.ZERO);
-        helper.getLevel().getChunkAt(pos); // Trigger chunk load (which eventually fires lighting logic)
+        var random = RandomSource.create();
+        var level = helper.getLevel();
+        var chunkSource = level.getChunkSource();
+
+        // try to find a far away chunk that is not already ticking
+        int attempts;
+        var origin = helper.absolutePos(BlockPos.ZERO);
+        ChunkAccess chunk = null;
+        for (attempts = 0; attempts < MAX_CHUNK_LOCATION_ATTEMPTS && chunk == null; attempts++) {
+            int x = random.nextInt(1, 10) * 10000;
+            int z = random.nextInt(1, 10) * 10000;
+            chunk = level.getChunk(origin.offset(x, 0, z));
+
+            // If the chunk is already ticking, we can't force it
+            chunk = chunkSource.isPositionTicking(chunk.getPos().toLong()) ? null : chunk;
+        }
+
+        if (chunk == null) {
+            helper.fail(Component.literal("Failed to find a far away chunk that is not already ticking after " + MAX_CHUNK_LOCATION_ATTEMPTS + " attempts"));
+            return;
+        } else if (attempts > 1) {
+            helper.say("WARNING: Finding a far away chunk took " + attempts + " attempts.", ChatFormatting.YELLOW);
+        }
 
         helper.runAfterDelay(20, () -> {
             if (!eventFired.getBool()) {

--- a/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
@@ -2,48 +2,39 @@ package net.minecraftforge.debug.chunk;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
-import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTest;
 import net.minecraftforge.gametest.GameTestNamespace;
 import net.minecraftforge.test.BaseTestMod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This is a test for the ChunkEvent.LightingCalculated event.
  */
-@Mod(LightingEventTest.MODID)
 @GameTestNamespace("forge")
+@Mod(LightingEventTest.MODID)
 public class LightingEventTest extends BaseTestMod {
     public static final String MODID = "lighting_event_test";
-
-    // Atomic boolean is to ensure multi-thread safety
-    private static final AtomicBoolean eventFired = new AtomicBoolean(false);
 
     public LightingEventTest(FMLJavaModLoadingContext context) {
         super(context);
     }
 
-    @net.minecraftforge.eventbus.api.SubscribeEvent
-    public static void onLightingCalculated(ChunkEvent.LightingCalculated event) {
-        ChunkAccess chunk = event.getChunk();
-        System.out.println("[DEBUG] LightingCalculated event fired for chunk: " + chunk.getPos());
-        eventFired.set(true);
-    }
-
-    @GameTest(structure = "lighting_event_test:lighting_event_test")
+    @GameTest
     public static void testLightingEventFires(GameTestHelper helper) {
+        var eventFired = helper.boolFlag("eventFired");
+        helper.<ChunkEvent.LightingCalculated>addEventListener(event -> eventFired.set(true));
+
         BlockPos pos = helper.absolutePos(BlockPos.ZERO);
         helper.getLevel().getChunkAt(pos); // Trigger chunk load (which eventually fires lighting logic)
 
-        helper.runAfterDelay(60, () -> {
-            if (eventFired.get()) {
-                helper.succeed();
-            } else {
+        helper.runAfterDelay(20, () -> {
+            if (!eventFired.getBool()) {
                 helper.fail("LightingCalculated event was not fired!");
             }
+
+            helper.succeed();
         });
     }
 }

--- a/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.debug.chunk;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraftforge.event.level.ChunkEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.gametest.GameTest;
+import net.minecraftforge.gametest.GameTestNamespace;
+import net.minecraftforge.test.BaseTestMod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This is a test for the ChunkEvent.LightingCalculated event.
+ */
+@Mod(LightingEventTest.MODID)
+@GameTestNamespace("forge")
+public class LightingEventTest extends BaseTestMod {
+    public static final String MODID = "lighting_event_test";
+
+    // Atomic boolean is to ensure multi-thread safety
+    private static final AtomicBoolean eventFired = new AtomicBoolean(false);
+
+    public LightingEventTest(FMLJavaModLoadingContext context) {
+        super(context);
+    }
+
+    @net.minecraftforge.eventbus.api.SubscribeEvent
+    public static void onLightingCalculated(ChunkEvent.LightingCalculated event) {
+        ChunkAccess chunk = event.getChunk();
+        System.out.println("[DEBUG] LightingCalculated event fired for chunk: " + chunk.getPos());
+        eventFired.set(true);
+    }
+
+    @GameTest(structure = "lighting_event_test:lighting_event_test")
+    public static void testLightingEventFires(GameTestHelper helper) {
+        BlockPos pos = helper.absolutePos(BlockPos.ZERO);
+        helper.getLevel().getChunkAt(pos); // Trigger chunk load (which eventually fires lighting logic)
+
+        helper.runAfterDelay(60, () -> {
+            if (eventFired.get()) {
+                helper.succeed();
+            } else {
+                helper.fail("LightingCalculated event was not fired!");
+            }
+        });
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -22,11 +22,11 @@ import net.minecraftforge.test.BaseTestMod;
 public class ForcedChunkLoadingTest extends BaseTestMod {
     static final String MOD_ID = "forced_chunk_loading";
 
+    private static final int MAX_CHUNK_LOCATION_ATTEMPTS = 5;
+
     public ForcedChunkLoadingTest(FMLJavaModLoadingContext context) {
         super(context);
     }
-
-    private static final int MAX_CHUNK_LOCATION_ATTEMPTS = 5;
 
     @GameTest
     public static void force_far_away_chunk(GameTestHelper helper) {


### PR DESCRIPTION
Adds an event, "LightingCalculated(ChunkAccess chunk)",  to the event bus in "ChunkEvent.java" that flags the lighting for a chunk as correct based on the "ThreadedLevelLightEngine.java" class using a hook in "ForgeHooks.java".

QA was completed via a custom logging mod and prints to the console as the game runs, as shown in the screenshot below.  Both the new event and the load event mentioned in the issue are tested to verify that there was no regression in the implementation of this event.

![image](https://github.com/user-attachments/assets/cebbabb7-3c78-487e-a434-89ca6198fab1)
