### PR TITLE
[1.21.10] Add `c:nuggets/copper` item tag

### DIFF
--- a/src/main/generated/data/c/tags/item/nuggets.json
+++ b/src/main/generated/data/c/tags/item/nuggets.json
@@ -2,6 +2,7 @@
   "values": [
     "#c:nuggets/gold",
     "#c:nuggets/iron",
+    "#c:nuggets/copper",
     {
       "id": "#forge:nuggets",
       "required": false

--- a/src/main/generated/data/c/tags/item/nuggets/copper.json
+++ b/src/main/generated/data/c/tags/item/nuggets/copper.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:copper_nugget"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -748,6 +748,7 @@ public class Tags {
          */
         public static final TagKey<Item> MUSIC_DISCS = cTag("music_discs");
         public static final TagKey<Item> NUGGETS = cTag("nuggets");
+        public static final TagKey<Item> NUGGETS_COPPER = cTag("nuggets/copper");
         public static final TagKey<Item> NUGGETS_GOLD = cTag("nuggets/gold");
         public static final TagKey<Item> NUGGETS_IRON = cTag("nuggets/iron");
         public static final TagKey<Item> ORES = cTag("ores");

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -195,8 +195,10 @@ public final class ForgeItemTagsProvider extends VanillaItemTagsProvider {
                 .add(Items.NETHER_STAR)
                 .addOptionalTag(forgeItemTagKey("nether_stars"));
         tag(Tags.Items.NUGGETS)
-                .addTags(Tags.Items.NUGGETS_GOLD, Tags.Items.NUGGETS_IRON)
+                .addTags(Tags.Items.NUGGETS_GOLD, Tags.Items.NUGGETS_IRON, Tags.Items.NUGGETS_COPPER)
                 .addOptionalTag(forgeItemTagKey("nuggets"));
+        tag(Tags.Items.NUGGETS_COPPER)
+                .add(Items.COPPER_NUGGET);
         tag(Tags.Items.NUGGETS_IRON)
                 .add(Items.IRON_NUGGET)
                 .addOptionalTag(forgeItemTagKey("nuggets/iron"));


### PR DESCRIPTION
Adds `c:nuggets/copper`.

Syncs with https://github.com/FabricMC/fabric/pull/4905 and https://github.com/neoforged/NeoForge/pull/2711