### PR TITLE
[1.21.10] Provide LevelRenderState during frame pass construction (#10867)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -25,7 +25,7 @@
          }
  
          this.addLateDebugPass(framegraphbuilder, this.levelRenderState.cameraRenderState.pos, p_407881_, frustum);
-+        net.minecraftforge.client.FramePassManager.insertForgePasses(framegraphbuilder, targets); // Forge: Modded passes are inserted here.
++        net.minecraftforge.client.FramePassManager.insertForgePasses(framegraphbuilder, targets, this.levelRenderState); // Forge: Modded passes are inserted here.
          profilerfiller.popPush("executeFrameGraph");
          framegraphbuilder.execute(p_367325_, new FrameGraphBuilder.Inspector() {
              @Override

--- a/src/main/java/net/minecraftforge/client/FramePassManager.java
+++ b/src/main/java/net/minecraftforge/client/FramePassManager.java
@@ -38,7 +38,16 @@ public class FramePassManager {
     }
 
     public interface PassDefinition {
+        /**
+         * Use to define which targets your pass will bind against. Additionally, this method should be used for extracting
+         * render states if necessary.
+         * A FramePass must bind to at least ONE target. Otherwise, you get freaky issues.
+         */
         void targets(LevelTargetBundle bundle, FramePass pass);
+
+        /**
+         * Use to define what your pass does during the render stage.
+         */
         void executes(LevelRenderState state);
     }
 

--- a/src/main/java/net/minecraftforge/client/FramePassManager.java
+++ b/src/main/java/net/minecraftforge/client/FramePassManager.java
@@ -7,10 +7,12 @@ package net.minecraftforge.client;
 
 import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
 import com.mojang.blaze3d.framegraph.FramePass;
+import com.mojang.blaze3d.resource.ResourceHandle;
 import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.state.LevelRenderState;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,28 +34,38 @@ public class FramePassManager {
         for (PassInfo info : addedPasses) {
             FramePass pass = graphBuilder.addPass(info.name);
             PassDefinition forgePass = info.pass;
-            forgePass.targets(bundle, pass);
+            forgePass.extracts(bundle, pass);
             pass.executes(() -> forgePass.executes(state));
         }
     }
 
     public interface PassDefinition {
         /**
-         * Use to define which targets your pass will bind against. Additionally, this method should be used for extracting
-         * render states if necessary.
-         * A FramePass must bind to at least ONE target. Otherwise, you get freaky issues.
+         * Use to define which targets your pass will bind against, see {@link FramePass#reads} and {@link FramePass#readsAndWrites}
+         * A FramePass must bind to at least ONE target. Otherwise, you get freaky issues with >1 modded passes.
+         * Additionally, this method should be used for extracting render states into instance variables if desired.
          */
-        void targets(LevelTargetBundle bundle, FramePass pass);
+        default void extracts(LevelTargetBundle bundle, FramePass pass) {
+            targets(bundle, pass);
+        }
+
+        /**
+         * Prefer {@link PassDefinition#extracts}
+         */
+        @Deprecated(forRemoval = true, since = "1.21.10")
+        default void targets(LevelTargetBundle bundle, FramePass pass) {}
 
         /**
          * Use to define what your pass does during the render stage.
          */
-        default void executes(LevelRenderState state) {executes();};
+        default void executes(LevelRenderState state) {
+            executes();
+        };
 
         /**
          * Use to define what your pass does during the render stage, prefer {@link PassDefinition#executes(LevelRenderState)}.
          */
-        @Deprecated()
+        @Deprecated(forRemoval = true, since = "1.21.10")
         default void executes(){};
     }
 

--- a/src/main/java/net/minecraftforge/client/FramePassManager.java
+++ b/src/main/java/net/minecraftforge/client/FramePassManager.java
@@ -48,7 +48,8 @@ public class FramePassManager {
         /**
          * Use to define what your pass does during the render stage.
          */
-        void executes(LevelRenderState state);
+        default void executes(LevelRenderState state) {executes();};
+        default void executes(){};
     }
 
     private record PassInfo(String name, PassDefinition pass){}

--- a/src/main/java/net/minecraftforge/client/FramePassManager.java
+++ b/src/main/java/net/minecraftforge/client/FramePassManager.java
@@ -8,6 +8,7 @@ package net.minecraftforge.client;
 import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
 import com.mojang.blaze3d.framegraph.FramePass;
 import net.minecraft.client.renderer.LevelTargetBundle;
+import net.minecraft.client.renderer.state.LevelRenderState;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -27,18 +28,18 @@ public class FramePassManager {
 
     // Note: Pass order is determined automatically within FrameGraphBuilder. It's unclear what must be done to guarantee ordering.
     @ApiStatus.Internal
-    public static void insertForgePasses(FrameGraphBuilder graphBuilder, LevelTargetBundle bundle) {
+    public static void insertForgePasses(FrameGraphBuilder graphBuilder, LevelTargetBundle bundle, LevelRenderState state) {
         for (PassInfo info : addedPasses) {
             FramePass pass = graphBuilder.addPass(info.name);
             PassDefinition forgePass = info.pass;
             forgePass.targets(bundle, pass);
-            pass.executes(forgePass::executes);
+            pass.executes(() -> forgePass.executes(state));
         }
     }
 
     public interface PassDefinition {
         void targets(LevelTargetBundle bundle, FramePass pass);
-        void executes();
+        void executes(LevelRenderState state);
     }
 
     private record PassInfo(String name, PassDefinition pass){}

--- a/src/main/java/net/minecraftforge/client/FramePassManager.java
+++ b/src/main/java/net/minecraftforge/client/FramePassManager.java
@@ -49,6 +49,11 @@ public class FramePassManager {
          * Use to define what your pass does during the render stage.
          */
         default void executes(LevelRenderState state) {executes();};
+
+        /**
+         * Use to define what your pass does during the render stage, prefer {@link PassDefinition#executes(LevelRenderState)}.
+         */
+        @Deprecated()
         default void executes(){};
     }
 

--- a/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.debug.client;
 
 import net.minecraft.client.renderer.LevelTargetBundle;
+import net.minecraft.client.renderer.state.LevelRenderState;
 import net.minecraftforge.client.FramePassManager;
 import net.minecraftforge.client.event.AddFramePassEvent;
 import net.minecraftforge.common.extensions.IForgeGameTestHelper;
@@ -48,7 +49,6 @@ public class RenderFrameLayerTest extends BaseTestMod {
      * If this is working, two white line box cubes will be rendered at ground level in a superflat world around (0,0)
      */
     public static void renderTest(AddFramePassEvent event) {
-        var mainCamera = Minecraft.getInstance().gameRenderer.getMainCamera();
         FramePassManager.PassDefinition def = new FramePassManager.PassDefinition() {
             @Override
             public void targets(LevelTargetBundle bundle, FramePass pass) {
@@ -56,10 +56,10 @@ public class RenderFrameLayerTest extends BaseTestMod {
             }
 
             @Override
-            public void executes() {
+            public void executes(LevelRenderState state) {
                 PoseStack ps = new PoseStack();
                 passOne.set(true);
-                ps.translate(mainCamera.getPosition().multiply(-1,-1,-1));
+                ps.translate(state.cameraRenderState.entityPos.multiply(-1,-1,-1));
                 ps.pushPose();
                 var buffSource = Minecraft.getInstance().renderBuffers().bufferSource();
                 var vc = buffSource.getBuffer(RenderType.lines());
@@ -77,10 +77,10 @@ public class RenderFrameLayerTest extends BaseTestMod {
             }
 
             @Override
-            public void executes() {
+            public void executes(LevelRenderState state) {
                 PoseStack ps = new PoseStack();
                 passTwo.set(true);
-                ps.translate(mainCamera.getPosition().multiply(-1,-1,-1));
+                ps.translate(state.cameraRenderState.entityPos.multiply(-1,-1,-1));
                 ps.pushPose();
                 var buffSource = Minecraft.getInstance().renderBuffers().bufferSource();
                 var vc = buffSource.getBuffer(RenderType.lines());

--- a/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
@@ -51,7 +51,7 @@ public class RenderFrameLayerTest extends BaseTestMod {
     public static void renderTest(AddFramePassEvent event) {
         FramePassManager.PassDefinition def = new FramePassManager.PassDefinition() {
             @Override
-            public void targets(LevelTargetBundle bundle, FramePass pass) {
+            public void extracts(LevelTargetBundle bundle, FramePass pass) {
                 bundle.main = pass.readsAndWrites(bundle.main);
             }
 
@@ -72,7 +72,7 @@ public class RenderFrameLayerTest extends BaseTestMod {
         event.addPass(rl(MODID), def);
         FramePassManager.PassDefinition def2 = new FramePassManager.PassDefinition() {
             @Override
-            public void targets(LevelTargetBundle bundle, FramePass pass) {
+            public void extracts(LevelTargetBundle bundle, FramePass pass) {
                 bundle.main = pass.readsAndWrites(bundle.main);
             }
 


### PR DESCRIPTION
Test(s) still work fine. There may be other work needed if modders need extra render context but at the moment this seems enough, at least until someone can provide a concrete example where extra details are needed.
<img width="634" height="424" alt="image" src="https://github.com/user-attachments/assets/89830fa6-1ee2-49c4-aee7-bad9c4763dba" />
