### PR TITLE
Revert "Remove runtime mods.toml string substitution (#10698)"

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -839,17 +839,10 @@ tasks.register('filterJarNewSRG', FilterNewJar).configure {
     blacklist = filterJarNew.blacklist
 }
 
-tasks.named('universalJar', Jar) {
+tasks.named('universalJar').configure {
     dependsOn downloadCrowdin
     from zipTree(downloadCrowdin.dest).matching {
         include 'assets/forge/lang/*.json'
-    }
-
-    final Map<String, String> replaceProperties = Map.of('forge_version', FORGE_VERSION)
-    inputs.properties replaceProperties
-
-    filesMatching(['META-INF/mods.toml']) {
-        expand replaceProperties + [project: project]
     }
 
     from(EXTRA_TXTS)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/StringSubstitutor.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/StringSubstitutor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.fml.loading;
+
+import net.minecraftforge.fml.loading.moddiscovery.ModFile;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.text.StrLookup;
+import org.apache.commons.lang3.text.StrSubstitutor;
+
+@SuppressWarnings("deprecation")
+public class StringSubstitutor {
+    private static final Map<String, String> GLOBALS = Map.of(
+        "mcVersion", FMLLoader.versionInfo().mcVersion(),
+        "forgeVersion", FMLLoader.versionInfo().forgeVersion()
+    );
+
+    public static String replace(final String in, final ModFile file) {
+        return new StrSubstitutor(getStringLookup(file)).replace(in);
+    }
+
+    private static StrLookup<String> getStringLookup(final ModFile file) {
+        return new StrLookup<>() {
+            @Override
+            public String lookup(String key) {
+                var parts = key.split("\\.");
+                if (parts.length == 1)
+                    return key;
+                var pfx = parts[0];
+
+                if ("global".equals(pfx))
+                    return GLOBALS.get(parts[1]);
+                else if ("file".equals(pfx) && file != null)
+                    return String.valueOf(file.getSubstitutionMap().get().get(parts[1]));
+
+                return key;
+            }
+        };
+    }
+}

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.fml.loading.moddiscovery;
 
+import com.google.common.collect.ImmutableMap;
 import com.mojang.logging.LogUtils;
 import cpw.mods.jarhandling.SecureJar;
 import net.minecraftforge.fml.loading.FMLLoader;
@@ -38,6 +39,7 @@ import java.util.jar.Manifest;
 public class ModFile implements IModFile {
     private static final Logger LOGGER = LogUtils.getLogger();
     private final String jarVersion;
+    private Map<String, Object> fileProperties;
     private List<IModLanguageProvider> loaders;
     private Throwable scanError;
     private final SecureJar jar;
@@ -67,10 +69,9 @@ public class ModFile implements IModFile {
     }
 
     @Override
-    public Supplier<Map<String, Object>> getSubstitutionMap() {
-        return Map::of;
+    public Supplier<Map<String,Object>> getSubstitutionMap() {
+        return () -> ImmutableMap.<String,Object>builder().put("jarVersion", jarVersion).putAll(fileProperties).build();
     }
-
     @Override
     public Type getType() {
         return modFileType;
@@ -150,7 +151,7 @@ public class ModFile implements IModFile {
     }
 
     public void setFileProperties(Map<String, Object> fileProperties) {
-        LOGGER.warn(LogMarkers.LOADING, "Setting file properties for the purposes of runtime mods.toml string substitution is no longer supported.");
+        this.fileProperties = fileProperties;
     }
 
     @Override

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -101,6 +101,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable {
             this.properties = config.<Map<String, Object>>getConfigElement("properties")
                     .orElse(Collections.emptyMap());
         }
+        this.modFile.setFileProperties(this.properties);
 
         final List<? extends IConfigurable> modConfigs = config.getConfigList("mods");
         if (modConfigs == null || modConfigs.isEmpty())

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import com.mojang.logging.LogUtils;
+import net.minecraftforge.fml.loading.StringSubstitutor;
 import net.minecraftforge.fml.loading.StringUtils;
 import net.minecraftforge.forgespi.language.IConfigurable;
 import net.minecraftforge.forgespi.language.IModInfo;
@@ -73,6 +74,7 @@ public record ModInfo(
         }
 
         ArtifactVersion version = config.<String>getConfigElement("version")
+                .map(s -> StringSubstitutor.replace(s, owningFile.getFile()))
                 .map(DefaultArtifactVersion::new)
                 .orElse(DEFAULT_VERSION);
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license="LGPL v2.1"
 
 [[mods]]
 modId="forge"
-version="${forge_version}"
+version="${global.forgeVersion}"
 updateJSONURL="https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json"
 displayURL="https://minecraftforge.net/"
 displayName="Forge"


### PR DESCRIPTION
- Reverts #10698.
- Reverts #10699.
- Reverts #10700.

This PR reverts the removal of `mods.toml` string substitution as the side-effects of doing so were not accounted for properly. This removal can be revisited at a later date.