### PR TITLE
[1.21.11] Deprecate instantiating non-final mod classes

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -38,9 +38,9 @@ public abstract class ModContainer {
     protected ModLoadingStage modLoadingStage;
     protected Supplier<?> contextExtension;
     protected final Map<ModLoadingStage, Runnable> activityMap = new EnumMap<>(ModLoadingStage.class);
-    protected final Map<Class<? extends IExtensionPoint<?>>, Supplier<?>> extensionPoints = new IdentityHashMap<>();
+    protected final Map<Class<? extends IExtensionPoint<?>>, Supplier<?>> extensionPoints = new IdentityHashMap<>(8);
     protected final EnumMap<ModConfig.Type, ModConfig> configs = new EnumMap<>(ModConfig.Type.class);
-    final Set<ModContainer> dependencies = new HashSet<>();
+    final Set<ModContainer> dependencies = new HashSet<>(8);
     /**
      * If you want to handle the event, override {@link #dispatchConfigEvent(IConfigEvent)}
      */

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -135,6 +135,7 @@ public class FMLModContainer extends ModContainer {
             LOGGER.trace(LOADING, "Loading mod instance {} of type {}", getModId(), modClass.getName());
 
             if (!Modifier.isFinal(modClass.getModifiers())) {
+                // TODO: [Forge][26.1] Promote this deprecation warning to an error
                 var errorMsg = "Mod class "  + modClass.getName() + " should be final. Instantiating non-final mod classes is deprecated and may fail in a future release.";
                 LOGGER.warn(LOADING, errorMsg);
                 if (!FMLEnvironment.production)

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -8,10 +8,13 @@ package net.minecraftforge.fml.javafmlmod;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.ModLoadingException;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.ModLoadingWarning;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.ModFileScanData;
 import net.minecraftforge.unsafe.UnsafeHacks;
@@ -26,6 +29,7 @@ import cpw.mods.jarhandling.SecureJar;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Objects;
 import java.util.jar.Attributes;
 
@@ -129,6 +133,14 @@ public class FMLModContainer extends ModContainer {
     private void constructMod() {
         try {
             LOGGER.trace(LOADING, "Loading mod instance {} of type {}", getModId(), modClass.getName());
+
+            if (!Modifier.isFinal(modClass.getModifiers())) {
+                var errorMsg = "Mod class "  + modClass.getName() + " should be final. Instantiating non-final mod classes is deprecated and may fail in a future release.";
+                LOGGER.warn(LOADING, errorMsg);
+                if (!FMLEnvironment.production)
+                    ModLoader.get().addWarning(new ModLoadingWarning(modInfo, ModLoadingStage.CONSTRUCT, errorMsg, modClass.getName()));
+            }
+
             Constructor<?> constructor;
             try {
                 constructor = modClass.getDeclaredConstructor(context.getClass());

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -180,7 +180,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApiStatus.Internal
-public class ForgeHooksClient {
+public final class ForgeHooksClient {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker CLIENTHOOKS = MarkerManager.getMarker("CLIENTHOOKS");
 

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -127,7 +127,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 @Mod("forge")
-public class ForgeMod {
+public final class ForgeMod {
     public static final String VERSION_CHECK_CAT = "version_checking";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker FORGEMOD = MarkerManager.getMarker("FORGEMOD");

--- a/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chunk/LightingEventTest.java
@@ -23,7 +23,7 @@ import net.minecraftforge.test.BaseTestMod;
  */
 @GameTestNamespace("forge")
 @Mod(LightingEventTest.MODID)
-public class LightingEventTest extends BaseTestMod {
+public final class LightingEventTest extends BaseTestMod {
     public static final String MODID = "lighting_event_test";
 
     private static final int MAX_CHUNK_LOCATION_ATTEMPTS = 5;

--- a/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
@@ -63,7 +63,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 @GameTestNamespace("forge")
 @Mod(AdditionalModelTest.MODID)
-public class AdditionalModelTest extends BaseTestMod {
+public final class AdditionalModelTest extends BaseTestMod {
     public static final String MODID = "additional_model";
 
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, MODID);

--- a/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ClientCommandTest.java
@@ -21,7 +21,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 
 @GameTestNamespace("forge")
 @Mod(ClientCommandTest.MODID)
-public class ClientCommandTest extends BaseTestMod {
+public final class ClientCommandTest extends BaseTestMod {
     public static final String MODID = "client_command";
     private static final String COMMAND = "testClientCommand";
     private static int LAST_COMMAND = -1;

--- a/src/test/java/net/minecraftforge/debug/client/CustomParticleTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomParticleTypeTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 @GameTestNamespace("forge")
 @Mod(CustomParticleTypeTest.MOD_ID)
-public class CustomParticleTypeTest extends BaseTestMod {
+public final class CustomParticleTypeTest extends BaseTestMod {
     public static final String MOD_ID = "custom_particle_type_test";
     private static final ParticleRenderType CUSTOM_TYPE = new ParticleRenderType("GRP_ONE");
     private static final ParticleRenderType CUSTOM_TYPE_TWO = new ParticleRenderType("GRP_TWO");

--- a/src/test/java/net/minecraftforge/debug/client/CustomizeGuiOverlayEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomizeGuiOverlayEventTest.java
@@ -9,7 +9,7 @@ import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod(CustomizeGuiOverlayEventTest.MODID)
-public class CustomizeGuiOverlayEventTest
+public final class CustomizeGuiOverlayEventTest
 {
     private static final boolean ENABLED = false;
 

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fml.common.Mod;
 import java.util.Random;
 
 @Mod(GuiLayeringTest.MODID)
-public class GuiLayeringTest {
+public final class GuiLayeringTest {
     private static final boolean ENABLED = false;
 
     private static final Random RANDOM = new Random();

--- a/src/test/java/net/minecraftforge/debug/client/LateBoundIdMapperTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/LateBoundIdMapperTest.java
@@ -26,7 +26,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 @Mod(LateBoundIdMapperTest.MODID)
 @GameTestNamespace("forge")
-public class LateBoundIdMapperTest extends BaseTestMod {
+public final class LateBoundIdMapperTest extends BaseTestMod {
     public LateBoundIdMapperTest(FMLJavaModLoadingContext context) {
         super(context, false, false);
     }

--- a/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
@@ -52,7 +52,7 @@ import com.google.gson.JsonElement;
 
 @Mod(ModelRenderLayerTest.MODID)
 @GameTestNamespace("forge")
-public class ModelRenderLayerTest extends BaseTestMod {
+public final class ModelRenderLayerTest extends BaseTestMod {
     public static final String MODID = "model_render_type";
     private static final String BLOCK_NAME = "cutout_block";
 

--- a/src/test/java/net/minecraftforge/debug/client/ModifyOverlayTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModifyOverlayTest.java
@@ -25,7 +25,7 @@ import static net.minecraftforge.client.gui.overlay.ForgeLayeredDraw.*;
 
 @GameTestNamespace("forge")
 @Mod(ModifyOverlayTest.MODID)
-public class ModifyOverlayTest extends BaseTestMod {
+public final class ModifyOverlayTest extends BaseTestMod {
     public static final String MODID = "modify_overlay_test";
 
     private static final Identifier myStackName = name("my_stack_name");

--- a/src/test/java/net/minecraftforge/debug/client/PictureInPictureTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/PictureInPictureTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 @GameTestNamespace("forge")
 @Mod(PictureInPictureTest.MODID)
-public class PictureInPictureTest extends BaseTestMod {
+public final class PictureInPictureTest extends BaseTestMod {
     public static final String MODID = "pip_test";
     private static int RENDER_FRAMES = 0;
 

--- a/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/RenderFrameLayerTest.java
@@ -26,7 +26,7 @@ import com.mojang.blaze3d.framegraph.FramePass;
 
 @GameTestNamespace("forge")
 @Mod(RenderFrameLayerTest.MODID)
-public class RenderFrameLayerTest extends BaseTestMod {
+public final class RenderFrameLayerTest extends BaseTestMod {
     public static final String MODID = "render_frame_layer_test";
     private static final IForgeGameTestHelper.BoolFlag passOne = new IForgeGameTestHelper.BoolFlag("pass_one_flag");
     private static final IForgeGameTestHelper.BoolFlag passTwo = new IForgeGameTestHelper.BoolFlag("pass_two_flag");

--- a/src/test/java/net/minecraftforge/debug/client/RenderTooltipTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/RenderTooltipTest.java
@@ -25,7 +25,7 @@ import java.util.Random;
 
 @GameTestNamespace("forge")
 @Mod(RenderTooltipTest.MODID)
-public class RenderTooltipTest extends BaseTestMod {
+public final class RenderTooltipTest extends BaseTestMod {
     public static final String MODID = "render_tooltip_test";
     private static boolean testMode = false;
     private static int shouldOpen = 0;

--- a/src/test/java/net/minecraftforge/debug/creativetabs/CreativeModeTabTest.java
+++ b/src/test/java/net/minecraftforge/debug/creativetabs/CreativeModeTabTest.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegisterEvent;
 
 @Mod(CreativeModeTabTest.MOD_ID)
-public class CreativeModeTabTest {
+public final class CreativeModeTabTest {
     public static final String MOD_ID = "creative_mode_tab_test";
     private static final boolean ENABLED = true;
 

--- a/src/test/java/net/minecraftforge/debug/dist/DistExecutorTest.java
+++ b/src/test/java/net/minecraftforge/debug/dist/DistExecutorTest.java
@@ -17,7 +17,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(DistExecutorTest.MOD_ID)
 @GameTestNamespace("forge")
-public class DistExecutorTest extends BaseTestMod {
+public final class DistExecutorTest extends BaseTestMod {
     static final String MOD_ID = "dist_executor";
 
     public DistExecutorTest(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/biome/BiomeTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/biome/BiomeTestMod.java
@@ -24,7 +24,7 @@ import net.minecraftforge.test.BaseTestMod;
 import java.util.List;
 
 @Mod(BiomeTestMod.MOD_ID)
-public class BiomeTestMod extends BaseTestMod {
+public final class BiomeTestMod extends BaseTestMod {
     public static final String MOD_ID = "biome_test";
 
     public static final DeferredRegisterData<ConfiguredFeature<?, ?>> CONFIGURED_FEATURES = DeferredRegisterData.create(Registries.CONFIGURED_FEATURE, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/block/ChorusBlockPlacementTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/block/ChorusBlockPlacementTest.java
@@ -24,7 +24,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(ChorusBlockPlacementTest.MOD_ID)
-public class ChorusBlockPlacementTest extends BaseTestMod {
+public final class ChorusBlockPlacementTest extends BaseTestMod {
     static final String MOD_ID = "chorus_block_placement";
 
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/block/CrafterBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/block/CrafterBlockTest.java
@@ -39,7 +39,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(CrafterBlockTest.MOD_ID)
-public class CrafterBlockTest extends BaseTestMod {
+public final class CrafterBlockTest extends BaseTestMod {
     static final String MOD_ID = "crafter_block";
 
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/block/PlantTypePlacementTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/block/PlantTypePlacementTest.java
@@ -38,7 +38,7 @@ import static net.minecraft.world.level.block.Blocks.*;
 
 @GameTestNamespace("forge")
 @Mod(PlantTypePlacementTest.MOD_ID)
-public class PlantTypePlacementTest extends BaseTestMod {
+public final class PlantTypePlacementTest extends BaseTestMod {
     static final String MOD_ID = "plant_type_placement";
 
     private static final Map<TagKey<Block>, List<Block>> TAGS = Util.make(new HashMap<>(), map -> {

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
@@ -43,7 +43,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(ConditionalRecipeTest.MODID)
-public class ConditionalRecipeTest extends BaseTestMod {
+public final class ConditionalRecipeTest extends BaseTestMod {
     static final String MODID = "conditional_recipe";
 
     public ConditionalRecipeTest(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/CustomIngredientsTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/CustomIngredientsTest.java
@@ -49,7 +49,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(CustomIngredientsTest.MODID)
-public class CustomIngredientsTest extends BaseTestMod implements INBTBuilder {
+public final class CustomIngredientsTest extends BaseTestMod implements INBTBuilder {
     static final String MODID = "custom_ingredients";
     private static final String TAG_DAMAGE = "damage";
     private static final int TEST_DAMAGE = 3;

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/TagsTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/TagsTest.java
@@ -18,7 +18,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(TagsTest.MODID)
 @GameTestNamespace("forge")
-public class TagsTest extends BaseTestMod {
+public final class TagsTest extends BaseTestMod {
     public static final String MODID = "tags_test";
 
     public TagsTest(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/data/DatapackBuiltinEntriesProviderTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/data/DatapackBuiltinEntriesProviderTest.java
@@ -34,7 +34,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 @Mod(DatapackBuiltinEntriesProviderTest.MOD_ID)
-public class DatapackBuiltinEntriesProviderTest extends BaseTestMod {
+public final class DatapackBuiltinEntriesProviderTest extends BaseTestMod {
 
     public static final String MOD_ID = "datapack_builtin_entries_provider_test";
     // Vanilla registry entries

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/GatherComponentsEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/GatherComponentsEventTest.java
@@ -18,7 +18,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(GatherComponentsEventTest.MOD_ID)
-public class GatherComponentsEventTest extends BaseTestMod {
+public final class GatherComponentsEventTest extends BaseTestMod {
     public static final String MOD_ID = "gather_components_test_event";
 
     public GatherComponentsEventTest(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ItemCapabilityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ItemCapabilityTest.java
@@ -39,7 +39,7 @@ import java.util.function.Consumer;
 
 @GameTestNamespace("forge")
 @Mod(ItemCapabilityTest.MOD_ID)
-public class ItemCapabilityTest extends BaseTestMod {
+public final class ItemCapabilityTest extends BaseTestMod {
     public static final String MOD_ID = "item_caps";
 
     public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENTS = DeferredRegister.create(Registries.DATA_COMPONENT_TYPE, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/PreventItemDamageTest.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
 
 @GameTestNamespace("forge")
 @Mod(PreventItemDamageTest.MOD_ID)
-public class PreventItemDamageTest extends BaseTestMod {
+public final class PreventItemDamageTest extends BaseTestMod {
     static final String MOD_ID = "prevent_item_damage";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
@@ -30,7 +30,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(ShearsBehaviorTest.MOD_ID)
 @GameTestNamespace("forge")
-public class ShearsBehaviorTest extends BaseTestMod {
+public final class ShearsBehaviorTest extends BaseTestMod {
     public static final String MOD_ID = "shears_behavior";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/ForcedChunkLoadingTest.java
@@ -19,7 +19,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(ForcedChunkLoadingTest.MOD_ID)
-public class ForcedChunkLoadingTest extends BaseTestMod {
+public final class ForcedChunkLoadingTest extends BaseTestMod {
     static final String MOD_ID = "forced_chunk_loading";
 
     private static final int MAX_CHUNK_LOCATION_ATTEMPTS = 5;

--- a/src/test/java/net/minecraftforge/debug/gameplay/level/TrySleepTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/level/TrySleepTest.java
@@ -24,7 +24,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(TrySleepTest.MOD_ID)
-public class TrySleepTest extends BaseTestMod {
+public final class TrySleepTest extends BaseTestMod {
     static final String MOD_ID = "try_sleep";
     static final long NIGHT = 13000;
     static final long DAY = 0;

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ConditionalLootPools.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ConditionalLootPools.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 
 @GameTestNamespace("forge")
 @Mod(ConditionalLootPools.MODID)
-public class ConditionalLootPools extends BaseTestMod {
+public final class ConditionalLootPools extends BaseTestMod {
     public static final String MODID = "conditional_loot_test";
 
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -81,7 +81,7 @@ import java.util.function.Supplier;
 
 @GameTestNamespace("forge")
 @Mod(GlobalLootModifiersTest.MODID)
-public class GlobalLootModifiersTest extends BaseTestMod {
+public final class GlobalLootModifiersTest extends BaseTestMod {
     public static final String MODID = "global_loot_test";
 
     private static final DeferredRegister<MapCodec<? extends IGlobalLootModifier>> GLM = DeferredRegister.create(ForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, MODID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/LootEventsTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/LootEventsTest.java
@@ -43,7 +43,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(LootEventsTest.MODID)
 @GameTestNamespace("forge")
-public class LootEventsTest extends BaseTestMod {
+public final class LootEventsTest extends BaseTestMod {
     public static final String MODID = "loot_events";
     @SuppressWarnings("unused")
     private static Logger LOGGER = LogManager.getLogger();

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ShearsLootTests.java
@@ -33,7 +33,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(ShearsLootTests.MODID)
 @GameTestNamespace("forge")
-public class ShearsLootTests extends BaseTestMod {
+public final class ShearsLootTests extends BaseTestMod {
     public static final String MODID = "shears_loot";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);

--- a/src/test/java/net/minecraftforge/debug/gameplay/redstone/UpdateOrder.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/redstone/UpdateOrder.java
@@ -27,7 +27,7 @@ import net.minecraftforge.gametest.GameTestNamespace;
  */
 @Mod(UpdateOrder.MODID)
 @GameTestNamespace("forge")
-public class UpdateOrder extends BaseTestMod {
+public final class UpdateOrder extends BaseTestMod {
     public static final String MODID = "update_order";
     private static final int PISTON_DELAY = 4;
 

--- a/src/test/java/net/minecraftforge/debug/gameplay/villager/VillagerTypeTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/villager/VillagerTypeTestMod.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 @GameTestNamespace("forge")
 @Mod(VillagerTypeTestMod.MOD_ID)
-public class VillagerTypeTestMod extends BaseTestMod {
+public final class VillagerTypeTestMod extends BaseTestMod {
     public static final String MOD_ID = "villager_type_test";
 
     private static final DeferredRegister<VillagerType> VILLAGER_TYPES = DeferredRegister.create(Registries.VILLAGER_TYPE, MOD_ID);

--- a/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingAfter.java
+++ b/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingAfter.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.test.BaseTestMod;
 
 @Mod(ModLoadSortingAfter.MODID)
-public class ModLoadSortingAfter extends BaseTestMod {
+public final class ModLoadSortingAfter extends BaseTestMod {
     static final String MODID = "load_sort_after";
     protected static final Logger LOGGER = LogUtils.getLogger();
     static boolean hasInit = false;

--- a/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingBefore.java
+++ b/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingBefore.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.test.BaseTestMod;
 
 @Mod(ModLoadSortingBefore.MODID)
-public class ModLoadSortingBefore extends BaseTestMod {
+public final class ModLoadSortingBefore extends BaseTestMod {
     static final String MODID = "load_sort_before";
     protected static final Logger LOGGER = LogUtils.getLogger();
     static boolean hasInit = false;

--- a/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingTest.java
+++ b/src/test/java/net/minecraftforge/debug/loading/sort/ModLoadSortingTest.java
@@ -18,7 +18,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(ModLoadSortingTest.MODID)
-public class ModLoadSortingTest extends BaseTestMod {
+public final class ModLoadSortingTest extends BaseTestMod {
     static final String MODID = "load_sort_test";
 
     protected static final Logger LOGGER = LogUtils.getLogger();

--- a/src/test/java/net/minecraftforge/debug/modules/automatic/AutomaticModuleMod.java
+++ b/src/test/java/net/minecraftforge/debug/modules/automatic/AutomaticModuleMod.java
@@ -14,7 +14,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(AutomaticModuleMod.MODID)
-public class AutomaticModuleMod extends BaseTestMod {
+public final class AutomaticModuleMod extends BaseTestMod {
     public static final String MODID = "automatic_module";
 
     public AutomaticModuleMod(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/modules/closed/ClosedMod.java
+++ b/src/test/java/net/minecraftforge/debug/modules/closed/ClosedMod.java
@@ -17,7 +17,7 @@ import net.minecraftforge.test.BaseTestMod;
 import net.minecraftforge.test.ModuleProvider;
 
 @Mod(ClosedMod.MODID)
-public class ClosedMod extends BaseTestMod {
+public final class ClosedMod extends BaseTestMod {
     public static final String MODID = "closed_module";
 
     public ClosedMod(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/modules/closedtest/ClosedTestsMod.java
+++ b/src/test/java/net/minecraftforge/debug/modules/closedtest/ClosedTestsMod.java
@@ -21,7 +21,7 @@ import net.minecraft.gametest.framework.GameTestHelper;
 
 @Mod(ClosedTestsMod.MODID)
 @GameTestNamespace("forge")
-public class ClosedTestsMod extends BaseTestMod {
+public final class ClosedTestsMod extends BaseTestMod {
     public static final String MODID = "closed_module_test";
 
     public ClosedTestsMod(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/debug/network/PacketTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/PacketTest.java
@@ -34,7 +34,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @Mod(PacketTest.MODID)
 @GameTestNamespace("forge")
-public class PacketTest extends BaseTestMod {
+public final class PacketTest extends BaseTestMod {
     static final String MODID = "packet";
 
     protected static final Logger LOGGER = LogUtils.getLogger();

--- a/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
@@ -29,7 +29,7 @@ import net.minecraftforge.test.BaseTestMod;
 
 @GameTestNamespace("forge")
 @Mod(NetworkDatapackRegistryTest.MODID)
-public class NetworkDatapackRegistryTest extends BaseTestMod {
+public final class NetworkDatapackRegistryTest extends BaseTestMod {
     private static final Logger LOGGER = LogUtils.getLogger();
     public static final String MODID = "network_data_registry";
     private static final ResourceKey<Registry<DataObject>> REGISTRY_KEY = ResourceKey.createRegistryKey(rl("registry"));

--- a/src/test/java/net/minecraftforge/mdk/Datagen.java
+++ b/src/test/java/net/minecraftforge/mdk/Datagen.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod(Datagen.MOD_ID)
-public class Datagen {
+public final class Datagen {
     static final String MOD_ID = "mdk_datagen";
 
     public Datagen(FMLJavaModLoadingContext context) {

--- a/src/test/java/net/minecraftforge/test/TestHelperMod.java
+++ b/src/test/java/net/minecraftforge/test/TestHelperMod.java
@@ -24,7 +24,7 @@ import net.minecraftforge.registries.RegisterEvent;
 
 /* A place where I can put common utility stuff for now. Until I re-write the test codebase. */
 @Mod(TestHelperMod.MOD_ID)
-public class TestHelperMod extends BaseTestMod {
+public final class TestHelperMod extends BaseTestMod {
     public static final String MOD_ID = "test_helper_mod";
     public static final ResourceKey<CreativeModeTab> TAB = ResourceKey.create(Registries.CREATIVE_MODE_TAB, Identifier.fromNamespaceAndPath(MOD_ID, "test_items"));
 


### PR DESCRIPTION
Mod classes are considered singletons in FML and aren't intended to be instantiated manually.

Requiring that these classes are final helps avoid confusion where a mod might not be loaded despite someone extending and calling super, or have two separate instances.

Additionally, having final on mod classes helps with warmup, as the JVM knows ahead of time that it doesn't need to account for the instance methods possibly being overridden by a subclass.

The example mod class in the MDK has already been marked as final for many versions.