### PR TITLE
Forge setup task fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -980,8 +980,8 @@ project(':forge') {
         // the clean project provides these. if we're not using it, we need to provide them ourselves
         if (System.env.TEAMCITY_VERSION) {
             mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
-            mcVersion = MC_VERSION
         }
+        mcVersion = MC_VERSION
 
         runs {
             forge_client {


### PR DESCRIPTION
#### `./gradlew setup` fails because of version error

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':forge'.
> Failed to notify project evaluation listener.
   > Cannot query the value of extension 'patcher' property 'mcVersion' because it has no value available.
   > Could not get unknown property 'prepareRuns' for project ':forge' of type org.gradle.api.Project.
```