### PR TITLE
[1.21.8] Deprecate global `IExtensibleEnum` support

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.mojang.logging.LogUtils;
+import net.minecraftforge.fml.loading.LoadingModList;
+import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -47,9 +49,14 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
     private static final EnumSet<Phase> YAY = EnumSet.of(Phase.AFTER);
     private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
 
+    private static final class LazyInit {
+        private LazyInit() {}
+        private static final boolean ANY_MODS = LoadingModList.get().getMods().size() > 2; // 2: forge, minecraft
+    }
+
     @Override
     public EnumSet<Phase> handlesClass(Type classType, boolean isEmpty) {
-        if (isEmpty)
+        if (isEmpty || !LazyInit.ANY_MODS)
             return NAY;
 
         String internalName = classType.getInternalName();

--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/RuntimeEnumExtender.java
@@ -68,6 +68,11 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
         if (!classNode.interfaces.contains(MARKER_IFACE.getInternalName()))
             return ComputeFlags.NO_REWRITE;
 
+        if (!classNode.name.startsWith("net/minecraft/")) {
+            LOGGER.warn("IExtensibleEnum found on non-Minecraft class: {}", classType.getClassName());
+            LOGGER.warn("This behaviour is deprecated for removal and will have no effect in a future MC release. Please use a record with static final field instances instead.");
+        }
+
         Type array = Type.getType("[" + classType.getDescriptor());
         String arrayDesc = array.getDescriptor();
 


### PR DESCRIPTION
This is intended for use with Minecraft classes only. Mod devs can support extending enums through other, more efficient means, such as converting their enum to a record and having static final fields of instances that correspond to each enum value.

Next MC, we can make RuntimeEnumExtender only target the specific MC classes that are known to have the annotation to remove yet another transformer parsing all classes that are loaded on the game layer, improving launch/startup times.