### PR TITLE
[1.20.1] Work around mixins targeting `IForgePlayer#canReach`

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -124,7 +_,11 @@
+@@ -124,7 +_,14 @@
     }
  
     public void m_214168_(BlockPos p_215120_, ServerboundPlayerActionPacket.Action p_215121_, Direction p_215122_, int p_215123_, int p_215124_) {
@@ -9,7 +9,10 @@
 +      if (event.isCanceled() || (!this.m_9295_() && event.getResult() == net.minecraftforge.eventbus.api.Event.Result.DENY)) {
 +         return;
 +      }
-+      if (!this.f_9245_.canReachRaw(p_215120_, 1.5)) { // Vanilla uses ServerGamePacketListenerImpl.MAX_INTERACTION_DISTANCE which is 6*6, default Block reach is 4.5 so add 1.5 padding
++
++      boolean canReachUnmodded = this.testPlayerCanReach(p_215120_);
++      boolean canReachModded = this.f_9245_.canReach(p_215120_, 1.5); // Vanilla uses ServerGamePacketListenerImpl.MAX_INTERACTION_DISTANCE which is 6*6, default Block reach is 4.5, so add 1.5 padding
++      if (canReachUnmodded == canReachModded ? !this.f_9245_.canReachRaw(p_215120_, 1.5) : !canReachModded) {
           this.m_215125_(p_215120_, false, p_215124_, "too far");
        } else if (p_215120_.m_123342_() >= p_215123_) {
           this.f_9245_.f_8906_.m_9829_(new ClientboundBlockUpdatePacket(p_215120_, this.f_9244_.m_8055_(p_215120_)));
@@ -21,6 +24,18 @@
                 blockstate.m_60686_(this.f_9244_, p_215120_, this.f_9245_);
                 f = blockstate.m_60625_(this.f_9245_, this.f_9245_.m_9236_(), p_215120_);
              }
+@@ -209,6 +_,11 @@
+       }
+    }
+ 
++   private boolean testPlayerCanReach(BlockPos pos) {
++      // don't mixin into this
++      return this.f_9245_.canReach(pos, 1.5);
++   }
++
+    public void m_215116_(BlockPos p_215117_, int p_215118_, String p_215119_) {
+       if (this.m_9280_(p_215117_)) {
+          this.m_215125_(p_215117_, true, p_215118_, p_215119_);
 @@ -221,7 +_,8 @@
  
     public boolean m_9280_(BlockPos p_9281_) {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -26,12 +26,14 @@
                 this.f_9743_.m_5810_();
              }
  
-@@ -1035,7 +_,7 @@
+@@ -1035,7 +_,9 @@
           Vec3 vec3 = blockhitresult.m_82450_();
           BlockPos blockpos = blockhitresult.m_82425_();
           Vec3 vec31 = Vec3.m_82512_(blockpos);
 -         if (!(this.f_9743_.m_146892_().m_82557_(vec31) > f_215198_)) {
-+         if (this.f_9743_.canReachRaw(blockpos, 1.5)) { // Vanilla uses eye-to-center distance < ServerGamePacketListenerImpl which is 6*6, default block reach is 4.5, so add 1.5 padding
++          boolean canReachUnmodded = this.testPlayerCanReach(blockpos);
++          boolean canReachModded = this.f_9743_.canReach(blockpos, 1.5); // Vanilla uses eye-to-center distance < ServerGamePacketListenerImpl which is 6*6, default block reach is 4.5, so add 1.5 padding
++         if (canReachUnmodded == canReachModded ? this.f_9743_.canReachRaw(blockpos, 1.5) : canReachModded) {
              Vec3 vec32 = vec3.m_82546_(vec31);
              double d0 = 1.0000001D;
              if (Math.abs(vec32.m_7096_()) < 1.0000001D && Math.abs(vec32.m_7098_()) < 1.0000001D && Math.abs(vec32.m_7094_()) < 1.0000001D) {
@@ -44,6 +46,17 @@
                       InteractionResult interactionresult = this.f_9743_.f_8941_.m_7179_(this.f_9743_, serverlevel, itemstack, interactionhand, blockhitresult);
                       if (direction == Direction.UP && !interactionresult.m_19077_() && blockpos.m_123342_() >= i - 1 && m_9790_(this.f_9743_, itemstack)) {
                          Component component = Component.m_237110_("build.tooHigh", i - 1).m_130940_(ChatFormatting.RED);
+@@ -1066,6 +_,10 @@
+       }
+    }
+ 
++   private boolean testPlayerCanReach(BlockPos pos) {
++      return this.f_9743_.canReach(pos, 1.5);
++   }
++
+    public void m_5760_(ServerboundUseItemPacket p_9932_) {
+       PacketUtils.m_131359_(p_9932_, this, this.f_9743_.m_284548_());
+       this.m_215201_(p_9932_.m_238013_());
 @@ -1187,10 +_,13 @@
                 }
  

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -43,12 +43,14 @@
              crashreportcategory.m_128159_("Item ID", Item.m_41393_(p_36042_.m_41720_()));
              crashreportcategory.m_128159_("Item data", p_36042_.m_41773_());
              crashreportcategory.m_128165_("Item name", () -> {
-@@ -530,7 +_,9 @@
+@@ -530,7 +_,11 @@
        if (this.f_35978_.m_213877_()) {
           return false;
        } else {
 -         return !(p_36009_.m_20280_(this.f_35978_) > 64.0D);
 +         // Vanilla uses 64 which is 8*8. Default reach is 3.0 so add 5.0 padding
++         // magic number so required Mixins can still target here
++         double reachOld = 64.0;
 +         double reach = p_36009_.m_21133_(net.minecraftforge.common.ForgeMod.ENTITY_REACH.get()) + 5.0;
 +         return !(p_36009_.m_20280_(this.f_35978_) > reach * reach);
        }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -251,7 +251,7 @@
                 }
  
                 float f4 = 0.0F;
-@@ -1121,8 +_,10 @@
+@@ -1121,8 +_,12 @@
                    if (flag3) {
                       float f3 = 1.0F + EnchantmentHelper.m_44821_(this) * f;
  
@@ -259,6 +259,8 @@
 -                        if (livingentity != this && livingentity != p_36347_ && !this.m_7307_(livingentity) && (!(livingentity instanceof ArmorStand) || !((ArmorStand)livingentity).m_31677_()) && this.m_20280_(livingentity) < 9.0D) {
 +                     for(LivingEntity livingentity : this.m_9236_().m_45976_(LivingEntity.class, this.m_21120_(InteractionHand.MAIN_HAND).getSweepHitBox(this, p_36347_))) {
 +                        // Use entity reach instead of constant 9.0. Vanilla uses bottom center-to-center checks here, so don't update this to use canReach, since it uses closest-corner checks.
++                        // magic number so required Mixins can still target here
++                        var reachOld = 9.0;
 +                        var reach = this.m_21133_(net.minecraftforge.common.ForgeMod.ENTITY_REACH.get());
 +                        if (livingentity != this && livingentity != p_36347_ && !this.m_7307_(livingentity) && (!(livingentity instanceof ArmorStand) || !((ArmorStand)livingentity).m_31677_()) && this.m_20280_(livingentity) < reach * reach) {
                             livingentity.m_147240_((double)0.4F, (double)Mth.m_14031_(this.m_146908_() * ((float)Math.PI / 180F)), (double)(-Mth.m_14089_(this.m_146908_() * ((float)Math.PI / 180F))));

--- a/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/world/inventory/AbstractContainerMenu.java
 +++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
-@@ -67,7 +_,9 @@
+@@ -67,7 +_,11 @@
  
     protected static boolean m_38889_(ContainerLevelAccess p_38890_, Player p_38891_, Block p_38892_) {
        return p_38890_.m_39299_((p_38916_, p_38917_) -> {
 -         return !p_38916_.m_8055_(p_38917_).m_60713_(p_38892_) ? false : p_38891_.m_20275_((double)p_38917_.m_123341_() + 0.5D, (double)p_38917_.m_123342_() + 0.5D, (double)p_38917_.m_123343_() + 0.5D) <= 64.0D;
 +         // Vanilla uses 64 which is 8*8. Default reach is 4.5 so add 3.5 padding
++         // magic number so required Mixins can still target here
++         double reachOld = 64.0;
 +         double reach = p_38891_.m_21133_(net.minecraftforge.common.ForgeMod.BLOCK_REACH.get()) + 3.5;
 +         return !p_38916_.m_8055_(p_38917_).m_60713_(p_38892_) ? false : p_38891_.m_20275_((double)p_38917_.m_123341_() + 0.5D, (double)p_38917_.m_123342_() + 0.5D, (double)p_38917_.m_123343_() + 0.5D) <= reach * reach;
        }, true);

--- a/patches/minecraft/net/minecraft/world/inventory/ItemCombinerMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/ItemCombinerMenu.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/world/inventory/ItemCombinerMenu.java
 +++ b/net/minecraft/world/inventory/ItemCombinerMenu.java
-@@ -108,7 +_,9 @@
+@@ -108,7 +_,11 @@
  
     public boolean m_6875_(Player p_39780_) {
        return this.f_39770_.m_39299_((p_39785_, p_39786_) -> {
 -         return !this.m_8039_(p_39785_.m_8055_(p_39786_)) ? false : p_39780_.m_20275_((double)p_39786_.m_123341_() + 0.5D, (double)p_39786_.m_123342_() + 0.5D, (double)p_39786_.m_123343_() + 0.5D) <= 64.0D;
 +         // Vanilla uses 64 which is 8*8. Default reach is 4.5 so add 3.5 padding
++         // magic number so required Mixins can still target here
++         double reachOld = 64.0;
 +         double reach = p_39780_.m_21133_(net.minecraftforge.common.ForgeMod.BLOCK_REACH.get()) + 3.5;
 +         return !this.m_8039_(p_39785_.m_8055_(p_39786_)) ? false : p_39780_.m_20275_((double)p_39786_.m_123341_() + 0.5D, (double)p_39786_.m_123342_() + 0.5D, (double)p_39786_.m_123343_() + 0.5D) <= reach * reach;
        }, true);


### PR DESCRIPTION
Works around mods that target `IForgePlayer#canReach` by calling it in method, then comparing it through the result inside of a bouncer method. If they match, use our method instead which fixes bugs with inventory reach and creative inventories.

Also for good measure, I added more magic numbers in the patches that were made along with that commit. [47.4.2 - @064e2fe](https://github.com/MinecraftForge/MinecraftForge/commit/064e2fed480040a37efb50432ed2ec44ae1ab842#diff-f701c1d78ec64aa5a274116feeac0fc4c55b40c88f11b81ae2ad54108b302003)

Faulty mods have faulty Mixins which target things they really shouldn't. But since 1.20.1 is so old, I'd rather we maintain compatibility than make everyone who uses their hacks update their mods. For this old of a version, I'm sorry, it's just not feasible.