### PR TITLE
Fix dependency version-range check for 0.0NONE

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -220,7 +220,7 @@ public class ModSorter {
                 continue;
 
             var range = dep.getVersionRange();
-            if (existing != null && (range.containsVersion(existing) || "0.0NONE".equals(existing.toString())))
+            if (existing != null && range.containsVersion(existing))
                 continue;
 
             if (!VersionSupportMatrix.testVersionSupportMatrix(range, modId, "mod"))


### PR DESCRIPTION
Fixes #10696.

When a mod resolves to `0.0NONE` (missing `Implementation-Version`), dependency version constraints should still be enforced.
Original report was on 1.20.1; same faulty condition exists there too.

### Change
- Removed special-case acceptance of `0.0NONE` in `ModSorter`
- Dependency validity now requires only `range.containsVersion(existing)`
### Validation
- `./gradlew :fmlloader:compileJava -x test` (success)