### PR TITLE
[1.21.8] Deprecate CapabilityTokenSubclass

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
@@ -18,6 +18,7 @@ import org.objectweb.asm.tree.MethodNode;
 
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 
+// Todo: Remove this in 1.21.9+
 /**
  * Implements getType() in CapabilityToken subclasses.
  *

--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
@@ -56,6 +56,9 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
         String internalName = classType.getInternalName();
         if (internalName.startsWith("net/minecraft/") || internalName.startsWith("com/mojang/"))
             return NAY;
+
+        if (internalName.startsWith("net/minecraftforge/") && !internalName.endsWith("/ForgeCapabilities"))
+            return NAY;
         
         return YAY;
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -30,7 +30,8 @@ public final class CapabilityManager {
      * this Capability is requested.
      */
     public static <T> Capability<T> get(CapabilityToken<T> type) {
-        return get(type.getType(), null, false);
+        var typeString = type instanceof CapabilityTokenDesc<?> desc ? desc.internalName : type.getType();
+        return get(typeString, null, false);
     }
 
     /**
@@ -46,7 +47,8 @@ public final class CapabilityManager {
      * distinguish between them. It is generally not safe to return your generic implementation for the root type when this is requested.
      */
     public static <T> Capability<T> get(CapabilityToken<T> type, ResourceLocation name) {
-        return get(type.getType(), name, false);
+        var typeString = type instanceof CapabilityTokenDesc<?> desc ? desc.internalName : type.getType();
+        return get(typeString, name, false);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -6,6 +6,9 @@
 package net.minecraftforge.common.capabilities;
 
 import net.minecraftforge.fml.common.asm.CapabilityTokenSubclass;
+import org.objectweb.asm.Type;
+
+import java.lang.constant.ClassDesc;
 
 /**
  * Inspired by {@link com.google.common.reflect.TypeToken TypeToken}, use a subclass to capture
@@ -26,8 +29,24 @@ public abstract class CapabilityToken<T> {
         throw new RuntimeException("This will be implemented by a transformer");
     }
 
+    /**
+     * @deprecated Use {@link #of(Class)} or {@link #of(ClassDesc)} instead
+     */
+    @Deprecated(forRemoval = true, since = "1.21.8")
+    public CapabilityToken() {}
+
     @Override
     public String toString() {
-        return "CapabilityToken[" + getType() + "]";
+        return "CapabilityToken[" + getType() + ']';
     }
+
+    public static <T> CapabilityToken<T> of(Class<T> clazz) {
+        return new CapabilityTokenDesc<>(Type.getInternalName(clazz));
+    }
+
+    public static <T> CapabilityToken<T> of(ClassDesc classDesc) {
+        var descriptorString = classDesc.descriptorString();
+        return new CapabilityTokenDesc<>(descriptorString.substring(1, descriptorString.length() - 1));
+    }
+
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityTokenDesc.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityTokenDesc.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.common.capabilities;
+
+final class CapabilityTokenDesc<T> extends CapabilityToken<T> {
+    final String internalName;
+
+    CapabilityTokenDesc(String internalName) {
+        this.internalName = internalName;
+    }
+
+    @Override
+    public String toString() {
+        return "CapabilityToken[" + internalName + ']';
+    }
+}


### PR DESCRIPTION
Removes the need for a runtime transformer while preserving type-safety by offering static of(ClassDesc) and of(Class<T>) methods.

Also narrowed the parsing rules in the transformer to skip processing Forge classes for all but the one where it's used.