### PR TITLE
[1.20.1] Fix HandshakeHandler potentially skipping last packet

### DIFF
--- a/src/main/java/net/minecraftforge/network/HandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/network/HandshakeHandler.java
@@ -374,7 +374,7 @@ public class HandshakeHandler
         });
 
         // we're done when sentMessages is empty
-        if (sentMessages.isEmpty() && packetPosition >= messageList.size()-1 && pendingFutures.isEmpty()) {
+        if (sentMessages.isEmpty() && packetPosition >= messageList.size() && pendingFutures.isEmpty()) {
             // clear ourselves - we're done!
             this.manager.channel().attr(NetworkConstants.FML_HANDSHAKE_HANDLER).set(null);
             LOGGER.debug(FMLHSMARKER, "Handshake complete!");


### PR DESCRIPTION
It looks like the check for `packetPosition` is off by one. If N packets need to be sent and none of them require a response, then the handler will exit early and remove itself from being ticked after packet N - 1 is sent. The last packet will silently be dropped.

This flaw appears to have been present for years, so my guess is that it's masked by enough packets requiring a response that takes a while to arrive, and doesn't actually manifest in practice. Still, I did not want to ignore the latent bug now that I noticed it.