### PR TITLE
[1.20.1] Add support for multiple access transformer configs. Backport (#10760)

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -202,7 +202,7 @@ public class FMLLoader
 
     public static void addAccessTransformer(Path atPath, ModFile modName)
     {
-        LOGGER.debug(SCAN, "Adding Access Transformer in {}", modName.getFilePath());
+        LOGGER.debug(SCAN, "Adding Access Transformer in {} in {}", atPath, modName.getFilePath());
         accessTransformer.offerResource(atPath, modName.getFileName());
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/LoadingModList.java
@@ -5,12 +5,14 @@
 
 package net.minecraftforge.fml.loading;
 
+import com.mojang.logging.LogUtils;
 import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
 import net.minecraftforge.fml.loading.moddiscovery.BackgroundScanHandler;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
 import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
 import net.minecraftforge.forgespi.locating.IModFile;
+import org.slf4j.Logger;
 
 import java.net.URL;
 import java.nio.file.Files;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
  */
 public class LoadingModList
 {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static LoadingModList INSTANCE;
     private final List<ModFileInfo> modFiles;
     private final List<ModInfo> sortedList;
@@ -78,9 +81,22 @@ public class LoadingModList
 
     public void addAccessTransformers()
     {
-        modFiles.stream()
-                .map(ModFileInfo::getFile)
-                .forEach(mod -> mod.getAccessTransformer().ifPresent(path -> FMLLoader.addAccessTransformer(path, mod)));
+        var errors = new ArrayList<EarlyLoadingException.ExceptionData>();
+        for (ModFileInfo modFile : modFiles) {
+            ModFile mod = modFile.getFile();
+            for (Path at : mod.getAccessTransformers()) {
+                if (!Files.exists(at)) {
+                    var message = "Invalid mod file: " + modFile.getFile().getFileName() + ". Missing Access Transformer: " + at;
+                    errors.add(new EarlyLoadingException.ExceptionData(message));
+                    LOGGER.error(message);
+                } else {
+                    FMLLoader.addAccessTransformer(at, mod);
+                }
+            }
+        }
+        if (!errors.isEmpty()) {
+            preLoadErrors.add(new EarlyLoadingException("Invalid Access Transformers", null, errors));
+        }
     }
 
     public void addForScanning(BackgroundScanHandler backgroundScanHandler)

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -115,7 +115,14 @@ public class ModFile implements IModFile {
         LOGGER.debug(LogMarkers.LOADING,"Loading mod file {} with languages {}", this.getFilePath(), this.modFileInfo.requiredLanguageLoaders());
         this.coreMods = ModFileParser.getCoreMods(this);
         this.coreMods.forEach(mi-> LOGGER.debug(LogMarkers.LOADING,"Found coremod {}", mi.getPath()));
-        var cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
+        List<String> cfg;
+        // Note: Some mods may have invalid tomls copied from other projects.
+        // Unfortunately we must protect against those landmines.
+        try {
+            cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
+        } catch (Exception e) {
+            cfg = null;
+        }
         if (cfg == null) {
             var path = findResource("META-INF", "accesstransformer.cfg");
             if (Files.exists(path)) {

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -122,7 +122,7 @@ public class ModFile implements IModFile {
             cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
         } catch (Exception e) {
             cfg = null;
-            LOGGER.warn("{} contains an invalid 'accessTransformers' TOML entry. Falling back to default.", this.getFileName());
+            LOGGER.warn("{} contains an invalid 'accessTransformers' TOML entry. Should be accessTransformers = [\"META-INF/accesstransformer.cfg\", \"META-INF/extra_at.cfg\"] or accessTransformers = [] for no ATs. Falling back to default.", this.getFileName());
         }
         if (cfg == null) {
             var path = findResource("META-INF", "accesstransformer.cfg");

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -24,10 +24,7 @@ import org.slf4j.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -60,6 +57,7 @@ public class ModFile implements IModFile {
     private CompletableFuture<ModFileScanData> futureScanResult;
     private List<CoreModFile> coreMods;
     private Path accessTransformer;
+    private List<Path> accessTransformers = Collections.emptyList();
 
     static final Attributes.Name TYPE = new Attributes.Name("FMLModType");
     private SecureJar.Status securityStatus;
@@ -104,7 +102,11 @@ public class ModFile implements IModFile {
     }
 
     public Optional<Path> getAccessTransformer() {
-        return Optional.ofNullable(Files.exists(accessTransformer) ? accessTransformer : null);
+        return Optional.ofNullable(accessTransformer);
+    }
+
+    public List<Path> getAccessTransformers() {
+        return accessTransformers;
     }
 
     public boolean identifyMods() {
@@ -113,7 +115,20 @@ public class ModFile implements IModFile {
         LOGGER.debug(LogMarkers.LOADING,"Loading mod file {} with languages {}", this.getFilePath(), this.modFileInfo.requiredLanguageLoaders());
         this.coreMods = ModFileParser.getCoreMods(this);
         this.coreMods.forEach(mi-> LOGGER.debug(LogMarkers.LOADING,"Found coremod {}", mi.getPath()));
-        this.accessTransformer = findResource("META-INF", "accesstransformer.cfg");
+        var cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
+        if (cfg == null) {
+            var path = findResource("META-INF", "accesstransformer.cfg");
+            if (Files.exists(path)) {
+                this.accessTransformer = path;
+                this.accessTransformers = List.of(path);
+            }
+        } else if (!cfg.isEmpty()) {
+            var paths = new ArrayList<Path>(cfg.size());
+            for (var path : cfg) {
+                paths.add(getSecureJar().getPath(path.replace('\\', '/')));
+            }
+            this.accessTransformers = List.copyOf(paths);
+        }
         return true;
     }
 

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -122,7 +122,7 @@ public class ModFile implements IModFile {
             cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
         } catch (Exception e) {
             cfg = null;
-            LOGGER.warn("{} contains an invalid 'accessTransformers' TOML entry. Should be accessTransformers = [\"META-INF/accesstransformer.cfg\", \"META-INF/extra_at.cfg\"] or accessTransformers = [] for no ATs. Falling back to default.", this.getFileName());
+            LOGGER.warn("{} contains an invalid 'accessTransformers' TOML entry. Should be e.g. accessTransformers = [\"META-INF/accesstransformer.cfg\", \"META-INF/extra_at.cfg\"] or accessTransformers = [] for no ATs. Falling back to default.", this.getFileName());
         }
         if (cfg == null) {
             var path = findResource("META-INF", "accesstransformer.cfg");

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -24,7 +24,12 @@ import org.slf4j.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Collections;
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -122,6 +122,7 @@ public class ModFile implements IModFile {
             cfg = this.modFileInfo.getConfig().<List<String>>getConfigElement("accessTransformers").orElse(null);
         } catch (Exception e) {
             cfg = null;
+            LOGGER.warn("{} contains an invalid 'accessTransformers' TOML entry. Falling back to default.", this.getFileName());
         }
         if (cfg == null) {
             var path = findResource("META-INF", "accesstransformer.cfg");

--- a/mdk/src/main/resources/META-INF/mods.toml
+++ b/mdk/src/main/resources/META-INF/mods.toml
@@ -41,6 +41,12 @@ authors="${mod_authors}" #optional
 # IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
 #displayTest="MATCH_VERSION" # if nothing is specified, MATCH_VERSION is the default when clientSideOnly=false, otherwise IGNORE_ALL_VERSION when clientSideOnly=true (#optional)
 
+# Access Transformers
+# Optional, if not specified Forge will attempt to find the default META-INF/accesstransformer.cfg and silently continue if not found. May default to an empty list in a future MC.
+# If you specify AT path strings in this list, Forge will attempt to load each of them and throw errors for any that aren't found.
+# Specifying an empty list when your mod has no ATs is recommended to opt-out of the default for slightly better loading performance.
+#accessTransformers = []
+
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.


### PR DESCRIPTION
Backport note: adds fallback in case of folks having their toml in an invalid format (e.g. copying from other projects without paying attention).