### PR TITLE
Update CREDITS.txt to fix typo

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -58,7 +58,7 @@ It also contains code from the Maven project for performing versioned dependency
 resolution. http://maven.apache.org/
 
 It also contains a partial repackaging of the javaxdelta library from http://sourceforge.net/projects/javaxdelta/
-with credit to it's authors.
+with credit to its authors.
 
 Forge Mod Loader downloads components from the Minecraft Coder Pack
 (http://mcp.ocean-labs.de/index.php/Main_Page) with kind permission from the MCP team.


### PR DESCRIPTION
Fixed a grammatical error in `CREDITS.txt`: corrected "it's authors" to the proper possessive form "its authors" in a sentence crediting the javaxdelta library authors.