### PR TITLE
[1.19.2] Fix `Material#isFlammable` not being accounted for in flamability

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -607,7 +607,7 @@ public interface IForgeBlock
      */
     default boolean isFlammable(BlockState state, BlockGetter level, BlockPos pos, Direction direction)
     {
-        return state.getFlammability(level, pos, direction) > 0;
+        return state.getMaterial().isFlammable() && state.getFlammability(level, pos, direction) > 0;
     }
 
     /**


### PR DESCRIPTION
- Backport of #10571 to 1.19.2.
- Fixes #8449 for 1.19.2.