### PR TITLE
[1.21.5] Update MDK to fix OOM error and Mixin

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -22,17 +22,13 @@ minecraft {
     // official   MCVersion             Official field/method names from Mojang mapping files
     // parchment  YYYY.MM.DD-MCVersion  Open community-sourced parameter names and javadocs layered on top of official
     //
-    // You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
-    // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
-    //
     // Parchment is an unofficial project maintained by ParchmentMC, separate from MinecraftForge
     // Additional setup is needed to use their mappings: https://parchmentmc.org/docs/getting-started
     //
-    // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
     mappings channel: mapping_channel, version: mapping_version
-    
-    // Tell FG to not automtically create the reobf tasks, as we now use Official mappings at runtime, If you don't use them at dev time then you'll have to fix your reobf yourself.
+
+    // Forge 1.20.6 and newer use official mappings at runtime, so we shouldn't reobf from official to SRG
     reobf = false
 
     // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.
@@ -50,8 +46,7 @@ minecraft {
     // By default, the folder name of a run configuration is the name of the Gradle project containing it.
     // generateRunFolders = true
 
-    // This property enables access transformers for use in development.
-    // They will be applied to the Minecraft artifact.
+    // This property enables access transformers for use in development, applied to the Minecraft artifact.
     // The access transformer file can be anywhere in the project.
     // However, it must be at "META-INF/accesstransformer.cfg" in the final mod jar to be loaded by Forge.
     // This default location is a best practice to automatically put the file in the right place in the final jar.
@@ -72,9 +67,6 @@ minecraft {
             // "REGISTRYDUMP": For getting the contents of all registries.
             property 'forge.logging.markers', 'REGISTRIES'
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             property 'forge.logging.console.level', 'debug'
         }
 
@@ -213,8 +205,7 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
 }
 
-// IntelliJ no longer downloads javadocs and sources by default.
-// This tells Gradle to force IDEA to do it.
+// IntelliJ no longer downloads javadocs and sources by default, this tells Gradle to force IntelliJ to do it.
 idea.module { downloadJavadoc = downloadSources = true }
 
 eclipse {
@@ -224,8 +215,7 @@ eclipse {
     synchronizationTasks 'genEclipseRuns'
 }
 
-// Merge the resources and classes into the same directory. 
-// This is done because java expects modules to be in a single directory.
+// Merge the resources and classes into the same directory, because Java expects modules to be in a single directory.
 // And if we have it in multiple we have to do performance intensive hacks like having the UnionFileSystem
 // This will eventually be migrated to ForgeGradle so modders don't need to manually do it. But that is later.
 sourceSets.each {

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -110,7 +110,26 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
     // Put repositories for dependencies here
-    // ForgeGradle automatically adds the Forge maven and Maven Central for you
+    mavenCentral()
+    maven {
+        name = 'Forge'
+        url = 'https://maven.minecraftforge.net'
+    }
+    maven {
+        name = 'Minecraft libraries'
+        url = 'https://libraries.minecraft.net'
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'Sponge'
+                url = 'https://repo.spongepowered.org/repository/maven-public'
+            }
+        }
+        filter {
+            includeGroupAndSubgroups('org.spongepowered')
+        }
+    }
 
     // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -60,12 +60,11 @@ minecraft {
         configureEach {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
+            // Optional additional logging. The markers can be added/remove as needed, separated by commas.
             // "SCAN": For mods scan.
             // "REGISTRIES": For firing of registry events.
             // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
+//            property 'forge.logging.markers', 'REGISTRIES'
 
             property 'forge.logging.console.level', 'debug'
         }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0.24,6.2)'
+    id 'net.minecraftforge.gradle' version '[6.0.36,6.2)'
 }
 
 version = mod_version

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -157,7 +157,7 @@ dependencies {
 // A missing property will result in an error. Properties are expanded using ${} Groovy notation.
 // When "copyIdeResources" is enabled, this will also run before the game launches in IDE environments.
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-tasks.named('processResources', ProcessResources).configure {
+tasks.named('processResources', ProcessResources) {
     var replaceProperties = [
             minecraft_version: minecraft_version, minecraft_version_range: minecraft_version_range,
             forge_version: forge_version, forge_version_range: forge_version_range,
@@ -173,7 +173,7 @@ tasks.named('processResources', ProcessResources).configure {
 }
 
 // Example for how to get properties into the manifest for reading at runtime.
-tasks.named('jar', Jar).configure {
+tasks.named('jar', Jar) {
     manifest {
         attributes([
             'Specification-Title'     : mod_id,
@@ -183,6 +183,7 @@ tasks.named('jar', Jar).configure {
             'Implementation-Version'  : project.jar.archiveVersion,
             'Implementation-Vendor'   : mod_authors
         ])
+//        attributes['MixinConfigs'] = "${mod_id}.mixins.json"
     }
 }
 

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -67,6 +67,8 @@ minecraft {
 //            property 'forge.logging.markers', 'REGISTRIES'
 
             property 'forge.logging.console.level', 'debug'
+
+//            arg "-mixin.config=${mod_id}.mixins.json"
         }
 
         client {

--- a/mdk/gradle.properties
+++ b/mdk/gradle.properties
@@ -1,7 +1,14 @@
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
+# Sets default memory used for Gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx5G
 org.gradle.daemon=false
+
+# In the case that Gradle needs to fork to recompile, this will set the memory for that process.
+systemProp.net.minecraftforge.gradle.repo.recompile.fork=true
+systemProp.net.minecraftforge.gradle.repo.recompile.fork.args=-Xmx5G
+
+# Opts-out of ForgeGradle automatically adding mavenCentral(), Forge's maven and MC libs maven to the repositories block
+systemProp.net.minecraftforge.gradle.repo.attach=false
 
 
 ## Environment Properties

--- a/mdk/settings.gradle
+++ b/mdk/settings.gradle
@@ -9,5 +9,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
 }


### PR DESCRIPTION
- Fix intermittent OOM error when Gradle is ran with a different version of Java than what is needed for MC
- Reduce comment and logging verbosity a tad
- Add some commented out lines that simplifies getting started with Mixin
    - A common pitfall is people adding SpongeMixin which makes refmaps and stuff which breaks things. The correct way for now is to set the MixinConfigs manifest attribute manually.