### PR TITLE
[1.21.10] Fix Minecraft version being incorrectly included in Forge mods.toml

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -845,7 +845,7 @@ tasks.named('universalJar', Jar) {
         include 'assets/forge/lang/*.json'
     }
 
-    final Map<String, String> replaceProperties = Map.of('forge_version', (String) version)
+    final Map<String, String> replaceProperties = Map.of('forge_version', FORGE_VERSION)
     inputs.properties replaceProperties
 
     filesMatching(['META-INF/mods.toml']) {


### PR DESCRIPTION
- Follow-up to #10699
- Follow-up to #10698

This PR fixes yet another oversight in #10699 where the wrong version was included in Forge's `mods.toml`.

This is an urgent PR and needs to be merged as soon as possible.

On another note, we should have GitHub Actions run the game test server as part of validation when we move to it. I can add it to ForgeDev 7 if you'd like. Sorry about this.