### PR TITLE
[1.21.11] Make `loaderVersion` optional in mods.toml

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -64,7 +64,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable {
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader in file", this));
         // as is modloader version
         var modLoaderVerStr = config.<String>getConfigElement("loaderVersion")
-                .orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
+                .orElse("*");
         var modLoaderVersion = MavenVersionAdapter.createFromVersionSpec(modLoaderVerStr);
         this.languageSpecs = new ArrayList<>(List.of(new LanguageSpec(modLoader, modLoaderVersion)));
 

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@
 # References: https://github.com/MinecraftForge/MDKExamples
 
 modLoader="javafml"
-loaderVersion="[@FORGE_SPEC_VERSION@,)"
+#loaderVersion="[@FORGE_SPEC_VERSION@,)" #optional, default="*"
 license="All Rights Reserved"
 #issueTrackerURL="https://github.com/MyOrganization/MyMod/" #optional
 #clientSideOnly=true #optional, default=false
@@ -26,12 +26,10 @@ Newline characters can be used like this, and rendered on the mods screen proper
     modId="forge"
     mandatory=true
     versionRange="[@FORGE_SPEC_VERSION@,)"
-    ordering="NONE"
-    side="BOTH"
+    #ordering="NONE" #optional
+    #side="BOTH" #optional
 
 [[dependencies.examplemod]] #recommended
     modId="minecraft"
     mandatory=true
     versionRange="[@MC_VERSION@,@MC_NEXT_VERSION@,)"
-    ordering="NONE"
-    side="BOTH"


### PR DESCRIPTION
The javafml loaderVersion has been tied to the Forge version for a long time but gives a less obvious error to users than a dep on Minecraft and/or Forge. Making this optional and default to any version allows the more helpful error message to be surfaced instead and avoids a double version comparison internally.