### PR TITLE
[1.21.8] Minor cleanup to FML, fix double parsing of mods.toml

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -39,14 +39,13 @@ import java.util.jar.Manifest;
 public class ModFile implements IModFile {
     private static final Logger LOGGER = LogUtils.getLogger();
     private final String jarVersion;
-    private final ModFileFactory.ModFileInfoParser parser;
     private Map<String, Object> fileProperties;
     private List<IModLanguageProvider> loaders;
     private Throwable scanError;
     private final SecureJar jar;
     private final Type modFileType;
     private final IModProvider provider;
-    private       IModFileInfo modFileInfo;
+    private final IModFileInfo modFileInfo;
     private ModFileScanData fileModFileScanData;
     private CompletableFuture<ModFileScanData> futureScanResult;
     private List<CoreModFile> coreMods;
@@ -62,12 +61,11 @@ public class ModFile implements IModFile {
     public ModFile(final SecureJar jar, final IModProvider provider, final ModFileFactory.ModFileInfoParser parser, String type) {
         this.provider = provider;
         this.jar = jar;
-        this.parser = parser;
 
         var manifest = this.jar.moduleDataProvider().getManifest();
         modFileType = Type.valueOf(type);
         jarVersion = Optional.ofNullable(manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION)).orElse("0.0NONE");
-        this.modFileInfo = ModFileParser.readModList(this, this.parser);
+        this.modFileInfo = ModFileParser.readModList(this, parser);
     }
 
     @Override
@@ -99,7 +97,6 @@ public class ModFile implements IModFile {
     }
 
     public boolean identifyMods() {
-        this.modFileInfo = ModFileParser.readModList(this, this.parser);
         if (this.modFileInfo == null) return this.getType() != Type.MOD;
         LOGGER.debug(LogMarkers.LOADING,"Loading mod file {} with languages {}", this.getFilePath(), this.modFileInfo.requiredLanguageLoaders());
         this.coreMods = ModFileParser.getCoreMods(this);

--- a/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
+++ b/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
@@ -5,21 +5,20 @@
 
 package net.minecraftforge.fml.lowcodemod;
 
-import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.loading.LogMarkers;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.ModFileScanData;
-import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LowCodeModContainer extends ModContainer {
-    private static final Logger LOGGER = LogUtils.getLogger();
     private final Object modInstance;
 
     public LowCodeModContainer(IModInfo info, ModFileScanData modFileScanResults, ModuleLayer gameLayer) {
         super(info);
-        LOGGER.debug(LogMarkers.LOADING, "Creating LowCodeModContainer for {}", info.getModId());
+        LoggerFactory.getLogger(LowCodeModContainer.class)
+                .debug(LogMarkers.LOADING, "Creating LowCodeModContainer for {}", info.getModId());
         this.modInstance = new Object();
         this.contextExtension = () -> null;
         this.extensionPoints.remove(IExtensionPoint.DisplayTest.class);

--- a/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
+++ b/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
@@ -5,20 +5,21 @@
 
 package net.minecraftforge.fml.lowcodemod;
 
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.loading.LogMarkers;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.ModFileScanData;
-import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class LowCodeModContainer extends ModContainer {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private final Object modInstance;
 
     public LowCodeModContainer(IModInfo info, ModFileScanData modFileScanResults, ModuleLayer gameLayer) {
         super(info);
-        LoggerFactory.getLogger(LowCodeModContainer.class)
-                .debug(LogMarkers.LOADING, "Creating LowCodeModContainer for {}", info.getModId());
+        LOGGER.debug(LogMarkers.LOADING, "Creating LowCodeModContainer for {}", info.getModId());
         this.modInstance = new Object();
         this.contextExtension = () -> null;
         this.extensionPoints.remove(IExtensionPoint.DisplayTest.class);

--- a/mclanguage/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModContainer.java
+++ b/mclanguage/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModContainer.java
@@ -8,8 +8,6 @@ package net.minecraftforge.fml.mclanguageprovider;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.forgespi.language.IModInfo;
 
-import java.util.Objects;
-
 public class MinecraftModContainer extends ModContainer {
     private static final String MCMODINSTANCE = "minecraft, the mod";
 
@@ -20,7 +18,7 @@ public class MinecraftModContainer extends ModContainer {
 
     @Override
     public boolean matches(final Object mod) {
-        return Objects.equals(mod, MCMODINSTANCE);
+        return MCMODINSTANCE.equals(mod);
     }
 
     @Override

--- a/mclanguage/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModLanguageProvider.java
+++ b/mclanguage/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModLanguageProvider.java
@@ -10,7 +10,6 @@ import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.IModLanguageProvider;
 import net.minecraftforge.forgespi.language.ModFileScanData;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
@@ -20,7 +19,7 @@ import java.util.function.Supplier;
 import static net.minecraftforge.fml.Logging.LOADING;
 
 public class MinecraftModLanguageProvider implements IModLanguageProvider {
-    private static final Logger LOGGER = LogManager.getLogger();
+
     @Override
     public String name() {
         return "minecraft";
@@ -45,7 +44,7 @@ public class MinecraftModLanguageProvider implements IModLanguageProvider {
                 final Class<?> mcModClass = Class.forName(getClass().getModule(), "net.minecraftforge.fml.mclanguageprovider.MinecraftModContainer");
                 return (T)mcModClass.getConstructor(IModInfo.class).newInstance(info);
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                LOGGER.fatal(LOADING,"Unable to load MinecraftModContainer, wut?", e);
+                LogManager.getLogger().fatal(LOADING, "Unable to load MinecraftModContainer, wut?", e);
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
- Only parse mods.toml once
- Avoid a redundant null check in MinecraftModContainer#matches
- Only grab a logger in the rare case MinecraftModLanguageProvider fails