### PR TITLE
[1.21.1] Fix incorrect blend state for blur effects causing issues in pause screen. #10541

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/platform/GlStateManager.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/platform/GlStateManager.java.patch
@@ -1,5 +1,17 @@
 --- a/com/mojang/blaze3d/platform/GlStateManager.java
 +++ b/com/mojang/blaze3d/platform/GlStateManager.java
+@@ -96,6 +_,11 @@
+         BLEND.mode.enable();
+     }
+ 
++    public static boolean _getBlendState() {
++        RenderSystem.assertOnRenderThread();
++        return BLEND.mode.enabled;
++    }
++
+     public static void _blendFunc(int p_84329_, int p_84330_) {
+         RenderSystem.assertOnRenderThread();
+         if (p_84329_ != BLEND.srcRgb || p_84330_ != BLEND.dstRgb) {
 @@ -493,9 +_,17 @@
          }
      }

--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -9,15 +9,16 @@
          }
      }
  
-@@ -350,8 +_,11 @@
+@@ -350,8 +_,12 @@
      public void processBlurEffect(float p_333718_) {
          float f = (float)this.minecraft.options.getMenuBackgroundBlurriness();
          if (this.blurEffect != null && f >= 1.0F) {
++            boolean previousBlendState = GlStateManager._getBlendState();
 +            // FORGE: Blending the blur was removed in 1.21. This is necessary for screen layering to work properly. https://github.com/MinecraftForge/MinecraftForge/issues/10114
-+            RenderSystem.enableBlend();
++            RenderSystem.disableBlend();
              this.blurEffect.setUniform("Radius", f);
              this.blurEffect.process(p_333718_);
-+            RenderSystem.disableBlend();
++            if (previousBlendState) RenderSystem.enableBlend();
          }
      }
  


### PR DESCRIPTION
The original issue stems from #10114, with the subsequent patch of #10115, affecting builds [52.0.16,) 

Tested with author of 10114's mod to ensure that their mod still has the correct render state.
Check #10541 for current behavior on pause screen and #10114 for the author's symptoms in 52.0.15 and under.
Now:
<img width="854" height="516" alt="image" src="https://github.com/user-attachments/assets/999fe892-63c0-4176-a3a3-bcf79f0f69ba" />
And the mod that had the issue:
<img width="816" height="494" alt="image" src="https://github.com/user-attachments/assets/2ad735f0-07af-4566-9a98-7abc058fa559" />

No bizarre darkening and no need for the mod author to make any changes. Blend state is expected to be disabled during the blur effect, so this fix disables it during that portion of rendering, restoring the prior blend state afterwards.