### PR TITLE
[1.21.x] Replace certain ToolActions with DataComponents

### DIFF
--- a/patches/minecraft/net/minecraft/core/component/DataComponents.java.patch
+++ b/patches/minecraft/net/minecraft/core/component/DataComponents.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/core/component/DataComponents.java
++++ b/net/minecraft/core/component/DataComponents.java
+@@ -374,6 +_,13 @@
+     public static final DataComponentType<DyeColor> SHULKER_COLOR = register(
+         "shulker/color", p_389661_ -> p_389661_.persistent(DyeColor.CODEC).networkSynchronized(DyeColor.STREAM_CODEC)
+     );
++    /* Forge components start */
++    public static final DataComponentType<Unit> SWEEP = register("sweep", builder -> builder.persistent(Unit.CODEC).networkSynchronized(Unit.STREAM_CODEC));
++    // Shear behavior
++    public static final DataComponentType<Unit> CAN_SHEAR_HARVEST = register("can_shear_harvest", builder -> builder.persistent(Unit.CODEC).networkSynchronized(Unit.STREAM_CODEC));
++    public static final DataComponentType<Unit> CAN_CARVE = register("can_carve", builder -> builder.persistent(Unit.CODEC).networkSynchronized(Unit.STREAM_CODEC));
++    public static final DataComponentType<Unit> CAN_DISARM = register("can_disarm", builder -> builder.persistent(Unit.CODEC).networkSynchronized(Unit.STREAM_CODEC));
++    /* Forge components end */
+     public static final DataComponentMap COMMON_ITEM_COMPONENTS = DataComponentMap.builder()
+         .set(MAX_STACK_SIZE, 64)
+         .set(LORE, ItemLore.EMPTY)

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -201,7 +201,7 @@
                              double d0 = this.getKnownMovement().horizontalDistanceSqr();
                              double d1 = this.getSpeed() * 2.5;
 -                            if (d0 < Mth.square(d1) && this.getItemInHand(InteractionHand.MAIN_HAND).is(ItemTags.SWORDS)) {
-+                            if (d0 < Mth.square(d1) && this.getItemInHand(InteractionHand.MAIN_HAND).canPerformAction(net.minecraftforge.common.ToolActions.SWORD_SWEEP)) {
++                            if (d0 < Mth.square(d1) && this.getItemInHand(InteractionHand.MAIN_HAND).getComponents().has(DataComponents.SWEEP)) {
                                  flag2 = true;
                              }
                          }

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -63,10 +63,11 @@
      public final ItemStack getCraftingRemainder() {
          return this.craftingRemainingItem == null ? ItemStack.EMPTY : new ItemStack(this.craftingRemainingItem);
      }
-@@ -354,6 +_,30 @@
+@@ -354,7 +_,31 @@
          return false;
      }
  
