### PR TITLE
[1.21.11] Skip runtime annotation scanning for MC itself, blacklist common inconsequential annotations

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/MinecraftLocator.java
@@ -14,6 +14,7 @@ import net.minecraftforge.forgespi.locating.IModLocator;
 import net.minecraftforge.forgespi.locating.ModFileFactory;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.jetbrains.annotations.ApiStatus;
 
@@ -56,5 +57,10 @@ public final class MinecraftLocator extends AbstractModProvider implements IModL
     @Override
     public String name() {
         return "minecraft";
+    }
+
+    @Override
+    public void scanFile(IModFile file, Consumer<Path> pathConsumer) {
+        // skip annotation scanning for MC itself
     }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotation.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotation.java
@@ -19,7 +19,7 @@ import org.objectweb.asm.Type;
 import com.google.common.base.MoreObjects;
 
 @ApiStatus.Internal
-class ModAnnotation {
+final class ModAnnotation {
     public static ModFileScanData.AnnotationData fromModAnnotation(Type clazz, ModAnnotation annotation) {
         return new ModFileScanData.AnnotationData(annotation.asmType, annotation.type, clazz, annotation.member, annotation.values);
     }
@@ -84,6 +84,7 @@ class ModAnnotation {
     }
 
     public void endArray() {
+        arrayList.trimToSize();
         values.put(arrayName, arrayList);
         arrayList = null;
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
@@ -22,7 +22,47 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApiStatus.Internal
-class ModClassVisitor extends ClassVisitor {
+final class ModClassVisitor extends ClassVisitor {
+    private static final Set<String> ANNOTATION_BLACKLIST;
+
+    private static final Type OBJECT_TYPE = Type.getObjectType("java/lang/Object");
+    private static final Type RECORD_TYPE = Type.getObjectType("java/lang/Record");
+
+    static {
+        var customBlacklist = System.getProperty("forge.annotationScanningBlacklist");
+        if (customBlacklist != null) {
+            ANNOTATION_BLACKLIST = Set.of(customBlacklist.split(","));
+        } else {
+            ANNOTATION_BLACKLIST = Set.of(
+                    "Ljava/lang/Deprecated;",
+                    "Ljava/lang/FunctionalInterface;",
+                    "Ljava/lang/SafeVarargs;",
+
+                    "Ljava/lang/annotation/Retention;",
+                    "Ljava/lang/annotation/Target;",
+
+                    "Ljavax/annotation/Nullable;",
+
+                    "Lorg/jspecify/nullness/NonNull;",
+                    "Lorg/jspecify/nullness/Nullable;",
+                    "Lorg/jspecify/annotations/NullMarked;",
+                    "Lorg/jspecify/annotations/NullUnmarked;",
+
+                    "Lorg/jetbrains/annotations/ApiStatus$Internal;",
+                    "Lorg/jetbrains/annotations/Contract;",
+                    "Lorg/jetbrains/annotations/Nullable;",
+                    "Lorg/jetbrains/annotations/NotNull;",
+                    "Lorg/jetbrains/annotations/VisibleForTesting;",
+
+                    "Lcom/google/common/annotations/VisibleForTesting;",
+
+                    "Lnet/minecraftforge/api/distmarker/OnlyIn", // should not be used by mods
+                    // @Mod.EventBusSubscriber doesn't use scan data for finding @SubscribeEvent annotated methods
+                    "Lnet/minecraftforge/eventbus/api/listener/SubscribeEvent;"
+            );
+        }
+    }
+
     private Type asmType;
     private Type asmSuperType;
     private Set<Type> interfaces;
@@ -35,12 +75,17 @@ class ModClassVisitor extends ClassVisitor {
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         this.asmType = Type.getObjectType(name);
-        this.asmSuperType = superName != null && !superName.isEmpty() ? Type.getObjectType(superName) : null;
+        this.asmSuperType = superName != null && !superName.isEmpty() ? switch (superName) {
+            case "java/lang/Object" -> OBJECT_TYPE;
+            case "java/lang/Record" -> RECORD_TYPE;
+            default -> Type.getObjectType(superName);
+        } : null;
         this.interfaces = Stream.of(interfaces).map(Type::getObjectType).collect(Collectors.toSet());
     }
 
     @Override
     public AnnotationVisitor visitAnnotation(final String annotationName, final boolean runtimeVisible) {
+        if (ANNOTATION_BLACKLIST.contains(annotationName)) return null;
         var ann = new ModAnnotation(ElementType.TYPE, Type.getType(annotationName), this.asmType.getClassName());
         annotations.addFirst(ann);
         return new ModAnnotationVisitor(ann);
@@ -51,6 +96,7 @@ class ModClassVisitor extends ClassVisitor {
         return new FieldVisitor(Opcodes.ASM9) {
             @Override
             public AnnotationVisitor visitAnnotation(String annotationName, boolean runtimeVisible) {
+                if (ANNOTATION_BLACKLIST.contains(annotationName)) return null;
                 var ann = new ModAnnotation(ElementType.FIELD, Type.getType(annotationName), name);
                 annotations.addFirst(ann);
                 return new ModAnnotationVisitor(ann);
@@ -63,6 +109,7 @@ class ModClassVisitor extends ClassVisitor {
         return new MethodVisitor(Opcodes.ASM9) {
             @Override
             public AnnotationVisitor visitAnnotation(String annotationName, boolean runtimeVisible) {
+                if (ANNOTATION_BLACKLIST.contains(annotationName)) return null;
                 ModAnnotation ann = new ModAnnotation(ElementType.METHOD, Type.getType(annotationName), name + desc);
                 annotations.addFirst(ann);
                 return new ModAnnotationVisitor(ann);
@@ -78,7 +125,7 @@ class ModClassVisitor extends ClassVisitor {
         }
     }
 
-    private class ModAnnotationVisitor extends AnnotationVisitor {
+    private final class ModAnnotationVisitor extends AnnotationVisitor {
         private final ModAnnotation annotation;
         private boolean array;
         private boolean isSubAnnotation;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -186,7 +186,7 @@ public class ModFile implements IModFile {
             var service = services.findLanguage(this, spec.languageName(), spec.acceptedVersions());
             lst.add(service);
         }
-        this.loaders = Collections.unmodifiableList(lst);
+        this.loaders = List.copyOf(lst);
     }
 
     @Override

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -31,13 +31,18 @@ record Scanner(ModFile fileToScan, ModFileScanData result) {
 
     public ModFileScanData scan() {
         result.addModFileInfo(fileToScan.getModFileInfo());
-        fileToScan.scanFile(this::fileVisitor);
         final List<IModLanguageProvider> loaders = fileToScan.getLoaders();
         if (loaders != null) {
+            // Skip runtime annotation scanning for MC itself
+            if (!"minecraft".equals(loaders.getFirst().name()))
+                fileToScan.scanFile(this::fileVisitor);
+
             for (IModLanguageProvider loader : loaders) {
                 if (DEBUG) LOGGER.debug("Scanning {} with language loader {}", fileToScan.getFilePath(), loader.name());
                 loader.getFileVisitor().accept(result);
             }
+        } else {
+            fileToScan.scanFile(this::fileVisitor);
         }
         return result;
     }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -31,18 +31,13 @@ record Scanner(ModFile fileToScan, ModFileScanData result) {
 
     public ModFileScanData scan() {
         result.addModFileInfo(fileToScan.getModFileInfo());
+        fileToScan.scanFile(this::fileVisitor);
         final List<IModLanguageProvider> loaders = fileToScan.getLoaders();
         if (loaders != null) {
-            // Skip runtime annotation scanning for MC itself
-            if (!"minecraft".equals(loaders.getFirst().name()))
-                fileToScan.scanFile(this::fileVisitor);
-
             for (IModLanguageProvider loader : loaders) {
                 if (DEBUG) LOGGER.debug("Scanning {} with language loader {}", fileToScan.getFilePath(), loader.name());
                 loader.getFileVisitor().accept(result);
             }
-        } else {
-            fileToScan.scanFile(this::fileVisitor);
         }
         return result;
     }


### PR DESCRIPTION
The background scanner collects data about each class in each mod file, additionally allowing language providers to offer extra data. These collections can get quite large and store wrappers of wrappers, using a fair bit of memory.

https://github.com/MinecraftForge/ForgeSPI/blob/master/src/main/java/net/minecraftforge/forgespi/language/ModFileScanData.java

All of this is stored in mutable collections in ForgeSPI without any freeze or unmodifiable view stage, so these collections have some slack as well (they're not exactly sized).

Without this PR, thousands of the game's class files are scanned and populate scan data, but said data for MC itself isn't useful nor needed in practice.
<img width="329" height="173" alt="image" src="https://github.com/user-attachments/assets/f5455575-95f0-4d7e-801f-a0d94a5dbaa8" />
<img width="1071" height="219" alt="image" src="https://github.com/user-attachments/assets/6f89dee5-9697-40c9-873a-8598f01fbcdf" />

This PR skips this scanning for MC itself, which speeds up the background scanner by about a couple of seconds on my machine and saves a bunch of memory. The modTargets are still populated correctly, as that's offered by the language provider separate to the class file scanning:
<img width="329" height="173" alt="image" src="https://github.com/user-attachments/assets/8a545b74-76d7-48e3-8a6e-6e504d9657cb" />

More context on Discord, including a dump of the full scan data for Minecraft 1.21.11 with Forge: https://discord.com/channels/1129059589325852724/1129095235889270844/1472717212472053892