### PR TITLE
[1.21.6]: Fix for client commands

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -71,3 +71,11 @@
          SignableCommand<ClientSuggestionProvider> signablecommand = SignableCommand.of(this.commands.parse(p_250092_, this.suggestionsProvider));
          if (signablecommand.arguments().isEmpty()) {
              this.send(new ServerboundChatCommandPacket(p_250092_));
+@@ -2641,6 +_,7 @@
+     }
+ 
+     public void sendUnattendedCommand(String p_407213_, @Nullable Screen p_406262_) {
++        if (net.minecraftforge.client.ClientCommandHandler.runCommand(p_407213_)) return;
+         switch (this.verifyCommand(p_407213_)) {
+             case NO_ISSUES:
+                 this.send(new ServerboundChatCommandPacket(p_407213_));

--- a/src/test/generated/client_command_test/data/forge/test_instance/client_command_test/client_command_test.json
+++ b/src/test/generated/client_command_test/data/forge/test_instance/client_command_test/client_command_test.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:client_command_test/client_command_test",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.debug.client;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.GuiMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.commands.Commands;
 import net.minecraft.gametest.framework.GameTestHelper;
@@ -15,8 +16,13 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraftforge.client.event.RegisterClientCommandsEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTest;
 import net.minecraftforge.gametest.GameTestNamespace;
+import net.minecraftforge.test.BaseTestMod;
+
+import java.lang.reflect.Field;
+import java.util.List;
 
 /**
  * run /testClickEvent to create a clickable chat message to print player locations.
@@ -24,10 +30,11 @@ import net.minecraftforge.gametest.GameTestNamespace;
  */
 @GameTestNamespace("forge")
 @Mod(ClientCommandTest.MODID)
-public class ClientCommandTest {
+public class ClientCommandTest extends BaseTestMod {
     public static final String MODID = "client_command_test";
 
-    public ClientCommandTest() {
+    public ClientCommandTest(FMLJavaModLoadingContext context) {
+        super(context, false, false);
         RegisterClientCommandsEvent.BUS.addListener(this::addCommand);
     }
 
@@ -49,11 +56,18 @@ public class ClientCommandTest {
     }
 
     @GameTest(name = MODID)
-    public static void testCommand(GameTestHelper helper) {
+    public static void testCommand(GameTestHelper helper) throws IllegalAccessException {
         var mc = Minecraft.getInstance();
         var packetHandler = mc.getConnection();
         packetHandler.sendUnattendedCommand("playerPos", null);
-        helper.assertTrue(mc.gui.getChat().getRecentChat().peekLast().equals(mc.player.position().toString()), "Client command executed successfully" );
+        var storeState = mc.gui.getChat().storeState();
+        Field messageField = storeState.getClass().getDeclaredFields()[0];
+        messageField.setAccessible(true);
+        List<GuiMessage> messages = (List<GuiMessage>) messageField.get(storeState);
+        List<String> messageStrings = messages.stream().map(guiMessage -> guiMessage.content().getString()).toList();
+        var success = messageStrings.contains(mc.player.position().toString());
+        helper.assertTrue(success, "Client command executed successfully");
+        helper.succeed();
     }
 
     private void testClickEvent() {

--- a/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.Mod;
 @Mod(ClientCommandTest.MODID)
 public class ClientCommandTest
 {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
 
     public static final String MODID = "client_command_test";
 

--- a/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.debug.client;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * run /testClickEvent to create a clickable chat message to print player locations.
+ * run /playerPos to run the client command to print player location
+ */
+@Mod(ClientCommandTest.MODID)
+public class ClientCommandTest
+{
+    private static final boolean ENABLED = true;
+
+    public static final String MODID = "client_command_test";
+
+    public ClientCommandTest() {
+        if (ENABLED) {
+            RegisterClientCommandsEvent.BUS.addListener(this::addCommand);
+        }
+    }
+
+    private void addCommand(RegisterClientCommandsEvent event) {
+        event.getDispatcher().
+                register(Commands.literal("playerPos")
+                        .executes(ctx -> {
+                                    this.printLoc();
+                                    return 1;
+                                }
+                        ));
+        event.getDispatcher().
+                register(Commands.literal("testClickEvent")
+                        .executes(ctx -> {
+                                    this.testClickEvent();
+                                    return 1;
+                                }
+                        ));
+    }
+
+    private void testClickEvent() {
+        MutableComponent clickable = Component.literal("Click §b§nHere§r to print your location");
+        clickable.withStyle(style -> style.withClickEvent(new ClickEvent.RunCommand("/playerPos")));
+        MutableComponent hover = Component.literal("Click Here to print out your location");
+        hover.withStyle(style -> style.withColor(net.minecraft.network.chat.TextColor.fromLegacyFormat(ChatFormatting.YELLOW)));
+        clickable.withStyle(style -> style.withHoverEvent(new HoverEvent.ShowText(hover)));
+        Minecraft.getInstance().gui.getChat().addMessage(clickable);
+    }
+
+    private void printLoc() {
+        var player = Minecraft.getInstance().player;
+        Minecraft.getInstance().gui.getChat().addMessage(Component.literal(player.position().toString()));
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
@@ -1,30 +1,34 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.client;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.commands.Commands;
+import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraftforge.client.event.RegisterClientCommandsEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.gametest.GameTest;
+import net.minecraftforge.gametest.GameTestNamespace;
 
 /**
  * run /testClickEvent to create a clickable chat message to print player locations.
  * run /playerPos to run the client command to print player location
  */
+@GameTestNamespace("forge")
 @Mod(ClientCommandTest.MODID)
-public class ClientCommandTest
-{
-    private static final boolean ENABLED = false;
-
+public class ClientCommandTest {
     public static final String MODID = "client_command_test";
 
     public ClientCommandTest() {
-        if (ENABLED) {
-            RegisterClientCommandsEvent.BUS.addListener(this::addCommand);
-        }
+        RegisterClientCommandsEvent.BUS.addListener(this::addCommand);
     }
 
     private void addCommand(RegisterClientCommandsEvent event) {
@@ -42,6 +46,14 @@ public class ClientCommandTest
                                     return 1;
                                 }
                         ));
+    }
+
+    @GameTest(name = MODID)
+    public static void testCommand(GameTestHelper helper) {
+        var mc = Minecraft.getInstance();
+        var packetHandler = mc.getConnection();
+        packetHandler.sendUnattendedCommand("playerPos", null);
+        helper.assertTrue(mc.gui.getChat().getRecentChat().peekLast().equals(mc.player.position().toString()), "Client command executed successfully" );
     }
 
     private void testClickEvent() {

--- a/src/test/resources/client_command_test/META-INF/mods.toml
+++ b/src/test/resources/client_command_test/META-INF/mods.toml
@@ -1,0 +1,1 @@
+clientSideOnly=true


### PR DESCRIPTION
This patch fixes component `ClickEvent.RunCommand` which goes through the unsigned command or in 1.21.6 unattendedCommand instead of `ClientPacketListener#sendCommand` 

Likely other use cases for this too. 