### PR TITLE
[1.21.10] Require CapabilityToken subclasses to be anonymous

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
@@ -56,11 +56,8 @@ public final class CapabilityTokenSubclass implements ILaunchPluginService {
         if (internalName.startsWith("net/minecraft/") || internalName.startsWith("com/mojang/"))
             return NAY;
 
-        // The only relevant targets in Forge's codebase are CapabilityToken and ForgeCapabilities, skip everything else
-        if (internalName.startsWith("net/minecraftforge/")) {
-            var forgeCaps = "net/minecraftforge/common/capabilities/ForgeCapabilities";
-            return (internalName.equals(forgeCaps) || internalName.equals(CAP_INJECT)) ? YAY : NAY;
-        }
+        if (internalName.startsWith("net/minecraftforge/common/capabilities/"))
+            return YAY;
         
         return internalName.contains("$") ? YAY : NAY; // Anonymous subclasses only
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/common/asm/CapabilityTokenSubclass.java
@@ -34,11 +34,10 @@ import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
  *  }</code>
  * </pre>
  */
-public class CapabilityTokenSubclass implements ILaunchPluginService {
-
+public final class CapabilityTokenSubclass implements ILaunchPluginService {
     private static final String FUNC_NAME = "getType";
     private static final String FUNC_DESC = "()Ljava/lang/String;";
-    private static final String CAP_INJECT = "net/minecraftforge/common/capabilities/CapabilityToken"; //Don't directly reference this to prevent class loading.
+    private static final String CAP_INJECT = "net/minecraftforge/common/capabilities/CapabilityToken"; // Don't directly reference this to prevent class loading.
 
     @Override
     public String name() {
@@ -56,8 +55,14 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
         String internalName = classType.getInternalName();
         if (internalName.startsWith("net/minecraft/") || internalName.startsWith("com/mojang/"))
             return NAY;
+
+        // The only relevant targets in Forge's codebase are CapabilityToken and ForgeCapabilities, skip everything else
+        if (internalName.startsWith("net/minecraftforge/")) {
+            var forgeCaps = "net/minecraftforge/common/capabilities/ForgeCapabilities";
+            return (internalName.equals(forgeCaps) || internalName.equals(CAP_INJECT)) ? YAY : NAY;
+        }
         
-        return YAY;
+        return internalName.contains("$") ? YAY : NAY; // Anonymous subclasses only
     }
 
     @Override
@@ -70,7 +75,7 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
             }
             return ComputeFlags.SIMPLE_REWRITE;
         } else if (CAP_INJECT.equals(classNode.superName)) {
-            Holder cls = new Holder();
+            var cls = new Object() { String value = null; };
 
             SignatureReader reader = new SignatureReader(classNode.signature); // Having a node version of this would probably be useful.
             reader.accept(new SignatureVisitor(Opcodes.ASM9) {
@@ -105,9 +110,5 @@ public class CapabilityTokenSubclass implements ILaunchPluginService {
         } else {
             return ComputeFlags.NO_REWRITE;
         }
-    }
-
-    private static final class Holder {
-        String value;
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -10,18 +10,20 @@ import net.minecraftforge.fml.common.asm.CapabilityTokenSubclass;
 /**
  * Inspired by {@link com.google.common.reflect.TypeToken TypeToken}, use a subclass to capture
  * generic types. Then uses {@link CapabilityTokenSubclass a transformer}
- * to convert that generic into a string returned by {@link #getType}
+ * to convert that generic into a string returned by {@link #getType}.
  * This allows us to know the generic type, without having a hard reference to the
  * class.
  *
- * Example usage:
+ * <p>Example usage:</p>
  * <pre>{@code
- *    public static Capability<IDataHolder> DATA_HOLDER_CAPABILITY
+ *    public static final Capability<IDataHolder> DATA_HOLDER_CAPABILITY
  *    		= CapabilityManager.get(new CapabilityToken<>(){});
  * }</pre>
  *
  */
 public abstract class CapabilityToken<T> {
+    protected CapabilityToken() {}
+
     protected final String getType() {
         throw new RuntimeException("This will be implemented by a transformer");
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ForgeCapabilities.java
@@ -11,12 +11,11 @@ import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.items.IItemHandler;
 
 /*
- * References to  Forge's built in capabilities.
+ * References to Forge's built in capabilities.
  * Modders are recommended to use their own CapabilityTokens for 3rd party caps to maintain soft dependencies.
  * However, since nobody has a soft dependency on Forge, we expose this as API.
  */
-public class ForgeCapabilities
-{
+public class ForgeCapabilities {
     public static final Capability<IEnergyStorage> ENERGY = CapabilityManager.get(new CapabilityToken<>(){});
     public static final Capability<IFluidHandler> FLUID_HANDLER = CapabilityManager.get(new CapabilityToken<>(){});
     public static final Capability<IFluidHandlerItem> FLUID_HANDLER_ITEM = CapabilityManager.get(new CapabilityToken<>(){});


### PR DESCRIPTION
Supersedes #10663.

- Only anon classes are now supported, which is the only documented format anyway (`new CapabilityToken<>() {}`)
- Skip parsing of non-anon classes and most Forge classes for better startup performance