### PR TITLE
[1.20.1] Add DeferredForgeRegistry to allow easier creation of custom IForgeRegistry's.

### DIFF
--- a/src/main/java/net/minecraftforge/registries/DeferredForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredForgeRegistry.java
@@ -1,0 +1,196 @@
+package net.minecraftforge.registries;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.tags.ITagManager;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+@ApiStatus.Internal
+public class DeferredForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegistryModifiable<V> {
+    private final ResourceLocation name;
+    private final ResourceKey<Registry<V>> key;
+    private final Supplier<ForgeRegistry<V>> registry;
+
+    DeferredForgeRegistry(ResourceKey<? extends Registry<V>> key, Supplier<IForgeRegistry<V>> registry) {
+        this(key.location(), registry);
+    }
+
+    DeferredForgeRegistry(ResourceLocation name, Supplier<IForgeRegistry<V>> registry) {
+        this.name = name;
+        this.key = ResourceKey.createRegistryKey(name);
+        this.registry = () -> (ForgeRegistry<V>) registry.get();
+    }
+
+    @Override
+    public void setSlaveMap(ResourceLocation name, Object obj) {
+        registry.get().setSlaveMap(name, obj);
+    }
+
+    @Override
+    public void register(int id, ResourceLocation key, V value) {
+        registry.get().register(id, key, value);
+    }
+
+    @Override
+    public V getValue(int id) {
+        return registry.get().getValue(id);
+    }
+
+    @Override
+    public void clear() {
+        registry.get().clear();
+    }
+
+    @Override
+    public V remove(ResourceLocation key) {
+        return registry.get().remove(key);
+    }
+
+    @Override
+    public boolean isLocked() {
+        return registry.get().isLocked();
+    }
+
+    @Override
+    public ResourceKey<Registry<V>> getRegistryKey() {
+        return this.key;
+    }
+
+    @Override
+    public ResourceLocation getRegistryName() {
+        return this.name;
+    }
+
+    @Override
+    public void register(String key, V value) {
+        registry.get().register(key, value);
+    }
+
+    @Override
+    public void register(ResourceLocation key, V value) {
+        registry.get().register(key, value);
+    }
+
+    @Override
+    public boolean containsKey(ResourceLocation key) {
+        return registry.get().containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(V value) {
+        return registry.get().containsValue(value);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return registry.get().isEmpty();
+    }
+
+    @Override
+    public @Nullable V getValue(ResourceLocation key) {
+        return registry.get().getValue(key);
+    }
+
+    @Override
+    public @Nullable ResourceLocation getKey(V value) {
+        return registry.get().getKey(value);
+    }
+
+    @Override
+    public @Nullable ResourceLocation getDefaultKey() {
+        return registry.get().getDefaultKey();
+    }
+
+    @Override
+    public @NotNull Optional<ResourceKey<V>> getResourceKey(V value) {
+        return registry.get().getResourceKey(value);
+    }
+
+    @Override
+    public @NotNull Set<ResourceLocation> getKeys() {
+        return registry.get().getKeys();
+    }
+
+    @Override
+    public @NotNull Collection<V> getValues() {
+        return registry.get().getValues();
+    }
+
+    @Override
+    public @NotNull Set<Map.Entry<ResourceKey<V>, V>> getEntries() {
+        return registry.get().getEntries();
+    }
+
+    @Override
+    public @NotNull Codec<V> getCodec() {
+        return registry.get().getCodec();
+    }
+
+    @Override
+    public @NotNull Optional<Holder<V>> getHolder(ResourceKey<V> key) {
+        return registry.get().getHolder(key);
+    }
+
+    @Override
+    public @NotNull Optional<Holder<V>> getHolder(ResourceLocation location) {
+        return registry.get().getHolder(location);
+    }
+
+    @Override
+    public @NotNull Optional<Holder<V>> getHolder(V value) {
+        return registry.get().getHolder(value);
+    }
+
+    @Override
+    public @Nullable ITagManager<V> tags() {
+        return registry.get().tags();
+    }
+
+    @Override
+    public @NotNull Optional<Holder.Reference<V>> getDelegate(ResourceKey<V> rkey) {
+        return registry.get().getDelegate(rkey);
+    }
+
+    @Override
+    public Holder.@NotNull Reference<V> getDelegateOrThrow(ResourceKey<V> rkey) {
+        return registry.get().getDelegateOrThrow(rkey);
+    }
+
+    @Override
+    public @NotNull Optional<Holder.Reference<V>> getDelegate(ResourceLocation key) {
+        return registry.get().getDelegate(key);
+    }
+
+    @Override
+    public Holder.@NotNull Reference<V> getDelegateOrThrow(ResourceLocation key) {
+        return registry.get().getDelegateOrThrow(key);
+    }
+
+    @Override
+    public @NotNull Optional<Holder.Reference<V>> getDelegate(V value) {
+        return registry.get().getDelegate(value);
+    }
+
+    @Override
+    public Holder.@NotNull Reference<V> getDelegateOrThrow(V value) {
+        return registry.get().getDelegateOrThrow(value);
+    }
+
+    @Override
+    public <T> T getSlaveMap(ResourceLocation slaveMapName, Class<T> type) {
+        return registry.get().getSlaveMap(slaveMapName, type);
+    }
+
+    @Override
+    public @NotNull Iterator<V> iterator() {
+        return registry.get().iterator();
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -204,9 +204,9 @@ public class DeferredRegister<T>
      * @return A supplier of the {@link IForgeRegistry} created by the builder.
      * Will always return null until after the {@link NewRegistryEvent} event fires.
      */
-    public Supplier<IForgeRegistry<T>> makeRegistrySupplier(final Supplier<RegistryBuilder<T>> sup)
+    public Supplier<IForgeRegistry<T>> makeRegistry(final Supplier<RegistryBuilder<T>> sup)
     {
-        return makeRegistrySupplier(this.registryKey.location(), sup);
+        return makeRegistry(this.registryKey.location(), sup);
     }
 
     /**
@@ -218,9 +218,9 @@ public class DeferredRegister<T>
      * @return A {@link DeferredForgeRegistry} holding a supplier of the {@link IForgeRegistry} created by the builder.
      * This ensures that the {@link IForgeRegistry} can be used to register {@link RegistryObject RegistryObjects} before a {@link NewRegistryEvent} is fired.
      */
-    public IForgeRegistry<T> makeRegistry(final Supplier<RegistryBuilder<T>> sup)
+    public IForgeRegistry<T> makeRegistryEagerly(final Supplier<RegistryBuilder<T>> sup)
     {
-        return makeRegistry(this.registryKey.location(), sup);
+        return makeRegistryEagerly(this.registryKey.location(), sup);
     }
 
     /**
@@ -367,12 +367,12 @@ public class DeferredRegister<T>
         return Objects.requireNonNull(this.registryKey).location();
     }
 
-    private Supplier<IForgeRegistry<T>> makeRegistrySupplier(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
-        IForgeRegistry<T> reg = makeRegistry(registryName, sup);
+    private Supplier<IForgeRegistry<T>> makeRegistry(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
+        IForgeRegistry<T> reg = makeRegistryEagerly(registryName, sup);
         return () -> reg;
     }
 
-    private IForgeRegistry<T> makeRegistry(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
+    private IForgeRegistry<T> makeRegistryEagerly(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
         if (registryName == null)
             throw new IllegalStateException("Cannot create a registry without specifying a registry name");
         if (RegistryManager.ACTIVE.getRegistry(registryName) != null || this.registryFactory != null)

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -204,7 +204,21 @@ public class DeferredRegister<T>
      * @return A supplier of the {@link IForgeRegistry} created by the builder.
      * Will always return null until after the {@link NewRegistryEvent} event fires.
      */
-    public Supplier<IForgeRegistry<T>> makeRegistry(final Supplier<RegistryBuilder<T>> sup)
+    public Supplier<IForgeRegistry<T>> makeRegistrySupplier(final Supplier<RegistryBuilder<T>> sup)
+    {
+        return makeRegistrySupplier(this.registryKey.location(), sup);
+    }
+
+    /**
+     * Only used for custom registries to fill the forge registry held in this DeferredRegister.
+     *
+     * Calls {@link RegistryBuilder#setName} automatically.
+     *
+     * @param sup Supplier of a RegistryBuilder that initializes a {@link IForgeRegistry} during the {@link NewRegistryEvent} event
+     * @return A {@link DeferredForgeRegistry} holding a supplier of the {@link IForgeRegistry} created by the builder.
+     * This ensures that the {@link IForgeRegistry} can be used to register {@link RegistryObject RegistryObjects} before a {@link NewRegistryEvent} is fired.
+     */
+    public IForgeRegistry<T> makeRegistry(final Supplier<RegistryBuilder<T>> sup)
     {
         return makeRegistry(this.registryKey.location(), sup);
     }
@@ -353,14 +367,20 @@ public class DeferredRegister<T>
         return Objects.requireNonNull(this.registryKey).location();
     }
 
-    private Supplier<IForgeRegistry<T>> makeRegistry(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
+    private Supplier<IForgeRegistry<T>> makeRegistrySupplier(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
+        IForgeRegistry<T> reg = makeRegistry(registryName, sup);
+        return () -> reg;
+    }
+
+    private IForgeRegistry<T> makeRegistry(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {
         if (registryName == null)
             throw new IllegalStateException("Cannot create a registry without specifying a registry name");
         if (RegistryManager.ACTIVE.getRegistry(registryName) != null || this.registryFactory != null)
             throw new IllegalStateException("Cannot create a registry for a type that already exists");
 
         this.registryFactory = () -> sup.get().setName(registryName);
-        return new RegistryHolder<>(this.registryKey);
+        return new DeferredForgeRegistry<>(this.registryKey,
+                new RegistryHolder<>(this.registryKey));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -104,44 +104,44 @@ public class ForgeRegistries
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#ENTITY_DATA_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<EntityDataSerializer<?>>> ENTITY_DATA_SERIALIZERS = DEFERRED_ENTITY_DATA_SERIALIZERS.makeRegistrySupplier(GameData::getDataSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<EntityDataSerializer<?>>> ENTITY_DATA_SERIALIZERS = DEFERRED_ENTITY_DATA_SERIALIZERS.makeRegistry(GameData::getDataSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends IGlobalLootModifier>> DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#GLOBAL_LOOT_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends IGlobalLootModifier>>> GLOBAL_LOOT_MODIFIER_SERIALIZERS = DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getGLMSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends IGlobalLootModifier>>> GLOBAL_LOOT_MODIFIER_SERIALIZERS = DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS.makeRegistry(GameData::getGLMSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends BiomeModifier>> DEFERRED_BIOME_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.BIOME_MODIFIER_SERIALIZERS, Keys.BIOME_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#BIOME_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends BiomeModifier>>> BIOME_MODIFIER_SERIALIZERS = DEFERRED_BIOME_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getBiomeModifierSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends BiomeModifier>>> BIOME_MODIFIER_SERIALIZERS = DEFERRED_BIOME_MODIFIER_SERIALIZERS.makeRegistry(GameData::getBiomeModifierSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends StructureModifier>> DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.STRUCTURE_MODIFIER_SERIALIZERS, Keys.STRUCTURE_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#STRUCTURE_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends StructureModifier>>> STRUCTURE_MODIFIER_SERIALIZERS = DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getStructureModifierSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends StructureModifier>>> STRUCTURE_MODIFIER_SERIALIZERS = DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS.makeRegistry(GameData::getStructureModifierSerializersRegistryBuilder);
     static final DeferredRegister<FluidType> DEFERRED_FLUID_TYPES = DeferredRegister.create(Keys.FLUID_TYPES, Keys.FLUID_TYPES.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#FLUID_TYPES} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<FluidType>> FLUID_TYPES = DEFERRED_FLUID_TYPES.makeRegistrySupplier(GameData::getFluidTypeRegistryBuilder);
+    public static final Supplier<IForgeRegistry<FluidType>> FLUID_TYPES = DEFERRED_FLUID_TYPES.makeRegistry(GameData::getFluidTypeRegistryBuilder);
     static final DeferredRegister<HolderSetType> DEFERRED_HOLDER_SET_TYPES = DeferredRegister.create(Keys.HOLDER_SET_TYPES, "forge");
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#HOLDER_SET_TYPES} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<HolderSetType>> HOLDER_SET_TYPES = DEFERRED_HOLDER_SET_TYPES.makeRegistrySupplier(GameData::makeUnsavedAndUnsynced);
+    public static final Supplier<IForgeRegistry<HolderSetType>> HOLDER_SET_TYPES = DEFERRED_HOLDER_SET_TYPES.makeRegistry(GameData::makeUnsavedAndUnsynced);
 
     static final DeferredRegister<ItemDisplayContext> DEFERRED_DISPLAY_CONTEXTS = DeferredRegister.create(Keys.DISPLAY_CONTEXTS, "forge");
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#DISPLAY_CONTEXTS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = DEFERRED_DISPLAY_CONTEXTS.makeRegistrySupplier(GameData::getItemDisplayContextRegistryBuilder);
+    public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = DEFERRED_DISPLAY_CONTEXTS.makeRegistry(GameData::getItemDisplayContextRegistryBuilder);
 
     public static final class Keys {
         //Vanilla

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -46,12 +46,8 @@ import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.world.BiomeModifier;
 import net.minecraftforge.fluids.FluidType;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.holdersets.HolderSetType;
 
-import java.util.Arrays;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import net.minecraftforge.common.world.StructureModifier;
 
@@ -108,44 +104,44 @@ public class ForgeRegistries
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#ENTITY_DATA_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<EntityDataSerializer<?>>> ENTITY_DATA_SERIALIZERS = DEFERRED_ENTITY_DATA_SERIALIZERS.makeRegistry(GameData::getDataSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<EntityDataSerializer<?>>> ENTITY_DATA_SERIALIZERS = DEFERRED_ENTITY_DATA_SERIALIZERS.makeRegistrySupplier(GameData::getDataSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends IGlobalLootModifier>> DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#GLOBAL_LOOT_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends IGlobalLootModifier>>> GLOBAL_LOOT_MODIFIER_SERIALIZERS = DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS.makeRegistry(GameData::getGLMSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends IGlobalLootModifier>>> GLOBAL_LOOT_MODIFIER_SERIALIZERS = DEFERRED_GLOBAL_LOOT_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getGLMSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends BiomeModifier>> DEFERRED_BIOME_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.BIOME_MODIFIER_SERIALIZERS, Keys.BIOME_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#BIOME_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends BiomeModifier>>> BIOME_MODIFIER_SERIALIZERS = DEFERRED_BIOME_MODIFIER_SERIALIZERS.makeRegistry(GameData::getBiomeModifierSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends BiomeModifier>>> BIOME_MODIFIER_SERIALIZERS = DEFERRED_BIOME_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getBiomeModifierSerializersRegistryBuilder);
     static final DeferredRegister<Codec<? extends StructureModifier>> DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS = DeferredRegister.create(Keys.STRUCTURE_MODIFIER_SERIALIZERS, Keys.STRUCTURE_MODIFIER_SERIALIZERS.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#STRUCTURE_MODIFIER_SERIALIZERS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<Codec<? extends StructureModifier>>> STRUCTURE_MODIFIER_SERIALIZERS = DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS.makeRegistry(GameData::getStructureModifierSerializersRegistryBuilder);
+    public static final Supplier<IForgeRegistry<Codec<? extends StructureModifier>>> STRUCTURE_MODIFIER_SERIALIZERS = DEFERRED_STRUCTURE_MODIFIER_SERIALIZERS.makeRegistrySupplier(GameData::getStructureModifierSerializersRegistryBuilder);
     static final DeferredRegister<FluidType> DEFERRED_FLUID_TYPES = DeferredRegister.create(Keys.FLUID_TYPES, Keys.FLUID_TYPES.location().getNamespace());
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#FLUID_TYPES} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<FluidType>> FLUID_TYPES = DEFERRED_FLUID_TYPES.makeRegistry(GameData::getFluidTypeRegistryBuilder);
+    public static final Supplier<IForgeRegistry<FluidType>> FLUID_TYPES = DEFERRED_FLUID_TYPES.makeRegistrySupplier(GameData::getFluidTypeRegistryBuilder);
     static final DeferredRegister<HolderSetType> DEFERRED_HOLDER_SET_TYPES = DeferredRegister.create(Keys.HOLDER_SET_TYPES, "forge");
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#HOLDER_SET_TYPES} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<HolderSetType>> HOLDER_SET_TYPES = DEFERRED_HOLDER_SET_TYPES.makeRegistry(GameData::makeUnsavedAndUnsynced);
+    public static final Supplier<IForgeRegistry<HolderSetType>> HOLDER_SET_TYPES = DEFERRED_HOLDER_SET_TYPES.makeRegistrySupplier(GameData::makeUnsavedAndUnsynced);
 
     static final DeferredRegister<ItemDisplayContext> DEFERRED_DISPLAY_CONTEXTS = DeferredRegister.create(Keys.DISPLAY_CONTEXTS, "forge");
     /**
      * Calling {@link Supplier#get()} before {@link NewRegistryEvent} is fired will result in a null registry returned.
      * Use {@link Keys#DISPLAY_CONTEXTS} to create a {@link DeferredRegister}.
      */
-    public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = DEFERRED_DISPLAY_CONTEXTS.makeRegistry(GameData::getItemDisplayContextRegistryBuilder);
+    public static final Supplier<IForgeRegistry<ItemDisplayContext>> DISPLAY_CONTEXTS = DEFERRED_DISPLAY_CONTEXTS.makeRegistrySupplier(GameData::getItemDisplayContextRegistryBuilder);
 
     public static final class Keys {
         //Vanilla

--- a/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
@@ -59,7 +59,7 @@ public class DeferredRegistryTest {
     private static final RegistryObject<PosRuleTestType<?>> POS_RULE_TEST_TYPE = POS_RULE_TEST_TYPES.register("test", () -> () -> null);
 
     private static final TagKey<Custom> CUSTOM_TAG_KEY = CUSTOMS.createOptionalTagKey("test_tag", Set.of(CUSTOM));
-    private static final Supplier<IForgeRegistry<Custom>> CUSTOM_REG = CUSTOMS.makeRegistrySupplier(() ->
+    private static final Supplier<IForgeRegistry<Custom>> CUSTOM_REG = CUSTOMS.makeRegistry(() ->
         new RegistryBuilder<Custom>().disableSaving().setMaxID(Integer.MAX_VALUE - 1).hasTags()
             .onAdd((owner, stage, id, key, obj, old) -> LOGGER.info("Custom Added: " + id + " " + obj.foo()))
     );

--- a/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
@@ -59,7 +59,7 @@ public class DeferredRegistryTest {
     private static final RegistryObject<PosRuleTestType<?>> POS_RULE_TEST_TYPE = POS_RULE_TEST_TYPES.register("test", () -> () -> null);
 
     private static final TagKey<Custom> CUSTOM_TAG_KEY = CUSTOMS.createOptionalTagKey("test_tag", Set.of(CUSTOM));
-    private static final Supplier<IForgeRegistry<Custom>> CUSTOM_REG = CUSTOMS.makeRegistry(() ->
+    private static final Supplier<IForgeRegistry<Custom>> CUSTOM_REG = CUSTOMS.makeRegistrySupplier(() ->
         new RegistryBuilder<Custom>().disableSaving().setMaxID(Integer.MAX_VALUE - 1).hasTags()
             .onAdd((owner, stage, id, key, obj, old) -> LOGGER.info("Custom Added: " + id + " " + obj.foo()))
     );


### PR DESCRIPTION
Because IForgeRegistry's are null until NewRegistryEvent is fired, creating a custom IForgeRegistry can be quite annoying to do. In my mod-api, [ErrorLib API](https://github.com/Unknown303YT/errorlib/tree/abilities-dev), I ended up needing to manually do this outside of Forge to make making IForgeRegistry's easier.

DeferredForgeRegistry works by providing the ResourceKey and ResourceLocation directly, and using a Supplier of the proper IForgeRegistry for all other methods. This makes it so that `DeferredRegister#create(IForgeRegistry, String)` can be used for custom IForgeRegistry's as well.

Unfortunately, I had to change the existing methods names in order to stop errors caused by having the same method name and same parameters. If it would be preferred, I would be happy to change it so that the new method has the different name instead, which would make it so that it has compatibility with mods using older versions of Forge should this be added.

I have tested this, and it works by itself. It would be very easy to make this compatible with previous versions of forge, so if that would be better I will make those changes, as it would just be refactoring some methods back to what they were and changing the names of the methods I added to DeferredRegister.