### PR TITLE
Add support for multiple access transformer configs.

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -166,7 +166,7 @@ public class FMLLoader {
     }
 
     public static void addAccessTransformer(Path atPath, ModFile modName) {
-        LOGGER.debug(SCAN, "Adding Access Transformer in {}", modName.getFilePath());
+        LOGGER.debug(SCAN, "Adding Access Transformer {} in {}", atPath, modName.getFilePath());
         accessTransformer.offerResource(atPath, modName.getFileName());
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.fml.loading;
 
+import net.minecraftforge.fml.loading.EarlyLoadingException.ExceptionData;
 import net.minecraftforge.fml.loading.moddiscovery.BackgroundScanHandler;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
@@ -19,11 +20,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+
+import com.mojang.logging.LogUtils;
+
 /**
  * Master list of all mods <em>in the loading context. This class cannot refer outside the
  * loading package</em>
  */
 public class LoadingModList {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static LoadingModList INSTANCE;
     private final List<ModFileInfo> modFiles;
     private final List<ModInfo> sortedList;
@@ -57,13 +63,22 @@ public class LoadingModList {
     }
 
     public void addAccessTransformers() {
+        var errors = new ArrayList<ExceptionData>();
+
         for (ModFileInfo modFile : modFiles) {
             ModFile mod = modFile.getFile();
-            var at = mod.getAccessTransformer().orElse(null);
-            if (at != null) {
-                FMLLoader.addAccessTransformer(at, mod);
+            for (var at : mod.getAccessTransformers()) {
+                if (!Files.exists(at)) {
+                    var message = String.format("Invalid mod file: %s Missing Access Transformer: %s", modFile.getFile().getFileName(), at);
+                    errors.add(new ExceptionData(message));
+                    LOGGER.error(message);
+                } else
+                    FMLLoader.addAccessTransformer(at, mod);
             }
         }
+
+        if (!errors.isEmpty())
+            preLoadErrors.add(new EarlyLoadingException("Invalid Access Transformers", null, errors));
     }
 
     public void addForScanning(BackgroundScanHandler backgroundScanHandler) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
@@ -69,7 +69,7 @@ public class LoadingModList {
             ModFile mod = modFile.getFile();
             for (var at : mod.getAccessTransformers()) {
                 if (!Files.exists(at)) {
-                    var message = String.format("Invalid mod file: %s Missing Access Transformer: %s", modFile.getFile().getFileName(), at);
+                    var message = "Invalid mod file: " + modFile.getFile().getFileName() + ". Missing Access Transformer: " + at;
                     errors.add(new ExceptionData(message));
                     LOGGER.error(message);
                 } else

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -49,6 +49,7 @@ public class ModFile implements IModFile {
     private ModFileScanData fileModFileScanData;
     private CompletableFuture<ModFileScanData> futureScanResult;
     private Path accessTransformer;
+    private List<Path> accessTransformers = Collections.emptyList();
 
     static final Attributes.Name TYPE = new Attributes.Name("FMLModType");
     private SecureJar.Status securityStatus;
@@ -91,14 +92,35 @@ public class ModFile implements IModFile {
         return modFileInfo.getMods();
     }
 
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public Optional<Path> getAccessTransformer() {
-        return Optional.ofNullable(Files.exists(accessTransformer) ? accessTransformer : null);
+        return Optional.ofNullable(accessTransformer);
+    }
+
+    public List<Path> getAccessTransformers() {
+        return this.accessTransformers;
     }
 
     public boolean identifyMods() {
         if (this.modFileInfo == null) return this.getType() != Type.MOD;
         LOGGER.debug(LogMarkers.LOADING,"Loading mod file {} with languages {}", this.getFileName(), this.modFileInfo.requiredLanguageLoaders());
-        this.accessTransformer = findResource("META-INF", "accesstransformer.cfg");
+        var cfg = this.modFileInfo.getConfig()
+            .<List<String>>getConfigElement("accessTransformers")
+            .orElse(null);
+
+        if (cfg == null) {
+            var path = findResource("META-INF", "accesstransformer.cfg");
+            if (Files.exists(path)) {
+                this.accessTransformer = path;
+                this.accessTransformers = List.of(path);
+            }
+        } else if (!cfg.isEmpty()) {
+            var paths = new ArrayList<Path>(cfg.size());
+            for (var path : cfg)
+                paths.add(getSecureJar().getPath(path.replace('\\', '/')));
+            this.accessTransformers = Collections.unmodifiableList(paths);
+        }
+
         return true;
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -118,7 +118,7 @@ public class ModFile implements IModFile {
             var paths = new ArrayList<Path>(cfg.size());
             for (var path : cfg)
                 paths.add(getSecureJar().getPath(path.replace('\\', '/')));
-            this.accessTransformers = Collections.unmodifiableList(paths);
+            this.accessTransformers = List.copyOf(paths);
         }
 
         return true;

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -45,8 +45,9 @@ authors="${mod_authors}" #optional
 description='''${mod_description}'''
 
 # Access Transformers
-# Optional, if not specified Forge will attempt to find the default META-INF/accesstransformer.cfg
-# Specifying a empty list is recommended to opt-out of the default for slightly better loading performance.
+# Optional, if not specified Forge will attempt to find the default META-INF/accesstransformer.cfg and silently continue if not found. May default to an empty list in a future MC.
+# If you specify AT path strings in this list, Forge will attempt to load each of them and throw errors for any that aren't found.
+# Specifying an empty list when your mod has no ATs is recommended to opt-out of the default for slightly better loading performance.
 #accessTransformers = []
 
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -43,6 +43,12 @@ authors="${mod_authors}" #optional
 
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''
+
+# Access Transformers
+# Optional, if not specified Forge will attempt to find the default META-INF/accesstransformer.cfg
+# Specifying a empty list is recommended to opt-out of the default for slightly better loading performance.
+#accessTransformers = []
+
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.${mod_id}]] #optional
     # the modid of the dependency


### PR DESCRIPTION
It was requested by paint in https://github.com/MinecraftForge/MinecraftForge/issues/10758
Discussing a bit on discord, with 1.20.5+ using official mappings at runtime, and FG7 supporting them at dev time there is no real need for this.
But its a simple change as the rest of the toolchain supports it.
I'm entertaining this as it could be back ported to older versions where runtime mappings could be different then dev.