### PR TITLE
[1.20.1] Add mandatory field to MC mod file info to make ModVersion constructor happy

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
@@ -65,6 +65,7 @@ public class MinecraftLocator extends AbstractModProvider implements IModLocator
         // We haven't changed this in years, and I can't be asked right now to special case this one file in the path.
         final var conf = Config.inMemory();
         conf.set("modLoader", "minecraft");
+        conf.set("mandatory", "true"); // This field is required to make ModVersion constructor happy, no longer used in Forge for newer MC
         conf.set("loaderVersion", "1");
         conf.set("license", "Mojang Studios, All Rights Reserved");
         final var mods = Config.inMemory();


### PR DESCRIPTION
The mandatory field in mods.toml files is deprecated in newer Forge but still used on Forge for MC 1.20.1, and the MC locator seemed not to add the mandatory field to the generated TOML, making ModVersion constructor fail and leads to dev client crash.