### PR TITLE
[1.21.5] Simplify ModLoader#hasCompletedState

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -352,8 +352,16 @@ public class ModLoader {
         return loadingStateValid;
     }
 
+    /**
+     * @deprecated Use {@link #hasCompletedState(IModLoadingState)} instead
+     */
+    @Deprecated(forRemoval = true)
     public boolean hasCompletedState(final String stateName) {
         IModLoadingState state = stateManager.findState(stateName);
+        return completedStates.contains(state);
+    }
+
+    public boolean hasCompletedState(IModLoadingState state) {
         return completedStates.contains(state);
     }
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -113,16 +113,16 @@ public class ModLoader {
 
     private static String computeLanguageList() {
         return "\n" + FMLLoader.getLanguageLoadingProvider()
-                .applyForEach(lp -> lp.name() + "@" + lp.getClass().getPackage().getImplementationVersion())
+                .applyForEach(lp -> lp.name() + '@' + lp.getClass().getPackage().getImplementationVersion())
                 .collect(Collectors.joining("\n\t\t", "\t\t", ""));
     }
 
     private static String computeModLauncherServiceList() {
         final List<Map<String, String>> mods = FMLLoader.modLauncherModList();
-        return "\n"+mods.stream().map(mod->mod.getOrDefault("file","nofile")+
-                " "+mod.getOrDefault("name", "missing")+
-                " "+mod.getOrDefault("type","NOTYPE")+
-                " "+mod.getOrDefault("description", "")).
+        return "\n" + mods.stream().map(mod -> mod.getOrDefault("file","nofile") +
+                ' ' + mod.getOrDefault("name", "missing") +
+                ' ' + mod.getOrDefault("type","NOTYPE") +
+                ' ' + mod.getOrDefault("description", "")).
                 collect(Collectors.joining("\n\t\t","\t\t",""));
     }
 

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModStateManager.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModStateManager.java
@@ -41,11 +41,13 @@ public class ModStateManager {
     }
 
     public IModLoadingState findState(final String stateName) {
-        return stateMap.values()
+        var result = stateMap.values()
                 .stream()
                 .flatMap(List::stream)
                 .filter(mls -> mls.name().equals(stateName))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown IModLoadingState: " + stateName));
+                .orElse(null);
+        if (result != null) return result;
+        else throw new IllegalArgumentException("Unknown IModLoadingState: " + stateName);
     }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -146,10 +146,9 @@ public class FMLLoader {
         runtimeDistCleaner.getExtension().accept(dist);
     }
 
-    public static List<ITransformationService.Resource> beginModScan(final Map<String,?> arguments) {
-        LOGGER.debug(SCAN,"Scanning for Mod Locators");
-        var modDiscoverer = new ModDiscoverer(arguments);
-        modValidator = modDiscoverer.discoverMods();
+    public static List<ITransformationService.Resource> beginModScan(final Map<String, ?> arguments) {
+        LOGGER.debug(SCAN, "Scanning for Mod Locators");
+        modValidator = ModDiscoverer.discoverMods(arguments);
         var pluginResources = modValidator.getPluginResources();
         return List.of(pluginResources);
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
@@ -35,10 +35,8 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class ModDiscoverer {
+public final class ModDiscoverer {
     private static final Logger LOGGER = LogUtils.getLogger();
-    private final ServiceLoader<IModLocator> modLocators;
-    private final ServiceLoader<IDependencyLocator> dependencyLocators;
     private final List<IModLocator>          modLocatorList;
     private final List<IDependencyLocator>   dependencyLocatorList;
 
@@ -46,13 +44,13 @@ public class ModDiscoverer {
         Launcher.INSTANCE.environment().computePropertyIfAbsent(Environment.Keys.MODDIRECTORYFACTORY.get(), v->ModsFolderLocator::new);
         Launcher.INSTANCE.environment().computePropertyIfAbsent(Environment.Keys.PROGRESSMESSAGE.get(), v-> StartupNotificationManager.locatorConsumer().orElseGet(()-> s->{}));
         final var moduleLayerManager = Launcher.INSTANCE.environment().findModuleLayerManager().orElseThrow();
-        modLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IModLocator.class);
-        dependencyLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IDependencyLocator.class);
-        modLocatorList = ServiceLoaderUtils.streamServiceLoader(()-> modLocators, sce->LOGGER.error("Failed to load mod locator list", sce)).collect(Collectors.toList());
+        ServiceLoader<IModLocator> modLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IModLocator.class);
+        ServiceLoader<IDependencyLocator> dependencyLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IDependencyLocator.class);
+        modLocatorList = ServiceLoaderUtils.streamWithErrorHandling(modLocators, sce->LOGGER.error("Failed to load mod locator list", sce)).collect(Collectors.toList());
         for (IModLocator iModLocator : modLocatorList) {
             iModLocator.initArguments(arguments);
         }
-        dependencyLocatorList = ServiceLoaderUtils.streamServiceLoader(()-> dependencyLocators, sce->LOGGER.error("Failed to load dependency locator list", sce)).collect(Collectors.toList());
+        dependencyLocatorList = ServiceLoaderUtils.streamWithErrorHandling(dependencyLocators, sce->LOGGER.error("Failed to load dependency locator list", sce)).collect(Collectors.toList());
         for (IDependencyLocator l : dependencyLocatorList) {
             l.initArguments(arguments);
         }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
@@ -36,39 +36,36 @@ import java.util.stream.Collectors;
 
 @ApiStatus.Internal
 public final class ModDiscoverer {
-    private static final Logger LOGGER = LogUtils.getLogger();
-    private final List<IModLocator>          modLocatorList;
-    private final List<IDependencyLocator>   dependencyLocatorList;
+    private ModDiscoverer() {}
 
-    public ModDiscoverer(Map<String, ?> arguments) {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    @SuppressWarnings("removal")
+    public static ModValidator discoverMods(Map<String, ?> arguments) {
         Launcher.INSTANCE.environment().computePropertyIfAbsent(Environment.Keys.MODDIRECTORYFACTORY.get(), v->ModsFolderLocator::new);
         Launcher.INSTANCE.environment().computePropertyIfAbsent(Environment.Keys.PROGRESSMESSAGE.get(), v-> StartupNotificationManager.locatorConsumer().orElseGet(()-> s->{}));
         final var moduleLayerManager = Launcher.INSTANCE.environment().findModuleLayerManager().orElseThrow();
         ServiceLoader<IModLocator> modLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IModLocator.class);
         ServiceLoader<IDependencyLocator> dependencyLocators = ServiceLoader.load(moduleLayerManager.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow(), IDependencyLocator.class);
-        modLocatorList = ServiceLoaderUtils.streamWithErrorHandling(modLocators, sce->LOGGER.error("Failed to load mod locator list", sce)).collect(Collectors.toList());
+        List<IModLocator> modLocatorList = ServiceLoaderUtils.streamWithErrorHandling(modLocators, sce->LOGGER.error("Failed to load mod locator list", sce)).toList();
         for (IModLocator iModLocator : modLocatorList) {
             iModLocator.initArguments(arguments);
         }
-        dependencyLocatorList = ServiceLoaderUtils.streamWithErrorHandling(dependencyLocators, sce->LOGGER.error("Failed to load dependency locator list", sce)).collect(Collectors.toList());
+        List<IDependencyLocator> dependencyLocatorList = ServiceLoaderUtils.streamWithErrorHandling(dependencyLocators, sce->LOGGER.error("Failed to load dependency locator list", sce)).toList();
         for (IDependencyLocator l : dependencyLocatorList) {
             l.initArguments(arguments);
         }
-        if (LOGGER.isDebugEnabled(LogMarkers.CORE))
-        {
+        if (LOGGER.isDebugEnabled(LogMarkers.CORE)) {
             LOGGER.debug(LogMarkers.CORE, "Found Mod Locators : {}", modLocatorList.stream()
-                                                                       .map(modLocator -> "(%s:%s)".formatted(modLocator.name(),
-                                                                         modLocator.getClass().getPackage().getImplementationVersion())).collect(Collectors.joining(",")));
+                    .map(modLocator -> "(%s:%s)".formatted(modLocator.name(),
+                            modLocator.getClass().getPackage().getImplementationVersion())).collect(Collectors.joining(",")));
 
             LOGGER.debug(LogMarkers.CORE, "Found Dependency Locators : {}", dependencyLocatorList.stream()
-                                                                       .map(dependencyLocator -> "(%s:%s)".formatted(dependencyLocator.name(),
-                                                                         dependencyLocator.getClass().getPackage().getImplementationVersion())).collect(Collectors.joining(",")));
+                    .map(dependencyLocator -> "(%s:%s)".formatted(dependencyLocator.name(),
+                            dependencyLocator.getClass().getPackage().getImplementationVersion())).collect(Collectors.joining(",")));
         }
-    }
 
-    @SuppressWarnings("removal")
-    public ModValidator discoverMods() {
-        LOGGER.debug(LogMarkers.SCAN,"Scanning for mods and other resources to load. We know {} ways to find mods", modLocatorList.size());
+        LOGGER.debug(LogMarkers.SCAN, "Scanning for mods and other resources to load. We know {} ways to find mods", modLocatorList.size());
         List<ModFile> loadedFiles = new ArrayList<>();
         List<EarlyLoadingException.ExceptionData> discoveryErrorData = new ArrayList<>();
         boolean successfullyLoadedMods = true;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -52,7 +52,7 @@ public class ModValidator {
     }
 
     private static List<ModFile> lst(List<ModFile> files) {
-        return files == null ? new ArrayList<>() : new ArrayList<>(files);
+        return files == null ? new ArrayList<>() : files;
     }
 
     public void stage1Validation() {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -52,7 +52,9 @@ public class ModValidator {
     }
 
     private static List<ModFile> lst(List<ModFile> files) {
-        return files == null ? new ArrayList<>() : files;
+        if (files == null) return new ArrayList<>();
+        if (files instanceof ArrayList<ModFile>) return files;
+        return new ArrayList<>(files);
     }
 
     public void stage1Validation() {

--- a/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/Sheets.java.patch
@@ -30,7 +30,7 @@
 +    }
 +
 +    static {
-+        if (net.minecraftforge.fml.ModLoader.isLoadingStateValid() && !net.minecraftforge.fml.ModLoader.get().hasCompletedState("LOAD_REGISTRIES")) {
++        if (net.minecraftforge.fml.ModLoader.isLoadingStateValid() && !net.minecraftforge.fml.ModLoader.get().hasCompletedState(net.minecraftforge.common.ForgeStatesProvider.LOAD_REGISTRIES)) {
 +            com.mojang.logging.LogUtils.getLogger().error(
 +                    "net.minecraft.client.renderer.Sheets loaded too early, modded registry-based materials may not work correctly",
 +                    new IllegalStateException("net.minecraft.client.renderer.Sheets loaded too early")


### PR DESCRIPTION
Adds a new variant of ModLoader#hasCompletedState which takes in the state directly, which is less error-prone than a string and avoids having to search for one that matches the given name.

Also includes some minor cleanup to FML internals to reduce allocating lambdas, indirection in string concat internals, redundant collection copying, etc...

Targeting 1.21.5 so as to not affect the 1.21.9 port, but this PR should be able to target 1.20.1 - 1.21.9 inclusive.