### PR TITLE
[1.21.5] Update to EventBus 6.2.32

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
+            library('eventbus', 'net.minecraftforge:eventbus:6.2.32')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -29,7 +29,7 @@ import net.minecraftforge.server.command.ForgeCommand;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import net.minecraftforge.server.command.ConfigCommand;
 
-public class ForgeInternalHandler {
+public final class ForgeInternalHandler {
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onEntityJoinWorld(EntityJoinLevelEvent event) {
         Entity entity = event.getEntity();
@@ -111,8 +111,8 @@ public class ForgeInternalHandler {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
-        if(event.getEntity() instanceof Mob mob && mob.isSpawnCancelled())
-            event.setCanceled(true);
+        if (event.getEntity() instanceof Mob mob && mob.isSpawnCancelled())
+            event.cancel();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -11,6 +11,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;
@@ -30,11 +31,15 @@ import java.util.function.Supplier;
 public class MinecraftForge {
     /**
      * The EventBus for all the Forge Events.
-     *
+     * <br>
      * Events marked with {@link net.minecraftforge.fml.event.IModBusEvent}
      * belong on the ModBus and not this bus
      */
-    public static final IEventBus EVENT_BUS = BusBuilder.builder().startShutdown().useModLauncher().build();
+    public static final IEventBus EVENT_BUS = BusBuilder.builder()
+            .startShutdown()
+            .useModLauncher()
+            .setPhasesToTrack(EventPriority.MONITOR)
+            .build();
 
     static final ForgeInternalHandler INTERNAL_HANDLER = new ForgeInternalHandler();
     private static final Logger LOGGER = LogManager.getLogger();


### PR DESCRIPTION
- Performance improvements, especially for posting to zero or one listeners on an event
- New Event#cancel() convenience method
- Only the monitor priority is tracked on the Forge bus now