### PR TITLE
[1.19.4] Fix `Material#isFlammable` not being accounted for in flamability

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -606,7 +606,7 @@ public interface IForgeBlock
      */
     default boolean isFlammable(BlockState state, BlockGetter level, BlockPos pos, Direction direction)
     {
-        return state.getFlammability(level, pos, direction) > 0;
+        return state.getMaterial().isFlammable() && state.getFlammability(level, pos, direction) > 0;
     }
 
     /**


### PR DESCRIPTION
- Fixes #8449 for 1.19.4.

While in 1.20.1 the `BlockState#ignitedByLava` check was used unconditionally, in 1.19.4 and older the `Material#isFlammable` check was omitted entirely. This means that vanilla blocks that have a set flammability as returned by `IForgeBlock#getFlammability` could still be set on fire despite their material not being flammable. This is how scaffolding was able to catch fire from lava.