### PR TITLE
Cache the interim fluid push map in a field

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -320,7 +320,7 @@
      public boolean isPushedByFluid() {
          return true;
      }
-@@ -3594,9 +_,17 @@
+@@ -3594,9 +_,20 @@
          return Mth.lerp(p_344421_, this.yRotO, this.yRot);
      }
  
@@ -332,18 +332,25 @@
 +        else return false;
 +     }
 +
-+     public void updateFluidHeightAndDoFluidPushing(Predicate<FluidState> shouldUpdate) {
++    // Forge: cache field to prevent allocating a new map every tick
++    private it.unimi.dsi.fastutil.objects. @Nullable Object2ObjectMap<net.minecraftforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> fluidPushCalcs;
++
++    public void updateFluidHeightAndDoFluidPushing(Predicate<FluidState> shouldUpdate) {
          if (this.touchingUnloadedChunk()) {
 -            return false;
 +            return;
          } else {
              AABB aabb = this.getBoundingBox().deflate(0.001);
              int i = Mth.floor(aabb.minX);
-@@ -3611,25 +_,28 @@
+@@ -3611,25 +_,32 @@
              Vec3 vec3 = Vec3.ZERO;
              int k1 = 0;
              BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
-+            var interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<net.minecraftforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>>(net.minecraftforge.fluids.FluidType.SIZE.get() - 1);
++            if (fluidPushCalcs == null) {
++                fluidPushCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(2);
++            } else if (!fluidPushCalcs.isEmpty()) {
++                fluidPushCalcs.clear();
++            }
  
              for (int l1 = i; l1 < j; l1++) {
                  for (int i2 = k; i2 < l; i2++) {
@@ -358,7 +365,7 @@
                                  flag1 = true;
 -                                d0 = Math.max(d1 - aabb.minY, d0);
 -                                if (flag) {
-+                                var interim = interimCalcs.computeIfAbsent(fluidType, t -> org.apache.commons.lang3.tuple.MutableTriple.of(0.0D, Vec3.ZERO, 0));
++                                var interim = fluidPushCalcs.computeIfAbsent(fluidType, t -> org.apache.commons.lang3.tuple.MutableTriple.of(0.0D, Vec3.ZERO, 0));
 +                                interim.setLeft(Math.max(d1 - aabb.minY, interim.getLeft()));
 +                                if (this.isPushedByFluid(fluidType)) {
                                      Vec3 vec31 = fluidstate.getFlow(this.level(), blockpos$mutableblockpos);
@@ -382,7 +389,7 @@
 -            if (vec3.length() > 0.0) {
 -                if (k1 > 0) {
 -                    vec3 = vec3.scale(1.0 / k1);
-+            interimCalcs.forEach((fluidType, interim) -> {
++            fluidPushCalcs.forEach((fluidType, interim) -> {
 +            if (interim.getMiddle().length() > 0.0D) {
 +                if (interim.getRight() > 0) {
 +                    interim.setMiddle(interim.getMiddle().scale(1.0D / (double)interim.getRight()));


### PR DESCRIPTION
This massively reduces the allocations from this method when playing with mods that add a lot of fluids, such as Tinkers Construct. Example of this happening and this method causing 3% of my allocations (1.20.1, however the code functionality is unchanged since then): https://spark.lucko.me/alpwV7K4rG?hl=4176. Note I plan on making a 1.20.1 PR as well.
<img width="875" height="297" alt="Spark Report showing Entity.updateFluidHeightAndDoFluidPushing() takes 3.97% of allocations, of whch 53MB is from Object2ObjectArrayMap.<init>" src="https://github.com/user-attachments/assets/fc1a38c7-3ce3-4a3d-a3bc-a3aaf3451aee" />


The initial size of 2 was chosen as a small number that 99.9% of entities will never need the full capacity of (it is hard to get player sized mobs into two different fluids and for this to happen during gameplay is near impossible unless someone is trying to do it). In case an entity does end up in more than two fluids at once, the map will double in size until they fit, and this same map will be kept around until the entity is garbage collected.

The field is not filled until needed, to prevent allocating for entities that don't use normal movement logic.


I have done some rough testing with water and lava pushing various entities (players, ghasts, happy ghasts and cows) around in fluid and the behaviour seems normal, which given the size of this change is enough for me to assume it hasn't broken anything.


Conversation in MC Forge Discord for a bit more design context: https://discord.com/channels/1129059589325852724/1129095235889270844/1459047852360732672