### PR TITLE
[1.21.11] General cleanup of references to MinecraftForge#EVENT_BUS in javadocs

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/AddFramePassEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/AddFramePassEvent.java
@@ -15,8 +15,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Fired after all vanilla frame passes are added into the pass list.
  *
- * <p>This event is fired on the {@linkplain net.minecraftforge.common.MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain net.minecraftforge.fml.LogicalSide#CLIENT logical client}.
+ * <p>This event is fired only on the {@linkplain net.minecraftforge.fml.LogicalSide#CLIENT logical client}.
  */
 @NullMarked
 public record AddFramePassEvent() implements RecordEvent {
@@ -25,11 +24,11 @@ public record AddFramePassEvent() implements RecordEvent {
      * Adds a frame pass to pass list.
      * Create a new {@linkplain FramePassManager.PassDefinition} to handle render targets and render code.
      *
-     * @param rl Resource location for frame pass name. Use RLs to avoid duplicate names.
+     * @param id Identifer for frame pass name, this will identify whose pass is rendering if the game crashes.
      * @param definition see usages of {@linkplain com.mojang.blaze3d.framegraph.FramePass} in {@linkplain net.minecraft.client.renderer.LevelRenderer}
      * @throws IllegalArgumentException If the name is a duplicate.
      */
-    public void addPass(Identifier rl, FramePassManager.PassDefinition definition) {
-        ForgeHooksClient.addFramePass(rl, definition);
+    public void addPass(Identifier id, FramePassManager.PassDefinition definition) {
+        ForgeHooksClient.addFramePass(id, definition);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -21,8 +21,7 @@ import org.jspecify.annotations.Nullable;
  * <p>This event is {@linkplain Cancellable cancellable}.
  * If the event is cancelled, the chat message will not be sent to the server.</p>
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
 @NullMarked
 public final class ClientChatEvent extends MutableEvent implements Cancellable {

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -9,7 +9,6 @@ import net.minecraft.util.Util;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.InheritableEvent;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -25,8 +24,7 @@ import java.util.UUID;
  * <p>This event is {@linkplain Cancellable cancellable}.
  * If the event is cancelled, the message is not displayed in the chat message window.</p>
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see ChatType
  */
@@ -79,7 +77,7 @@ public sealed class ClientChatReceivedEvent extends MutableEvent implements Canc
      * {@return {@code true} if the message was sent by the system, {@code false} otherwise}
      *
      * @deprecated Mojang made ChatType a registry, which isn't always accessible when the System messages are sent.
-     * So moved to it's own event. {@link SystemMessageReceivedEvent}
+     * So moved to its own event. {@link SystemMessageReceivedEvent}
      */
     @Deprecated(forRemoval = true, since = "1.21.1")
     public boolean isSystem() {
@@ -92,8 +90,7 @@ public sealed class ClientChatReceivedEvent extends MutableEvent implements Canc
      * <p>This event is {@linkplain Cancellable cancellable}.
      * If the event is cancelled, the message is not displayed in the chat message window.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see ChatType
      */

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -20,8 +20,7 @@ import org.jspecify.annotations.NullMarked;
  * Fired for different client connectivity events.
  * See the various subclasses to listen for specific events.
  *
- * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see LoggingIn
  * @see LoggingOut
@@ -48,8 +47,7 @@ public sealed interface ClientPlayerNetworkEvent extends InheritableEvent {
     /**
      * Fired when the client player logs in to the server. The player should be initialized.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @NullMarked
     record LoggingIn(MultiPlayerGameMode getMultiPlayerGameMode, LocalPlayer getPlayer, Connection getConnection)
@@ -63,8 +61,7 @@ public sealed interface ClientPlayerNetworkEvent extends InheritableEvent {
     /**
      * Fired when the client player logs out. This event may also fire when a new integrated server is being created.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @SuppressWarnings("NullableProblems")
     // Shush IntelliJ, we override non-nullables as nullables in this specific event; see later comment
@@ -117,8 +114,7 @@ public sealed interface ClientPlayerNetworkEvent extends InheritableEvent {
     /**
      * Fired when the client player respawns, creating a new player instance to replace the old player instance.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @param getOldPlayer the previous player instance
      * @param getNewPlayer the newly created player instance

--- a/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
@@ -17,8 +17,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Fired after the field of vision (FOV) modifier for the player is calculated to allow developers to adjust it further.
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see ViewportEvent.ComputeFov
  */

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -17,8 +17,7 @@ import org.jetbrains.annotations.ApiStatus;
  * Fired for hooking into {@link AbstractContainerScreen} events.
  * See the subclasses to listen for specific events.
  *
- * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Render.Foreground
  * @see Render.Background
@@ -33,8 +32,7 @@ public sealed interface ContainerScreenEvent {
      * Fired every time an {@link AbstractContainerScreen} renders.
      * See the two subclasses to listen for foreground or background rendering.
      *
-     * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see Foreground
      * @see Background
@@ -62,8 +60,7 @@ public sealed interface ContainerScreenEvent {
          * <p>This can be used for rendering elements that must be above other screen elements, but
          * below tooltips and the dragged stack, such as slot or item stack specific overlays.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Foreground(
                 AbstractContainerScreen<?> getContainerScreen,
@@ -81,8 +78,7 @@ public sealed interface ContainerScreenEvent {
          * Fired after the container screen's background layer and elements are drawn.
          * This can be used for rendering new background elements.
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Background(
                 AbstractContainerScreen<?> getContainerScreen,

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -39,8 +39,7 @@ public sealed interface CustomizeGuiOverlayEvent {
      * <p>This event is {@linkplain Cancellable cancellable}.
      * Cancelling this event will prevent the given bar from rendering.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     final class BossEventProgress extends MutableEvent implements Cancellable, CustomizeGuiOverlayEvent {
         public static final CancellableEventBus<BossEventProgress> BUS = CancellableEventBus.create(BossEventProgress.class);
@@ -121,8 +120,7 @@ public sealed interface CustomizeGuiOverlayEvent {
      * Fired <b>before</b> textual information is rendered to the debug screen.
      * This can be used to add or remove text information.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @param getText the modifiable list of text to render on the side
      * @param getSide the side of the text getting rendered
@@ -148,8 +146,7 @@ public sealed interface CustomizeGuiOverlayEvent {
     /**
      * Fired <b>before</b> the chat messages overlay is rendered to the screen.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     final class Chat extends MutableEvent implements CustomizeGuiOverlayEvent {
         public static final EventBus<Chat> BUS = EventBus.create(Chat.class);

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -15,8 +15,7 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Fired when the {@link ClientRecipeBook} has updated information about recipes from the server to the client.
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @param getRecipeBook the recipe manager
  */

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -69,8 +69,7 @@ public sealed interface RenderLivingEvent<T extends LivingEntity, S extends Livi
      * If this event is cancelled, then the entity will not be rendered and the corresponding
      * {@link RenderLivingEvent.Post} will not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired on only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @param <T> the living entity that is being rendered
      * @param <M> the model for the living entity
@@ -91,8 +90,7 @@ public sealed interface RenderLivingEvent<T extends LivingEntity, S extends Livi
     /**
      * Fired <b>after</b> an entity is rendered, if the corresponding {@link RenderLivingEvent.Post} is not cancelled.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @param <T> the living entity that was rendered
      * @param <M> the model for the living entity

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -118,8 +118,7 @@ public abstract sealed class RenderTooltipEvent extends MutableEvent implements 
      * If this event is cancelled, then the list of components will be empty, causing the tooltip to not be rendered and
      * the corresponding {@link RenderTooltipEvent.Pre} to not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static final class GatherComponents extends MutableEvent implements Cancellable {
         public static final CancellableEventBus<GatherComponents> BUS = CancellableEventBus.create(GatherComponents.class);
@@ -199,8 +198,7 @@ public abstract sealed class RenderTooltipEvent extends MutableEvent implements 
      * <p>This event is {@linkplain Cancellable cancellable}.
      * If this event is cancelled, then the tooltip will not be rendered
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static final class Pre extends RenderTooltipEvent implements Cancellable {
         public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -35,8 +35,7 @@ import java.util.function.Consumer;
  * Fired on different events/actions when a {@link Screen} is active and visible.
  * See the various subclasses for listening to different events.
  *
- * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Init
  * @see Render
@@ -115,8 +114,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the initialization method will not be called, and the widgets and children lists
          * will not be cleared.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static final class Pre extends Init implements Cancellable {
             public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
@@ -130,8 +128,7 @@ public sealed interface ScreenEvent {
         /**
          * Fired <b>after</b> the screen's overridable initialization method is called.
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static final class Post extends Init {
             public static final EventBus<Post> BUS = EventBus.create(Post.class);
@@ -177,8 +174,7 @@ public sealed interface ScreenEvent {
          * <p>This event is {@linkplain Cancellable cancellable}.
          * If the event is cancelled, the screen will not be drawn.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, GuiGraphics getGuiGraphics, int getMouseX, int getMouseY, float getPartialTick)
                 implements Cancellable, Render, RecordEvent {
@@ -191,8 +187,7 @@ public sealed interface ScreenEvent {
         /**
          * Fired <b>after</b> the screen is drawn.
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(Screen getScreen, GuiGraphics getGuiGraphics, int getMouseX, int getMouseY, float getPartialTick)
                 implements Render, RecordEvent {
@@ -207,8 +202,7 @@ public sealed interface ScreenEvent {
      * Fired directly after the background of the screen is drawn.
      * Can be used for drawing above the background but below the tooltips.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @param getGuiGraphics the gui graphics used for rendering
      */
@@ -220,14 +214,13 @@ public sealed interface ScreenEvent {
     }
 
     /**
-     * Fired ahead of rendering any active mob effects in the {@link EffectsInInventory inventory screen}.
+     * Fired ahead of rendering any active mob effects in the {@link net.minecraft.client.gui.screens.inventory.EffectsInInventory inventory screen}.
      * Can be used to select the size of the effects display (full or compact) or even hide or replace vanilla's rendering entirely.
      * This event can also be used to modify the horizontal position of the stack of effects being rendered.
      *
      * <p>This event is {@linkplain Cancellable cancellable}. Cancelling this event will prevent vanilla rendering.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     final class RenderInventoryMobEffects extends MutableEvent implements Cancellable, ScreenEvent {
         public static final CancellableEventBus<RenderInventoryMobEffects> BUS = CancellableEventBus.create(RenderInventoryMobEffects.class);
@@ -344,8 +337,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's mouse click handler will be bypassed
          * and the corresponding {@link MouseButtonPressed.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, double getMouseX, double getMouseY, MouseButtonEvent getInfo)
                 implements Cancellable, MouseButtonPressed, RecordEvent {
@@ -363,12 +355,11 @@ public sealed interface ScreenEvent {
          * <ul>
          *   <li>{@link Result#ALLOW} - forcibly sets the mouse click as handled</li>
          *   <li>{@link Result#DEFAULT} - defaults to the return value of
-         *   {@link Screen#mouseClicked(double, double, int)} from the screen (see {@link #wasHandled()}.</li>
+         *   {@link net.minecraft.client.gui.components.events.ContainerEventHandler#mouseClicked(MouseButtonEvent, boolean)} from the screen (see {@link #wasHandled()}.</li>
          *   <li>{@link Result#DENY} - forcibly sets the mouse click as not handled.</li>
          * </ul>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(
                 Screen getScreen,
@@ -416,8 +407,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's mouse release handler will be bypassed
          * and the corresponding {@link MouseButtonReleased.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, double getMouseX, double getMouseY, int getButton)
                 implements Cancellable, MouseButtonReleased, RecordEvent {
@@ -439,8 +429,7 @@ public sealed interface ScreenEvent {
          *   <li>{@link Result#DENY} - forcibly sets the mouse release as not handled.</li>
          * </ul>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(
                 Screen getScreen,
@@ -500,8 +489,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's mouse drag handler will be bypassed
          * and the corresponding {@link MouseDragged.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(
                 Screen getScreen,
@@ -524,8 +512,7 @@ public sealed interface ScreenEvent {
          * <p>This event is not {@linkplain Cancellable cancellable}, and does not {@linkplain HasResult have a result}.
          * If the event is cancelled, the mouse drag will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(
                 Screen getScreen,
@@ -568,8 +555,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's mouse scroll handler will be bypassed
          * and the corresponding {@link MouseScrolled.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, double getMouseX, double getMouseY, double getDeltaX, double getDeltaY)
                 implements Cancellable, MouseScrolled, RecordEvent {
@@ -586,8 +572,7 @@ public sealed interface ScreenEvent {
          * <p>This event is not {@linkplain Cancellable cancellable}, and does not {@linkplain HasResult have a result}.
          * If the event is cancelled, the mouse scroll will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(Screen getScreen, double getMouseX, double getMouseY, double getDeltaX, double getDeltaY)
                 implements MouseScrolled, RecordEvent {
@@ -632,7 +617,7 @@ public sealed interface ScreenEvent {
          * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending
          * on the platform but they are safe to save to disk as custom key bindings.
          *
-         * @see InputConstants#getKey(int, int)
+         * @see InputConstants#getKey(KeyEvent)
          */
         default int getScanCode() {
             return getInfo().scancode();
@@ -669,8 +654,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's key press handler will be bypassed
          * and the corresponding {@link KeyPressed.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, KeyEvent getInfo) implements Cancellable, KeyPressed, RecordEvent {
             public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
@@ -686,8 +670,7 @@ public sealed interface ScreenEvent {
          * <p>This event is {@linkplain Cancellable cancellable}.
          * If the event is cancelled, the key press will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(Screen getScreen, KeyEvent getInfo) implements Cancellable, KeyPressed, RecordEvent {
             public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
@@ -712,8 +695,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's key release handler will be bypassed
          * and the corresponding {@link KeyReleased.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, KeyEvent getInfo) implements Cancellable, KeyReleased, RecordEvent {
             public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
@@ -729,8 +711,7 @@ public sealed interface ScreenEvent {
          * <p>This event is {@linkplain Cancellable cancellable}.
          * If the event is cancelled, the key release will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(Screen getScreen, KeyEvent getInfo) implements Cancellable, KeyReleased, RecordEvent {
             public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
@@ -784,8 +765,7 @@ public sealed interface ScreenEvent {
          * If the event is cancelled, the screen's character input handler will be bypassed
          * and the corresponding {@link CharacterTyped.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Pre(Screen getScreen, CharacterEvent getInfo) implements Cancellable, CharacterTyped, RecordEvent {
             public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
@@ -801,8 +781,7 @@ public sealed interface ScreenEvent {
          * <p>This event is {@linkplain Cancellable cancellable}.
          * If the event is cancelled, the character input will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         record Post(Screen getScreen, CharacterEvent getInfo) implements CharacterTyped, RecordEvent {
             public static final EventBus<Post> BUS = EventBus.create(Post.class);
@@ -821,8 +800,7 @@ public sealed interface ScreenEvent {
      * will remain open. However, cancelling this event will not prevent the closing of screen layers which happened before
      * this event fired.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     final class Opening extends MutableEvent implements Cancellable, ScreenEvent {
         public static final CancellableEventBus<Opening> BUS = CancellableEventBus.create(Opening.class);
@@ -873,8 +851,7 @@ public sealed interface ScreenEvent {
      * Fired before a {@link Screen} is closed.
      * All screen layers on the screen are closed before this event is fired.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     record Closing(Screen getScreen) implements ScreenEvent, RecordEvent {
         public static final EventBus<Closing> BUS = EventBus.create(Closing.class);

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -27,8 +27,7 @@ import java.io.IOException;
  * If this event is cancelled, then the screenshot is not written to disk, and the message in the event will be posted
  * to the player's chat.</p>
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Screenshot
  */

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -19,8 +19,7 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is {@linkplain Cancellable cancellable}.
  * Cancelling the event stops the toast from being queued, which means it never renders.</p>
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public record ToastAddEvent(Toast getToast) implements Cancellable, RecordEvent {
     public static final CancellableEventBus<ToastAddEvent> BUS = CancellableEventBus.create(ToastAddEvent.class);

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -26,8 +26,7 @@ import org.jspecify.annotations.NullMarked;
  * These can be used for customizing the visual features visible to the player.
  * See the various subclasses for listening to different features.
  *
- * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see RenderFog
  * @see ComputeFogColor
@@ -56,8 +55,7 @@ public sealed interface ViewportEvent {
      * <p>This event is {@linkplain Cancellable cancellable}.<br>
      * The event must be cancelled for any changes to the plane distances to take effect.</p>
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     record RenderFog(
             GameRenderer getRenderer,
@@ -141,8 +139,7 @@ public sealed interface ViewportEvent {
     /**
      * Fired for customizing the <b>color</b> of the fog visible to the player.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     final class ComputeFogColor extends MutableEvent implements ViewportEvent {
         public static final EventBus<ComputeFogColor> BUS = EventBus.create(ComputeFogColor.class);
@@ -233,8 +230,7 @@ public sealed interface ViewportEvent {
      * Fired to allow altering the angles of the player's camera.
      * This can be used to alter the player's view for different effects, such as applying roll.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @NullMarked
     final class ComputeCameraAngles extends MutableEvent implements ViewportEvent {
@@ -325,8 +321,7 @@ public sealed interface ViewportEvent {
      * Fired for altering the raw field of view (FOV).
      * This is after the FOV settings are applied, and before modifiers such as the Nausea effect.
      *
-     * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see ComputeFovModifierEvent
      */

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -19,8 +19,7 @@ import org.jetbrains.annotations.ApiStatus;
  * in a buffer before being played, and used for most sounds of short length such as sound effects for clicking
  * buttons.
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see PlayStreamingSourceEvent
  */

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -19,8 +19,7 @@ import org.jetbrains.annotations.ApiStatus;
  * (such as a file), and used for sounds of long length which are unsuitable to keep fully loaded in-memory in a buffer
  * (as is done for regular non-streaming sounds), such as background music or music discs.
  *
- * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>This event is fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see PlayStreamingSourceEvent
  */

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -18,8 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Superclass for sound related events.
  *
- * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see SoundSourceEvent
  * @see PlaySoundEvent
@@ -34,8 +33,7 @@ public sealed interface SoundEvent permits PlaySoundEvent, SoundEngineLoadEvent,
     /**
      * Superclass for when a sound has started to play on an audio channel.
      *
-     * <p>These events are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     * <p>These events are fired only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see PlaySoundSourceEvent
      * @see PlayStreamingSourceEvent

--- a/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
+++ b/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.NullMarked;
  * Does not fire for the Integrated Server on a physical Client.
  * <br>
  * On the client, the GL Context is still valid when the event is fired.
- * Fired on the FORGE event bus.
  *
  * @author Curle
  */

--- a/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
+++ b/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
@@ -145,8 +145,6 @@ public sealed class PlayLevelSoundEvent extends MutableEvent implements Cancella
      * If this event is cancelled, the sound is not played.
      * <p>
      * This event does not have a result.
-     * <p>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
     public static final class AtEntity extends PlayLevelSoundEvent {
         public static final EventBus<AtEntity> BUS = EventBus.create(AtEntity.class);
@@ -174,8 +172,6 @@ public sealed class PlayLevelSoundEvent extends MutableEvent implements Cancella
      * If this event is cancelled, the sound is not played.
      * <p>
      * This event does not have a result.
-     * <p>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
     public static final class AtPosition extends PlayLevelSoundEvent {
         public static final EventBus<AtPosition> BUS = EventBus.create(AtPosition.class);

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -17,6 +17,7 @@ import net.minecraftforge.eventbus.api.event.RecordEvent;
 /**
  * Commands are rebuilt whenever {@link ReloadableServerResources} is recreated.
  * You can use this event to register your commands whenever the {@link Commands} class in constructed.
+ * If you are strictly interested in registering client commands, see {@link net.minecraftforge.client.event.RegisterClientCommandsEvent}
  *
  * @param getDispatcher The command dispatcher for registering commands to be executed on the client
  * @param getCommandSelection The environment the command is being registered for

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -51,8 +51,6 @@ public sealed abstract class PotionBrewEvent extends MutableEvent implements Inh
      * This event is {@link Cancellable}.<br>
      * If the event is not cancelled, the vanilla brewing will take place instead of modded brewing.
      * <br>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
-     * <br>
      * If this event is canceled, and items have been modified, PotionBrewEvent.Post will automatically be fired.
      **/
     public static final class Pre extends PotionBrewEvent implements Cancellable {
@@ -70,7 +68,6 @@ public sealed abstract class PotionBrewEvent extends MutableEvent implements Inh
      * <br>
      * {@link #stacks} contains the itemstack array from the TileEntityBrewer holding all items in Brewer.<br>
      * <br>
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
     public static final class Post extends PotionBrewEvent {
         public static final EventBus<Post> BUS = EventBus.create(Post.class);

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
@@ -25,8 +25,7 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is {@linkplain Cancellable cancellable}.
  * If the event is cancelled, the entity will not be added to the level.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * on both logical sides.
+ * This event is fired on both logical sides.
  **/
 public record EntityJoinLevelEvent(Entity getEntity, Level getLevel, boolean loadedFromDisk)
         implements Cancellable, EntityEvent, RecordEvent {

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
@@ -16,7 +16,7 @@ import net.minecraftforge.eventbus.api.event.RecordEvent;
  * This event is fired whenever an {@link Entity} leaves a {@link Level}.
  * This event is fired whenever an entity is removed from the level in {@link LevelCallback#onTrackingEnd(Object)}.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus} on both logical sides.
+ * This event is fired on both logical sides.
  **/
 public record EntityLeaveLevelEvent(Entity getEntity, Level getLevel) implements RecordEvent, EntityEvent {
     public static final EventBus<EntityLeaveLevelEvent> BUS = EventBus.create(EntityLeaveLevelEvent.class);

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Objects;
 
 /**
- * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  * This event is fired when a projectile entity impacts something.<br>
  * This event is fired via {@link ForgeEventFactory#onProjectileImpact(Projectile, HitResult)}
  * This event is fired for all vanilla projectiles by Forge,

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.Nullable;
  * If this event is cancelled, the child Entity is not added to the world, and the parents <br>
  * will no longer attempt to mate.
  * <br>
- * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public final class BabyEntitySpawnEvent extends MutableEvent implements Cancellable {
     public static final CancellableEventBus<BabyEntitySpawnEvent> BUS = CancellableEventBus.create(BabyEntitySpawnEvent.class);

--- a/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
@@ -22,8 +22,6 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * This event is fired when an interaction between a {@link LivingEntity} and {@link MobEffectInstance} happens.
- * <p>
- * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 public sealed interface MobEffectEvent extends LivingEvent, InheritableEvent {
     EventBus<MobEffectEvent> BUS = EventBus.create(MobEffectEvent.class);

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -101,8 +101,7 @@ public abstract sealed class MobSpawnEvent extends MutableEvent implements Entit
      * <li>Default - The value of the vanilla check will be used to determine success.</li>
      * <li>Deny - The check will fail, and the spawn process will abort.</li>
      * </ul>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      * <p>
      * This event is not fired for mob spawners which utilize {@link CustomSpawnRules}, as they do not check spawn placements.
      * @apiNote If your modifications are for a single entity, and do not vary at runtime, use {@link SpawnPlacementRegisterEvent}.
@@ -210,8 +209,7 @@ public abstract sealed class MobSpawnEvent extends MutableEvent implements Entit
      * <li>Default - The position will be accepted if {@link Mob#checkSpawnRules} and {@link Mob#checkSpawnObstruction} are both true.</li>
      * <li>Deny - The position will not be accepted. The spawn process will abort, and further events will not be called.</li>
      * </ul>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      *
      * @apiNote This event fires after Spawn Placement checks, which are the primary set of spawn checks.
      * @see {@link SpawnPlacementRegisterEvent} To modify spawn placements statically at startup.
@@ -269,7 +267,7 @@ public abstract sealed class MobSpawnEvent extends MutableEvent implements Entit
      * Canceling this event will result in {@link Mob#finalizeSpawn} not being called, and the returned value always being null, instead of propagating the SpawnGroupData.<br>
      * The entity will still be spawned. If you want to prevent the spawn, use {@link FinalizeSpawn#setSpawnCancelled}, which will cause Forge to prevent the spawn.
      * <p>
-     * This event is fired on {@link MinecraftForge#EVENT_BUS}, and is only fired on the logical server.
+     * This event is only fired on the logical server.
      * @see ForgeEventFactory#onFinalizeSpawn
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
@@ -404,8 +402,7 @@ public abstract sealed class MobSpawnEvent extends MutableEvent implements Entit
      * {@link Result#ALLOW} indicates that the mob should forcefully despawn.
      * {@link Result#DENY} indicates that the mob should forcefully stay spawned.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      *
      * @see LivingEntity#checkDespawn()
      * @author cpw

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -55,8 +55,6 @@ public sealed abstract class ZombieEvent implements EntityEvent, InheritableEven
      *     <li>{@link Result#ALLOW} Zombie is summoned.</li>
      *     <li>{@link Result#DENY} Zombie is not summoned.</li>
      * </ul>
-     *
-     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
     public static final class SummonAidEvent extends ZombieEvent implements HasResult {
         public static final EventBus<SummonAidEvent> BUS = EventBus.create(SummonAidEvent.class);

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -40,7 +40,6 @@ import java.util.Objects;
 
 /**
  * PlayerInteractEvent is fired when a player interacts in some way.
- * All subclasses are fired on {@link MinecraftForge#EVENT_BUS}.
  * See the individual documentation on each subevent for more details.
  **/
 public sealed abstract class PlayerInteractEvent implements PlayerEvent, InheritableEvent {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -16,8 +16,6 @@ import org.jspecify.annotations.NullMarked;
 
 /**
  * PlayerXpEvent is fired whenever an event involving player experience occurs.
- * <br>
- * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @NullMarked
 public sealed interface PlayerXpEvent extends PlayerEvent {

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -22,8 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * This event is not {@linkplain Cancellable cancellable}.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
+ * This event is fired only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
 public final class AlterGroundEvent extends MutableEvent {
     public static final EventBus<AlterGroundEvent> BUS = EventBus.create(AlterGroundEvent.class);

--- a/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
@@ -25,8 +25,7 @@ import org.jspecify.annotations.NullMarked;
  * is by first changing it from 31 to 46, and then queuing the update from 46 to 32. However, when going from 32 to 31,
  * vanilla is able to go directly.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * only on the {@linkplain LogicalSide#SERVER logical server}.
+ * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
  *
  * @param getLevel the server level containing the chunk
  * @param getChunkPos the long representation of the chunk position the ticket level changed for

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -20,8 +20,7 @@ import net.minecraftforge.fml.LogicalSide;
  * The {@linkplain #getPlayer() player}'s level may not be the same as the {@linkplain #getLevel() level of the chunk}
  * when the player is teleporting to another dimension.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * only on the {@linkplain LogicalSide#SERVER logical server}.
+ * These events are fired only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 public sealed interface ChunkWatchEvent extends InheritableEvent {
     EventBus<ChunkWatchEvent> BUS = EventBus.create(ChunkWatchEvent.class);
@@ -46,8 +45,7 @@ public sealed interface ChunkWatchEvent extends InheritableEvent {
      * <p>
      * This event may be used to send additional chunk-related data to the client.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     record Watch(ServerPlayer getPlayer, ChunkPos getPos, LevelChunk getChunk, ServerLevel getLevel)
             implements ChunkWatchEvent {
@@ -61,8 +59,7 @@ public sealed interface ChunkWatchEvent extends InheritableEvent {
     /**
      * This event is fired when server sends "forget chunk" packet to the {@link ServerPlayer}.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     record UnWatch(ServerPlayer getPlayer, ChunkPos getPos, ServerLevel getLevel) implements ChunkWatchEvent {
         public static final EventBus<UnWatch> BUS = EventBus.create(UnWatch.class);

--- a/src/main/java/net/minecraftforge/event/level/LevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/LevelEvent.java
@@ -53,8 +53,7 @@ public sealed interface LevelEvent extends InheritableEvent
      * This event is fired whenever a level loads in ClientLevel's constructor and
      * {@literal MinecraftServer#createLevels(ChunkProgressListener)}.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * on both logical sides.
+     * This event is fired on both logical sides.
      **/
     record Load(LevelAccessor getLevel) implements LevelEvent {
         public static final EventBus<Load> BUS = EventBus.create(Load.class);
@@ -67,8 +66,7 @@ public sealed interface LevelEvent extends InheritableEvent
      * {@link MinecraftServer#stopServer()},
      * {@link Minecraft#clearClientLevel(Screen)}.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * on both logical sides.
+     * This event is fired on both logical sides.
      **/
     record Unload(LevelAccessor getLevel) implements LevelEvent {
         public static final EventBus<Unload> BUS = EventBus.create(Unload.class);
@@ -79,8 +77,7 @@ public sealed interface LevelEvent extends InheritableEvent
      * This event is fired when a level is saved in
      * {@link ServerLevel#save(ProgressListener, boolean, boolean)}.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     record Save(LevelAccessor getLevel) implements LevelEvent {
         public static final EventBus<Save> BUS = EventBus.create(Save.class);
@@ -93,8 +90,7 @@ public sealed interface LevelEvent extends InheritableEvent
      * This event is {@linkplain Cancellable cancellable}.
      * If the event is cancelled, the vanilla logic to choose a spawn position will be skipped.
      * <p>
-     * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
-     * only on the {@linkplain LogicalSide#SERVER logical server}.
+     * This event is fired only on the {@linkplain LogicalSide#SERVER logical server}.
      *
      * @see ServerLevelData#isInitialized()
      */

--- a/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
@@ -27,8 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * using the features set on the event.
  * {@linkplain Result#DENY DENY} will prevent the sapling from growing.
  * <p>
- * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
- * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
+ * This event is fired only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
 // TODO: Rename to BlockFeatureGrowEvent in 1.20
 @Deprecated(forRemoval = true, since = "1.21.1") // Dont remove, rename

--- a/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
@@ -21,7 +21,6 @@ import net.minecraftforge.event.server.ServerAboutToStartEvent;
 
 /**
  * WandererTradesEvent is fired during the {@link ServerAboutToStartEvent}.  It is used to gather the trade lists for the wandering merchant.
- * It is fired on the {@link MinecraftForge#EVENT_BUS}.
  * The wandering merchant picks {@link Pool#rolls} from each {@link Pool}
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.
 */

--- a/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS forge bus}.
+ * Fired when there are missing registries of a world with respect to the actual loaded registries.
  */
 public final class MissingMappingsEvent extends MutableEvent {
     public static final EventBus<MissingMappingsEvent> BUS = EventBus.create(MissingMappingsEvent.class);


### PR DESCRIPTION
Also includes param name change in `AddFramePassEvent#addPass` (with some extra doc info) and fixing some broken `@ link`s in ScreenEvent. No functional code changes.