+-    public static class Properties {
 +    private Object renderProperties;
 +
 +    /*
@@ -91,9 +92,19 @@
 +
 +    public void initializeClient(java.util.function.Consumer<net.minecraftforge.client.extensions.common.IClientItemExtensions> consumer) { }
 +
-     public static class Properties {
++    public static class Properties implements net.minecraftforge.common.extensions.IForgeItemProperty {
          private static final DependantName<Item, String> BLOCK_DESCRIPTION_ID = p_367498_ -> Util.makeDescriptionId("block", p_367498_.location());
          private static final DependantName<Item, String> ITEM_DESCRIPTION_ID = p_367603_ -> Util.makeDescriptionId("item", p_367603_.location());
+         private final DataComponentMap.Builder components = DataComponentMap.builder().addAll(DataComponents.COMMON_ITEM_COMPONENTS);
+@@ -452,7 +_,7 @@
+         }
+ 
+         public Item.Properties sword(ToolMaterial p_395594_, float p_395179_, float p_392972_) {
+-            return p_395594_.applySwordProperties(this, p_395179_, p_392972_);
++            return p_395594_.applySwordProperties(this, p_395179_, p_392972_).sweepLikeSword();
+         }
+ 
+         public Item.Properties spawnEgg(EntityType<?> p_422939_) {
 @@ -599,6 +_,11 @@
  
          boolean isPeaceful();

--- a/patches/minecraft/net/minecraft/world/level/block/BeehiveBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BeehiveBlock.java.patch
@@ -5,7 +5,7 @@
          if (i >= 5) {
              Item item = p_331014_.getItem();
 -            if (p_329187_ instanceof ServerLevel serverlevel && p_331014_.is(Items.SHEARS)) {
-+            if (p_329187_ instanceof ServerLevel serverlevel && p_331014_.canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_HARVEST)) {
++            if (p_329187_ instanceof ServerLevel serverlevel && p_331014_.getComponents().has(net.minecraft.core.component.DataComponents.CAN_SHEAR_HARVEST)) {
                  dropHoneycomb(serverlevel, p_331014_, p_328141_, p_329187_.getBlockEntity(p_335985_), p_336201_, p_335985_);
                  p_329187_.playSound(null, p_336201_.getX(), p_336201_.getY(), p_336201_.getZ(), SoundEvents.BEEHIVE_SHEAR, SoundSource.BLOCKS, 1.0F, 1.0F);
                  p_331014_.hurtAndBreak(1, p_336201_, p_333071_.asEquipmentSlot());

--- a/patches/minecraft/net/minecraft/world/level/block/PumpkinBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PumpkinBlock.java.patch
@@ -5,7 +5,7 @@
          ItemStack p_330568_, BlockState p_330263_, Level p_327756_, BlockPos p_328675_, Player p_334049_, InteractionHand p_331851_, BlockHitResult p_329008_
      ) {
 -        if (!p_330568_.is(Items.SHEARS)) {
-+        if (p_330568_.canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_CARVE)) {
++        if (!p_330568_.has(net.minecraft.core.component.DataComponents.CAN_CARVE) && !p_330568_.is(Items.SHEARS)) {
              return super.useItemOn(p_330568_, p_330263_, p_327756_, p_328675_, p_334049_, p_331851_, p_329008_);
          } else if (p_327756_ instanceof ServerLevel serverlevel) {
              Direction direction = p_329008_.getDirection();

--- a/patches/minecraft/net/minecraft/world/level/block/TripWireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/TripWireBlock.java.patch
@@ -5,7 +5,7 @@
      @Override
      public BlockState playerWillDestroy(Level p_57615_, BlockPos p_57616_, BlockState p_57617_, Player p_57618_) {
 -        if (!p_57615_.isClientSide() && !p_57618_.getMainHandItem().isEmpty() && p_57618_.getMainHandItem().is(Items.SHEARS)) {
-+        if (!p_57615_.isClientSide() && !p_57618_.getMainHandItem().isEmpty() && p_57618_.getMainHandItem().canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_DISARM)) {
++        if (!p_57615_.isClientSide() && !p_57618_.getMainHandItem().isEmpty() && p_57618_.getMainHandItem().has(net.minecraft.core.component.DataComponents.CAN_DISARM)) {
              p_57615_.setBlock(p_57616_, p_57617_.setValue(DISARMED, true), 260);
              p_57615_.gameEvent(p_57618_, GameEvent.SHEAR, p_57616_);
          }

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -69,7 +69,9 @@ public class ToolActions
      *  Used during player attack to figure out if a sweep attack should be performed
      *
      *  @see IForgeItem#getSweepHitBox
+     *  @deprecated Fully replaced by DataComponents#SWEEP
      */
+    @Deprecated(since="1.21.10")
     public static final ToolAction SWORD_SWEEP = ToolAction.get("sword_sweep");
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemProperty.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemProperty.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.util.Unit;
+import net.minecraft.world.item.Item;
+
+public interface IForgeItemProperty {
+    default Item.Properties self() {
+        return (Item.Properties) this;
+    }
+
+    default Item.Properties actAsShears() {
+        return self().harvestLikeShears().carveLikeShears().canDisarmLikeShears();
+    }
+
+    /**
+     * Any {@link Item} with this property will create a sweep attack when hitting an enemy like a sword does.
+     * Testing for this property should be done by testing for the {@link DataComponents#SWEEP} component.
+     */
+    default Item.Properties sweepLikeSword() {
+        return self().component(DataComponents.SWEEP, Unit.INSTANCE);
+    }
+
+    /**
+     * Any {@link Item} with this property will carve pumpkins like vanilla shears do.
+     * Testing for this property should be done by testing for the {@link DataComponents#CAN_CARVE} component.
+     */
+    default Item.Properties carveLikeShears() {
+        return self().component(DataComponents.CAN_CARVE, Unit.INSTANCE);
+    }
+
+    /**
+     * Any {@link Item} with this property will harvest a block like shears do.
+     * Vanilla's uses are resetting the honey level in a beehive and clipping the antenna off a copper golem.
+     * Testing for this property should be done by testing for the {@link DataComponents#CAN_SHEAR_HARVEST} component.
+     */
+    default Item.Properties harvestLikeShears() {
+        return self().component(DataComponents.CAN_SHEAR_HARVEST, Unit.INSTANCE);
+    }
+
+    /**
+     * Any {@link Item} with this property will disarm tripwires when breaking them like shears do.
+     * Testing for this property should be done by testing for the {@link DataComponents#CAN_DISARM} component.
+     */
+    default Item.Properties canDisarmLikeShears() {
+        return self().component(DataComponents.CAN_DISARM, Unit.INSTANCE);
+    }
+}


### PR DESCRIPTION
ToolActions is old and, quoting Jonathan, "Yeah ToolActions imo for a cope for the fact that tags are synchronized"

This initial draft demonstrates replacing some of these behaviors. Not every ToolAction can be replaced with a DataComponent, unfortunately, as they're too tightly tied with the specific item type. For example, the shovel's ability to flatten ground is bound to ShovelItem, but shear's ability to disarm traps is in the Tripwire block. (Not to say it's impossible, just haven't looked at it long enough)

As a result, this PR allows for _any_ item to be able to act like shears or sweep like a sword if given the appropriate component. As a bonus, this does not interrupt vanilla connections in any way. Forge -> Vanilla & Vanilla -> Forge both connect and work as expected.

So far, the newly deprecated (when I get around to actually @ deprecating them all) ToolActions are:
SWORD_SWEEP (already deprecated, but behavior is generified now)
SHEARS_HARVEST
SHEARS_CARVE
SHEARS_DISARM

This adds DataComponents:
SWEEP
CAN_SHEAR_HARVEST
CAN_CARVE
CAN_DISARM

Obviously this is a breaking change, all mods using the above ToolActions will no longer work and will need to apply the associated components in their `Item.Properties`.