### PR TITLE
[1.21.11] Migrate the MDK to ForgeGradle 7

### DIFF
--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -940,7 +940,7 @@ tasks.register('installerJar', InstallerJar) {
 }
 
 final mdkGradleWrapper = tasks.register('mdkGradleWrapper', Wrapper) {
-    gradleVersion = '9.2.0'
+    gradleVersion = '9.3.1'
 }
 
 tasks.register('mdkZip', Zip) {

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -972,7 +972,8 @@ tasks.register('mdkZip', Zip) {
             MAPPING_CHANNEL: MAPPING_CHANNEL,
             MAPPING_VERSION: MAPPING_VERSION,
             FORGE_SPEC_VERSION: SPEC_VERSION.split("\\.")[0],
-            MC_NEXT_VERSION: MC_NEXT_VERSION
+            MC_NEXT_VERSION: MC_NEXT_VERSION,
+            EVENTBUS_VERSION: libs.versions.eventbus.get()
         ])
         rename 'gitignore\\.txt', '.gitignore'
         rename 'gitattributes\\.txt', '.gitattributes'

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -959,10 +959,11 @@ tasks.register('mdkZip', Zip) {
         from mdkGradleWrapper.map(Wrapper.&getPropertiesFile)
     }
     from(rootProject.file('mdk/')){
-        rootProject.file('mdk/gitignore.txt').eachLine{
+        rootProject.file('mdk/gitignore.txt').eachLine {
             if (!it.trim().isEmpty() && !it.trim().startsWith('#'))
                 exclude it
         }
+
         filter(ReplaceTokens, tokens: [
             FORGE_VERSION: FORGE_VERSION,
             FORGE_GROUP: project.group,

--- a/build_forge.gradle
+++ b/build_forge.gradle
@@ -939,17 +939,24 @@ tasks.register('installerJar', InstallerJar) {
     jarSigner.sign(it)
 }
 
+final mdkGradleWrapper = tasks.register('mdkGradleWrapper', Wrapper) {
+    gradleVersion = '9.2.0'
+}
+
 tasks.register('mdkZip', Zip) {
+    dependsOn mdkGradleWrapper
+
     archiveBaseName = project.name
     archiveClassifier = 'mdk'
     archiveVersion = project.version
     destinationDirectory = file('build/libs')
 
-    from rootProject.file('gradlew')
-    from rootProject.file('gradlew.bat')
+    from mdkGradleWrapper.map(Wrapper.&getScriptFile)
+    from mdkGradleWrapper.map(Wrapper.&getBatchScript)
     from(EXTRA_TXTS)
-    from(rootProject.file('gradle/')){
-        into('gradle/')
+    into('gradle/wrapper/') {
+        from mdkGradleWrapper.map(Wrapper.&getJarFile)
+        from mdkGradleWrapper.map(Wrapper.&getPropertiesFile)
     }
     from(rootProject.file('mdk/')){
         rootProject.file('mdk/gitignore.txt').eachLine{

--- a/mdk/README.txt
+++ b/mdk/README.txt
@@ -1,3 +1,4 @@
+TODO [Forge][MDK] Rework or trim down this entire document
 
 Source installation information for modders
 -------------------------------------------

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'eclipse'
-    id 'net.minecraftforge.gradle' version '7.0.0-beta.46'
+    id 'net.minecraftforge.gradle' version '[7.0.3,8)'
 }
 
 version = '1.0.0'
@@ -46,13 +46,13 @@ minecraft {
 }
 
 repositories {
-    maven minecraft.mavenizer
+    minecraft.mavenizer(it) // In Kotlin, it = this
     maven fg.forgeMaven
     maven fg.minecraftLibsMaven
     mavenCentral()
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:@MC_VERSION@-@FORGE_VERSION@'
+    implementation minecraft.dependency('net.minecraftforge:forge:@MC_VERSION@-@FORGE_VERSION@')
     annotationProcessor 'net.minecraftforge:eventbus-validator:@EVENTBUS_VERSION@'
 }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -56,3 +56,9 @@ dependencies {
     implementation minecraft.dependency('net.minecraftforge:forge:@MC_VERSION@-@FORGE_VERSION@')
     annotationProcessor 'net.minecraftforge:eventbus-validator:@EVENTBUS_VERSION@'
 }
+
+tasks.withType(JavaCompile).configureEach {
+    // Use the UTF-8 charset for Java compilation
+    // This is done by default in Java 18+, but this ensures it no matter the Java or Gradle version
+    options.encoding = 'UTF-8'
+}

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -1,235 +1,61 @@
+// This is a minimal setup to that works on all IDEs and environments.
+// For complex examples, see https://github.com/MinecraftForge/MDKExamples
+
 plugins {
-    id 'eclipse'
+    id 'java'
     id 'idea'
-    id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0.46,6.2)'
+    id 'eclipse'
+    id 'net.minecraftforge.gradle' version '7.0.0-beta.46'
 }
 
-version = mod_version
-group = mod_group_id
-
-base {
-    archivesName = mod_id
-}
+version = '1.0.0'
+group = 'com.example.examplemod'
 
 // Mojang ships Java 21 to end users in 1.20.5+, so your mod should target Java 21.
 java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
-println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
+// Include generated resources
+sourceSets.main.resources { srcDir 'src/generated/resources' }
+
 minecraft {
-    // The mappings can be changed at any time and must be in the following format.
-    // Channel:   Version:
-    // official   MCVersion             Official field/method names from Mojang mapping files
-    // parchment  YYYY.MM.DD-MCVersion  Open community-sourced parameter names and javadocs layered on top of official
-    //
-    // Parchment is an unofficial project maintained by ParchmentMC, separate from MinecraftForge
-    // Additional setup is needed to use their mappings: https://parchmentmc.org/docs/getting-started
-    //
-    // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: mapping_channel, version: mapping_version
+    mappings channel: 'official', version: '@MC_VERSION@'
 
-    // Forge 1.20.6 and newer use official mappings at runtime, so we shouldn't reobf from official to SRG
-    reobf = false
-
-    // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.
-    // In most cases, it is not necessary to enable.
-    // enableEclipsePrepareRuns = true
-    // enableIdeaPrepareRuns = true
-
-    // This property allows configuring Gradle's ProcessResources task(s) to run on IDE output locations before launching the game.
-    // It is REQUIRED to be set to true for this template to function.
-    // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-    copyIdeResources = true
-
-    // When true, this property will add the folder name of all declared run configurations to generated IDE run configurations.
-    // The folder name can be set on a run configuration using the "folderName" property.
-    // By default, the folder name of a run configuration is the name of the Gradle project containing it.
-    // generateRunFolders = true
-
-    // This property enables access transformers for use in development, applied to the Minecraft artifact.
-    // The access transformer file can be anywhere in the project.
-    // However, it must be at "META-INF/accesstransformer.cfg" in the final mod jar to be loaded by Forge.
-    // This default location is a best practice to automatically put the file in the right place in the final jar.
-    // See https://docs.minecraftforge.net/en/latest/advanced/accesstransformers/ for more information.
-    // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
-
-    // Default run configurations.
-    // These can be tweaked, removed, or duplicated as needed.
     runs {
-        // applies to all the run configs below
         configureEach {
-            workingDirectory project.file('run')
+            workingDir = layout.projectDirectory.dir('run')
 
-            // Optional additional logging. The markers can be added/remove as needed, separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-//            property 'forge.logging.markers', 'REGISTRIES'
-
-            property 'forge.logging.console.level', 'debug'
-
-            // Recommended for development - enables more descriptive errors at the cost of slower startup and registration.
-            property 'eventbus.api.strictRuntimeChecks', 'true'
-
-//            arg "-mixin.config=${mod_id}.mixins.json"
+            systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
         }
 
-        client {
-            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'forge.enabledGameTestNamespaces', mod_id
+        register('client') {
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
         }
 
-        server {
-            property 'forge.enabledGameTestNamespaces', mod_id
+        register('server') {
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
             args '--nogui'
         }
 
-        // This run config launches GameTestServer and runs all registered gametests, then exits.
-        // By default, the server will crash when no gametests are provided.
-        // The gametest system is also enabled by default for other run configs under the /test command.
-        gameTestServer {
-            property 'forge.enabledGameTestNamespaces', mod_id
+        register('gameTestServer') {
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
         }
 
-        data {
-            // example of overriding the workingDirectory set in configureEach above
-            workingDirectory project.file('run-data')
+        register('data') {
+            workingDir = layout.projectDirectory.dir('run-data')
 
-            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            args '--mod', mod_id, '--all', '--output', layout.projectDirectory.dir('src/generated/resources'), '--existing', layout.projectDirectory.dir('src/main/resources')
         }
     }
 }
 
-// Include resources generated by data generators.
-sourceSets.main.resources { srcDir 'src/generated/resources' }
-
 repositories {
-    // Put repositories for dependencies here
+    maven minecraft.mavenizer
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
     mavenCentral()
-    maven {
-        name = 'Forge'
-        url = 'https://maven.minecraftforge.net'
-    }
-    maven {
-        name = 'Minecraft libraries'
-        url = 'https://libraries.minecraft.net'
-    }
-    exclusiveContent {
-        forRepository {
-            maven {
-                name = 'Sponge'
-                url = 'https://repo.spongepowered.org/repository/maven-public'
-            }
-        }
-        filter {
-            includeGroupAndSubgroups('org.spongepowered')
-        }
-    }
-
-    // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
-    // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
-    // flatDir {
-    //     dir 'libs'
-    // }
 }
 
 dependencies {
-    // Specify the version of Minecraft to use.
-    // Any artifact can be supplied so long as it has a "userdev" classifier artifact and is a compatible patcher artifact.
-    // The "userdev" classifier will be requested and setup by ForgeGradle.
-    // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
-    // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-
-    // Forge 1.21.6+ uses EventBus 7, which shifts most of its runtime validation to compile-time via an annotation processor
-    // to improve performance in production environments. This line is required to enable said compile-time validation
-    // in your development environment, helping you catch issues early.
+    minecraft 'net.minecraftforge:forge:@MC_VERSION@-@FORGE_VERSION@'
     annotationProcessor 'net.minecraftforge:eventbus-validator:7.0-beta.12'
-
-    // Example mod dependency with JEI
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly "mezz.jei:jei-${mc_version}-common-api:${jei_version}"
-    // compileOnly "mezz.jei:jei-${mc_version}-forge-api:${jei_version}"
-    // runtimeOnly "mezz.jei:jei-${mc_version}-forge:${jei_version}"
-
-    // Example mod dependency using a mod jar from ./libs with a flat dir repository
-    // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
-    // The group id is ignored when searching -- in this case, it is "blank"
-    // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
-
-    // For more info:
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-}
-
-// This block of code expands all declared replace properties in the specified resource targets.
-// A missing property will result in an error. Properties are expanded using ${} Groovy notation.
-// When "copyIdeResources" is enabled, this will also run before the game launches in IDE environments.
-// See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-tasks.named('processResources', ProcessResources) {
-    var replaceProperties = [
-            minecraft_version: minecraft_version, minecraft_version_range: minecraft_version_range,
-            forge_version: forge_version, forge_version_range: forge_version_range,
-            loader_version_range: loader_version_range,
-            mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors: mod_authors, mod_description: mod_description,
-    ]
-    inputs.properties replaceProperties
-
-    filesMatching(['META-INF/mods.toml', 'pack.mcmeta']) {
-        expand replaceProperties + [project: project]
-    }
-}
-
-// Example for how to get properties into the manifest for reading at runtime.
-tasks.named('jar', Jar) {
-    manifest {
-        attributes([
-            'Specification-Title'     : mod_id,
-            'Specification-Vendor'    : mod_authors,
-            'Specification-Version'   : '1', // We are version 1 of ourselves
-            'Implementation-Title'    : project.name,
-            'Implementation-Version'  : project.jar.archiveVersion,
-            'Implementation-Vendor'   : mod_authors
-        ])
-//        attributes['MixinConfigs'] = "${mod_id}.mixins.json"
-    }
-}
-
-// Example configuration to allow publishing using the maven-publish plugin
-publishing {
-    publications {
-        register('mavenJava', MavenPublication) {
-            artifact jar
-        }
-    }
-    repositories {
-        maven {
-            url "file://${project.projectDir}/mcmodsrepo"
-        }
-    }
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
-}
-
-// IntelliJ no longer downloads javadocs and sources by default, this tells Gradle to force IntelliJ to do it.
-idea.module { downloadJavadoc = downloadSources = true }
-
-eclipse {
-    // Run everytime eclipse builds the code
-    //autoBuildTasks genEclipseRuns
-    // Run when importing the project
-    synchronizationTasks 'genEclipseRuns'
-}
-
-// Merge the resources and classes into the same directory, because Java expects modules to be in a single directory.
-// And if we have it in multiple we have to do performance intensive hacks like having the UnionFileSystem
-// This will eventually be migrated to ForgeGradle so modders don't need to manually do it. But that is later.
-sourceSets.each {
-    def dir = layout.buildDirectory.dir("sourcesSets/$it.name")
-    it.output.resourcesDir = dir
-    it.java.destinationDirectory = dir
 }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -54,5 +54,5 @@ repositories {
 
 dependencies {
     minecraft 'net.minecraftforge:forge:@MC_VERSION@-@FORGE_VERSION@'
-    annotationProcessor 'net.minecraftforge:eventbus-validator:7.0-beta.12'
+    annotationProcessor 'net.minecraftforge:eventbus-validator:@EVENTBUS_VERSION@'
 }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -1,4 +1,4 @@
-// This is a minimal setup that works on all IDEs and environments without compromise.
+// This is a minimal setup of a Forge mod workspace.
 // For complex examples (including AccessTransformers, Jar-in-Jar, and Mixin), see our examples repository.
 // https://github.com/MinecraftForge/MDKExamples
 

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -25,20 +25,16 @@ minecraft {
             workingDir = layout.projectDirectory.dir('run')
 
             systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
+            systemProperty 'forge.enabledGameTestNamespaces', 'examplemod'
         }
 
-        register('client') {
-            systemProperty 'forge.enabledGameTestNamespaces', mod_id
-        }
+        register('client')
 
         register('server') {
-            systemProperty 'forge.enabledGameTestNamespaces', mod_id
             args '--nogui'
         }
 
-        register('gameTestServer') {
-            systemProperty 'forge.enabledGameTestNamespaces', mod_id
-        }
+        register('gameTestServer')
 
         register('data') {
             workingDir = layout.projectDirectory.dir('run-data')

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -1,5 +1,6 @@
-// This is a minimal setup to that works on all IDEs and environments.
-// For complex examples, see https://github.com/MinecraftForge/MDKExamples
+// This is a minimal setup that works on all IDEs and environments without compromise.
+// For complex examples (including AccessTransformers, Jar-in-Jar, and Mixin), see our examples repository.
+// https://github.com/MinecraftForge/MDKExamples
 
 plugins {
     id 'java'

--- a/mdk/forge_README.txt
+++ b/mdk/forge_README.txt
@@ -1,14 +1,8 @@
-TODO [Forge][MDK] Rework or trim down this entire document
-
 Source installation information for modders
 -------------------------------------------
 This code follows the Minecraft Forge installation methodology. It will apply
-some small patches to the vanilla MCP source code, giving you and it access 
+some small patches to the vanilla MCP source code, giving you and it access
 to some of the data and functions you need to build a successful mod.
-
-Note also that the patches are built against "un-renamed" MCP source code (aka
-SRG Names) - this means that you will not be able to read them directly against
-normal code.
 
 Setup Process:
 ==============================
@@ -18,26 +12,17 @@ Step 1: Open your command-line and browse to the folder where you extracted the 
 Step 2: You're left with a choice.
 If you prefer to use Eclipse:
 1. Run the following command: `./gradlew genEclipseRuns`
-2. Open Eclipse, Import > Existing Gradle Project > Select Folder 
+2. Open Eclipse, Import > Existing Gradle Project > Select Folder
    or run `gradlew eclipse` to generate the project.
 
 If you prefer to use IntelliJ:
 1. Open IDEA, and import project.
 2. Select your build.gradle file and have it import.
-3. Run the following command: `./gradlew genIntellijRuns`
-4. Refresh the Gradle Project in IDEA if required.
+3. Use the run tasks located under the "Slime Launcher" Gradle task group.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can 
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 
 (this does not affect your code) and then start the process again.
-
-Mapping Names:
-=============================
-By default, the MDK is configured to use the official mapping names from Mojang for methods and fields 
-in the Minecraft codebase. These names are covered by a specific license. All modders should be aware of this
-license, if you do not agree with it you can change your mapping names to other crowdsourced names in your 
-build.gradle. For the latest license text, refer to the mapping file itself, or the reference copy here:
-https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
 
 Additional Resources: 
 =========================

--- a/mdk/forge_README.txt
+++ b/mdk/forge_README.txt
@@ -4,6 +4,9 @@ This code follows the Minecraft Forge installation methodology. It will apply
 some small patches to the vanilla MCP source code, giving you and it access
 to some of the data and functions you need to build a successful mod.
 
+Please note that this example MDK is a simple showcase for the most basic of mods.
+To see more examples see our dedicated examples repository under the "Additional Resources" section.
+
 Setup Process:
 ==============================
 
@@ -27,6 +30,7 @@ run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean`
 Additional Resources: 
 =========================
 Community Documentation: https://docs.minecraftforge.net/en/latest/gettingstarted/
+Additional Examples: https://github.com/MinecraftForge/MDKExamples
 LexManos' Install Video: https://youtu.be/8VEdtQLuLO0
 Forge Forums: https://forums.minecraftforge.net/
 Forge Discord: https://discord.minecraftforge.net/

--- a/mdk/gitignore.txt
+++ b/mdk/gitignore.txt
@@ -22,4 +22,5 @@ eclipse
 run
 
 # Files from Forge MDK
+forge_README.txt
 forge*changelog.txt

--- a/mdk/gradle.properties
+++ b/mdk/gradle.properties
@@ -1,66 +1,9 @@
-# Sets default memory used for Gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx5G
-org.gradle.daemon=false
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
 
-# In the case that Gradle needs to fork to recompile, this will set the memory for that process.
-systemProp.net.minecraftforge.gradle.repo.recompile.fork=true
-systemProp.net.minecraftforge.gradle.repo.recompile.fork.args=-Xmx5G
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.problems=warn
 
-# Opts-out of ForgeGradle automatically adding mavenCentral(), Forge's maven and MC libs maven to the repositories block
-systemProp.net.minecraftforge.gradle.repo.attach=false
-
-
-## Environment Properties
-
-# The Minecraft version must agree with the Forge version to get a valid artifact
-minecraft_version=@MC_VERSION@
-# The Minecraft version range can use any release version of Minecraft as bounds.
-# Snapshots, pre-releases, and release candidates are not guaranteed to sort properly
-# as they do not follow standard versioning conventions.
-minecraft_version_range=[@MC_VERSION@,@MC_NEXT_VERSION@)
-# The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=@FORGE_VERSION@
-# The Forge version range can use any version of Forge as bounds or match the loader version range
-forge_version_range=[@FORGE_SPEC_VERSION@,)
-# The loader version range can only use the major version of Forge/FML as bounds
-loader_version_range=[@FORGE_SPEC_VERSION@,)
-# The mapping channel to use for mappings.
-# The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
-# Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.
-#
-# | Channel   | Version              |                                                                                |
-# |-----------|----------------------|--------------------------------------------------------------------------------|
-# | official  | MCVersion            | Official field/method names from Mojang mapping files                          |
-# | parchment | YYYY.MM.DD-MCVersion | Open community-sourced parameter names and javadocs layered on top of official |
-#
-# You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
-# See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
-#
-# Parchment is an unofficial project maintained by ParchmentMC, separate from Minecraft Forge.
-# Additional setup is needed to use their mappings, see https://parchmentmc.org/docs/getting-started
-mapping_channel=@MAPPING_CHANNEL@
-# The mapping version to query from the mapping channel.
-# This must match the format required by the mapping channel.
-mapping_version=@MAPPING_VERSION@
-
-
-## Mod Properties
-
-# The unique mod identifier for the mod. Must be lowercase in English locale. Must fit the regex [a-z][a-z0-9_]{1,63}
-# Must match the String constant located in the main mod class annotated with @Mod.
-mod_id=examplemod
-# The human-readable display name for the mod.
-mod_name=Example Mod
-# The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
-mod_license=All Rights Reserved
-# The mod version. See https://semver.org/
-mod_version=1.0.0
-# The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
-# This should match the base package used for the mod sources.
-# See https://maven.apache.org/guides/mini/guide-naming-conventions.html
-mod_group_id=com.example.examplemod
-# The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
-mod_authors=YourNameHere, OtherNameHere
-# The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
-mod_description=Example mod description.\nNewline characters can be used and will be replaced properly.
+net.minecraftforge.gradle.merge-source-sets=true

--- a/mdk/settings.gradle
+++ b/mdk/settings.gradle
@@ -1,3 +1,5 @@
+// NOTE: When ForgeGradle 7 is stabilized, it will be uploaded to the Gradle Plugin Portal.
+//       This block will be removed when that happens.
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -9,5 +11,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
+
+rootProject.name = 'examplemod'

--- a/mdk/settings.gradle
+++ b/mdk/settings.gradle
@@ -1,5 +1,3 @@
-// NOTE: When ForgeGradle 7 is stabilized, it will be uploaded to the Gradle Plugin Portal.
-//       This block will be removed when that happens.
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }

--- a/mdk/settings.gradle
+++ b/mdk/settings.gradle
@@ -1,15 +1,5 @@
 // NOTE: When ForgeGradle 7 is stabilized, it will be uploaded to the Gradle Plugin Portal.
 //       This block will be removed when that happens.
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        maven {
-            name = 'MinecraftForge'
-            url = 'https://maven.minecraftforge.net/'
-        }
-    }
-}
-
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -1,73 +1,36 @@
-# This is an example mods.toml file. It contains the data relating to the loading mods.
-# There are several mandatory fields (#mandatory), and many more that are optional (#optional).
-# The overall format is standard TOML format, v0.5.0.
-# Note that there are a couple of TOML lists in this file.
-# Find more information on toml format here:  https://github.com/toml-lang/toml
-# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
-modLoader="javafml" #mandatory
-# A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="${loader_version_range}" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
-# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
-# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
-license="${mod_license}"
-# A URL to refer people to when problems occur with this mod
-#issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
-# If your mod is purely client-side and has no multiplayer functionality (be it dedicated servers or Open to LAN),
-# set this to true, and Forge will set the correct displayTest for you and skip loading your mod on dedicated servers.
-#clientSideOnly=true #optional - defaults to false if absent
-# A list of mods - how many allowed here is determined by the individual mod loader
-[[mods]] #mandatory
-# The modid of the mod
-modId="${mod_id}" #mandatory
-# The version number of the mod
-version="${mod_version}" #mandatory
-# A display name for the mod
-displayName="${mod_name}" #mandatory
-# A URL to query for updates for this mod. See the JSON update specification https://docs.minecraftforge.net/en/latest/misc/updatechecker/
-#updateJSONURL="https://change.me.example.invalid/updates.json" #optional
-# A URL for the "homepage" for this mod, displayed in the mod UI
-#displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
-# A file name (in the root of the mod JAR) containing a logo for display
-#logoFile="examplemod.png" #optional
-# A text field displayed in the mod UI
-#credits="" #optional
-# A text field displayed in the mod UI
-authors="${mod_authors}" #optional
-# Display Test controls the display for your mod in the server connection screen
-# MATCH_VERSION means that your mod will cause a red X if the versions on client and server differ. This is the default behaviour and should be what you choose if you have server and client elements to your mod.
-# IGNORE_SERVER_VERSION means that your mod will not cause a red X if it's present on the server but not on the client. This is what you should use if you're a server only mod.
-# IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
-# NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
-# IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
-#displayTest="MATCH_VERSION" # if nothing is specified, MATCH_VERSION is the default when clientSideOnly=false, otherwise IGNORE_ALL_VERSION when clientSideOnly=true (#optional)
+# See https://docs.minecraftforge.net/en/1.21.x/gettingstarted/modfiles/#modstoml
+# There are lots of things you can do with the mods.toml, and not all fields are included with this MDK
 
-# The description text for the mod (multi line!) (#mandatory)
-description='''${mod_description}'''
-# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.${mod_id}]] #optional
-    # the modid of the dependency
-    modId="forge" #mandatory
-    # Does this dependency have to exist - if not, ordering below must be specified
-    mandatory=true #mandatory
-    # The version range of the dependency
-    versionRange="${forge_version_range}" #mandatory
-    # An ordering relationship for the dependency - BEFORE or AFTER required if the dependency is not mandatory
-    # BEFORE - This mod is loaded BEFORE the dependency
-    # AFTER - This mod is loaded AFTER the dependency
+modLoader="javafml"
+loaderVersion="[@FORGE_SPEC_VERSION@,)"
+license="${mod_license}"
+#issueTrackerURL="https://github.com/MyOrganization/MyMod/"
+#clientSideOnly=true #optional, default=false
+
+[[mods]]
+modId="examplemod"
+version="1.0.0"
+displayName="Example Mod"
+#updateJSONURL="https://example.com/updates.json" #optional
+#displayURL="https://example.com/" #optional
+#logoFile="examplemod.png" #optional
+#credits="" #optional
+authors="YourNameHere, OtherNameHere" #optional
+#displayTest="MATCH_VERSION" #optional, default=MATCH_VERSION when not clientSideOnly, else IGNORE_ALL_VERSION
+
+description='''Example mod description.
+Newline characters can be used and will be replaced properly.'''
+
+[[dependencies.examplemod]] #recommended
+    modId="forge"
+    mandatory=true
+    versionRange="[@FORGE_SPEC_VERSION@,)"
     ordering="NONE"
-    # Side this dependency is applied on - BOTH, CLIENT, or SERVER
     side="BOTH"
-# Here's another dependency
-[[dependencies.${mod_id}]]
+
+[[dependencies.examplemod]] #recommended
     modId="minecraft"
     mandatory=true
-    # This version range declares a minimum of the current minecraft version up to but not including the next major version
-    versionRange="${minecraft_version_range}"
+    versionRange="[@MC_VERSION@,@MC_NEXT_VERSION@,)"
     ordering="NONE"
     side="BOTH"
-
-# Features are specific properties of the game environment, that you may want to declare you require. This example declares
-# that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
-# stop your mod loading on the server for example.
-#[features.${mod_id}]
-#openGLVersion="[3.2,)"

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ authors="YourNameHere, OtherNameHere" #optional
 #displayTest="MATCH_VERSION" #optional, default=MATCH_VERSION when not clientSideOnly, else IGNORE_ALL_VERSION
 
 description='''Example mod description.
-Newline characters can be used and will be replaced properly.'''
+Newline characters can be used like this, and rendered on the mods screen properly.'''
 
 [[dependencies.examplemod]] #recommended
     modId="forge"

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@
 
 modLoader="javafml"
 loaderVersion="[@FORGE_SPEC_VERSION@,)"
-license="${mod_license}"
+#license="All Rights Reserved"
 #issueTrackerURL="https://github.com/MyOrganization/MyMod/"
 #clientSideOnly=true #optional, default=false
 

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -3,8 +3,8 @@
 
 modLoader="javafml"
 loaderVersion="[@FORGE_SPEC_VERSION@,)"
-#license="All Rights Reserved"
-#issueTrackerURL="https://github.com/MyOrganization/MyMod/"
+license="All Rights Reserved"
+#issueTrackerURL="https://github.com/MyOrganization/MyMod/" #optional
 #clientSideOnly=true #optional, default=false
 
 [[mods]]

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,8 +31,9 @@ dependencyResolutionManagement {
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods-api', 'net.minecraftforge:coremods-api:5.3.0')
-            library('eventbus', 'net.minecraftforge:eventbus:7.0-beta.12')
-            library('eventbus-validator', 'net.minecraftforge:eventbus-validator:7.0-beta.12')
+            version('eventbus', '7.0-beta.12')
+            library('eventbus', 'net.minecraftforge', 'eventbus').versionRef('eventbus')
+            library('eventbus-validator', 'net.minecraftforge', 'eventbus-validator').versionRef('eventbus')
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 
             library('roimfs', 'net.minecraftforge:roimfs:1.0.0') // ReadOnlyInMemoryFileSystem - Used for JarInJar extraction at runtime


### PR DESCRIPTION
This PR migrates the MDK to ForgeGradle 7, and in the process, strips it of all complex tasks and build setup.

Complex MDKs will be created and preserved in the new [MDKExamples](https://github.com/MinecraftForge/MDKExamples). The top of the `build.gradle` file includes a link to this repository. I'm still unsure of what to do with `README.txt`.