### PR TITLE
[1.20.4] Ignore item equality when checking `IForgeItemStack#shouldCauseBlockBreakReset`

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -88,12 +88,14 @@
     }
  
     public void tick() {
-@@ -263,7 +_,7 @@
+@@ -263,7 +_,9 @@
  
     private boolean sameDestroyTarget(BlockPos p_105282_) {
        ItemStack itemstack = this.minecraft.player.getMainHandItem();
 -      return p_105282_.equals(this.destroyBlockPos) && ItemStack.isSameItemSameTags(itemstack, this.destroyingItem);
-+      return p_105282_.equals(this.destroyBlockPos) && ItemStack.isSameItemSameTags(itemstack, this.destroyingItem) && !destroyingItem.shouldCauseBlockBreakReset(itemstack);
++      if (Boolean.FALSE)
++          ItemStack.isSameItemSameTags(itemstack, this.destroyingItem);
++      return p_105282_.equals(this.destroyBlockPos) && !destroyingItem.shouldCauseBlockBreakReset(itemstack);
     }
  
     private void ensureHasSentCarriedItem() {


### PR DESCRIPTION
- Fixes #10645 for 1.20.4.

An interesting note is that `Boolean.FALSE` has the same effect as `Boolean.valueOf(false)` since it is the boxed `Boolean` type rather than the primitive. So in the bytecode, the JVM runs `Boolean.FALSE.booleanValue()` which keeps the bytecode of the branch side effect intact.