### PR TITLE
Ensure changes from keyboard in ForgeSlider behave as changes from mouse

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java
@@ -109,7 +109,10 @@ public class ForgeSlider extends AbstractSliderButton {
      * @param value The new slider value
      */
     public void setValue(double value) {
+        double oldValue = this.value;
         this.value = this.snapToNearest((value - this.minValue) / (this.maxValue - this.minValue));
+        if (!Mth.equal(oldValue, this.value))
+            this.applyValue();
         this.updateMessage();
     }
 


### PR DESCRIPTION
## Description

Using `ForgeSlider` in a screen, I wanted to get notifications when the slider's value changes. To do so, I extended the class and overrode the `applyValue()` method. Here is my custom slider:
```java
    private final static class CustomSlider extends ForgeSlider {

        public interface ChangeListener {
            public void onValueChanged(int value);
        }

        private final ChangeListener changeListener;

        public CustomSlider(final int x, final int y, final int width, final int height,
                final Component prefix, final Component suffix, final double minValue,
                final double maxValue, final double currentValue, final double stepSize,
                final int precision, final boolean drawString,
                final ChangeListener changeListener) {
            super(x, y, width, height, prefix, suffix, minValue, maxValue, currentValue, stepSize,
                    precision, drawString);
            this.changeListener = changeListener;
        }

        @Override
        protected void applyValue() {
            changeListener.onValueChanged(getValueInt());
        }
    }
```

It's working well when using the mouse but it doesn't when using the keyboard on the slider. Checking the code, I saw the mouse changes lead to a [`setSliderValue()`](https://github.com/MinecraftForge/MinecraftForge/blob/77af36b8078af8ad71fadd336d439a2ec8b2a971/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java#L155) call when keyboard changes are calling [`setValue()`](https://github.com/MinecraftForge/MinecraftForge/blob/77af36b8078af8ad71fadd336d439a2ec8b2a971/src/main/java/net/minecraftforge/client/gui/widget/ForgeSlider.java#L112). The first one calls `applyValue()` but the second doesn't.

## Changes made

This PR modifies the `setValue()` method to behaves as the `setSliderValue()` and have a consistent behavior.
