### PR TITLE
[1.21.10] shears fixes

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -238,7 +238,12 @@
              p_409579_.addFreshEntity(itementity);
              return itementity;
          }
-@@ -2177,7 +_,7 @@
+@@ -2173,11 +_,11 @@
+         }
+ 
+         ItemStack itemstack = p_19978_.getItemInHand(p_19979_);
+-        if (itemstack.is(Items.SHEARS) && this.shearOffAllLeashConnections(p_19978_)) {
++        if (itemstack.canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_HARVEST) && this.shearOffAllLeashConnections(p_19978_)) {
              itemstack.hurtAndBreak(1, p_19978_, p_19979_);
              return InteractionResult.SUCCESS;
          } else if (this instanceof Mob mob

--- a/patches/minecraft/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java
++++ b/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java
+@@ -216,7 +_,7 @@
+         }
+ 
+         Level level = this.level();
+-        if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
++        if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { // Forge: Moved to onSheared
+             if (level instanceof ServerLevel serverlevel) {
+                 this.shear(serverlevel, SoundSource.PLAYERS, itemstack);
+                 this.gameEvent(GameEvent.SHEAR, p_430585_);
+@@ -429,6 +_,18 @@
+         ItemStack itemstack = this.getItemBySlot(EQUIPMENT_SLOT_ANTENNA);
+         this.setItemSlot(EQUIPMENT_SLOT_ANTENNA, ItemStack.EMPTY);
+         this.spawnAtLocation(p_428037_, itemstack, 1.5F);
++    }
++
++    @Override
++    public java.util.List<ItemStack> onSheared(@org.jetbrains.annotations.Nullable Player player, @org.jetbrains.annotations.NotNull ItemStack item, Level world, net.minecraft.core.BlockPos pos, int fortune) {
++        if (world instanceof ServerLevel server) {
++            server.playSound(null, this, SoundEvents.COPPER_GOLEM_SHEAR, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
++            var ret = new java.util.ArrayList<ItemStack>();
++            ret.add(this.getItemBySlot(EQUIPMENT_SLOT_ANTENNA));
++            this.setItemSlot(EQUIPMENT_SLOT_ANTENNA, ItemStack.EMPTY);
++            return ret;
++        }
++        return java.util.Collections.emptyList();
+     }
+ 
+     @Override

--- a/patches/minecraft/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/coppergolem/CopperGolem.java.patch
@@ -16,7 +16,7 @@
 +    }
 +
 +    @Override
-+    public java.util.List<ItemStack> onSheared(@org.jetbrains.annotations.Nullable Player player, @org.jetbrains.annotations.NotNull ItemStack item, Level world, net.minecraft.core.BlockPos pos, int fortune) {
++    public java.util.List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level world, net.minecraft.core.BlockPos pos, int fortune) {
 +        if (world instanceof ServerLevel server) {
 +            server.playSound(null, this, SoundEvents.COPPER_GOLEM_SHEAR, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
 +            var ret = new java.util.ArrayList<ItemStack>();

--- a/patches/minecraft/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
++++ b/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
+@@ -72,7 +_,7 @@
+         if (this.level().isClientSide()) {
+             return InteractionResult.SUCCESS;
+         } else {
+-            if (p_31842_.getItemInHand(p_31843_).is(Items.SHEARS)) {
++            if (p_31842_.getItemInHand(p_31843_).canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_HARVEST)) {
+                 InteractionResult interactionresult = super.interact(p_31842_, p_31843_);
+                 if (interactionresult instanceof InteractionResult.Success interactionresult$success && interactionresult$success.wasItemInteraction()) {
+                     return interactionresult;

--- a/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_shear_copper_golem_poppy.json
+++ b/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_shear_copper_golem_poppy.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:shears_behavior/custom_shears_shear_copper_golem_poppy",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_unleash_entity.json
+++ b/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_unleash_entity.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:shears_behavior/custom_shears_unleash_entity",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_unleash_knot.json
+++ b/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_unleash_knot.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:shears_behavior/custom_shears_unleash_knot",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug.gameplay.item;
 
 import net.minecraft.core.BlockPos;

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
@@ -51,7 +51,7 @@ public class ShearsBehaviorTest extends BaseTestMod {
         var cowPos = new BlockPos(0, 1, 1);
         helper.setBlock(fencePos, Blocks.OAK_FENCE);
         var cow = helper.spawnWithNoFreeWill(EntityType.COW, cowPos);
-        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), fencePos);
+        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), helper.absolutePos(fencePos));
         cow.setLeashedTo(knot, true);
         helper.assertTrue(cow.isLeashed(), "Cow should start leashed");
 
@@ -79,7 +79,7 @@ public class ShearsBehaviorTest extends BaseTestMod {
         var cowPos = new BlockPos(0, 1, 1);
         helper.setBlock(fencePos, Blocks.OAK_FENCE);
         var cow = helper.spawnWithNoFreeWill(EntityType.COW, cowPos);
-        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), fencePos);
+        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), helper.absolutePos(fencePos));
         cow.setLeashedTo(knot, true);
         helper.assertTrue(cow.isLeashed(), "Cow should start leashed");
 
@@ -90,11 +90,11 @@ public class ShearsBehaviorTest extends BaseTestMod {
         var result = player.interactOn(knot, InteractionHand.MAIN_HAND);
 
         // assert
-        helper.succeedOnTickWhen(1, () -> { // wait one tick for leash to update
-            //helper.assertTrue(result.consumesAction(), "Using custom shears on leash knot should result in consume action"); //it is also not true for vanilla shears
-            helper.assertTrue(!cow.isLeashed(), "Cow should be unleashed by sheared knot");
-            helper.assertItemEntityPresent(Items.LEAD);
-        });
+        helper.assertTrue(result.consumesAction(), "Using custom shears on leash knot should result in consume action");
+        helper.assertTrue(!cow.isLeashed(), "Cow should be unleashed by sheared knot");
+        helper.assertItemEntityPresent(Items.LEAD);
+
+        helper.succeed();
     }
 
     @GameTest

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
@@ -1,0 +1,135 @@
+package net.minecraftforge.debug.gameplay.item;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.coppergolem.CopperGolem;
+import net.minecraft.world.entity.decoration.LeashFenceKnotEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ShearsItem;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.gametest.GameTest;
+import net.minecraftforge.gametest.GameTestNamespace;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.test.BaseTestMod;
+
+@Mod(ShearsBehaviorTest.MOD_ID)
+@GameTestNamespace("forge")
+public class ShearsBehaviorTest extends BaseTestMod {
+    public static final String MOD_ID = "shears_behavior";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+    private static final RegistryObject<Item> CUSTOM_SHEARS_ITEM = ITEMS.register("custom_shears_item", () -> new ShearsItem(
+            new Item.Properties().stacksTo(1).setId(ITEMS.key("custom_shears_item"))
+    ));
+    private static final RegistryObject<Item> CUSTOM_SHEARS_HARVEST_ITEM = ITEMS.register("custom_shears_harvest_item", () -> new ShearsHarvestItem(
+            new Item.Properties().stacksTo(1).setId(ITEMS.key("custom_shears_harvest_item"))
+    ));
+
+    public ShearsBehaviorTest(FMLJavaModLoadingContext context) {
+        super(context, false, true);
+        this.testItem(lookup -> CUSTOM_SHEARS_ITEM.get().getDefaultInstance());
+        this.testItem(lookup -> CUSTOM_SHEARS_HARVEST_ITEM.get().getDefaultInstance());
+    }
+
+    @GameTest
+    public static void custom_shears_unleash_entity(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup: fence + knot + leash cow
+        var fencePos = new BlockPos(1, 1, 1);
+        var cowPos = new BlockPos(0, 1, 1);
+        helper.setBlock(fencePos, Blocks.OAK_FENCE);
+        var cow = helper.spawnWithNoFreeWill(EntityType.COW, cowPos);
+        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), fencePos);
+        cow.setLeashedTo(knot, true);
+        helper.assertTrue(cow.isLeashed(), "Cow should start leashed");
+
+        // act: interact with cow using custom shears
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        var shears = CUSTOM_SHEARS_HARVEST_ITEM.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shears);
+        var result = player.interactOn(cow, InteractionHand.MAIN_HAND);
+
+        // assert
+        helper.assertTrue(result.consumesAction(), "Using custom shears on leashed cow should result in consume action");
+        helper.assertTrue(!cow.isLeashed(), "Cow should be unleashed by custom shears");
+        helper.assertItemEntityPresent(Items.LEAD);
+
+        helper.succeed();
+    }
+
+
+    @GameTest
+    public static void custom_shears_unleash_knot(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup: fence + knot + leash cow
+        var fencePos = new BlockPos(1, 1, 1);
+        var cowPos = new BlockPos(0, 1, 1);
+        helper.setBlock(fencePos, Blocks.OAK_FENCE);
+        var cow = helper.spawnWithNoFreeWill(EntityType.COW, cowPos);
+        var knot = LeashFenceKnotEntity.getOrCreateKnot(helper.getLevel(), fencePos);
+        cow.setLeashedTo(knot, true);
+        helper.assertTrue(cow.isLeashed(), "Cow should start leashed");
+
+        // act: interact with knot using custom shears
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        var shears = CUSTOM_SHEARS_HARVEST_ITEM.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shears);
+        var result = player.interactOn(knot, InteractionHand.MAIN_HAND);
+
+        // assert
+        helper.succeedOnTickWhen(1, () -> { // wait one tick for leash to update
+            //helper.assertTrue(result.consumesAction(), "Using custom shears on leash knot should result in consume action"); //it is also not true for vanilla shears
+            helper.assertTrue(!cow.isLeashed(), "Cow should be unleashed by sheared knot");
+            helper.assertItemEntityPresent(Items.LEAD);
+        });
+    }
+
+    @GameTest
+    public static void custom_shears_shear_copper_golem_poppy(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup: copper golem with poppy
+        var golemPos = new BlockPos(1, 1, 1);
+        var golem = helper.spawnWithNoFreeWill(EntityType.COPPER_GOLEM, golemPos);
+        golem.setItemSlot(CopperGolem.EQUIPMENT_SLOT_ANTENNA, new ItemStack(Items.POPPY));
+        helper.assertTrue(golem.readyForShearing(), "Golem should start shearable (has poppy)");
+
+        // act: interact with copper golem using custom shears
+        var player = helper.makeMockPlayer(GameType.SURVIVAL);
+        var shears = CUSTOM_SHEARS_ITEM.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shears);
+        var result = player.interactOn(golem, InteractionHand.MAIN_HAND);
+
+        // assert
+        helper.assertTrue(result.consumesAction(), "Using custom shears on copper golem should result in consume action");
+        helper.assertTrue(golem.getItemBySlot(CopperGolem.EQUIPMENT_SLOT_ANTENNA).isEmpty(), "Copper golem poppy should be sheared off with custom shears");
+        helper.assertItemEntityPresent(Items.POPPY);
+
+        helper.succeed();
+    }
+
+    private static final class ShearsHarvestItem extends Item {
+        ShearsHarvestItem(Item.Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        public boolean canPerformAction(ItemStack stack, ToolAction action) {
+            return action == ToolActions.SHEARS_HARVEST;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR fixes shearing leads with custom shears. Interacting with entites or leash knots (lead on fences) didn't result in shearing off the leads as vanilla shears.

I reused the tool action SHEARS_HARVEST, because I don't think an extra tool action for handling leads is necessary.

The changes should also be backported to 1.21.8 because these vanilla changes were made in 1.21.6.

Additionally this PR fixes shearing off the poppy of the copper golem with custom shears. To test that, you can spawn a copper golem like this:

```
/summon copper_golem ~ ~ ~ {equipment:{saddle:{id:"minecraft:poppy",count:1}}}
```