### PR TITLE
[1.17.1] Allow command suggestions/autocomplete to search all modded paths at once without namespace provided

### DIFF
--- a/patches/minecraft/net/minecraft/commands/SharedSuggestionProvider.java.patch
+++ b/patches/minecraft/net/minecraft/commands/SharedSuggestionProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/commands/SharedSuggestionProvider.java
++++ b/net/minecraft/commands/SharedSuggestionProvider.java
+@@ -60,7 +_,7 @@
+             if (m_82949_(p_82946_, s)) {
+                p_82948_.accept(t);
+             }
+-         } else if (m_82949_(p_82946_, resourcelocation.m_135827_()) || resourcelocation.m_135827_().equals("minecraft") && m_82949_(p_82946_, resourcelocation.m_135815_())) {
++         } else if (m_82949_(p_82946_, resourcelocation.m_135827_()) || m_82949_(p_82946_, resourcelocation.m_135815_())) { // Forge: Removed "minecraft" namespace requirement for path searching to allow modded path suggestions to show up
+             p_82948_.accept(t);
+          }
+       }


### PR DESCRIPTION
Backport of https://github.com/MinecraftForge/MinecraftForge/commit/d00f5c4013cdb93c094aa34d73892f942e3cd228