### PR TITLE
Allow command suggestions/autocomplete to search all modded paths at once without namespace provided

### DIFF
--- a/patches/minecraft/net/minecraft/commands/SharedSuggestionProvider.java.patch
+++ b/patches/minecraft/net/minecraft/commands/SharedSuggestionProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/commands/SharedSuggestionProvider.java
++++ b/net/minecraft/commands/SharedSuggestionProvider.java
+@@ -98,7 +_,7 @@
+                     p_82948_.accept(t);
+                 }
+             } else if (matchesSubStr(p_82946_, resourcelocation.getNamespace())
+-                || resourcelocation.getNamespace().equals("minecraft") && matchesSubStr(p_82946_, resourcelocation.getPath())) {
++                || matchesSubStr(p_82946_, resourcelocation.getPath())) { // Forge: Removed "minecraft" namespace requirement for path searching to allow modded path suggestions to show up
+                 p_82948_.accept(t);
+             }
+         }


### PR DESCRIPTION
Allows it so when typing "scope" in give command autocomplete, you will now get all modded items that have "scope" in the path as well. No longer need to specify the modid namespace to search paths anymore. This works for all commands that make use of SharedSuggestionProvider.

Forge Port of https://github.com/neoforged/NeoForge/pull/2522 & https://github.com/FabricMC/fabric/pull/4755