### PR TITLE
[1.21.9] Move more events away from the mod BusGroup

### DIFF
--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -48,11 +48,13 @@ import java.util.stream.Collectors;
  * annotations and passes the class instances to the {@link Bus}
  * defined by the annotation. Defaults to {@code MinecraftForge#EVENT_BUS}
  */
-public class AutomaticEventSubscriber {
+public final class AutomaticEventSubscriber {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Type AUTO_SUBSCRIBER = Type.getType(EventBusSubscriber.class);
     private static final Type MOD_TYPE = Type.getType(Mod.class);
     private static final Type ONLY_IN_TYPE = Type.getType(OnlyIn.class);
+    private static final List<EnumData> DEFAULT_SIDES = List.of(new EnumData(null, "CLIENT"), new EnumData(null, "DEDICATED_SERVER"));
+    private static final EnumData DEFAULT_BUS = new EnumData(null, "BOTH");
 
     public static void inject(ModContainer mod, ModFileScanData scanData, ClassLoader loader) {
         if (scanData == null) return;
@@ -71,9 +73,6 @@ public class AutomaticEventSubscriber {
             .filter(data -> MOD_TYPE.equals(data.annotationType()))
             .collect(Collectors.toMap(a -> a.clazz().getClassName(), a -> (String)a.annotationData().get("value")));
 
-        var defaultSides = List.of(new EnumData(null, "CLIENT"), new EnumData(null, "DEDICATED_SERVER"));
-        var defaultBus = new EnumData(null, "FORGE");
-
         for (var data : targets) {
             if (!FMLEnvironment.production && onlyIns.contains(data.clazz().getClassName())) {
                 throw new RuntimeException("Found @OnlyIn on @EventBusSubscriber class " + data.clazz().getClassName() + " - this is not allowed as it causes crashes. Remove the OnlyIn and set value=Dist.CLIENT in the EventBusSubscriber annotation instead");
@@ -82,13 +81,13 @@ public class AutomaticEventSubscriber {
             var modId = modids.getOrDefault(data.clazz().getClassName(), mod.getModId());
             modId = value(data, "modid", modId);
 
-            var sidesValue = value(data, "value", defaultSides);
+            var sidesValue = value(data, "value", DEFAULT_SIDES);
             var sides = sidesValue.stream()
                 .map(EnumData::value)
                 .map(Dist::valueOf)
                 .collect(Collectors.toSet());
 
-            var busName = value(data, "bus", defaultBus).value();
+            var busName = value(data, "bus", DEFAULT_BUS).value();
             var busTarget = Bus.valueOf(busName);
             if (Objects.equals(mod.getModId(), modId) && sides.contains(FMLEnvironment.dist)) {
                 try {
@@ -282,7 +281,7 @@ public class AutomaticEventSubscriber {
                         ? FMLJavaModLoadingContext.get().getModBusGroup()
                         : BusGroup.DEFAULT;
             } else if (strict) {
-                String solution = "Please remove the bus() param from your @EventBusSubscriber annotation so that both bus groups are used, or move this event listener to another class.";
+                String solution = "To fix this, remove the bus param from your @EventBusSubscriber annotation or move this event listener to another class.";
                 var isDefaultBusGroup = busGroup == BusGroup.DEFAULT;
                 var isModBusEvent = IModBusEvent.class.isAssignableFrom(eventType);
                 if (isDefaultBusGroup && isModBusEvent) { // requested forge bus and has IModBusEvent

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -173,7 +173,7 @@ public class AutomaticEventSubscriber {
                 Class<? extends Event> eventType = (Class<? extends Event>) parameterTypes[0];
                 var subscribeEventAnnotation = method.getAnnotation(SubscribeEvent.class);
 
-                registerListener(busGroup, paramCount, returnType, eventType, subscribeEventAnnotation, method);
+                registerListener(busGroup, paramCount, returnType, eventType, subscribeEventAnnotation, method, false);
                 listenersCount++;
 
                 if (firstValidListenerEventType == null)
@@ -259,7 +259,7 @@ public class AutomaticEventSubscriber {
                             throw fail(method, "Return type boolean is only valid for cancellable events");
                     }
 
-                    registerListener(busGroup, paramCount, returnType, eventType, subscribeEventAnnotation, method);
+                    registerListener(busGroup, paramCount, returnType, eventType, subscribeEventAnnotation, method, true);
                     listenersCount++;
 
                     if (firstValidListenerEventType == null)
@@ -276,11 +276,22 @@ public class AutomaticEventSubscriber {
         @SuppressWarnings({"unchecked", "rawtypes"})
         private static EventListener registerListener(@Nullable BusGroup busGroup,
                                                       int paramCount, Class<?> returnType, Class<? extends Event> eventType,
-                                                      SubscribeEvent subscribeEventAnnotation, Method method) {
+                                                      SubscribeEvent subscribeEventAnnotation, Method method, boolean strict) {
             if (busGroup == null) {
                 busGroup = IModBusEvent.class.isAssignableFrom(eventType)
                         ? FMLJavaModLoadingContext.get().getModBusGroup()
                         : BusGroup.DEFAULT;
+            } else if (strict) {
+                String solution = "Please remove the bus() param from your @EventBusSubscriber annotation so that both bus groups are used, or move this event listener to another class.";
+                if (busGroup == BusGroup.DEFAULT && IModBusEvent.class.isAssignableFrom(eventType)) { // requested forge bus and has IModBusEvent
+                    throw fail(method, "Event type " + eventType.getName()
+                            + " is on the mod BusGroup but you are asking to register it on the default BusGroup (BusGroup.DEFAULT/EventBusSubscriber.Bus.FORGE). "
+                            + solution);
+                } else if (busGroup != BusGroup.DEFAULT && !IModBusEvent.class.isAssignableFrom(eventType)) { // requested mod bus and does not have IModBusEvent
+                    throw fail(method, "Event type " + eventType.getName()
+                            + " is on the default BusGroup but you are asking to register it on the mod BusGroup (context.getModBusGroup()/EventBusSubscriber.Bus.MOD). "
+                            + solution);
+                }
             }
 
             // determine the listener type from its parameters and return type

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -283,11 +283,13 @@ public class AutomaticEventSubscriber {
                         : BusGroup.DEFAULT;
             } else if (strict) {
                 String solution = "Please remove the bus() param from your @EventBusSubscriber annotation so that both bus groups are used, or move this event listener to another class.";
-                if (busGroup == BusGroup.DEFAULT && IModBusEvent.class.isAssignableFrom(eventType)) { // requested forge bus and has IModBusEvent
+                var isDefaultBusGroup = busGroup == BusGroup.DEFAULT;
+                var isModBusEvent = IModBusEvent.class.isAssignableFrom(eventType);
+                if (isDefaultBusGroup && isModBusEvent) { // requested forge bus and has IModBusEvent
                     throw fail(method, "Event type " + eventType.getName()
                             + " is on the mod BusGroup but you are asking to register it on the default BusGroup (BusGroup.DEFAULT/EventBusSubscriber.Bus.FORGE). "
                             + solution);
-                } else if (busGroup != BusGroup.DEFAULT && !IModBusEvent.class.isAssignableFrom(eventType)) { // requested mod bus and does not have IModBusEvent
+                } else if (!isDefaultBusGroup && !isModBusEvent) { // requested mod bus and does not have IModBusEvent
                     throw fail(method, "Event type " + eventType.getName()
                             + " is on the default BusGroup but you are asking to register it on the mod BusGroup (context.getModBusGroup()/EventBusSubscriber.Bus.MOD). "
                             + solution);

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -43,7 +43,7 @@ public class FMLModContainer extends ModContainer {
         LOGGER.debug(LOADING,"Creating FMLModContainer instance for {}", className);
         this.scanResults = modFileScanResults;
         activityMap.put(ModLoadingStage.CONSTRUCT, this::constructMod);
-        this.eventBusGroup = BusGroup.create("modBusFor" + info.getModId());
+        this.eventBusGroup = BusGroup.create("modBusFor" + info.getModId(), IModBusEvent.class);
         this.contextExtension = () -> context;
         try {
             var moduleName = info.getOwningFile().moduleName();
@@ -193,6 +193,6 @@ public class FMLModContainer extends ModContainer {
 
     @Override
     public String toString() {
-        return "FMLModContainer[" + this.getModInfo().getModId() + ", " + this.getClass().getName() + "]";
+        return "FMLModContainer[" + this.getModInfo().getModId() + ", " + this.getClass().getName() + ']';
     }
 }

--- a/patches/minecraft/net/minecraft/client/sounds/SoundEngine.java.patch
+++ b/patches/minecraft/net/minecraft/client/sounds/SoundEngine.java.patch
@@ -4,7 +4,7 @@
          this.soundManager = p_120236_;
          this.options = p_120237_;
          this.soundBuffers = new SoundBufferLibrary(p_249332_);
-+        net.minecraftforge.fml.ModLoader.postEvent(new net.minecraftforge.client.event.sound.SoundEngineLoadEvent(this));
++        net.minecraftforge.client.event.sound.SoundEngineLoadEvent.BUS.post(new net.minecraftforge.client.event.sound.SoundEngineLoadEvent(this));
      }
  
      public void reload() {
@@ -12,7 +12,7 @@
  
          this.destroy();
          this.loadLibrary();
-+        net.minecraftforge.fml.ModLoader.postEvent(new net.minecraftforge.client.event.sound.SoundEngineLoadEvent(this));
++        net.minecraftforge.client.event.sound.SoundEngineLoadEvent.BUS.post(new net.minecraftforge.client.event.sound.SoundEngineLoadEvent(this));
      }
  
      private synchronized void loadLibrary() {

--- a/patches/minecraft/net/minecraft/server/packs/repository/ServerPacksSource.java.patch
+++ b/patches/minecraft/net/minecraft/server/packs/repository/ServerPacksSource.java.patch
@@ -6,7 +6,7 @@
      public static PackRepository createPackRepository(Path p_251569_, DirectoryValidator p_300268_) {
 -        return new PackRepository(new ServerPacksSource(p_300268_), new FolderRepositorySource(p_251569_, PackType.SERVER_DATA, PackSource.WORLD, p_300268_));
 +        var ret = new PackRepository(new ServerPacksSource(p_300268_), new FolderRepositorySource(p_251569_, PackType.SERVER_DATA, PackSource.WORLD, p_300268_));
-+        net.minecraftforge.fml.ModLoader.postEvent(new net.minecraftforge.event.AddPackFindersEvent(PackType.SERVER_DATA, ret::addPackFinder));
++        net.minecraftforge.event.AddPackFindersEvent.BUS.post(new net.minecraftforge.event.AddPackFindersEvent(PackType.SERVER_DATA, ret::addPackFinder));
 +        return ret;
      }
  

--- a/patches/minecraft/net/minecraft/world/entity/SpawnPlacements.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/SpawnPlacements.java.patch
@@ -28,7 +28,7 @@
 +    public static void fireSpawnPlacementEvent() {
 +        Map<EntityType<?>, net.minecraftforge.event.entity.SpawnPlacementRegisterEvent.MergedSpawnPredicate<?>> map = Maps.newHashMap();
 +        DATA_BY_TYPE.forEach((type, data) -> map.put(type, new net.minecraftforge.event.entity.SpawnPlacementRegisterEvent.MergedSpawnPredicate<>(data.predicate, data.placement, data.heightMap)));
-+        net.minecraftforge.fml.ModLoader.postEvent(new net.minecraftforge.event.entity.SpawnPlacementRegisterEvent(map));
++        net.minecraftforge.event.entity.SpawnPlacementRegisterEvent.BUS.post(new net.minecraftforge.event.entity.SpawnPlacementRegisterEvent(map));
 +        map.forEach(((entityType, merged) -> DATA_BY_TYPE.put(entityType, new SpawnPlacements.Data(merged.getHeightmapType(), merged.getSpawnType(), merged.build()))));
      }
  }

--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -7,6 +7,7 @@ package net.minecraftforge.client;
 
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.resources.model.UnbakedGeometry;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
@@ -21,10 +22,10 @@ import net.minecraftforge.fml.common.Mod;
 public class ClientForgeMod {
     @SubscribeEvent
     public static void onRegisterGeometryLoaders(ModelEvent.RegisterGeometryLoaders event) {
-        event.register("empty", (json, ctx) -> UnbakedGeometry.EMPTY);
-        event.register("obj", ObjLoader.INSTANCE);
-        event.register("fluid_container", DynamicFluidContainerModel.Loader.INSTANCE);
-        event.register("item_layers", ItemLayerGeometry.Loader.INSTANCE);
+        event.register(forgeRL("empty"), (json, ctx) -> UnbakedGeometry.EMPTY);
+        event.register(forgeRL("obj"), ObjLoader.INSTANCE);
+        event.register(forgeRL("fluid_container"), DynamicFluidContainerModel.Loader.INSTANCE);
+        event.register(forgeRL("item_layers"), ItemLayerGeometry.Loader.INSTANCE);
     }
 
     @SubscribeEvent
@@ -35,5 +36,9 @@ public class ClientForgeMod {
     @SubscribeEvent
     public static void onRegisterNamedRenderTypes(RegisterNamedRenderTypesEvent event) {
         event.register("item_unlit", ChunkSectionLayer.TRANSLUCENT, ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+    }
+
+    private static ResourceLocation forgeRL(String path) {
+        return ResourceLocation.fromNamespaceAndPath("forge", path);
     }
 }

--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -35,7 +35,7 @@ public class ClientForgeMod {
 
     @SubscribeEvent
     public static void onRegisterNamedRenderTypes(RegisterNamedRenderTypesEvent event) {
-        event.register("item_unlit", ChunkSectionLayer.TRANSLUCENT, ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+        event.register(forgeRL("item_unlit"), ChunkSectionLayer.TRANSLUCENT, ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
     }
 
     private static ResourceLocation forgeRL(String path) {

--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -17,7 +17,7 @@ import net.minecraftforge.client.model.obj.ObjLoader;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD, modid = "forge")
+@Mod.EventBusSubscriber(value = Dist.CLIENT, modid = "forge")
 public class ClientForgeMod {
     @SubscribeEvent
     public static void onRegisterGeometryLoaders(ModelEvent.RegisterGeometryLoaders event) {

--- a/src/main/java/net/minecraftforge/client/ColorResolverManager.java
+++ b/src/main/java/net/minecraftforge/client/ColorResolverManager.java
@@ -9,7 +9,6 @@ import net.minecraft.client.color.block.BlockTintCache;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
@@ -27,7 +26,7 @@ public final class ColorResolverManager {
     @ApiStatus.Internal
     public static void init() {
         var builder = new ArrayList<ColorResolver>();
-        ModLoader.postEvent(new RegisterColorHandlersEvent.ColorResolvers(builder));
+        RegisterColorHandlersEvent.ColorResolvers.BUS.post(new RegisterColorHandlersEvent.ColorResolvers(builder));
         colorResolvers = List.copyOf(builder);
     }
 

--- a/src/main/java/net/minecraftforge/client/DimensionSpecialEffectsManager.java
+++ b/src/main/java/net/minecraftforge/client/DimensionSpecialEffectsManager.java
@@ -9,7 +9,6 @@ import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraftforge.client.event.RegisterDimensionSpecialEffectsEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
@@ -38,7 +37,7 @@ public final class DimensionSpecialEffectsManager {
         var effects = new HashMap<ResourceLocation, DimensionSpecialEffects>();
         DEFAULT_EFFECTS = preRegisterVanillaEffects(effects);
         var event = new RegisterDimensionSpecialEffectsEvent(effects);
-        ModLoader.postEventWrapContainerInModOrder(event);
+        RegisterDimensionSpecialEffectsEvent.BUS.post(event);
         EFFECTS = Map.copyOf(effects);
     }
 

--- a/src/main/java/net/minecraftforge/client/EntitySpectatorShaderManager.java
+++ b/src/main/java/net/minecraftforge/client/EntitySpectatorShaderManager.java
@@ -8,9 +8,9 @@ package net.minecraftforge.client;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraftforge.client.event.RegisterEntitySpectatorShadersEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,24 +20,24 @@ import java.util.Map;
  * <p>
  * Provides a lookup.
  */
+@NullMarked
 public final class EntitySpectatorShaderManager {
     private EntitySpectatorShaderManager() {}
 
-    private static Map<EntityType<?>, ResourceLocation> SHADERS;
+    private static @Nullable Map<EntityType<?>, ResourceLocation> SHADERS;
 
     /**
      * Finds the path to the spectator mode shader used for the specified entity type, or null if none is registered.
      */
-    @Nullable
-    public static ResourceLocation get(EntityType<?> entityType) {
+    public static @Nullable ResourceLocation get(EntityType<?> entityType) {
+        assert SHADERS != null;
         return SHADERS.get(entityType);
     }
 
     @ApiStatus.Internal
     public static void init() {
         var shaders = new HashMap<EntityType<?>, ResourceLocation>();
-        var event = new RegisterEntitySpectatorShadersEvent(shaders);
-        ModLoader.postEventWrapContainerInModOrder(event);
+        RegisterEntitySpectatorShadersEvent.BUS.post(new RegisterEntitySpectatorShadersEvent(shaders));
         SHADERS = Map.copyOf(shaders);
     }
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -273,7 +273,7 @@ public class ForgeHooksClient {
     }
 
     public static void onBlockColorsInit(BlockColors blockColors) {
-        ModLoader.postEvent(new RegisterColorHandlersEvent.Block(blockColors));
+        RegisterColorHandlersEvent.Block.BUS.post(new RegisterColorHandlersEvent.Block(blockColors));
     }
 
     public static Model getArmorModel(HumanoidRenderState state, ItemStack itemStack, EquipmentSlot slot, HumanoidModel<?> _default) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -359,11 +359,11 @@ public class ForgeHooksClient {
     }
 
     public static void onModifyBakingResult(ModelBakery modelBakery, ModelBakery.BakingResult results) {
-        ModLoader.postEvent(new ModelEvent.ModifyBakingResult(modelBakery, results));
+        ModelEvent.ModifyBakingResult.BUS.post(new ModelEvent.ModifyBakingResult(modelBakery, results));
     }
 
     public static void onModelBake(ModelManager modelManager, ModelBakery modelBakery) {
-        ModLoader.postEvent(new ModelEvent.BakingCompleted(modelManager, modelBakery));
+        ModelEvent.BakingCompleted.BUS.post(new ModelEvent.BakingCompleted(modelManager, modelBakery));
     }
 
     public static TextureAtlasSprite[] getFluidSprites(BlockAndTintGetter level, BlockPos pos, FluidState fluidStateIn) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -269,7 +269,7 @@ public class ForgeHooksClient {
     }
 
     public static void onTextureStitchedPost(TextureAtlas map) {
-        ModLoader.postEvent(new TextureStitchEvent.Post(map));
+        TextureStitchEvent.Post.BUS.post(new TextureStitchEvent.Post(map));
     }
 
     public static void onBlockColorsInit(BlockColors blockColors) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -799,7 +799,7 @@ public class ForgeHooksClient {
             throw new IllegalStateException("Client hooks initialized more than once");
         initializedClientHooks = true;
 
-        ModLoader.postEvent(new RegisterClientReloadListenersEvent(resourceManager));
+        RegisterClientReloadListenersEvent.BUS.post(new RegisterClientReloadListenersEvent(resourceManager));
         EntityRenderersEvent.RegisterLayerDefinitions.BUS.post(new EntityRenderersEvent.RegisterLayerDefinitions());
         EntityRenderersEvent.RegisterRenderers.BUS.post(new EntityRenderersEvent.RegisterRenderers());
         TextureAtlasSpriteLoaderManager.init();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -615,7 +615,7 @@ public class ForgeHooksClient {
     }
 
     public static void onRegisterParticleProviders(ParticleResources particles) {
-        ModLoader.postEvent(new RegisterParticleProvidersEvent(particles));
+        RegisterParticleProvidersEvent.BUS.post(new RegisterParticleProvidersEvent(particles));
     }
 
     public static void onRegisterKeyMappings(Options options) {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -800,8 +800,8 @@ public class ForgeHooksClient {
         initializedClientHooks = true;
 
         ModLoader.postEvent(new RegisterClientReloadListenersEvent(resourceManager));
-        ModLoader.postEvent(new EntityRenderersEvent.RegisterLayerDefinitions());
-        ModLoader.postEvent(new EntityRenderersEvent.RegisterRenderers());
+        EntityRenderersEvent.RegisterLayerDefinitions.BUS.post(new EntityRenderersEvent.RegisterLayerDefinitions());
+        EntityRenderersEvent.RegisterRenderers.BUS.post(new EntityRenderersEvent.RegisterRenderers());
         TextureAtlasSpriteLoaderManager.init();
         ClientTooltipComponentManager.init();
         EntitySpectatorShaderManager.init();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -619,7 +619,7 @@ public class ForgeHooksClient {
     }
 
     public static void onRegisterKeyMappings(Options options) {
-        ModLoader.postEvent(new RegisterKeyMappingsEvent(options));
+        RegisterKeyMappingsEvent.BUS.post(new RegisterKeyMappingsEvent(options));
     }
 
     public static void onRegisterPictureInPictureRenderers(List<PictureInPictureRenderer<?>> renderers,

--- a/src/main/java/net/minecraftforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/minecraftforge/client/ItemDecoratorHandler.java
@@ -18,7 +18,6 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.RegisterItemDecorationsEvent;
-import net.minecraftforge.fml.ModLoader;
 
 @ApiStatus.Internal
 public final class ItemDecoratorHandler {
@@ -37,8 +36,7 @@ public final class ItemDecoratorHandler {
 
     public static void init() {
         var decorators = new HashMap<Item, List<IItemDecorator>>();
-        var event = new RegisterItemDecorationsEvent(decorators);
-        ModLoader.postEventWrapContainerInModOrder(event);
+        RegisterItemDecorationsEvent.BUS.post(new RegisterItemDecorationsEvent(decorators));
         var builder = new ImmutableMap.Builder<Item, ItemDecoratorHandler>();
         for (var entry : decorators.entrySet()) {
             Item item = entry.getKey();

--- a/src/main/java/net/minecraftforge/client/NamedRenderTypeManager.java
+++ b/src/main/java/net/minecraftforge/client/NamedRenderTypeManager.java
@@ -5,12 +5,10 @@
 
 package net.minecraftforge.client;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.RegisterNamedRenderTypesEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
@@ -22,7 +20,7 @@ import java.util.Map;
  * Provides a lookup.
  */
 public final class NamedRenderTypeManager {
-    private static ImmutableMap<ResourceLocation, RenderTypeGroup> RENDER_TYPES;
+    private static Map<ResourceLocation, RenderTypeGroup> RENDER_TYPES;
 
     /**
      * Finds the {@link RenderTypeGroup} for a given name, or the {@link RenderTypeGroup#EMPTY empty group} if not found.
@@ -35,9 +33,8 @@ public final class NamedRenderTypeManager {
     public static void init() {
         var renderTypes = new HashMap<ResourceLocation, RenderTypeGroup>();
         preRegisterVanillaRenderTypes(renderTypes);
-        var event = new RegisterNamedRenderTypesEvent(renderTypes);
-        ModLoader.postEventWrapContainerInModOrder(event);
-        RENDER_TYPES = ImmutableMap.copyOf(renderTypes);
+        RegisterNamedRenderTypesEvent.BUS.post(new RegisterNamedRenderTypesEvent(renderTypes));
+        RENDER_TYPES = Map.copyOf(renderTypes);
     }
 
     /**
@@ -53,9 +50,9 @@ public final class NamedRenderTypeManager {
         blockRenderTypes.put(rl("tripwire"), new RenderTypeGroup(ChunkSectionLayer.TRIPWIRE, ForgeRenderTypes.ITEM_LAYERED_TRANSLUCENT.get()));
     }
 
-    private static ResourceLocation rl(String paht) {
-        return ResourceLocation.withDefaultNamespace(paht);
+    private static ResourceLocation rl(String path) {
+        return ResourceLocation.withDefaultNamespace(path);
     }
 
-    private NamedRenderTypeManager() { }
+    private NamedRenderTypeManager() {}
 }

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -35,12 +35,13 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 import java.util.Set;
@@ -51,30 +52,30 @@ import java.util.function.Supplier;
  * Fired for on different events/actions relating to {@linkplain EntityRenderer entity renderers}.
  * See the various subclasses for listening to different events.
  *
- * <p>These events are fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see EntityRenderersEvent.RegisterLayerDefinitions
  * @see EntityRenderersEvent.RegisterRenderers
  * @see EntityRenderersEvent.AddLayers
+ * @see EntityRenderersEvent.CreateSkullModels
  */
-public abstract sealed class EntityRenderersEvent implements IModBusEvent {
-    @ApiStatus.Internal
-    protected EntityRenderersEvent() {}
-
+public sealed interface EntityRenderersEvent {
     /**
      * Fired for registering layer definitions at the appropriate time.
      *
-     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired on only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static final class RegisterLayerDefinitions extends EntityRenderersEvent implements SelfDestructing {
+    @NullMarked
+    record RegisterLayerDefinitions() implements SelfDestructing, RecordEvent, EntityRenderersEvent {
+        public static final EventBus<RegisterLayerDefinitions> BUS = EventBus.create(RegisterLayerDefinitions.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<RegisterLayerDefinitions> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, RegisterLayerDefinitions.class);
+            return BUS;
         }
 
         @ApiStatus.Internal
-        public RegisterLayerDefinitions() {}
+        public RegisterLayerDefinitions {}
 
         /**
          * Registers a layer definition supplier with the given {@link ModelLayerLocation}.
@@ -95,16 +96,19 @@ public abstract sealed class EntityRenderersEvent implements IModBusEvent {
      * For registering entity renderer layers to existing entity renderers (whether vanilla or registered through this
      * event), listen for the {@link AddLayers} event instead.
      *
-     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static final class RegisterRenderers extends EntityRenderersEvent implements SelfDestructing {
+    @NullMarked
+    record RegisterRenderers() implements SelfDestructing, RecordEvent, EntityRenderersEvent {
+        public static final EventBus<RegisterRenderers> BUS = EventBus.create(RegisterRenderers.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<RegisterRenderers> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, RegisterRenderers.class);
+            return BUS;
         }
 
         @ApiStatus.Internal
-        public RegisterRenderers() {}
+        public RegisterRenderers {}
 
         /**
          * Registers an entity renderer for the given entity type.
@@ -131,14 +135,14 @@ public abstract sealed class EntityRenderersEvent implements IModBusEvent {
      * Fired for registering entity renderer layers at the appropriate time, after the entity and player renderers maps
      * have been created.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
-     *
-     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static final class AddLayers extends EntityRenderersEvent {
+    final class AddLayers extends MutableEvent implements EntityRenderersEvent {
+        public static final EventBus<AddLayers> BUS = EventBus.create(AddLayers.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<AddLayers> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, AddLayers.class);
+            return BUS;
         }
 
         private final Map<EntityType<?>, EntityRenderer<?, ?>> renderers;
@@ -222,14 +226,14 @@ public abstract sealed class EntityRenderersEvent implements IModBusEvent {
     /**
      * Fired for registering additional {@linkplain net.minecraft.client.model.SkullModelBase skull models} at the appropriate time.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
-     *
-     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static final class CreateSkullModels extends EntityRenderersEvent {
+    final class CreateSkullModels extends MutableEvent implements EntityRenderersEvent {
+        public static final EventBus<CreateSkullModels> BUS = EventBus.create(CreateSkullModels.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<CreateSkullModels> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, CreateSkullModels.class);
+            return BUS;
         }
 
         private final ImmutableMap.Builder<Type, Function<EntityModelSet, SkullModelBase>> builder;

--- a/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
+++ b/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
@@ -273,8 +273,7 @@ public final class ForgeEventFactoryClient {
     }
 
     public static ModelEvent.RegisterModelStateDefinitions onRegisterModeStateDefinitions() {
-        // This is on the mod bus because it happens during the initial texture reload, which is while the Forge bus is shut down.
-        return ModLoader.postEventWithReturn(new ModelEvent.RegisterModelStateDefinitions());
+        return ModelEvent.RegisterModelStateDefinitions.BUS.fire(new ModelEvent.RegisterModelStateDefinitions());
     }
 
     public static void onInitLevelRenderer() {

--- a/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
+++ b/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
@@ -76,8 +76,7 @@ public final class ForgeEventFactoryClient {
     private ForgeEventFactoryClient() {}
 
     public static void onGatherLayers(Map<EntityType<?>, EntityRenderer<?, ?>> renderers, Map<PlayerModelType, AvatarRenderer<AbstractClientPlayer>> playerRenderers, Map<PlayerModelType, AvatarRenderer<ClientMannequin>> mannequinRenderers, Context context) {
-        // TODO: Why is this a ModLoader event...
-        ModLoader.postEvent(new EntityRenderersEvent.AddLayers(renderers, playerRenderers, mannequinRenderers, context));
+        EntityRenderersEvent.AddLayers.BUS.post(new EntityRenderersEvent.AddLayers(renderers, playerRenderers, mannequinRenderers, context));
     }
 
     public static boolean onScreenMouseReleased(Screen screen, double mouseX, double mouseY, MouseButtonEvent event) {
@@ -269,7 +268,7 @@ public final class ForgeEventFactoryClient {
 
     public static Map<Type, Function<EntityModelSet, SkullModelBase>> onCreateSkullModels() {
         var builder = ImmutableMap.<Type, Function<EntityModelSet, SkullModelBase>>builder();
-        ModLoader.postEvent(new EntityRenderersEvent.CreateSkullModels(builder));
+        EntityRenderersEvent.CreateSkullModels.BUS.post(new EntityRenderersEvent.CreateSkullModels(builder));
         return builder.build();
     }
 

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -15,6 +15,8 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -45,9 +47,12 @@ public sealed interface ModelEvent {
      * @param getResults the modifiable registry map of models and their model names
      */
     record ModifyBakingResult(ModelBakery getModelBakery, ModelBakery.BakingResult getResults)
-            implements IModBusEvent, ModelEvent {
+            implements RecordEvent, ModelEvent {
+        public static final EventBus<ModifyBakingResult> BUS = EventBus.create(ModifyBakingResult.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<ModifyBakingResult> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, ModifyBakingResult.class);
+            return BUS;
         }
 
         @ApiStatus.Internal
@@ -66,9 +71,12 @@ public sealed interface ModelEvent {
      * @param getModelBakery the model loader
      */
     record BakingCompleted(ModelManager getModelManager, ModelBakery getModelBakery)
-            implements IModBusEvent, ModelEvent {
+            implements RecordEvent, ModelEvent {
+        public static final EventBus<BakingCompleted> BUS = EventBus.create(BakingCompleted.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<BakingCompleted> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, BakingCompleted.class);
+            return BUS;
         }
 
         @ApiStatus.Internal
@@ -83,16 +91,19 @@ public sealed interface ModelEvent {
      *
      * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    final class RegisterModelStateDefinitions implements IModBusEvent, ModelEvent {
+    final class RegisterModelStateDefinitions extends MutableEvent implements ModelEvent {
+        public static final EventBus<RegisterModelStateDefinitions> BUS = EventBus.create(RegisterModelStateDefinitions.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<RegisterModelStateDefinitions> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, RegisterModelStateDefinitions.class);
+            return BUS;
         }
 
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> states = new HashMap<>();
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> view = Collections.unmodifiableMap(states);
 
         @ApiStatus.Internal
-        public RegisterModelStateDefinitions() { }
+        public RegisterModelStateDefinitions() {}
 
         /**
          * Returns a read only view of the extra registered models

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -21,6 +21,7 @@ import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,9 +126,13 @@ public sealed interface ModelEvent {
      *
      * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    final class RegisterGeometryLoaders implements IModBusEvent, ModelEvent {
+    @NullMarked
+    final class RegisterGeometryLoaders extends MutableEvent implements ModelEvent {
+        public static final EventBus<RegisterGeometryLoaders> BUS = EventBus.create(RegisterGeometryLoaders.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<RegisterGeometryLoaders> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, RegisterGeometryLoaders.class);
+            return BUS;
         }
 
         private final Map<ResourceLocation, IGeometryLoader> loaders;
@@ -139,13 +144,11 @@ public sealed interface ModelEvent {
 
         /**
          * Registers a new geometry loader.
+         * @param resourceLocation The namespace should match your mod's namespace, such as your mod ID
          */
-        public void register(String name, IGeometryLoader loader) {
-            @SuppressWarnings("removal")
-            var namespace = ModLoadingContext.get().getActiveNamespace();
-            var key = ResourceLocation.fromNamespaceAndPath(namespace, name);
-            Preconditions.checkArgument(!loaders.containsKey(key), "Geometry loader already registered: " + key);
-            loaders.put(key, loader);
+        public void register(ResourceLocation resourceLocation, IGeometryLoader loader) {
+            Preconditions.checkArgument(!loaders.containsKey(resourceLocation), "Geometry loader already registered: " + resourceLocation);
+            loaders.put(resourceLocation, loader);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
@@ -11,11 +11,11 @@ import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Fired to allow mods to register their reload listeners on the client-side resource manager.
@@ -23,12 +23,15 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>For registering reload listeners on the server-side resource manager, see {@link AddReloadListenerEvent}.</p>
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterClientReloadListenersEvent implements SelfDestructing, IModBusEvent {
+@NullMarked
+public final class RegisterClientReloadListenersEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterClientReloadListenersEvent> BUS = EventBus.create(RegisterClientReloadListenersEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterClientReloadListenersEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterClientReloadListenersEvent.class);
+        return BUS;
     }
 
     private final ReloadableResourceManager resourceManager;

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
@@ -9,11 +9,11 @@ import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -22,12 +22,15 @@ import java.util.function.Function;
  * Allows users to register custom {@link net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent}
  * factories for their {@link net.minecraft.world.inventory.tooltip.TooltipComponent} types.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterClientTooltipComponentFactoriesEvent implements SelfDestructing, IModBusEvent {
+@NullMarked
+public final class RegisterClientTooltipComponentFactoriesEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterClientTooltipComponentFactoriesEvent> BUS = EventBus.create(RegisterClientTooltipComponentFactoriesEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterClientTooltipComponentFactoriesEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterClientTooltipComponentFactoriesEvent.class);
+        return BUS;
     }
 
     private final Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> factories;

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -11,10 +11,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -24,24 +24,23 @@ import java.util.ArrayList;
  * Fired for registering block and item color handlers at the appropriate time.
  * See the two subclasses for registering block or item color handlers.
  *
- * <p>These events are fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see RegisterColorHandlersEvent.Block
  * @see RegisterColorHandlersEvent.ColorResolvers
  */
-public sealed interface RegisterColorHandlersEvent extends IModBusEvent {
+public sealed interface RegisterColorHandlersEvent {
     /**
      * Fired for registering block color handlers.
      *
-     * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
-     *
-     * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    record Block(BlockColors getBlockColors) implements RegisterColorHandlersEvent {
+    record Block(BlockColors getBlockColors) implements RecordEvent, RegisterColorHandlersEvent {
+        public static final EventBus<Block> BUS = EventBus.create(Block.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<Block> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, Block.class);
+            return BUS;
         }
 
         @ApiStatus.Internal
@@ -73,9 +72,12 @@ public sealed interface RegisterColorHandlersEvent extends IModBusEvent {
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
     @NullMarked
-    final class ColorResolvers implements RegisterColorHandlersEvent, SelfDestructing {
+    final class ColorResolvers extends MutableEvent implements SelfDestructing, RegisterColorHandlersEvent {
+        public static final EventBus<ColorResolvers> BUS = EventBus.create(ColorResolvers.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<ColorResolvers> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, ColorResolvers.class);
+            return BUS;
         }
 
         private final ArrayList<ColorResolver> builder;

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public final class RegisterDimensionSpecialEffectsEvent extends MutableEvent implements SelfDestructing {
     public static final EventBus<RegisterDimensionSpecialEffectsEvent> BUS = EventBus.create(RegisterDimensionSpecialEffectsEvent.class);
 
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterDimensionSpecialEffectsEvent> getBus(BusGroup modBusGroup) {
         return BUS;
     }

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -9,10 +9,9 @@ import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -21,13 +20,14 @@ import java.util.Map;
 /**
  * Allows users to register custom {@link DimensionSpecialEffects} for their dimensions.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @NullMarked
-public final class RegisterDimensionSpecialEffectsEvent implements SelfDestructing, IModBusEvent {
+public final class RegisterDimensionSpecialEffectsEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterDimensionSpecialEffectsEvent> BUS = EventBus.create(RegisterDimensionSpecialEffectsEvent.class);
+
     public static EventBus<RegisterDimensionSpecialEffectsEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterDimensionSpecialEffectsEvent.class);
+        return BUS;
     }
 
     private final Map<ResourceLocation, DimensionSpecialEffects> effects;

--- a/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
@@ -9,10 +9,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -22,13 +21,15 @@ import java.util.Map;
  * Allows users to register custom shaders to be used when the player spectates a certain kind of entity.
  * Vanilla examples of this are the green effect for creepers and the invert effect for endermen.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired on only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @NullMarked
-public final class RegisterEntitySpectatorShadersEvent implements SelfDestructing, IModBusEvent {
+public final class RegisterEntitySpectatorShadersEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterEntitySpectatorShadersEvent> BUS = EventBus.create(RegisterEntitySpectatorShadersEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterEntitySpectatorShadersEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterEntitySpectatorShadersEvent.class);
+        return BUS;
     }
 
     private final Map<EntityType<?>, ResourceLocation> shaders;

--- a/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
@@ -11,11 +11,11 @@ import net.minecraftforge.client.IItemDecorator;
 
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +24,15 @@ import java.util.Map;
 /**
  * Allows users to register custom {@linkplain IItemDecorator IItemDecorator} to Items.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterItemDecorationsEvent implements SelfDestructing, IModBusEvent {
+@NullMarked
+public final class RegisterItemDecorationsEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterItemDecorationsEvent> BUS = EventBus.create(RegisterItemDecorationsEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterItemDecorationsEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterItemDecorationsEvent.class);
+        return BUS;
     }
 
     private final Map<Item, List<IItemDecorator>> decorators;

--- a/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
@@ -9,22 +9,25 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Allows users to register custom {@link net.minecraft.client.KeyMapping key mappings}.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterKeyMappingsEvent implements SelfDestructing, IModBusEvent {
+@NullMarked
+public final class RegisterKeyMappingsEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterKeyMappingsEvent> BUS = EventBus.create(RegisterKeyMappingsEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterKeyMappingsEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterKeyMappingsEvent.class);
+        return BUS;
     }
 
     private final Options options;

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -13,9 +13,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.RenderTypeGroup;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
@@ -25,9 +25,12 @@ import java.util.Map;
  *
  * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterNamedRenderTypesEvent implements IModBusEvent {
+public final class RegisterNamedRenderTypesEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterNamedRenderTypesEvent> BUS = EventBus.create(RegisterNamedRenderTypesEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterNamedRenderTypesEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterNamedRenderTypesEvent.class);
+        return BUS;
     }
 
     private final Map<ResourceLocation, RenderTypeGroup> renderTypes;
@@ -40,26 +43,24 @@ public final class RegisterNamedRenderTypesEvent implements IModBusEvent {
     /**
      * Registers a named {@link RenderTypeGroup}.
      *
-     * @param name             The name
+     * @param resourceLocation The namespace should match your mod's namespace, such as your mod ID
      * @param blockRenderType  What ChunkSectionLayer to render in
      * @param entityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
      */
-    public void register(String name, ChunkSectionLayer blockRenderType, RenderType entityRenderType) {
-        register(name, blockRenderType, entityRenderType, entityRenderType);
+    public void register(ResourceLocation resourceLocation, ChunkSectionLayer blockRenderType, RenderType entityRenderType) {
+        register(resourceLocation, blockRenderType, entityRenderType, entityRenderType);
     }
 
     /**
      * Registers a named {@link RenderTypeGroup}.
      *
-     * @param name                     The name
+     * @param key                      The namespace should match your mod's namespace, such as your mod ID
      * @param blockRenderType          What ChunkSectionLayer to render in
      * @param entityRenderType         A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
      * @param fabulousEntityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY} for use when
      *                                 "fabulous" rendering is enabled
      */
-    public void register(String name, ChunkSectionLayer blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType) {
-        @SuppressWarnings("removal")
-        var key = ResourceLocation.fromNamespaceAndPath(ModLoadingContext.get().getActiveNamespace(), name);
+    public void register(ResourceLocation key, ChunkSectionLayer blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType) {
         Preconditions.checkArgument(!renderTypes.containsKey(key), "Render type already registered: " + key);
         Preconditions.checkArgument(entityRenderType.format() == DefaultVertexFormat.NEW_ENTITY, "The entity render type must use the NEW_ENTITY vertex format.");
         Preconditions.checkArgument(fabulousEntityRenderType.format() == DefaultVertexFormat.NEW_ENTITY, "The fabulous entity render type must use the NEW_ENTITY vertex format.");

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -11,11 +11,11 @@ import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegisterEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Fired for registering particle providers at the appropriate time.
@@ -23,14 +23,15 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>{@link ParticleType}s must be registered during {@link RegisterEvent} as usual;
  * this event is only for the {@link ParticleProvider}s.</p>
  *
- * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
- *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterParticleProvidersEvent implements IModBusEvent {
+@NullMarked
+public final class RegisterParticleProvidersEvent extends MutableEvent {
+    public static EventBus<RegisterParticleProvidersEvent> BUS = EventBus.create(RegisterParticleProvidersEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterParticleProvidersEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterParticleProvidersEvent.class);
+        return BUS;
     }
 
     private final ParticleResources particles;

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -12,22 +12,22 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.textures.ITextureAtlasSpriteLoader;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Allows users to register custom {@link ITextureAtlasSpriteLoader texture atlas sprite loaders}.
  *
- * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public final class RegisterTextureAtlasSpriteLoadersEvent implements SelfDestructing, IModBusEvent {
+public final class RegisterTextureAtlasSpriteLoadersEvent extends MutableEvent implements SelfDestructing {
+    public static final EventBus<RegisterTextureAtlasSpriteLoadersEvent> BUS = EventBus.create(RegisterTextureAtlasSpriteLoadersEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterTextureAtlasSpriteLoadersEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterTextureAtlasSpriteLoadersEvent.class);
+        return BUS;
     }
 
     private final BiMap<ResourceLocation, ITextureAtlasSpriteLoader> loaders;
@@ -39,12 +39,11 @@ public final class RegisterTextureAtlasSpriteLoadersEvent implements SelfDestruc
 
     /**
      * Registers a custom {@link ITextureAtlasSpriteLoader sprite loader}.
+     * @param resourceLocation The namespace should match your mod's namespace, such as your mod ID
      */
-    public void register(String name, ITextureAtlasSpriteLoader loader) {
-        @SuppressWarnings("removal")
-        var key = ResourceLocation.fromNamespaceAndPath(ModLoadingContext.get().getActiveNamespace(), name);
-        Preconditions.checkArgument(!loaders.containsKey(key), "Sprite loader already registered: " + key);
+    public void register(ResourceLocation resourceLocation, ITextureAtlasSpriteLoader loader) {
+        Preconditions.checkArgument(!loaders.containsKey(resourceLocation), "Sprite loader already registered: " + resourceLocation);
         Preconditions.checkArgument(!loaders.containsValue(loader), "Sprite loader already registered as " + loaders.inverse().get(loader));
-        loaders.put(key, loader);
+        loaders.put(resourceLocation, loader);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.client.event;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -31,8 +31,7 @@ public sealed interface TextureStitchEvent {
     //  * <p>Fired <b>before</b> a texture atlas is stitched together.
     //  * This can be used to add custom sprites to be stitched into the atlas.</p>
     //  *
-    //  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus()} mod-specific event bus},
-    //  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+    //  * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
     //  */
     // public static class Pre extends TextureStitchEvent {
     //     private final Set<ResourceLocation> sprites;
@@ -61,9 +60,12 @@ public sealed interface TextureStitchEvent {
      *
      * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    record Post(TextureAtlas getAtlas) implements TextureStitchEvent, IModBusEvent {
+    record Post(TextureAtlas getAtlas) implements RecordEvent, TextureStitchEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<Post> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, Post.class);
+            return BUS;
         }
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -8,9 +8,10 @@ package net.minecraftforge.client.event.sound;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Fired when the {@link SoundEngine} is constructed or (re)loaded, such as during game initialization or when the sound
@@ -18,9 +19,13 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public record SoundEngineLoadEvent(SoundEngine getEngine) implements IModBusEvent, SoundEvent {
+@NullMarked
+public record SoundEngineLoadEvent(SoundEngine getEngine) implements RecordEvent, SoundEvent {
+    public static final EventBus<SoundEngineLoadEvent> BUS = EventBus.create(SoundEngineLoadEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<SoundEngineLoadEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, SoundEngineLoadEvent.class);
+        return BUS;
     }
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/gui/ClientTooltipComponentManager.java
+++ b/src/main/java/net/minecraftforge/client/gui/ClientTooltipComponentManager.java
@@ -5,15 +5,14 @@
 
 package net.minecraftforge.client.gui;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraftforge.client.event.RegisterClientTooltipComponentFactoriesEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -22,13 +21,12 @@ import java.util.function.Function;
  * Provides a lookup.
  */
 public final class ClientTooltipComponentManager {
-    private static ImmutableMap<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> FACTORIES;
+    private static Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> FACTORIES;
 
     /**
-     * Creates a client component for the given argument, or null if unsupported.
+     * Creates a client component for the given argument
      */
-    @Nullable
-    public static ClientTooltipComponent createClientTooltipComponent(TooltipComponent component) {
+    public static @NonNull ClientTooltipComponent createClientTooltipComponent(@NonNull TooltipComponent component) {
         var factory = FACTORIES.get(component.getClass());
         var ret = factory != null ? factory.apply(component) : null;
         if (ret == null)
@@ -40,9 +38,9 @@ public final class ClientTooltipComponentManager {
     public static void init() {
         var factories = new HashMap<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>>();
         var event = new RegisterClientTooltipComponentFactoriesEvent(factories);
-        ModLoader.postEventWrapContainerInModOrder(event);
-        FACTORIES = ImmutableMap.copyOf(factories);
+        RegisterClientTooltipComponentFactoriesEvent.BUS.post(event);
+        FACTORIES = Map.copyOf(factories);
     }
 
-    private ClientTooltipComponentManager() { }
+    private ClientTooltipComponentManager() {}
 }

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -48,7 +48,7 @@ public class ClientModLoader {
         createRunnableWithCatch(()->ModLoader.get().gatherAndInitializeMods(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor(), ImmediateWindowHandler::renderTick)).run();
         if (error == null) {
             ResourcePackLoader.loadResourcePacks(defaultResourcePacks, true);
-            ModLoader.postEvent(new AddPackFindersEvent(PackType.CLIENT_RESOURCES, defaultResourcePacks::addPackFinder));
+            net.minecraftforge.event.AddPackFindersEvent.BUS.post(new AddPackFindersEvent(PackType.CLIENT_RESOURCES, defaultResourcePacks::addPackFinder));
             DataPackConfig.DEFAULT.addModPacks(ResourcePackLoader.getPackNames());
             mcResourceManager.registerReloadListener(ClientModLoader::onResourceReload);
             mcResourceManager.registerReloadListener(BrandingControl.resourceManagerReloadListener());

--- a/src/main/java/net/minecraftforge/client/model/geometry/GeometryLoaderManager.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/GeometryLoaderManager.java
@@ -5,14 +5,13 @@
 
 package net.minecraftforge.client.model.geometry;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.ModelEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -21,7 +20,7 @@ import java.util.stream.Collectors;
  * Provides a lookup.
  */
 public final class GeometryLoaderManager {
-    private static ImmutableMap<ResourceLocation, IGeometryLoader> LOADERS;
+    private static Map<ResourceLocation, IGeometryLoader> LOADERS;
     private static String LOADER_LIST;
 
     /**
@@ -42,11 +41,10 @@ public final class GeometryLoaderManager {
     @ApiStatus.Internal
     public static void init() {
         var loaders = new HashMap<ResourceLocation, IGeometryLoader>();
-        var event = new ModelEvent.RegisterGeometryLoaders(loaders);
-        ModLoader.postEventWrapContainerInModOrder(event);
-        LOADERS = ImmutableMap.copyOf(loaders);
+        ModelEvent.RegisterGeometryLoaders.BUS.post(new ModelEvent.RegisterGeometryLoaders(loaders));
+        LOADERS = Map.copyOf(loaders);
         LOADER_LIST = loaders.keySet().stream().map(ResourceLocation::toString).collect(Collectors.joining(", "));
     }
 
-    private GeometryLoaderManager() { }
+    private GeometryLoaderManager() {}
 }

--- a/src/main/java/net/minecraftforge/client/textures/TextureAtlasSpriteLoaderManager.java
+++ b/src/main/java/net/minecraftforge/client/textures/TextureAtlasSpriteLoaderManager.java
@@ -10,7 +10,6 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableBiMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.RegisterTextureAtlasSpriteLoadersEvent;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,8 +38,7 @@ public final class TextureAtlasSpriteLoaderManager {
     @ApiStatus.Internal
     public static void init() {
         var loaders = HashBiMap.<ResourceLocation, ITextureAtlasSpriteLoader>create();
-        var event = new RegisterTextureAtlasSpriteLoadersEvent(loaders);
-        ModLoader.postEventWrapContainerInModOrder(event);
+        RegisterTextureAtlasSpriteLoadersEvent.BUS.post(new RegisterTextureAtlasSpriteLoadersEvent(loaders));
         LOADERS = ImmutableBiMap.copyOf(loaders);
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1066,7 +1066,7 @@ public final class ForgeHooks {
             entries.put(stack, vis);
         });
 
-        ModLoader.postEvent(new BuildCreativeModeTabContentsEvent(tab, tabKey, params, entries));
+        BuildCreativeModeTabContentsEvent.BUS.post(new BuildCreativeModeTabContentsEvent(tab, tabKey, params, entries));
 
         for (var entry : entries)
             output.accept(entry.getKey(), entry.getValue());

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -790,7 +790,7 @@ public final class ForgeHooks {
 
     @Deprecated
     public static void modifyAttributes() {
-        ModLoader.postEvent(new EntityAttributeCreationEvent(FORGE_ATTRIBUTES));
+        EntityAttributeCreationEvent.BUS.post(new EntityAttributeCreationEvent(FORGE_ATTRIBUTES));
         Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> finalMap = new HashMap<>();
         ModLoader.postEvent(new EntityAttributeModificationEvent(finalMap));
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -792,7 +792,7 @@ public final class ForgeHooks {
     public static void modifyAttributes() {
         EntityAttributeCreationEvent.BUS.post(new EntityAttributeCreationEvent(FORGE_ATTRIBUTES));
         Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> finalMap = new HashMap<>();
-        ModLoader.postEvent(new EntityAttributeModificationEvent(finalMap));
+        EntityAttributeModificationEvent.BUS.post(new EntityAttributeModificationEvent(finalMap));
 
         finalMap.forEach((k, v) -> {
             AttributeSupplier supplier = DefaultAttributes.getSupplier(k);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -386,7 +386,7 @@ public class ForgeMod {
 
         BusGroup modBusGroup = context.getModBusGroup();
         // Forge-provided datapack registries
-        DataPackRegistryEvent.NewRegistry.getBus(modBusGroup).addListener(event -> {
+        DataPackRegistryEvent.NewRegistry.BUS.addListener(event -> {
             event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
             event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
         });
@@ -395,7 +395,7 @@ public class ForgeMod {
         var registerEventBus = RegisterEvent.getBus(modBusGroup);
         registerEventBus.addListener(ForgeMod::registerFluids);
         registerEventBus.addListener(ForgeMod::registerVanillaDisplayContexts);
-        EntityAttributeModificationEvent.getBus(modBusGroup).addListener(ForgeMod::onRegisterAttributes);
+        EntityAttributeModificationEvent.BUS.addListener(ForgeMod::onRegisterAttributes);
         ForgeDeferredRegistriesSetup.setup(modBusGroup);
         for (var reg : registries)
             reg.register(modBusGroup);

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoader;
+import net.minecraftforge.forgespi.language.ModFileScanData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.ApiStatus;
@@ -91,7 +92,7 @@ public final class CapabilityManager {
         var autos = modlist.getAllScanData().stream()
             .flatMap(e -> e.getAnnotations().stream())
             .filter(a -> AUTO_REGISTER.equals(a.annotationType()))
-            .map(a -> a.clazz())
+            .map(ModFileScanData.AnnotationData::clazz)
             .distinct()
             .sorted(Comparator.comparing(Type::toString))
             .toList();
@@ -102,8 +103,7 @@ public final class CapabilityManager {
         }
 
         @SuppressWarnings("removal")
-        var event = new RegisterCapabilitiesEvent();
-        ModLoader.postEvent(event);
+        var event = RegisterCapabilitiesEvent.BUS.fire(new RegisterCapabilitiesEvent());
     }
 
     private static void error(String message) {

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -9,9 +9,9 @@ import java.util.Objects;
 
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import org.jspecify.annotations.NullMarked;
 import org.objectweb.asm.Type;
-
-import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
  * This event fires when it is time to register your capabilities.
@@ -20,9 +20,13 @@ import net.minecraftforge.fml.event.IModBusEvent;
  * @deprecated Use {@link AutoRegisterCapability} annotation on your class.
  */
 @Deprecated(forRemoval = true, since = "1.21")
-public final class RegisterCapabilitiesEvent implements IModBusEvent {
+@NullMarked
+public record RegisterCapabilitiesEvent() implements RecordEvent {
+    public static final EventBus<RegisterCapabilitiesEvent> BUS = EventBus.create(RegisterCapabilitiesEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<RegisterCapabilitiesEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, RegisterCapabilitiesEvent.class);
+        return BUS;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.repository.RepositorySource;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
 
 import java.util.function.Consumer;
 
@@ -19,9 +19,12 @@ import java.util.function.Consumer;
  *
  * @param getPackType the {@link PackType} of the pack repository being constructed.
  */
-public record AddPackFindersEvent(PackType getPackType, Consumer<RepositorySource> sourceAdder) implements IModBusEvent {
+public record AddPackFindersEvent(PackType getPackType, Consumer<RepositorySource> sourceAdder) implements RecordEvent {
+    public static final EventBus<AddPackFindersEvent> BUS = EventBus.create(AddPackFindersEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<AddPackFindersEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, AddPackFindersEvent.class);
+        return BUS;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
@@ -13,10 +13,10 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.event.IModBusEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.function.Supplier;
 
@@ -26,9 +26,13 @@ import java.util.function.Supplier;
  * <p>
  * This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
-public final class BuildCreativeModeTabContentsEvent implements IModBusEvent, CreativeModeTab.Output {
+@NullMarked
+public final class BuildCreativeModeTabContentsEvent extends MutableEvent implements CreativeModeTab.Output {
+    public static final EventBus<BuildCreativeModeTabContentsEvent> BUS = EventBus.create(BuildCreativeModeTabContentsEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<BuildCreativeModeTabContentsEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, BuildCreativeModeTabContentsEvent.class);
+        return BUS;
     }
 
     private final CreativeModeTab tab;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -942,9 +942,8 @@ public final class ForgeEventFactory {
         PlayerInteractEvent.RightClickEmpty.BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
     }
 
-    // TODO: Remove from mod bus - Lex 04222024
     public static void addPackFindersServer(Consumer<RepositorySource> consumer) {
-        ModLoader.postEvent(new AddPackFindersEvent(PackType.SERVER_DATA, consumer));
+        net.minecraftforge.event.AddPackFindersEvent.BUS.post(new AddPackFindersEvent(PackType.SERVER_DATA, consumer));
     }
 
     public static boolean onEntityJoinLevel(Entity entity, Level level) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
@@ -13,18 +13,19 @@ import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * EntityAttributeCreationEvent.<br>
  * Use this event to register attributes for your own EntityTypes.
  * This event is fired after registration and before common setup.
- * <br>
- * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public final class EntityAttributeCreationEvent implements IModBusEvent {
+public final class EntityAttributeCreationEvent extends MutableEvent {
+    public static final EventBus<EntityAttributeCreationEvent> BUS = EventBus.create(EntityAttributeCreationEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<EntityAttributeCreationEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, EntityAttributeCreationEvent.class);
+        return BUS;
     }
 
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier> map;

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
@@ -5,8 +5,6 @@
 
 package net.minecraftforge.event.entity;
 
-import com.google.common.collect.ImmutableList;
-
 import net.minecraft.core.Holder;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -15,23 +13,23 @@ import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * EntityAttributeModificationEvent.<br>
  * Use this event to add attributes to existing entity types.
  * This event is fired after registration and before common setup, and after {@link EntityAttributeCreationEvent}
- * <br>
- * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public final class EntityAttributeModificationEvent implements IModBusEvent {
+public final class EntityAttributeModificationEvent extends MutableEvent {
+    public static final EventBus<EntityAttributeModificationEvent> BUS = EventBus.create(EntityAttributeModificationEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<EntityAttributeModificationEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, EntityAttributeModificationEvent.class);
+        return BUS;
     }
 
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> entityAttributes;
@@ -40,11 +38,11 @@ public final class EntityAttributeModificationEvent implements IModBusEvent {
     @SuppressWarnings("unchecked")
     public EntityAttributeModificationEvent(Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> mapIn) {
         this.entityAttributes = mapIn;
-        this.entityTypes = ImmutableList.copyOf(
+        this.entityTypes = List.copyOf(
             ForgeRegistries.ENTITY_TYPES.getValues().stream()
                 .filter(DefaultAttributes::hasSupplier)
                 .map(entityType -> (EntityType<? extends LivingEntity>) entityType)
-                .collect(Collectors.toList())
+                .toList()
         );
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -18,7 +18,8 @@ import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -26,24 +27,23 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * This event allows each {@link EntityType} to have a {@link SpawnPlacements.SpawnPredicate} registered or modified.
  * Spawn Predicates are checked whenever an {@link Entity} of the given {@link EntityType} spawns in the world naturally.
- *
- * If registering your own entity's spawn placements, you should use {@link SpawnPlacementRegisterEvent#register(EntityType, SpawnPlacements.Type, Heightmap.Types, SpawnPlacements.SpawnPredicate, Operation)}
+ * <br>
+ * If registering your own entity's spawn placements, you should use {@link SpawnPlacementRegisterEvent#register(EntityType, SpawnPlacementType, Heightmap.Types, SpawnPlacements.SpawnPredicate, Operation)}
  * So that you ensure that your entity has a heightmap type and placement type registered.
- *
+ * <br>
  * If modifying vanilla or another mod's spawn placements, you can use three operations:
- *  REPLACE: checked first, the last mod to replace the predicate wipes out all other predicates. Listen with a low {@link EventPriority} if you need to do this.
- *  OR: checked second, only one of these predicates must pass along with the original predicate
- *  AND: checked third, these predicates must all pass along with the original predicate
- *
- * <p>
- * This event is not {@linkplain Cancelable cancellable} and does not {@linkplain Event.HasResult have a result}.
- * <p>
- *
- *  Fired on the Mod bus {@link IModBusEvent}.<br>
+ * <ul>
+ *     <li>REPLACE: checked first, the last mod to replace the predicate wipes out all other predicates. Listen with a low {@link Priority} if you need to do this.</li>
+ *     <li>OR: checked second, only one of these predicates must pass along with the original predicate</li>
+ *     <li>AND: checked third, these predicates must all pass along with the original predicate</li>
+ * </ul>
  */
-public final class SpawnPlacementRegisterEvent implements IModBusEvent {
+public final class SpawnPlacementRegisterEvent extends MutableEvent {
+    public static final EventBus<SpawnPlacementRegisterEvent> BUS = EventBus.create(SpawnPlacementRegisterEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<SpawnPlacementRegisterEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, SpawnPlacementRegisterEvent.class);
+        return BUS;
     }
 
     private final Map<EntityType<?>, MergedSpawnPredicate<?>> map;
@@ -151,7 +151,7 @@ public final class SpawnPlacementRegisterEvent implements IModBusEvent {
         }
 
         @ApiStatus.Internal
-        public SpawnPlacements.SpawnPredicate<T> build() {
+        public final SpawnPlacements.SpawnPredicate<T> build() {
             if (replacementPredicate != null) {
                 return replacementPredicate;
             }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -17,14 +17,14 @@ import java.util.function.Consumer;
 
 /**
  * This is the first of four commonly called events during mod initialization.
- *
+ * <br><br>
  * Called after {@link net.minecraftforge.registries.RegisterEvent} events have been fired and before 
  * {@link FMLClientSetupEvent} or {@link FMLDedicatedServerSetupEvent} during mod startup.
- *
+ * <br><br>
  * Either register your listener using {@link net.minecraftforge.fml.javafmlmod.AutomaticEventSubscriber} and
- * {@link net.minecraftforge.eventbus.api.SubscribeEvent} or
- * {@link net.minecraftforge.eventbus.api.IEventBus#addListener(Consumer)} in your constructor.
- *
+ * {@link net.minecraftforge.eventbus.api.listener.SubscribeEvent} or
+ * {@link net.minecraftforge.eventbus.api.bus.EventBus#addListener(Consumer)} in your constructor.
+ * <br><br>
  * Most non-specific mod setup will be performed here. Note that this is a parallel dispatched event - you cannot
  * interact with game state in this event.
  *

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
@@ -14,30 +14,28 @@ import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public sealed abstract class DataPackRegistryEvent implements IModBusEvent {
-    @ApiStatus.Internal
-    protected DataPackRegistryEvent() {}
-
+public sealed interface DataPackRegistryEvent {
     /**
      * Fired when datapack registries can be registered.
      * Datapack registries are registries which can only load entries through JSON files from datapacks.
      * <p>
      * Data JSONs will be loaded from {@code data/<datapack_namespace>/modid/registryname/}, where {@code modid} is the namespace of the registry key.
      * <p>
-     * This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
-     * <p>
-     * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
-     * on both {@linkplain LogicalSide logical sides}.
+     * This event is fired on both {@linkplain LogicalSide logical sides}.
      */
-    public static final class NewRegistry extends DataPackRegistryEvent {
+    final class NewRegistry extends MutableEvent implements DataPackRegistryEvent {
+        public static final EventBus<NewRegistry> BUS = EventBus.create(NewRegistry.class);
+
+        @Deprecated(forRemoval = true, since = "1.21.9")
         public static EventBus<NewRegistry> getBus(BusGroup modBusGroup) {
-            return IModBusEvent.getBus(modBusGroup, NewRegistry.class);
+            return BUS;
         }
 
         private final List<DataPackRegistryData<?>> registryDataList = new ArrayList<>();

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -12,7 +12,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.javafmlmod.FMLModContainer;
 import net.minecraftforge.registries.tags.ITagManager;
@@ -20,7 +19,6 @@ import net.minecraftforge.registries.tags.ITagManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -322,7 +320,9 @@ public class DeferredRegister<T> {
      *                    your language provider's equivalent.
      */
     public void register(BusGroup modBusGroup) {
-        modBusGroup.register(EventDispatcher.LOOKUP, new EventDispatcher());
+        var dispatcher = new EventDispatcher();
+        RegisterEvent.getBus(modBusGroup).addListener(dispatcher::handleEvent);
+        NewRegistryEvent.BUS.addListener(dispatcher::createRegistry);
     }
 
     /**
@@ -376,9 +376,6 @@ public class DeferredRegister<T> {
     }
 
     private final class EventDispatcher {
-        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-
-        @SubscribeEvent
         public void handleEvent(RegisterEvent event) {
             if (event.getRegistryKey().equals(registryKey)) {
                 seenRegisterEvent = true;
@@ -392,7 +389,6 @@ public class DeferredRegister<T> {
             }
         }
 
-        @SubscribeEvent
         public void createRegistry(NewRegistryEvent event) {
             if (registryFactory != null)
                 event.create(registryFactory.get(), DeferredRegister.this::onFill);

--- a/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
@@ -16,16 +16,19 @@ import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
  * Register new registries when you receive this event through {@link RegistryBuilder} and {@link #create(RegistryBuilder)}.
  */
-public final class NewRegistryEvent implements IModBusEvent {
+public final class NewRegistryEvent extends MutableEvent {
+    public static final EventBus<NewRegistryEvent> BUS = EventBus.create(NewRegistryEvent.class);
+
+    @Deprecated(forRemoval = true, since = "1.21.9")
     public static EventBus<NewRegistryEvent> getBus(BusGroup modBusGroup) {
-        return IModBusEvent.getBus(modBusGroup, NewRegistryEvent.class);
+        return BUS;
     }
 
     private static final Logger LOGGER = LogUtils.getLogger();

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -131,12 +131,10 @@ public class RegistryManager {
     }
 
     public static void postNewRegistryEvent() {
-        NewRegistryEvent event = new NewRegistryEvent();
-        DataPackRegistryEvent.NewRegistry dataPackEvent = new DataPackRegistryEvent.NewRegistry();
         vanillaRegistryKeys = Set.copyOf(BuiltInRegistries.REGISTRY.keySet());
 
-        ModLoader.postEventWrapContainerInModOrder(event);
-        ModLoader.postEventWrapContainerInModOrder(dataPackEvent);
+        var event = NewRegistryEvent.BUS.fire(new NewRegistryEvent());
+        var dataPackEvent = DataPackRegistryEvent.NewRegistry.BUS.fire(new DataPackRegistryEvent.NewRegistry());
 
         event.fill();
         dataPackEvent.process();

--- a/src/test/java/com/example/examplemod/ExampleMod.java
+++ b/src/test/java/com/example/examplemod/ExampleMod.java
@@ -86,7 +86,7 @@ public final class ExampleMod {
         CREATIVE_MODE_TABS.register(modBusGroup);
 
         // Register the item to a creative tab
-        BuildCreativeModeTabContentsEvent.getBus(modBusGroup).addListener(ExampleMod::addCreative);
+        BuildCreativeModeTabContentsEvent.BUS.addListener(ExampleMod::addCreative);
 
         // Register our mod's ForgeConfigSpec so that Forge can create and load the config file for us
         context.registerConfig(ModConfig.Type.COMMON, Config.SPEC);

--- a/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
@@ -42,7 +42,6 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLLoader;
@@ -52,7 +51,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;
 
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -78,16 +76,16 @@ public class AdditionalModelTest extends BaseTestMod {
 
     public AdditionalModelTest(FMLJavaModLoadingContext context) {
         super(context, false, FMLLoader.getLaunchHandler().isData());
-        modBus.register(MethodHandles.lookup(), this);
+        GatherDataEvent.getBus(modBus).addListener(this::runData);
+        ModelEvent.RegisterModelStateDefinitions.BUS.addListener(this::onRegisterAdditional);
+        EntityRenderersEvent.AddLayers.BUS.addListener(this::onAddLayers);
     }
 
-    @SubscribeEvent
     public void runData(GatherDataEvent event) {
         var out = event.getGenerator().getPackOutput();
         event.getGenerator().addProvider(event.includeClient(), new ModelProvider(out));
     }
 
-    @SubscribeEvent
     public void onRegisterAdditional(ModelEvent.RegisterModelStateDefinitions event) {
         // Our fake blocks are only created during data gen, so we have to add a fake mapper
         event.register(rl("cow_head"), COW_HEAD_STATE);
@@ -119,7 +117,6 @@ public class AdditionalModelTest extends BaseTestMod {
     }
 
     // An example on how to render both the item and block model variants
-    @SubscribeEvent
     public void onAddLayers(EntityRenderersEvent.AddLayers event) {
         // Pigs get a block on their head, this is a test of going through the ItemModel loader
         LivingEntityRenderer<Pig, PigRenderState, PigModel> pig = event.getEntityRenderer(EntityType.PIG);

--- a/src/test/java/net/minecraftforge/debug/client/ModifyOverlayTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModifyOverlayTest.java
@@ -11,7 +11,6 @@ import net.minecraftforge.client.event.AddGuiOverlayLayersEvent;
 import net.minecraftforge.client.gui.overlay.ForgeLayer;
 import net.minecraftforge.client.gui.overlay.ForgeLayeredDraw;
 import net.minecraftforge.common.extensions.IForgeGameTestHelper;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTest;
@@ -120,7 +119,6 @@ public class ModifyOverlayTest extends BaseTestMod {
         });
     }
 
-    @SubscribeEvent
     private void overlayTestListener(AddGuiOverlayLayersEvent event) {
         drawStack = event.getLayeredDraw();
         var layeredDraw = event.getLayeredDraw();

--- a/src/test/java/net/minecraftforge/debug/creativetabs/CreativeModeTabTest.java
+++ b/src/test/java/net/minecraftforge/debug/creativetabs/CreativeModeTabTest.java
@@ -41,7 +41,7 @@ public class CreativeModeTabTest {
         var modBus = context.getModBusGroup();
 
         RegisterEvent.getBus(modBus).addListener(CreativeModeTabTest::onCreativeModeTabRegister);
-        BuildCreativeModeTabContentsEvent.getBus(modBus).addListener(CreativeModeTabTest::onCreativeModeTabBuildContents);
+        BuildCreativeModeTabContentsEvent.BUS.addListener(CreativeModeTabTest::onCreativeModeTabBuildContents);
     }
 
     private static void onCreativeModeTabRegister(RegisterEvent event) {

--- a/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
@@ -41,7 +41,7 @@ public class NetworkDatapackRegistryTest extends BaseTestMod {
 
     public NetworkDatapackRegistryTest(FMLJavaModLoadingContext context) {
         super(context, false, true);
-        DataPackRegistryEvent.NewRegistry.getBus(modBus).addListener(this::onNewDatapackRegistry);
+        DataPackRegistryEvent.NewRegistry.BUS.addListener(this::onNewDatapackRegistry);
     }
 
     public void onNewDatapackRegistry(DataPackRegistryEvent.NewRegistry event) {

--- a/src/test/java/net/minecraftforge/test/BaseTestMod.java
+++ b/src/test/java/net/minecraftforge/test/BaseTestMod.java
@@ -9,7 +9,6 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,7 +36,6 @@ import net.minecraftforge.common.data.DatapackBuiltinEntriesProvider;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.ForgeGameTestHooks;
@@ -62,8 +60,10 @@ public abstract class BaseTestMod {
     public BaseTestMod(FMLJavaModLoadingContext context, boolean registerSelf, boolean registerDeferred) {
         this.modBus = context.getModBusGroup();
 
-        if (registerSelf)
+        if (registerSelf) {
             modBus.register(LookupHelper.INSTANCE.in(this.getClass()), this);
+            BuildCreativeModeTabContentsEvent.BUS.addListener(this::onCreativeModeTabBuildContents);
+        }
 
         tests = ForgeGameTestHooks.gatherTests(getClass(), this);
 
@@ -103,7 +103,7 @@ public abstract class BaseTestMod {
     }
 
 
-    private final class LookupHelper {
+    private static final class LookupHelper {
         private static final Lookup INSTANCE;
         static {
             try {
@@ -153,7 +153,6 @@ public abstract class BaseTestMod {
         this.testItems.add(supplier);
     }
 
-    @SubscribeEvent
     protected void onCreativeModeTabBuildContents(BuildCreativeModeTabContentsEvent event) {
         var entries = event.getEntries();
         var lookup = event.getParameters().holders();


### PR DESCRIPTION
Various events in Forge were historically on the mod bus solely so that they can be fired before the Forge bus was started. With EventBus 7 having a unique EventBus per event, this is no longer necessary and was only kept as-is to limit the scope of the initial port to the new event system and with a mention in the Forge 1.21.6 event migration guide that we'll do the rest of the work in a future MC version.

The initial port of Forge to 1.21.9 finished most of that work, including removing the `InheritableEvent` characteristic from many events and turning them into records for further improved performance, as well as more jSpecify, fixed up javadocs and general code cleanup. Posting to mod bus groups is relatively slow and isn't necessary anymore for many events, so I propose moving the following events to the default BusGroup (`BusGroup.DEFAULT`):
- `EntityRenderersEvent.RegisterLayerDefinitions`
- `EntityRenderersEvent.RegisterRenderers`
- `EntityRenderersEvent.AddLayers`
- `EntityRenderersEvent.CreateSkullModels`
- `ModelEvent.ModifyBakingResult`
- `ModelEvent.BakingCompleted`
- `ModelEvent.RegisterModelStateDefinitions`
- `ModelEvent.RegisterGeometryLoaders`
- `RegisterClientReloadListenersEvent`
- `RegisterColorHandlersEvent.Block`
- `RegisterColorHandlersEvent.ColorResolvers`
- `RegisterKeyMappingsEvent`
- `RegisterParticleProvidersEvent`
- `TextureStitchEvent.Post`
- `SoundEngineLoadEvent`
- `AddPackFindersEvent`
- `BuildCreativeModeTabContentsEvent`
- `EntityAttributeCreationEvent`
- `EntityAttributeModificationEvent`
- `SpawnPlacementRegisterEvent`
- `RegisterClientTooltipComponentFactoriesEvent`
- `RegisterDimensionSpecialEffectsEvent`
- `RegisterEntitySpectatorShadersEvent`
- `RegisterItemDecorationsEvent`
- `RegisterCapabilitiesEvent`
- `NewRegistryEvent`
- `DataPackRegistryEvent.NewRegistry`
- `RegisterNamedRenderTypesEvent`
- `RegisterTextureAtlasSpriteLoadersEvent`

This is a breaking change for mod devs that use `@EventBusSubscriber` with `Bus.MOD` or bulk registration on the mod BusGroup (`modBusGroup.register(...)`).

If you use `@EventBusSubscriber` with the default `Bus.BOTH` or use individual add listener calls (e.g. `EventName.getBus(modBusGroup).addListener(...)`), you're probably fine, however the #getBus(BusGroup) methods are deprecated in favour of using the `BUS` field directly.

Additional checks have been added to aid migration. EventBusSubscriber now throws an exception if you specify a single bus and have an event listener intended for the other bus, and tells you how to fix it. The mod BusGroup also now has a baseType check against IModBusEvent, preventing events that don't implement that interface from being added to the mod bus group.