### PR TITLE
[1.20.1] Seal events that only have `@ApiStatus.Internal` constructors

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
 @Cancelable
-public class ClientChatEvent extends Event
+public final class ClientChatEvent extends Event
 {
     private String message;
     private final String originalMessage;

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -98,7 +98,7 @@ public class ClientChatReceivedEvent extends Event
      *
      * @see ChatType
      */
-    public static class Player extends ClientChatReceivedEvent
+    public static final class Player extends ClientChatReceivedEvent
     {
         private final PlayerChatMessage playerChatMessage;
 
@@ -128,7 +128,7 @@ public class ClientChatReceivedEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class System extends ClientChatReceivedEvent
+    public static final class System extends ClientChatReceivedEvent
     {
         private final boolean overlay;
 

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * @see ChatType
  */
 @Cancelable
-public class ClientChatReceivedEvent extends Event
+public sealed class ClientChatReceivedEvent extends Event
 {
     private Component message;
     private final ChatType.Bound boundChatType;

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class ClientPlayerChangeGameTypeEvent extends Event
+public final class ClientPlayerChangeGameTypeEvent extends Event
 {
     private final PlayerInfo info;
     private final GameType currentGameType;

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
  * @see LoggingOut
  * @see Clone
  **/
-public abstract class ClientPlayerNetworkEvent extends Event
+public abstract sealed class ClientPlayerNetworkEvent extends Event
 {
     private final MultiPlayerGameMode multiPlayerGameMode;
     private final LocalPlayer player;

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -72,7 +72,7 @@ public abstract class ClientPlayerNetworkEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class LoggingIn extends ClientPlayerNetworkEvent
+    public static final class LoggingIn extends ClientPlayerNetworkEvent
     {
         @ApiStatus.Internal
         public LoggingIn(final MultiPlayerGameMode controller, final LocalPlayer player, final Connection networkManager)
@@ -91,7 +91,7 @@ public abstract class ClientPlayerNetworkEvent extends Event
      */
     @SuppressWarnings("NullableProblems")
     // Shush IntelliJ, we override non-nullables as nullables in this specific event; see later comment
-    public static class LoggingOut extends ClientPlayerNetworkEvent
+    public static final class LoggingOut extends ClientPlayerNetworkEvent
     {
         @ApiStatus.Internal
         public LoggingOut(@Nullable final MultiPlayerGameMode controller, @Nullable final LocalPlayer player, @Nullable final Connection networkManager)
@@ -145,7 +145,7 @@ public abstract class ClientPlayerNetworkEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Clone extends ClientPlayerNetworkEvent
+    public static final class Clone extends ClientPlayerNetworkEvent
     {
         private final LocalPlayer oldPlayer;
 

--- a/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see ViewportEvent.ComputeFov
  */
-public class ComputeFovModifierEvent extends Event
+public final class ComputeFovModifierEvent extends Event
 {
     private final Player player;
     private final float fovModifier;

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Render.Foreground
  * @see Render.Background
  */
-public abstract class ContainerScreenEvent extends Event
+public abstract sealed class ContainerScreenEvent extends Event
 {
     private final AbstractContainerScreen<?> containerScreen;
 
@@ -51,7 +51,7 @@ public abstract class ContainerScreenEvent extends Event
      * @see Foreground
      * @see Background
      */
-    public static abstract class Render extends ContainerScreenEvent
+    public static abstract sealed class Render extends ContainerScreenEvent
     {
         private final GuiGraphics guiGraphics;
         private final int mouseX;

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -102,7 +102,7 @@ public abstract class ContainerScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Foreground extends Render
+        public static final class Foreground extends Render
         {
             @ApiStatus.Internal
             public Foreground(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY)
@@ -120,7 +120,7 @@ public abstract class ContainerScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Background extends Render
+        public static final class Background extends Render
         {
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY)

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
  * @see DebugText
  * @see Chat
  */
-public abstract class CustomizeGuiOverlayEvent extends Event
+public abstract sealed class CustomizeGuiOverlayEvent extends Event
 {
     private final Window window;
     private final GuiGraphics guiGraphics;

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -62,7 +62,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class BossEventProgress extends CustomizeGuiOverlayEvent
+    public static final class BossEventProgress extends CustomizeGuiOverlayEvent
     {
         private final LerpingBossEvent bossEvent;
         private final int x;
@@ -131,7 +131,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class DebugText extends CustomizeGuiOverlayEvent
+    public static final class DebugText extends CustomizeGuiOverlayEvent
     {
         private final ArrayList<String> left;
         private final ArrayList<String> right;
@@ -169,7 +169,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Chat extends CustomizeGuiOverlayEvent
+    public static final class Chat extends CustomizeGuiOverlayEvent
     {
         private int posX;
         private int posY;

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -52,7 +52,7 @@ import java.util.function.Supplier;
  * @see EntityRenderersEvent.RegisterRenderers
  * @see EntityRenderersEvent.AddLayers
  */
-public abstract class EntityRenderersEvent extends Event implements IModBusEvent
+public abstract sealed class EntityRenderersEvent extends Event implements IModBusEvent
 {
     @ApiStatus.Internal
     protected EntityRenderersEvent()

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -67,7 +67,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterLayerDefinitions extends EntityRenderersEvent
+    public static final class RegisterLayerDefinitions extends EntityRenderersEvent
     {
         @ApiStatus.Internal
         public RegisterLayerDefinitions()
@@ -99,7 +99,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterRenderers extends EntityRenderersEvent
+    public static final class RegisterRenderers extends EntityRenderersEvent
     {
         @ApiStatus.Internal
         public RegisterRenderers()
@@ -138,7 +138,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class AddLayers extends EntityRenderersEvent
+    public static final class AddLayers extends EntityRenderersEvent
     {
         private final Map<EntityType<?>, EntityRenderer<?>> renderers;
         private final Map<String, EntityRenderer<? extends Player>> skinMap;
@@ -233,7 +233,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class CreateSkullModels extends EntityRenderersEvent
+    public static final class CreateSkullModels extends EntityRenderersEvent
     {
         private final ImmutableMap.Builder<Type, SkullModelBase> builder;
         private final EntityModelSet entityModelSet;

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -105,7 +105,7 @@ public abstract class InputEvent extends Event
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
         @Cancelable
-        public static class Pre extends MouseButton
+        public static final class Pre extends MouseButton
         {
             @ApiStatus.Internal
             public Pre(int button, int action, int modifiers)
@@ -124,7 +124,7 @@ public abstract class InputEvent extends Event
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
-        public static class Post extends MouseButton
+        public static final class Post extends MouseButton
         {
             @ApiStatus.Internal
             public Post(int button, int action, int modifiers)
@@ -147,7 +147,7 @@ public abstract class InputEvent extends Event
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
     @Cancelable
-    public static class MouseScrollingEvent extends InputEvent
+    public static final class MouseScrollingEvent extends InputEvent
     {
         private final double scrollDelta;
         private final double mouseX;
@@ -224,7 +224,7 @@ public abstract class InputEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Key extends InputEvent
+    public static final class Key extends InputEvent
     {
         private final int key;
         private final int scanCode;
@@ -313,7 +313,7 @@ public abstract class InputEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class InteractionKeyMappingTriggered extends InputEvent
+    public static final class InteractionKeyMappingTriggered extends InputEvent
     {
         private final int button;
         private final KeyMapping keyMapping;

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -24,7 +24,7 @@ import org.lwjgl.glfw.GLFW;
  * @see Key
  * @see InteractionKeyMappingTriggered
  */
-public abstract class InputEvent extends Event
+public abstract sealed class InputEvent extends Event
 {
     @ApiStatus.Internal
     protected InputEvent()
@@ -41,7 +41,7 @@ public abstract class InputEvent extends Event
      * @see Pre
      * @see Post
      */
-    public static abstract class MouseButton extends InputEvent
+    public static abstract sealed class MouseButton extends InputEvent
     {
         private final int button;
         private final int action;

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -48,7 +48,7 @@ public abstract class ModelEvent extends Event
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ModifyBakingResult extends ModelEvent implements IModBusEvent
+    public static final class ModifyBakingResult extends ModelEvent implements IModBusEvent
     {
         private final Map<ResourceLocation, BakedModel> models;
         private final ModelBakery modelBakery;
@@ -88,7 +88,7 @@ public abstract class ModelEvent extends Event
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BakingCompleted extends ModelEvent implements IModBusEvent
+    public static final class BakingCompleted extends ModelEvent implements IModBusEvent
     {
         private final ModelManager modelManager;
         private final Map<ResourceLocation, BakedModel> models;
@@ -136,7 +136,7 @@ public abstract class ModelEvent extends Event
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterAdditional extends ModelEvent implements IModBusEvent
+    public static final class RegisterAdditional extends ModelEvent implements IModBusEvent
     {
         private final Set<ResourceLocation> models;
 
@@ -163,7 +163,7 @@ public abstract class ModelEvent extends Event
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent
+    public static final class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent
     {
         private final Map<ResourceLocation, IGeometryLoader<?>> loaders;
 

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -25,7 +25,7 @@ import java.util.Set;
 /**
  * Houses events related to models.
  */
-public abstract class ModelEvent extends Event
+public abstract sealed class ModelEvent extends Event
 {
     @ApiStatus.Internal
     protected ModelEvent()

--- a/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class MovementInputUpdateEvent extends PlayerEvent
+public final class MovementInputUpdateEvent extends PlayerEvent
 {
     private final Input input;
 

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RecipesUpdatedEvent extends Event
+public final class RecipesUpdatedEvent extends Event
 {
     private final RecipeManager recipeManager;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see net.minecraftforge.event.RegisterCommandsEvent
  */
-public class RegisterClientCommandsEvent extends Event
+public final class RegisterClientCommandsEvent extends Event
 {
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final CommandBuildContext context;

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientReloadListenersEvent extends Event implements IModBusEvent
+public final class RegisterClientReloadListenersEvent extends Event implements IModBusEvent
 {
     private final ReloadableResourceManager resourceManager;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientTooltipComponentFactoriesEvent extends Event implements IModBusEvent
+public final class RegisterClientTooltipComponentFactoriesEvent extends Event implements IModBusEvent
 {
     private final Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> factories;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -45,7 +45,7 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Block extends RegisterColorHandlersEvent
+    public static final class Block extends RegisterColorHandlersEvent
     {
         private final BlockColors blockColors;
 
@@ -88,7 +88,7 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Item extends RegisterColorHandlersEvent
+    public static final class Item extends RegisterColorHandlersEvent
     {
         private final ItemColors itemColors;
         private final BlockColors blockColors;
@@ -135,7 +135,7 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * Allows registration of custom {@link ColorResolver} implementations to be used with
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
-    public static class ColorResolvers extends RegisterColorHandlersEvent
+    public static final class ColorResolvers extends RegisterColorHandlersEvent
     {
         private final ImmutableList.Builder<ColorResolver> builder;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RegisterColorHandlersEvent.Block
  * @see RegisterColorHandlersEvent.Item
  */
-public abstract class RegisterColorHandlersEvent extends Event implements IModBusEvent
+public abstract sealed class RegisterColorHandlersEvent extends Event implements IModBusEvent
 {
     @ApiStatus.Internal
     protected RegisterColorHandlersEvent()

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterDimensionSpecialEffectsEvent extends Event implements IModBusEvent
+public final class RegisterDimensionSpecialEffectsEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, DimensionSpecialEffects> effects;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterEntitySpectatorShadersEvent extends Event implements IModBusEvent
+public final class RegisterEntitySpectatorShadersEvent extends Event implements IModBusEvent
 {
     private final Map<EntityType<?>, ResourceLocation> shaders;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterGuiOverlaysEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterGuiOverlaysEvent.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
+public final class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, IGuiOverlay> overlays;
     private final List<ResourceLocation> orderedOverlays;

--- a/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterItemDecorationsEvent extends Event implements IModBusEvent
+public final class RegisterItemDecorationsEvent extends Event implements IModBusEvent
 {
 
     private final Map<Item, List<IItemDecorator>> decorators;

--- a/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterKeyMappingsEvent extends Event implements IModBusEvent
+public final class RegisterKeyMappingsEvent extends Event implements IModBusEvent
 {
     private final Options options;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
+public final class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, RenderTypeGroup> renderTypes;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterParticleProvidersEvent extends Event implements IModBusEvent
+public final class RegisterParticleProvidersEvent extends Event implements IModBusEvent
 {
     private final ParticleEngine particleEngine;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterPresetEditorsEvent extends Event implements IModBusEvent
+public final class RegisterPresetEditorsEvent extends Event implements IModBusEvent
 {
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterRecipeBookCategoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterRecipeBookCategoriesEvent.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterRecipeBookCategoriesEvent extends Event implements IModBusEvent
+public final class RegisterRecipeBookCategoriesEvent extends Event implements IModBusEvent
 {
     private final Map<RecipeBookCategories, ImmutableList<RecipeBookCategories>> aggregateCategories;
     private final Map<RecipeBookType, ImmutableList<RecipeBookCategories>> typeCategories;

--- a/src/main/java/net/minecraftforge/client/event/RegisterShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterShadersEvent.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterShadersEvent extends Event implements IModBusEvent
+public final class RegisterShadersEvent extends Event implements IModBusEvent
 {
     private final ResourceProvider resourceProvider;
     private final List<Pair<ShaderInstance, Consumer<ShaderInstance>>> shaderList;

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IModBusEvent
+public final class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IModBusEvent
 {
     private final Map<ResourceLocation, ITextureAtlasSpriteLoader> loaders;
 

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @Cancelable
-public class RenderArmEvent extends Event
+public final class RenderArmEvent extends Event
 {
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 @Cancelable
-public class RenderBlockScreenEffectEvent extends Event
+public final class RenderBlockScreenEffectEvent extends Event
 {
     /**
      * The type of the block overlay to be rendered.

--- a/src/main/java/net/minecraftforge/client/event/RenderGuiEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGuiEvent.java
@@ -62,7 +62,7 @@ public abstract class RenderGuiEvent extends Event
      * @see Post
      */
     @Cancelable
-    public static class Pre extends RenderGuiEvent
+    public static final class Pre extends RenderGuiEvent
     {
         @ApiStatus.Internal
         public Pre(Window window, GuiGraphics guiGraphics, float partialTick)
@@ -79,7 +79,7 @@ public abstract class RenderGuiEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends RenderGuiEvent
+    public static final class Post extends RenderGuiEvent
     {
         @ApiStatus.Internal
         public Post(Window window, GuiGraphics guiGraphics, float partialTick)

--- a/src/main/java/net/minecraftforge/client/event/RenderGuiEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGuiEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Pre
  * @see Post
  */
-public abstract class RenderGuiEvent extends Event
+public abstract sealed class RenderGuiEvent extends Event
 {
     private final Window window;
     private final GuiGraphics guiGraphics;

--- a/src/main/java/net/minecraftforge/client/event/RenderGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGuiOverlayEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Pre
  * @see Post
  */
-public abstract class RenderGuiOverlayEvent extends Event
+public abstract sealed class RenderGuiOverlayEvent extends Event
 {
     private final Window window;
     private final GuiGraphics guiGraphics;

--- a/src/main/java/net/minecraftforge/client/event/RenderGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGuiOverlayEvent.java
@@ -72,7 +72,7 @@ public abstract class RenderGuiOverlayEvent extends Event
      * @see Post
      */
     @Cancelable
-    public static class Pre extends RenderGuiOverlayEvent
+    public static final class Pre extends RenderGuiOverlayEvent
     {
         @ApiStatus.Internal
         public Pre(Window window, GuiGraphics guiGraphics, float partialTick, NamedGuiOverlay overlay)
@@ -89,7 +89,7 @@ public abstract class RenderGuiOverlayEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends RenderGuiOverlayEvent
+    public static final class Post extends RenderGuiOverlayEvent
     {
         @ApiStatus.Internal
         public Post(Window window, GuiGraphics guiGraphics, float partialTick, NamedGuiOverlay overlay)

--- a/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderArmEvent
  */
 @Cancelable
-public class RenderHandEvent extends Event
+public final class RenderHandEvent extends Event
 {
     private final InteractionHand hand;
     private final PoseStack poseStack;

--- a/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
@@ -104,7 +104,7 @@ public abstract class RenderHighlightEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Block extends RenderHighlightEvent
+    public static final class Block extends RenderHighlightEvent
     {
         @ApiStatus.Internal
         public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
@@ -130,7 +130,7 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Entity extends RenderHighlightEvent
+    public static final class Entity extends RenderHighlightEvent
     {
         @ApiStatus.Internal
         public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)

--- a/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Entity
  */
 @Cancelable
-public abstract class RenderHighlightEvent extends Event
+public abstract sealed class RenderHighlightEvent extends Event
 {
     private final LevelRenderer levelRenderer;
     private final Camera camera;

--- a/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ItemFrameRenderer
  */
 @Cancelable
-public class RenderItemInFrameEvent extends Event
+public final class RenderItemInFrameEvent extends Event
 {
     private final ItemStack itemStack;
     private final ItemFrame itemFrameEntity;

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent
  * @see LivingEntityRenderer
  */
-public abstract class RenderLivingEvent<T extends LivingEntity, M extends EntityModel<T>> extends Event
+public abstract sealed class RenderLivingEvent<T extends LivingEntity, M extends EntityModel<T>> extends Event
 {
     private final LivingEntity entity;
     private final LivingEntityRenderer<T, M> renderer;

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -117,7 +117,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, M extends Entity
      * @param <M> the model for the living entity
      */
     @Cancelable
-    public static class Pre<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
+    public static final class Pre<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
     {
         @ApiStatus.Internal
         public Pre(LivingEntity entity, LivingEntityRenderer<T, M> renderer, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight)
@@ -137,7 +137,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, M extends Entity
      * @param <T> the living entity that was rendered
      * @param <M> the model for the living entity
      */
-    public static class Post<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
+    public static final class Post<T extends LivingEntity, M extends EntityModel<T>> extends RenderLivingEvent<T, M>
     {
         @ApiStatus.Internal
         public Post(LivingEntity entity, LivingEntityRenderer<T, M> renderer, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight)

--- a/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see EntityRenderer
  */
 @Event.HasResult
-public class RenderNameTagEvent extends EntityEvent
+public final class RenderNameTagEvent extends EntityEvent
 {
     private Component nameplateContent;
     private final Component originalContent;

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent.Post
  * @see PlayerRenderer
  */
-public abstract class RenderPlayerEvent extends PlayerEvent
+public abstract sealed class RenderPlayerEvent extends PlayerEvent
 {
     private final PlayerRenderer renderer;
     private final float partialTick;

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -97,7 +97,7 @@ public abstract class RenderPlayerEvent extends PlayerEvent
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Pre extends RenderPlayerEvent
+    public static final class Pre extends RenderPlayerEvent
     {
         @ApiStatus.Internal
         public Pre(Player player, PlayerRenderer renderer, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight)
@@ -114,7 +114,7 @@ public abstract class RenderPlayerEvent extends PlayerEvent
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends RenderPlayerEvent
+    public static final class Post extends RenderPlayerEvent
     {
         @ApiStatus.Internal
         public Post(Player player, PlayerRenderer renderer, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight)

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @see RenderTooltipEvent.Pre
  * @see RenderTooltipEvent.Color
  */
-public abstract sealed class RenderTooltipEvent extends Event
+public abstract class RenderTooltipEvent extends Event
 {
     @NotNull
     protected final ItemStack itemStack;
@@ -119,7 +119,7 @@ public abstract sealed class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static final class GatherComponents extends Event
+    public static class GatherComponents extends Event
     {
         private final ItemStack itemStack;
         private final int screenWidth;
@@ -208,7 +208,7 @@ public abstract sealed class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static final class Pre extends RenderTooltipEvent
+    public static non-sealed class Pre extends RenderTooltipEvent
     {
         private final int screenWidth;
         private final int screenHeight;
@@ -287,7 +287,7 @@ public abstract sealed class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static final class Color extends RenderTooltipEvent
+    public static non-sealed class Color extends RenderTooltipEvent
     {
         private final int originalBackground;
         private final int originalBorderStart;

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @see RenderTooltipEvent.Pre
  * @see RenderTooltipEvent.Color
  */
-public abstract class RenderTooltipEvent extends Event
+public abstract sealed class RenderTooltipEvent extends Event
 {
     @NotNull
     protected final ItemStack itemStack;

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -119,7 +119,7 @@ public abstract class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class GatherComponents extends Event
+    public static final class GatherComponents extends Event
     {
         private final ItemStack itemStack;
         private final int screenWidth;
@@ -208,7 +208,7 @@ public abstract class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Pre extends RenderTooltipEvent
+    public static final class Pre extends RenderTooltipEvent
     {
         private final int screenWidth;
         private final int screenHeight;
@@ -287,7 +287,7 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Color extends RenderTooltipEvent
+    public static final class Color extends RenderTooltipEvent
     {
         private final int originalBackground;
         private final int originalBorderStart;

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -120,7 +120,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends Init
+        public static final class Pre extends Init
         {
             @ApiStatus.Internal
             public Pre(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove)
@@ -137,7 +137,7 @@ public abstract class ScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Init
+        public static final class Post extends Init
         {
             @ApiStatus.Internal
             public Post(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove)
@@ -213,7 +213,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends Render
+        public static final class Pre extends Render
         {
             @ApiStatus.Internal
             public Pre(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
@@ -230,7 +230,7 @@ public abstract class ScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends Render
+        public static final class Post extends Render
         {
             @ApiStatus.Internal
             public Post(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
@@ -249,7 +249,7 @@ public abstract class ScreenEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BackgroundRendered extends ScreenEvent
+    public static final class BackgroundRendered extends ScreenEvent
     {
         private final GuiGraphics guiGraphics;
 
@@ -281,7 +281,7 @@ public abstract class ScreenEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class RenderInventoryMobEffects extends ScreenEvent
+    public static final class RenderInventoryMobEffects extends ScreenEvent
     {
         private final int availableSpace;
         private boolean compact;
@@ -424,7 +424,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseButtonPressed
+        public static final class Pre extends MouseButtonPressed
         {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button)
@@ -449,7 +449,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @HasResult
-        public static class Post extends MouseButtonPressed
+        public static final class Post extends MouseButtonPressed
         {
             private final boolean handled;
 
@@ -510,7 +510,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseButtonReleased
+        public static final class Pre extends MouseButtonReleased
         {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button)
@@ -535,7 +535,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @HasResult
-        public static class Post extends MouseButtonReleased
+        public static final class Post extends MouseButtonReleased
         {
             private final boolean handled;
 
@@ -616,7 +616,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseDragged
+        public static final class Pre extends MouseDragged
         {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY)
@@ -635,7 +635,7 @@ public abstract class ScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseDragged
+        public static final class Post extends MouseDragged
         {
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY)
@@ -682,7 +682,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends MouseScrolled
+        public static final class Pre extends MouseScrolled
         {
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, double scrollDelta)
@@ -701,7 +701,7 @@ public abstract class ScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends MouseScrolled
+        public static final class Post extends MouseScrolled
         {
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, double scrollDelta)
@@ -804,7 +804,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends KeyPressed
+        public static final class Pre extends KeyPressed
         {
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -824,7 +824,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Post extends KeyPressed
+        public static final class Post extends KeyPressed
         {
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -860,7 +860,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends KeyReleased
+        public static final class Pre extends KeyReleased
         {
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -880,7 +880,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Post extends KeyReleased
+        public static final class Post extends KeyReleased
         {
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -946,7 +946,7 @@ public abstract class ScreenEvent extends Event
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         @Cancelable
-        public static class Pre extends CharacterTyped
+        public static final class Pre extends CharacterTyped
         {
             @ApiStatus.Internal
             public Pre(Screen screen, char codePoint, int modifiers)
@@ -965,7 +965,7 @@ public abstract class ScreenEvent extends Event
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        public static class Post extends CharacterTyped
+        public static final class Post extends CharacterTyped
         {
             @ApiStatus.Internal
             public Post(Screen screen, char codePoint, int modifiers)
@@ -988,7 +988,7 @@ public abstract class ScreenEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class Opening extends ScreenEvent
+    public static final class Opening extends ScreenEvent
     {
         @Nullable
         private final Screen currentScreen;
@@ -1040,7 +1040,7 @@ public abstract class ScreenEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Closing extends ScreenEvent
+    public static final class Closing extends ScreenEvent
     {
         @ApiStatus.Internal
         public Closing(Screen screen)

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-public abstract class ScreenEvent extends Event
+public abstract sealed class ScreenEvent extends Event
 {
     private final Screen screen;
 
@@ -65,7 +65,7 @@ public abstract class ScreenEvent extends Event
      * @see Init.Pre
      * @see Init.Post
      */
-    public static abstract class Init extends ScreenEvent
+    public static abstract sealed class Init extends ScreenEvent
     {
         private final Consumer<GuiEventListener> add;
         private final Consumer<GuiEventListener> remove;
@@ -154,7 +154,7 @@ public abstract class ScreenEvent extends Event
      * @see Render.Pre
      * @see Render.Post
      */
-    public static abstract class Render extends ScreenEvent
+    public static abstract sealed class Render extends ScreenEvent
     {
         private final GuiGraphics guiGraphics;
         private final int mouseX;
@@ -354,7 +354,7 @@ public abstract class ScreenEvent extends Event
      * @see MouseDragged
      * @see MouseScrolled
      */
-    private static abstract class MouseInput extends ScreenEvent
+    private static abstract sealed class MouseInput extends ScreenEvent
     {
         private final double mouseX;
         private final double mouseY;
@@ -391,7 +391,7 @@ public abstract class ScreenEvent extends Event
      * @see MouseButtonPressed.Pre
      * @see MouseButtonPressed.Post
      */
-    public static abstract class MouseButtonPressed extends MouseInput
+    public static abstract sealed class MouseButtonPressed extends MouseInput
     {
         private final int button;
 
@@ -477,7 +477,7 @@ public abstract class ScreenEvent extends Event
      * @see MouseButtonReleased.Pre
      * @see MouseButtonReleased.Post
      */
-    public static abstract class MouseButtonReleased extends MouseInput
+    public static abstract sealed class MouseButtonReleased extends MouseInput
     {
         private final int button;
 
@@ -563,7 +563,7 @@ public abstract class ScreenEvent extends Event
      * @see MouseDragged.Pre
      * @see MouseDragged.Post
      */
-    public static abstract class MouseDragged extends MouseInput
+    public static abstract sealed class MouseDragged extends MouseInput
     {
         private final int mouseButton;
         private final double dragX;
@@ -652,7 +652,7 @@ public abstract class ScreenEvent extends Event
      * @see MouseScrolled.Pre
      * @see MouseScrolled.Post
      */
-    public static abstract class MouseScrolled extends MouseInput
+    public static abstract sealed class MouseScrolled extends MouseInput
     {
         private final double scrollDelta;
 
@@ -720,7 +720,7 @@ public abstract class ScreenEvent extends Event
      * @see InputConstants
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_key" target="_top">the online GLFW documentation</a>
      */
-    private static abstract class KeyInput extends ScreenEvent
+    private static abstract sealed class KeyInput extends ScreenEvent
     {
         private final int keyCode;
         private final int scanCode;
@@ -785,7 +785,7 @@ public abstract class ScreenEvent extends Event
      * @see KeyPressed.Pre
      * @see KeyPressed.Post
      */
-    public static abstract class KeyPressed extends KeyInput
+    public static abstract sealed class KeyPressed extends KeyInput
     {
         @ApiStatus.Internal
         public KeyPressed(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -841,7 +841,7 @@ public abstract class ScreenEvent extends Event
      * @see KeyReleased.Pre
      * @see KeyReleased.Post
      */
-    public static abstract class KeyReleased extends KeyInput
+    public static abstract sealed class KeyReleased extends KeyInput
     {
         @ApiStatus.Internal
         public KeyReleased(Screen screen, int keyCode, int scanCode, int modifiers)
@@ -898,7 +898,7 @@ public abstract class ScreenEvent extends Event
      * @see CharacterTyped.Post
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_char" target="_top">the online GLFW documentation</a>
      */
-    public static class CharacterTyped extends ScreenEvent
+    public static sealed class CharacterTyped extends ScreenEvent
     {
         private final char codePoint;
         private final int modifiers;

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * @see Screenshot
  */
 @Cancelable
-public class ScreenshotEvent extends Event
+public final class ScreenshotEvent extends Event
 {
     public static final Component DEFAULT_CANCEL_REASON = Component.literal("Screenshot canceled");
 

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -82,7 +82,7 @@ public class TextureStitchEvent extends Event implements IModBusEvent
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus()} mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends TextureStitchEvent
+    public static final class Post extends TextureStitchEvent
     {
         @ApiStatus.Internal
         public Post(TextureAtlas map)

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * @see TextureStitchEvent.Post
  * @see TextureAtlas
  */
-public class TextureStitchEvent extends Event implements IModBusEvent
+public sealed class TextureStitchEvent extends Event implements IModBusEvent
 {
     private final TextureAtlas atlas;
 

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -78,7 +78,7 @@ public abstract class ViewportEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @Cancelable
-    public static class RenderFog extends ViewportEvent
+    public static final class RenderFog extends ViewportEvent
     {
         private final FogMode mode;
         private final FogType type;
@@ -198,7 +198,7 @@ public abstract class ViewportEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeFogColor extends ViewportEvent
+    public static final class ComputeFogColor extends ViewportEvent
     {
         private float red;
         private float green;
@@ -277,7 +277,7 @@ public abstract class ViewportEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class ComputeCameraAngles extends ViewportEvent
+    public static final class ComputeCameraAngles extends ViewportEvent
     {
         private float yaw;
         private float pitch;
@@ -358,7 +358,7 @@ public abstract class ViewportEvent extends Event
      *
      * @see ComputeFovModifierEvent
      */
-    public static class ComputeFov extends ViewportEvent
+    public static final class ComputeFov extends ViewportEvent
     {
         private final boolean usedConfiguredFov;
         private double fov;

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ComputeCameraAngles
  * @see ComputeFov
  */
-public abstract class ViewportEvent extends Event
+public abstract sealed class ViewportEvent extends Event
 {
     private final GameRenderer renderer;
     private final Camera camera;

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * @see PlaySoundSourceEvent
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundEvent extends SoundEvent
+public final class PlaySoundEvent extends SoundEvent
 {
     private final String name;
     private final SoundInstance originalSound;

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundSourceEvent extends SoundSourceEvent
+public final class PlaySoundSourceEvent extends SoundSourceEvent
 {
     @ApiStatus.Internal
     public PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlayStreamingSourceEvent extends SoundSourceEvent
+public final class PlayStreamingSourceEvent extends SoundSourceEvent
 {
     @ApiStatus.Internal
     public PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
+public final class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
 {
     @ApiStatus.Internal
     public SoundEngineLoadEvent(SoundEngine manager)

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @see PlaySoundEvent
  * @see SoundEngineLoadEvent
  */
-public abstract class SoundEvent extends Event
+public abstract sealed class SoundEvent extends Event permits PlaySoundEvent, SoundEngineLoadEvent, SoundEvent.SoundSourceEvent
 {
     private final SoundEngine engine;
 
@@ -50,7 +50,7 @@ public abstract class SoundEvent extends Event
      * @see PlaySoundSourceEvent
      * @see PlayStreamingSourceEvent
      */
-    public static abstract class SoundSourceEvent extends SoundEvent
+    public static abstract sealed class SoundSourceEvent extends SoundEvent permits PlaySoundSourceEvent, PlayStreamingSourceEvent
     {
         private final SoundInstance sound;
         private final Channel channel;

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.ApiStatus;
  *  This also means that the two vanilla checks described above will not be called.
  */
 @Cancelable
-public class ItemStackedOnOtherEvent extends Event
+public final class ItemStackedOnOtherEvent extends Event
 {
     private final ItemStack carriedItem;
     private final ItemStack stackedOnItem;

--- a/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * on both {@linkplain LogicalSide logical sides}.</p>
  */
-public class ModMismatchEvent extends Event implements IModBusEvent
+public final class ModMismatchEvent extends Event implements IModBusEvent
 {
     /**
      * The level being loaded. Useful for things like {@link net.minecraft.world.level.storage.DimensionDataStorage}

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 @Cancelable
-public class ServerChatEvent extends Event
+public final class ServerChatEvent extends Event
 {
     private final ServerPlayer player;
     private final String username;

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -148,7 +148,7 @@ public class EntityTeleportEvent extends EntityEvent
      * If this event is canceled, the entity will not be teleported.
      */
     @Cancelable
-    public static class EnderPearl extends EntityTeleportEvent
+    public static final class EnderPearl extends EntityTeleportEvent
     {
         private final ServerPlayer player;
         private final ThrownEnderpearl pearlEntity;

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  *  Fired on the Mod bus {@link IModBusEvent}.<br>
  */
-public class SpawnPlacementRegisterEvent extends Event implements IModBusEvent
+public final class SpawnPlacementRegisterEvent extends Event implements IModBusEvent
 {
     private final Map<EntityType<?>, MergedSpawnPredicate<?>> map;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -23,7 +23,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  */
-public class LivingBreatheEvent extends LivingEvent {
+public final class LivingBreatheEvent extends LivingEvent {
     private boolean canBreathe;
     private boolean canRefillAir;
     private int consumeAirAmount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  **/
 @Cancelable
-public class LivingDrownEvent extends LivingEvent {
+public final class LivingDrownEvent extends LivingEvent {
     private boolean isDrowning;
     private float damageAmount;
     private int bubbleCount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import org.jetbrains.annotations.ApiStatus;
 
-public class LivingSwapItemsEvent extends LivingEvent
+public sealed class LivingSwapItemsEvent extends LivingEvent
 {
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
@@ -27,7 +27,7 @@ public class LivingSwapItemsEvent extends LivingEvent
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
      */
     @Cancelable
-    public static class Hands extends LivingSwapItemsEvent
+    public static final class Hands extends LivingSwapItemsEvent
     {
         private ItemStack toMainHand;
         private ItemStack toOffHand;

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -41,7 +41,7 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * {@link AllowDespawn} is not related to the mob spawn event flow, as it fires when a despawn is attempted.
  */
-public abstract class MobSpawnEvent extends EntityEvent
+public abstract sealed class MobSpawnEvent extends EntityEvent
 {
     private final ServerLevelAccessor level;
     private final double x;
@@ -221,7 +221,7 @@ public abstract class MobSpawnEvent extends EntityEvent
      * @see {@link SpawnPlacementCheck} To modify the result of spawn placements at runtime.
      */
     @HasResult
-    public static class PositionCheck extends MobSpawnEvent
+    public static non-sealed class PositionCheck extends MobSpawnEvent
     {
         @Nullable
         private final BaseSpawner spawner;
@@ -419,7 +419,7 @@ public abstract class MobSpawnEvent extends EntityEvent
     // TODO: 1.20 Move to standalone class, as it is unrelated to the complex mob spawning flow.
     // Such a refactor will allow the BaseSpawner and MobSpawnType params to be hoisted to MobSpawnEvent.
     @HasResult
-    public static class AllowDespawn extends MobSpawnEvent
+    public static non-sealed class AllowDespawn extends MobSpawnEvent
     {
         public AllowDespawn(Mob mob, ServerLevelAccessor level)
         {

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -116,7 +116,7 @@ public abstract class MobSpawnEvent extends EntityEvent
      * @see SpawnPlacementRegisterEvent
      */
     @HasResult
-    public static class SpawnPlacementCheck extends Event
+    public static final class SpawnPlacementCheck extends Event
     {
         private final EntityType<?> entityType;
         private final ServerLevelAccessor level;
@@ -269,7 +269,7 @@ public abstract class MobSpawnEvent extends EntityEvent
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
     @Cancelable
-    public static class FinalizeSpawn extends MobSpawnEvent
+    public static final class FinalizeSpawn extends MobSpawnEvent
     {
         private final MobSpawnType spawnType;
         @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -140,7 +140,7 @@ public class PlayerInteractEvent extends PlayerEvent
     {
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
-        private BlockHitResult hitVec;
+        private final BlockHitResult hitVec;
 
         public RightClickBlock(Player player, InteractionHand hand, BlockPos pos, BlockHitResult hitVec) {
             super(player, hand, pos, hitVec.getDirection());

--- a/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-public class TradeWithVillagerEvent extends PlayerEvent
+public final class TradeWithVillagerEvent extends PlayerEvent
 {
     private final MerchantOffer offer;
     private final AbstractVillager abstractVillager;

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
-public class AlterGroundEvent extends Event {
+public final class AlterGroundEvent extends Event {
     private final LevelSimulatedReader level;
     private final RandomSource random;
     private final BlockPos pos;

--- a/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
@@ -60,7 +60,7 @@ public class ChunkDataEvent extends ChunkEvent
      **/
     public static class Load extends ChunkDataEvent
     {
-        private ChunkStatus.ChunkType status;
+        private final ChunkStatus.ChunkType status;
 
         public Load(ChunkAccess chunk, CompoundTag data, ChunkStatus.ChunkType status)
         {

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -57,7 +57,7 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkEvent
+    public static final class Load extends ChunkEvent
     {
         private final boolean newChunk;
 

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class DataPackRegistryEvent extends Event implements IModBusEvent
+public sealed class DataPackRegistryEvent extends Event implements IModBusEvent
 {
     @ApiStatus.Internal
     public DataPackRegistryEvent() {}

--- a/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
+++ b/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
@@ -35,7 +35,7 @@ public class PermissionGatherEvent extends Event
      */
     public static class Handler extends PermissionGatherEvent
     {
-        private Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
+        private final Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
 
         public Handler()
         {


### PR DESCRIPTION
Adding `final` to these event classes allows for additional optimisations to be made by both the JVM and EventBus (such as [EventBus#85](<https://github.com/MinecraftForge/EventBus/pull/85>)). Partial backport of #10515 to 1.20.1.

It's not possible to extend these events without calling the constructor that is marked as internal, therefore extending was considered for internal use only and should be made `final`.

~~`sealed` has been skipped because EventBus 6 doesn't support using this for optimisations yet, although I can do that as well if wanted? Increases the chances of breaking a mod that relied on internals, but would mean I don't have to make another PR adding sealed later if I figure out a way for EB6 to recognise it.~~ [EventBus#98](<https://github.com/MinecraftForge/EventBus/pull/98>) adds support for optimisations on `sealed`.

Sidenote: it's a shame that so many events in 1.20.1 didn't have their constructors marked as internal by the old team before the first RB, especially the tick events... :/