### PR TITLE
[1.21.10] Introduce MixinExtras as an included, optional dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'net.minecraftforge.gradleutils' version '[2.6.4,2.7)'
     id 'eclipse'
     id 'de.undercouch.download' version '5.4.0'
-    id 'net.minecraftforge.gradle.patcher' version '[6.0.22,6.2)' apply false
-    id 'net.minecraftforge.gradle.mcp' version '[6.0.22,6.2)' apply false
+    id 'net.minecraftforge.gradle.patcher' version '[6.0.46,6.2)' apply false
+    id 'net.minecraftforge.gradle.mcp' version '[6.0.46,6.2)' apply false
     id 'net.minecraftforge.gradlejarsigner' version '1.0.4'
     id 'org.barfuin.gradle.taskinfo' version '2.1.0'
 }

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -302,6 +302,10 @@ tasks.userdevConfig.configure {
         libraries.add(dep)
     }
 
+    // TODO [ForgeDev][UserDev] Split API/Runtime elements in userdev config
+    //      so we don't gotta keep making exceptions for MixinExtras
+    mixinExtras = libs.mixinextras.common
+
     inject = '' // We don't have a userdev sourceset anymore. Empty as a gradle workaround...
     runs {
         client {

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -135,6 +135,7 @@ dependencies {
     installer(libs.maven.artifact)
     installer(libs.bundles.terminalconsoleappender)
     installer(libs.mixin)
+    installer(libs.mixinextras.forge)
     installer(libs.bundles.jarjar)
     installer(libs.roimfs)
 

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -304,7 +304,8 @@ tasks.userdevConfig.configure {
 
     // TODO [ForgeDev][UserDev] Split API/Runtime elements in userdev config
     //      so we don't gotta keep making exceptions for MixinExtras
-    mixinExtras = libs.mixinextras.common
+    addCompileDependency(libs.mixinextras.common)
+    addAnnotationProcessorDependency(libs.mixinextras.common)
 
     inject = '' // We don't have a userdev sourceset anymore. Empty as a gradle workaround...
     runs {

--- a/fmlloader/build.gradle
+++ b/fmlloader/build.gradle
@@ -108,6 +108,15 @@ tasks.register('jarJarOptionsJson', net.minecraftforge.forge.tasks.JarJarMetadat
     metadataFile = project.file('src/main/resources/jarjar_options.json')
     // This is resolved too early by cpw.mods.modlauncher.TransformationServicesHandler.discoverServices(DiscoveryData) But eventually...
     //add(libs.mixin, 'org/spongepowered/asm/mixin/Mixin.class')
+    add(libs.mixinextras.forge) {
+        containedJarMetadata {
+            path = ''
+        }
+        resource = 'com/llamalad7/mixinextras/platform/forge/MixinExtrasConfigPlugin.class'
+        layer = 'GAMELIBRARY'
+        id = 'mixinextras'
+        nested = true
+    }
 }
 
 tasks.named('generateResources').configure {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -7,8 +7,10 @@ package net.minecraftforge.fml.loading;
 
 import com.mojang.logging.LogUtils;
 import cpw.mods.jarhandling.SecureJar;
+import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
 import cpw.mods.modlauncher.api.NamedPath;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import cpw.mods.modlauncher.serviceapi.ITransformerDiscoveryService;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -40,6 +42,17 @@ public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService
 
     @Override
     public void earlyInitialization(final String launchTarget, final String[] arguments) {
+        boolean isMixinEnabledInDev = false;
+        for (String arg : arguments) {
+            if (arg.startsWith("-mixin.config")) {
+                isMixinEnabledInDev = true;
+                break;
+            }
+        }
+        Launcher.INSTANCE.blackboard().putIfAbsent(
+            TypesafeMap.Key.getOrCreate(Launcher.INSTANCE.blackboard(), "isMixinEnabledInDev", Boolean.class),
+            isMixinEnabledInDev
+        );
         ImmediateWindowHandler.load(launchTarget, arguments);
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -72,6 +72,7 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
     private static volatile boolean optionsLoaded = false;
 
     private static final Attributes.Name MIXIN_CONFIGS_ATTR = new Attributes.Name("MixinConfigs");
+    private static final Attributes.Name MIXIN_CONNECTOR_ATTR = new Attributes.Name("MixinConnector");
     private static final ContainedJarMetadata MIXIN_EXTRAS_DEPENDENCY = makeMixinExtraDependency();
 
     private static ContainedJarMetadata makeMixinExtraDependency() {
@@ -231,7 +232,8 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
         }
 
         for (var mod : mods) {
-            if (mod.getSecureJar().moduleDataProvider().getManifest().getMainAttributes().getValue(MIXIN_CONFIGS_ATTR) != null) {
+            var attributes = mod.getSecureJar().moduleDataProvider().getManifest().getMainAttributes();
+            if (attributes.getValue(MIXIN_CONFIGS_ATTR) != null || attributes.getValue(MIXIN_CONNECTOR_ATTR) != null) {
                 anyMixinsLoaded = true;
                 return true;
             }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -9,16 +9,23 @@ import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import com.electronwill.nightconfig.core.file.FileConfig;
 import com.mojang.logging.LogUtils;
 
+import cpw.mods.modlauncher.Launcher;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import net.minecraftforge.fml.loading.EarlyLoadingException;
 import net.minecraftforge.fml.loading.EarlyLoadingException.ExceptionData;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.locating.IDependencyLocator;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.IModFile.Type;
+import net.minecraftforge.jarjar.metadata.ContainedJarIdentifier;
 import net.minecraftforge.jarjar.metadata.ContainedJarMetadata;
+import net.minecraftforge.jarjar.metadata.ContainedVersion;
 import net.minecraftforge.jarjar.metadata.MetadataIOHandler;
 import net.minecraftforge.jarjar.selection.JarSelector;
 
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -44,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TreeMap;
+import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -63,6 +71,24 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
     private static final Map<Path, Option> OPTIONS = new HashMap<>();
     private static volatile boolean optionsLoaded = false;
 
+    private static final Attributes.Name MIXIN_CONFIGS_ATTR = new Attributes.Name("MixinConfigs");
+    private static final ContainedJarMetadata MIXIN_EXTRAS_DEPENDENCY = makeMixinExtraDependency();
+
+    private static ContainedJarMetadata makeMixinExtraDependency() {
+        VersionRange range = null;
+        try {
+            range = VersionRange.createFromVersionSpec("[0,)");
+        } catch (InvalidVersionSpecificationException e) {
+            throw new RuntimeException("Failed to create version range for mixinextras-forge dependency", e);
+        }
+
+        return new ContainedJarMetadata(
+            new ContainedJarIdentifier("io.github.llamalad7", "mixinextras-forge"),
+            new ContainedVersion(range, null),
+            null, false
+        );
+    }
+
     @Override
     public String name() {
         return "JarInJar";
@@ -80,7 +106,11 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
 
         var selector = new Selector(mods);
 
-        if (selector.entries.size() == mods.size()) {
+        // Add a synthetic Mixin-Extras dependency if we detect anyone using Mixin
+        if (anyMixinsLoaded(mods)) {
+            if (!selector.isRequired(MIXIN_EXTRAS_DEPENDENCY.identifier()))
+                selector.addRequirement(MIXIN_EXTRAS_DEPENDENCY);
+        } else if (selector.entries.size() == mods.size()) {
             LOGGER.info("No dependencies to load found. Skipping!");
             return Collections.emptyList();
         }
@@ -187,6 +217,28 @@ public class JarInJarDependencyLocator extends AbstractModProvider implements ID
         }
 
         return ret;
+    }
+
+    private static Boolean anyMixinsLoaded = null;
+    private static boolean anyMixinsLoaded(List<IModFile> mods) {
+        var ret = anyMixinsLoaded;
+        if (ret != null) return ret;
+
+        if (!FMLEnvironment.production
+                && Launcher.INSTANCE.blackboard().get(TypesafeMap.Key.getOrCreate(Launcher.INSTANCE.blackboard(), "isMixinEnabledInDev", Boolean.class)).orElse(false)) {
+            anyMixinsLoaded = true;
+            return true;
+        }
+
+        for (var mod : mods) {
+            if (mod.getSecureJar().moduleDataProvider().getManifest().getMainAttributes().getValue(MIXIN_CONFIGS_ATTR) != null) {
+                anyMixinsLoaded = true;
+                return true;
+            }
+        }
+
+        anyMixinsLoaded = false;
+        return false;
     }
 
     private record Options(List<OptionMetadata> options) {}

--- a/fmlloader/src/main/resources/jarjar_options.json
+++ b/fmlloader/src/main/resources/jarjar_options.json
@@ -1,3 +1,35 @@
 {
-  "options": []
+  "options": [
+    {
+      "resource": "com/llamalad7/mixinextras/platform/forge/MixinExtrasConfigPlugin.class",
+      "layer": "GAMELIBRARY",
+      "id": "mixinextras",
+      "deps": [
+        {
+          "identifier": {
+            "group": "com.github.LlamaLad7",
+            "artifact": "MixinExtras"
+          },
+          "version": {
+            "range": "[0.5.0,)",
+            "artifactVersion": "0.5.0"
+          },
+          "path": "",
+          "isObfuscated": false
+        }
+      ],
+      "meta": {
+        "identifier": {
+          "group": "io.github.llamalad7",
+          "artifact": "mixinextras-forge"
+        },
+        "version": {
+          "artifactVersion": "0.5.0"
+        },
+        "path": "",
+        "isObfuscated": false
+      },
+      "nested": true
+    }
+  ]
 }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0.36,6.2)'
+    id 'net.minecraftforge.gradle' version '[6.0.46,6.2)'
 }
 
 version = mod_version

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,9 @@ dependencyResolutionManagement {
 
             library('roimfs', 'net.minecraftforge:roimfs:1.0.0') // ReadOnlyInMemoryFileSystem - Used for JarInJar extraction at runtime
             library('mixin', 'org.spongepowered:mixin:0.8.7')
-            library('mixinextras-forge', 'io.github.llamalad7:mixinextras-forge:0.5.0')
+            version('mixinextras', '0.5.0')
+            library('mixinextras-forge', 'io.github.llamalad7', 'mixinextras-forge').versionRef('mixinextras')
+            library('mixinextras-common', 'io.github.llamalad7', 'mixinextras-common').versionRef('mixinextras')
             library('jetbrains-annotations', 'org.jetbrains:annotations:24.1.0') // for ApiStatus annotations
             library('jspecify', 'org.jspecify:jspecify:1.0.0') // for nullability annotations
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
 
             library('roimfs', 'net.minecraftforge:roimfs:1.0.0') // ReadOnlyInMemoryFileSystem - Used for JarInJar extraction at runtime
             library('mixin', 'org.spongepowered:mixin:0.8.7')
+            library('mixinextras-forge', 'io.github.llamalad7:mixinextras-forge:0.5.0')
             library('jetbrains-annotations', 'org.jetbrains:annotations:24.1.0') // for ApiStatus annotations
             library('jspecify', 'org.jspecify:jspecify:1.0.0') // for nullability annotations
             library('slf4j-api', 'org.slf4j:slf4j-api:2.0.7')


### PR DESCRIPTION
This PR introduces MixinExtras as a Jar-in-Jar'ed optional dependency (known as a JiJ Optional) to Forge.

- Depends on #10683
- Depends on MinecraftForge/ForgeGradle#1003

I'll go into the details of *why* we did things the way we did near the end of this PR's description. For now, I'd like to discuss *how* this is being implemented and what that means for you, the modder.

## Implementation in Forge

JiJ Optionals are dependencies that are shipped with Forge but are not necessarily loaded by Forge at runtime. They are, as the name suggests, optional. They can be requested by mods at load time, at which point, Forge Mod Loader will allow the dependency to be loaded as part of the startup process. If there are no mods which request the optional, it is never loaded and the game will not suffer from any potential startup impact it might have. Think of it as a Windows startup application.

A major benefit of using the JiJ Optionals system is that it lays the groundwork for future Forge features without impacting performance. In the case of MixinExtras, however, we decided to streamline its selection in Forge Mod Loader. This PR includes additional logic that checks a mod jar's manifest attributes for "MixinConfigs" or "MixinConnector" which, when found, will automatically assume that the mod will attempt to use MixinExtras and enable the optional. Additionally, FML now includes a check for the `mixin.config` system property which, if found, will also enable the MixinExtras optional.

> [!NOTE]
> The reason MixinExtras is automatically assumed to be used when Mixin is requested is due to its injectors that are recommended to be used over some of Mixin's own injectors (i.e. `@Redirect` -> `@WrapOperation`, `@Inject(at = @At("RETURN"))` -> `@ModifyReturnValue`, etc.). MixinExtras injectors make Mixins less brittle and more compatible with each other.

## Implementation in ForgeGradle

ForgeGradle 6.0 will be updated (via MinecraftForge/ForgeGradle#1003) to automatically add MixinExtras-Common to the your **compile classpath (not runtime classpath).** What this means is that the you will be able to reference MixinExtras members at compile time while Forge will handle the loading of MixinExtras in the runtime. If you decide not to use Mixin, MixinExtras will not be loaded, so the inclusion of MixinExtras in the compile classpath but not the runtime classpath is an intentional choice that is handled accordingly by Forge.

As for ForgeGradle 7.0, it will have this same kind of "magic" for MixinExtras on release, but the way it is applied may change depending on if we decide to add expressive dependencies in a future version of the patcher and/or userdev config specifications. Please note that if, in the future, we decide to add more JiJ Optionals to Forge, it will be very likely that you, the modder, will be responsible for enabling them through your buildscript (typically done with 2-3 lines, depending on the scenario).

## Why we did we do it this way?

Simply put, it is because Forge does not need to use MixinExtras. The same is true for Mixin itself, but Mixin was included in Forge at a different time, with a different team, and a different approach to handling third-party libraries. The same could easily have been done with MixinExtras, but since we are a different team with a different mindset on libraries and opinions on their inclusion with Forge, we took the opportunity to implement it the way we wanted. And to be clear, I believe we would have had the exact same process with Mixin proper if we had considered its inclusion now as opposed as to when it was first included in 1.16.1.

Without getting into loader drama, we are aware of MixinExtras's adoption in other mod loaders, which has caused people to expect the same for us: MixinExtras in the Forge environment without the need for Jar-in-Jar. While the JiJ Optionals system was born out of a compromise for what we (Forge) want versus what the general modding community wants, I do believe that it is a better view of how dependencies not used by Forge can still be offered to developers without the need for Jar-in-Jar. The name JiJ Optional comes from the fact that these optional dependencies are enabled through a constraint in the Jar-in-Jar metadata in the mod file. Though, given how extreme of an example MixinExtras is, we've had to lessen that requirement for this case.

There are a handful of other reasons why we continuously delayed on the addition of MixinExtras to the Forge environment, and @LexManos is free to share is thoughts on those in the comments of this PR if he so chooses. But to summarize: for Forge, it is a core design principle to not use libraries that we do not need. And this design principle will be expanded upon even further with the advent of the new loader once the new toolchain for modern versions is complete.

> [!IMPORTANT]
> With all of this being said, please do not take the inclusion of the MixinExtras optional as a sign that we endorse the usage of Mixin. Please always look for an API in Forge that suits your needs rather than immediately resorting to writing a Mixin. Mixin and MixinExtras are incredibly useful tools for prototyping, understanding how the game works, and deepening your knowledge of Java bytecode and functionalities. While their usage makes sense for a niche feature in a mod that we wouldn't want to maintain as a Forge API long-term, Mixix should not be treated as a crutch for your projects. I hope we've made it clear through our last few years of accepting PRs that we are always open to new contributions that can aid everyone without needing to resort to potentially dangerous hacks.

## Closing Thoughts

With the creation of this PR and its eventual merge into Forge, we are ready to move on to bigger and better things at Forge. I personally hope that a non-extreme example of a JiJ Optional presents itself in the future so that the new system can be used to its fullest potential, instead of just being a bunch of magic specific to MixinExtras.

This entire arc has also allowed us at the Forge team to internally address miscommunications that have been present from the beginning. We've become more aware of each other's intentions, opinions, and hopes for the project. I say it in Discord all the time, but we really are just three random internet dudes just trying to make cool shit. I believe that this mini-project has allowed us to have a better understanding of our priorities and goals as we move forward with the completion of the toolchain.

> [!WARNING]
> - We will not hesitate to lock this issue if discussion gets heated. Keep it civil, and keep drama out of the comment section. Thank you in advance.
> - If I have gotten any details incorrect, please point them out to me so I can edit this PR description accordingly.

## Special Thanks

And now, as a Jonathing tradition after a long GitHub wall of text, it's time to get sappy.

- Thank you @LexManos, for continuing to put up with my bullshit, keeping my head in the game, and allowing me to foster our new Gradle plugin ecosystem as well as our buildscripts. I've learned a lot from you during this process that will continue to aid me for the rest of my programming career long, long after this.
- Thank you @PaintNinja, for your thoughtful ideas, experiments, and wonder. Watching your work and dedication motivates me to continue making my own work better and better. And let's not forget about the community outreach you've done over the years. As someone who holes up in GitHub and my little #github-discussions channel, you have no idea how much I appreciate it.
- Thank you @Fealtous, for continuing to work on the Forge project in my stead while I dive head-first into toolchain development. It's always a fun time watching you try new ideas in the PRs you've created and the discussions you have in our support channels. And of course, welcome to the Triage team.
- And thank you, the modder, for reading all the way to the end and continuing to use our platform. We've got more to show very soon, and I can't wait to bring it to your hands.