### PR TITLE
[1.21.8] Optimise WorldWorkerManager

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -19,7 +19,6 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.event.network.ConnectionStartEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
-import net.minecraftforge.event.TickEvent.ServerTickEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
@@ -57,16 +56,6 @@ public final class ForgeInternalHandler {
             }
         }
         return false;
-    }
-
-    @SubscribeEvent
-    static void onServerTick(ServerTickEvent.Pre event) {
-        WorldWorkerManager.tick(true);
-    }
-
-    @SubscribeEvent
-    static void onServerTick(ServerTickEvent.Post event) {
-        WorldWorkerManager.tick(false);
     }
 
 //    @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
+++ b/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
@@ -25,8 +25,10 @@ public class WorldWorkerManager {
     public static void endTick() {
         index = 0;
         IWorker task = getNext();
-        if (task == null)
+        if (task == null) {
+            clear();
             return;
+        }
 
         long time = 50 - (System.currentTimeMillis() - startTime);
         if (time < 10)

--- a/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
+++ b/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
@@ -5,23 +5,24 @@
 
 package net.minecraftforge.common;
 
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.listener.EventListener;
+
 import java.util.ArrayList;
 import java.util.List;
 
-public class WorldWorkerManager
-{
+public class WorldWorkerManager {
     private static final List<IWorker> workers = new ArrayList<>();
     private static long startTime = -1;
     private static int index = 0;
+    private static EventListener tickStartListener;
+    private static EventListener tickEndListener;
 
-    public static void tick(boolean start)
-    {
-        if (start)
-        {
-            startTime = System.currentTimeMillis();
-            return;
-        }
+    public static void startTick() {
+        startTime = System.currentTimeMillis();
+    }
 
+    public static void endTick() {
         index = 0;
         IWorker task = getNext();
         if (task == null)
@@ -32,46 +33,56 @@ public class WorldWorkerManager
             time = 10; //If ticks are lagging, give us at least 10ms to do something.
         time += System.currentTimeMillis();
 
-        while (System.currentTimeMillis() < time && task != null)
-        {
+        while (System.currentTimeMillis() < time && task != null) {
             boolean again = task.doWork();
 
-            if (!task.hasWork())
-            {
+            if (!task.hasWork()) {
                 remove(task);
                 task = getNext();
-            }
-            else if (!again)
-            {
+            } else if (!again) {
                 task = getNext();
             }
         }
     }
 
-    public static synchronized void addWorker(IWorker worker)
-    {
-        workers.add(worker);
+    /**
+     * @deprecated Use {@link #startTick()} or {@link #endTick()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.21.8")
+    public static void tick(boolean start) {
+        if (start) startTick();
+        else endTick();
     }
 
-    private static synchronized IWorker getNext()
-    {
+    public static synchronized void addWorker(IWorker worker) {
+        workers.add(worker);
+        if (tickStartListener == null) {
+            tickStartListener = TickEvent.ServerTickEvent.Pre.BUS.addListener(event -> startTick());
+            tickEndListener = TickEvent.ServerTickEvent.Post.BUS.addListener(event -> endTick());
+        }
+    }
+
+    private static synchronized IWorker getNext() {
         return workers.size() > index ? workers.get(index++) : null;
     }
 
-    private static synchronized void remove(IWorker worker)
-    {
+    private static synchronized void remove(IWorker worker) {
         workers.remove(worker);
         index--;
     }
 
     //Internal only, used to clear everything when the server shuts down.
-    public static synchronized void clear()
-    {
+    public static synchronized void clear() {
         workers.clear();
+        if (tickStartListener != null) {
+            TickEvent.ServerTickEvent.Pre.BUS.removeListener(tickStartListener);
+            TickEvent.ServerTickEvent.Post.BUS.removeListener(tickEndListener);
+            tickStartListener = null;
+            tickEndListener = null;
+        }
     }
 
-    public static interface IWorker
-    {
+    public interface IWorker {
         boolean hasWork();
 
         /**

--- a/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
+++ b/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
@@ -9,20 +9,19 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.listener.EventListener;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class WorldWorkerManager {
-    private static final List<IWorker> workers = new ArrayList<>();
+    private static final ArrayList<IWorker> workers = new ArrayList<>();
     private static long startTime = -1;
     private static int index = 0;
     private static EventListener tickStartListener;
     private static EventListener tickEndListener;
 
-    public static void startTick() {
+    private static void startTick() {
         startTime = System.currentTimeMillis();
     }
 
-    public static void endTick() {
+    private static void endTick() {
         index = 0;
         IWorker task = getNext();
         if (task == null) {
@@ -47,9 +46,6 @@ public class WorldWorkerManager {
         }
     }
 
-    /**
-     * @deprecated Use {@link #startTick()} or {@link #endTick()} instead.
-     */
     @Deprecated(forRemoval = true, since = "1.21.8")
     public static void tick(boolean start) {
         if (start) startTick();


### PR DESCRIPTION
This PR makes WorldWorkerManager lazily probed. Instead of always updating the `startTime` and checking for tasks every server tick, it now only starts doing that when a worker is added. This speeds up the common case of no workers being added.