### PR TITLE
[1.21.10] Fix universal jar missing Forge version

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -839,10 +839,17 @@ tasks.register('filterJarNewSRG', FilterNewJar).configure {
     blacklist = filterJarNew.blacklist
 }
 
-tasks.named('universalJar').configure {
+tasks.named('universalJar', Jar) {
     dependsOn downloadCrowdin
     from zipTree(downloadCrowdin.dest).matching {
         include 'assets/forge/lang/*.json'
+    }
+
+    final Map<String, String> replaceProperties = Map.of('forge_version', (String) version)
+    inputs.properties replaceProperties
+
+    filesMatching(['META-INF/mods.toml']) {
+        expand replaceProperties + [project: project]
     }
 
     from(EXTRA_TXTS)
@@ -983,15 +990,6 @@ license {
 
 tasks.register('genAllData') {
     dependsOn 'forge_data', 'forge_test_data'
-}
-
-tasks.named('processResources', ProcessResources) {
-    final Map<String, String> replaceProperties = Map.of('forge_version', (String) version)
-    inputs.properties replaceProperties
-
-    filesMatching(['META-INF/mods.toml']) {
-        expand replaceProperties + [project: project]
-    }
 }
 
 if (project.hasProperty('UPDATE_MAPPINGS')) {


### PR DESCRIPTION
- Follows up on #10698.

This PR fixes an oversight that causes Forge to crash on startup in production due to the Forge version not being included in its own `mods.toml`.

This is an urgent PR and needs to be merged as soon as possible.