### PR TITLE
[1.20.1] Allow loading ImmediateWindowProvider from mods

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -28,7 +28,8 @@ public class ModDirTransformerDiscoverer implements ITransformerDiscoveryService
     private static final Set<String> SERVICES = Set.of(
         "cpw.mods.modlauncher.api.ITransformationService",
         "net.minecraftforge.forgespi.locating.IModLocator",
-        "net.minecraftforge.forgespi.locating.IDependencyLocator"
+        "net.minecraftforge.forgespi.locating.IDependencyLocator",
+        "net.minecraftforge.fml.loading.ImmediateWindowProvider"
     );
 
     @Override


### PR DESCRIPTION
Forge Loader loads quite a lot of useful services, but it does not allow loading `ImmediateWindowProvider` implementations from the mods directory. I found several implementations on the web that use hacks to avoid the loading problem. But their methods are pretty dirty to use.