### PR TITLE
[1.20.1] Fix `ignitedByLava` block property making blocks permanently flammable

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -40,7 +40,7 @@
     }
  
 +   private boolean isFlammable(LevelReader level, BlockPos pos, Direction face) {
-+      return pos.m_123342_() >= level.m_141937_() && pos.m_123342_() < level.m_151558_() && !level.m_46805_(pos) ? false : level.m_8055_(pos).isFlammable(level, pos, face);
++      return pos.m_123342_() >= level.m_141937_() && pos.m_123342_() < level.m_151558_() && !level.m_46805_(pos) ? false : level.m_8055_(pos).m_278200_() && level.m_8055_(pos).isFlammable(level, pos, face);
 +   }
 +
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -628,7 +628,7 @@ public interface IForgeBlock
      */
     default boolean isFlammable(BlockState state, BlockGetter level, BlockPos pos, Direction direction)
     {
-        return state.ignitedByLava() || state.getFlammability(level, pos, direction) > 0;
+        return state.getFlammability(level, pos, direction) > 0;
     }
 
     /**


### PR DESCRIPTION
- Backport of #9735 to 1.20.1.
- Fixes #9730 for 1.20.1.
- Fixes #8449 for 1.20.1.

While the immediate effects of this bug were not as present in 1.20.1 and older, blocks that should not have been ignited by lava were still able to be because of this same issue. I've backported it to this version and will do the same for older versions.

Here is a screencast of this PR's build showcasing that it fixes this bug.

https://youtu.be/1cL4AA5YHIA?si=12JSUKc3l0yMtmsH