### PR TITLE
[1.21.x] Expose movevector field for usage with MovementInputUpdateEvent

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
@@ -14,9 +14,12 @@ import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * Fired after the player's movement inputs are updated.
- * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * Fired after the local player's movement inputs are updated during a tick.
+ * May be used to modify the provided {@linkplain net.minecraft.client.player.ClientInput#moveVector} state for some movement overrides.
  *
+ *  <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ *
+ * @param getEntity the local player
  * @param getInput the player's movement inputs
  */
 public record MovementInputUpdateEvent(Player getEntity, ClientInput getInput) implements RecordEvent, PlayerEvent {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -442,6 +442,7 @@ public net.minecraft.client.particle.ParticleResources m_415611_(Lnet/minecraft/
 public net.minecraft.client.particle.ParticleResources m_419483_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V # register
 public net.minecraft.client.particle.ParticleResources$SpriteParticleRegistration
 public net.minecraft.client.player.LocalPlayer m_9242_()I # getPermissionLevel
+public net.minecraft.client.player.ClientInput f_381292_ #moveVector
 private-f net.minecraft.client.renderer.LevelRenderer f_348825_ # weatherEffectRenderer
 public net.minecraft.client.renderer.LevelRenderer m_109817_()Z # shouldShowEntityOutlines
 #group public net.minecraft.client.renderer.RenderPipelines *


### PR DESCRIPTION
Title is pretty descriptive. Mojang changed how movement is done on the client at some point between 1.20.1 and latest and so modifying this field is how overrides work now. Also updates relevant docs so this is known.