### PR TITLE
fix #9003 race conditions in NetworkRegistry + minor performance improvements

### DIFF
--- a/src/main/java/net/minecraftforge/network/ChannelListManager.java
+++ b/src/main/java/net/minecraftforge/network/ChannelListManager.java
@@ -83,7 +83,7 @@ public class ChannelListManager {
     }
 
     public static void addChannels(Connection connection) {
-        addChannels(connection, NetworkRegistry.buildRegisterList());
+        addChannels(connection, NetworkRegistry.getRegisterList());
     }
 
     public static void addChannels(Connection connection, Identifier... channels) {
@@ -120,7 +120,7 @@ public class ChannelListManager {
 
     private static void encode(FriendlyByteBuf buf, List<String> channels) {
         for (var c : channels) {
-            buf.writeBytes(c.toString().getBytes(StandardCharsets.UTF_8));
+            buf.writeBytes(c.getBytes(StandardCharsets.UTF_8));
             buf.writeByte(0);
         }
     }

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -180,7 +180,7 @@ public class NetworkRegistry {
     }
 
     public static Map<Identifier, Integer> buildChannelVersions() {
-        var ret = new Object2IntOpenHashMap<Identifier>(instances.size());
+        var ret = new Object2IntOpenHashMap<Identifier>(instances.size(), 1.0f);
         for (var net : instances.values()) {
             ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
         }

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,8 +42,8 @@ public class NetworkRegistry {
     static final Logger LOGGER = LogManager.getLogger();
     static final Marker NETREGISTRY = MarkerManager.getMarker("NETREGISTRY");
 
-    private static Map<Identifier, NetworkInstance> instances = Collections.synchronizedMap(new HashMap<>());
-    private static Map<Identifier, NetworkInstance> byName = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
+    private static final Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
 
     public static boolean acceptsVanillaClientConnections() {
         return listRejectedVanillaMods(n -> n.clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
@@ -196,20 +197,18 @@ public class NetworkRegistry {
 
     static void register(NetworkInstance instance, Identifier name) {
         checkLock(instance);
-        if (NetworkRegistry.byName.containsKey(name))
-            error("Payload name " + name + " already registered.");
 
-        byName.put(name, instance);
+        if (byName.putIfAbsent(name, instance) != null)
+            error("Payload name " + name + " already registered.");
     }
 
     static void register(NetworkInstance instance) {
         checkLock(instance);
 
         var name = instance.getChannelName();
-        if (NetworkRegistry.instances.containsKey(name))
-            error("Channel " + name + " already registered.");
 
-        instances.put(name, instance);
+        if (instances.putIfAbsent(name, instance) != null)
+            error("Channel " + name + " already registered.");
     }
 
     private static void checkLock(NetworkInstance instance) {

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -162,7 +162,7 @@ public class NetworkRegistry {
         return true;
     }
 
-    static boolean lock = false;
+    static volatile boolean lock = false;
     public static void lock() {
         lock = true;
     }

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 /**
@@ -201,7 +202,7 @@ public class NetworkRegistry {
             ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
         }
 
-        return ret;
+        return unmodifiableMap(ret);
     }
 
     public static List<Identifier> getRegisterList() {
@@ -214,10 +215,7 @@ public class NetworkRegistry {
             if (!"minecraft".equals(name.getNamespace()))
                 ret.add(name);
 
-        ret.trimToSize();
-        registerList = ret;
-
-        return registerList;
+        return unmodifiableList(registerList);
     }
 
     static void register(NetworkInstance instance, Identifier name) {

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 /**
  * Tracks channels created by {@link ChannelBuilder}. This class is not intended for use by modders.
  */
@@ -62,12 +61,18 @@ public class NetworkRegistry {
         return byName.get(Identifier);
     }
 
-    static Map<Identifier, ServerStatusPing.ChannelData> buildChannelVersionsForListPing() {
+    private static Map<Identifier, ServerStatusPing.ChannelData> channelVersionsForListPing = null;
+
+    public static Map<Identifier, ServerStatusPing.ChannelData> getChannelVersionsForListPing() {
+        return channelVersionsForListPing;
+    }
+
+    private static Map<Identifier, ServerStatusPing.ChannelData> buildChannelVersionsForListPing() {
         var ret = new HashMap<Identifier, ServerStatusPing.ChannelData>(instances.size(), 1.0f);
         for (var channel : instances.values()) {
             ret.put(channel.getChannelName(), channel.pingData);
         }
-        return ret;
+        return Map.copyOf(ret);
     }
 
     static List<String> listRejectedVanillaMods(Function<NetworkInstance, VersionTest> testFunction) {
@@ -172,6 +177,7 @@ public class NetworkRegistry {
         instances = Map.copyOf(instances);
 
         channelVersions = buildChannelVersions();
+        channelVersionsForListPing = buildChannelVersionsForListPing();
         registerList = buildRegisterList();
 
         LOCK.setRelease(true);

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -164,10 +165,14 @@ public class NetworkRegistry {
         return true;
     }
 
-    static volatile boolean lock = false;
-    public static void lock() {
+    static boolean lock = false;
+    public static synchronized void lock() {
         byName = unmodifiableMap(byName);
         instances = unmodifiableMap(instances);
+
+        buildChannelVersions();
+        buildRegisterList();
+
         lock = true;
     }
 
@@ -183,20 +188,35 @@ public class NetworkRegistry {
         }
     }
 
+    private static Object2IntOpenHashMap<Identifier> channelVersions = null;
     public static Map<Identifier, Integer> buildChannelVersions() {
-        var ret = new Object2IntOpenHashMap<Identifier>(instances.size(), 1.0f);
-        for (var net : instances.values()) {
-            ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
+        if (channelVersions != null) {
+            return channelVersions;
         }
-        return ret;
+
+        channelVersions = new Object2IntOpenHashMap<>(instances.size(), 1.0f);
+        for (var net : instances.values()) {
+            channelVersions.put(net.getChannelName(), net.getNetworkProtocolVersion());
+        }
+
+        return channelVersions;
     }
 
+    private static List<Identifier> registerList = null;
     static List<Identifier> buildRegisterList() {
+        if (registerList != null) {
+            return registerList;
+        }
+
         var ret = new ArrayList<Identifier>(byName.size());
         for (var name : byName.keySet())
             if (!"minecraft".equals(name.getNamespace()))
                 ret.add(name);
-        return ret;
+
+        ret.trimToSize();
+        registerList = ret;
+
+        return registerList;
     }
 
     static void register(NetworkInstance instance, Identifier name) {

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -34,6 +34,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.unmodifiableMap;
+
 /**
  * Tracks channels created by {@link ChannelBuilder}. This class is not intended for use by modders.
  */
@@ -42,8 +44,8 @@ public class NetworkRegistry {
     static final Logger LOGGER = LogManager.getLogger();
     static final Marker NETREGISTRY = MarkerManager.getMarker("NETREGISTRY");
 
-    private static final Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
-    private static final Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
+    private static Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
+    private static Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
 
     public static boolean acceptsVanillaClientConnections() {
         return listRejectedVanillaMods(n -> n.clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
@@ -164,6 +166,8 @@ public class NetworkRegistry {
 
     static volatile boolean lock = false;
     public static void lock() {
+        byName = unmodifiableMap(byName);
+        instances = unmodifiableMap(instances);
         lock = true;
     }
 

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -208,7 +208,7 @@ public class NetworkRegistry {
         return registerList;
     }
 
-    public static List<Identifier> buildRegisterList() {
+    private static List<Identifier> buildRegisterList() {
         var ret = new ArrayList<Identifier>(byName.size());
         for (var name : byName.keySet())
             if (!"minecraft".equals(name.getNamespace()))

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -59,7 +59,7 @@ public class NetworkRegistry {
     }
 
     static Map<Identifier, ServerStatusPing.ChannelData> buildChannelVersionsForListPing() {
-        var ret = new HashMap<Identifier, ServerStatusPing.ChannelData>();
+        var ret = new HashMap<Identifier, ServerStatusPing.ChannelData>(instances.size(), 1.0f);
         for (var channel : instances.values()) {
             ret.put(channel.getChannelName(), channel.pingData);
         }
@@ -188,7 +188,7 @@ public class NetworkRegistry {
     }
 
     static List<Identifier> buildRegisterList() {
-        var ret = new ArrayList<Identifier>(byName.keySet().size());
+        var ret = new ArrayList<Identifier>(byName.size());
         for (var name : byName.keySet())
             if (!"minecraft".equals(name.getNamespace()))
                 ret.add(name);

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -48,6 +48,9 @@ public class NetworkRegistry {
     private static Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
     private static Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
 
+    private static List<Identifier> registerList = null;
+    private static Map<Identifier, Integer> channelVersions = null;
+
     public static boolean acceptsVanillaClientConnections() {
         return listRejectedVanillaMods(n -> n.clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
     }
@@ -170,8 +173,8 @@ public class NetworkRegistry {
         byName = unmodifiableMap(byName);
         instances = unmodifiableMap(instances);
 
-        buildChannelVersions();
-        buildRegisterList();
+        channelVersions = buildChannelVersions();
+        registerList = buildRegisterList();
 
         lock = true;
     }
@@ -188,26 +191,24 @@ public class NetworkRegistry {
         }
     }
 
-    private static Object2IntOpenHashMap<Identifier> channelVersions = null;
-    public static Map<Identifier, Integer> buildChannelVersions() {
-        if (channelVersions != null) {
-            return channelVersions;
-        }
-
-        channelVersions = new Object2IntOpenHashMap<>(instances.size(), 1.0f);
-        for (var net : instances.values()) {
-            channelVersions.put(net.getChannelName(), net.getNetworkProtocolVersion());
-        }
-
+    public static Map<Identifier, Integer> getChannelVersions() {
         return channelVersions;
     }
 
-    private static List<Identifier> registerList = null;
-    static List<Identifier> buildRegisterList() {
-        if (registerList != null) {
-            return registerList;
+    private static Map<Identifier, Integer> buildChannelVersions() {
+        var ret = new Object2IntOpenHashMap<Identifier>(instances.size(), 1.0f);
+        for (var net : instances.values()) {
+            ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
         }
 
+        return ret;
+    }
+
+    public static List<Identifier> getRegisterList() {
+        return registerList;
+    }
+
+    public static List<Identifier> buildRegisterList() {
         var ret = new ArrayList<Identifier>(byName.size());
         for (var name : byName.keySet())
             if (!"minecraft".equals(name.getNamespace()))

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -42,11 +42,22 @@ public class NetworkRegistry {
     static final Logger LOGGER = LogManager.getLogger();
     static final Marker NETREGISTRY = MarkerManager.getMarker("NETREGISTRY");
 
-    private static Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
-    private static Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
+    private static final Map<Identifier, NetworkInstance> instances = new ConcurrentHashMap<>();
+    private static final Map<Identifier, NetworkInstance> byName = new ConcurrentHashMap<>();
 
-    private static List<Identifier> registerList = null;
-    private static Map<Identifier, Integer> channelVersions = null;
+    private static Map<Identifier, NetworkInstance> getByName() {
+        final class LazyInit {
+            static final Map<Identifier, NetworkInstance> BY_NAME = Map.copyOf(byName);
+        }
+        return LazyInit.BY_NAME;
+    }
+
+    private static Map<Identifier, NetworkInstance> getInstances() {
+        final class LazyInit {
+            static final Map<Identifier, NetworkInstance> INSTANCES = Map.copyOf(instances);
+        }
+        return LazyInit.INSTANCES;
+    }
 
     public static boolean acceptsVanillaClientConnections() {
         return listRejectedVanillaMods(n -> n.clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
@@ -58,16 +69,18 @@ public class NetworkRegistry {
 
     @Nullable
     public static NetworkInstance findTarget(Identifier Identifier) {
-        return byName.get(Identifier);
+        return getByName().get(Identifier);
     }
 
-    private static Map<Identifier, ServerStatusPing.ChannelData> channelVersionsForListPing = null;
-
     public static Map<Identifier, ServerStatusPing.ChannelData> getChannelVersionsForListPing() {
-        return channelVersionsForListPing;
+        final class LazyInit {
+            static final Map<Identifier, ServerStatusPing.ChannelData> CHANNEL_VERSIONS_FOR_LIST_PING = buildChannelVersionsForListPing();
+        }
+        return LazyInit.CHANNEL_VERSIONS_FOR_LIST_PING;
     }
 
     private static Map<Identifier, ServerStatusPing.ChannelData> buildChannelVersionsForListPing() {
+        var instances = getInstances();
         var ret = new HashMap<Identifier, ServerStatusPing.ChannelData>(instances.size(), 1.0f);
         for (var channel : instances.values()) {
             ret.put(channel.getChannelName(), channel.pingData);
@@ -77,7 +90,7 @@ public class NetworkRegistry {
 
     static List<String> listRejectedVanillaMods(Function<NetworkInstance, VersionTest> testFunction) {
         var results = new ArrayList<String>();
-        for (var net : instances.values()) {
+        for (var net : getInstances().values()) {
             boolean test = testFunction.apply(net).accepts(VersionTest.Status.VANILLA, -1);
             LOGGER.debug(NETREGISTRY, "Channel '{}' : Vanilla acceptance test: {}", net.getChannelName(), test ? "ACCEPTED" : "REJECTED");
             if (!test)
@@ -99,7 +112,7 @@ public class NetworkRegistry {
 
         Set<Identifier> missing = new HashSet<>();
         Map<Identifier, NetworkMismatchData.Version> results = new HashMap<>();
-        for (var net : instances.values()) {
+        for (var net : getInstances().values()) {
             var name = net.getChannelName();
             VersionTest test = fromClient ? net.clientAcceptedVersions : net.serverAcceptedVersions;
 
@@ -135,7 +148,7 @@ public class NetworkRegistry {
         Set<Identifier> handled = new HashSet<>();
         var rejected = new ArrayList<String>();
 
-        for (var net : instances.values()) {
+        for (var net : getInstances().values()) {
             var status = VersionTest.Status.MISSING;
             var version = 0;
             if (incoming.containsKey(net.getChannelName())) {
@@ -171,14 +184,16 @@ public class NetworkRegistry {
         return true;
     }
 
-    static final AtomicBoolean LOCK = new AtomicBoolean(false);
-    public static synchronized void lock() {
-        byName = Map.copyOf(byName);
-        instances = Map.copyOf(instances);
+    private static final AtomicBoolean LOCK = new AtomicBoolean(false);
+    public static void lock() {
+        getByName();
+        getInstances();
+        getChannelVersions();
+        getChannelVersionsForListPing();
+        getRegisterList();
 
-        channelVersions = buildChannelVersions();
-        channelVersionsForListPing = buildChannelVersionsForListPing();
-        registerList = buildRegisterList();
+        byName.clear();
+        instances.clear();
 
         LOCK.setRelease(true);
     }
@@ -187,7 +202,7 @@ public class NetworkRegistry {
     public static void onConnectionStart(Connection connection) {
         ForgeEventFactory.onConnectionStart(connection);
         var channel = connection.channel();
-        for (var inst : instances.values()) {
+        for (var inst : getInstances().values()) {
             if (inst.attributes != null)
                 inst.attributes.forEach((k, v) -> ((Attribute<Object>)channel.attr(k)).compareAndSet(null, (Object)v.apply(connection)));
             if (inst.channelHandler != null)
@@ -196,10 +211,14 @@ public class NetworkRegistry {
     }
 
     public static Map<Identifier, Integer> getChannelVersions() {
-        return channelVersions;
+        final class LazyInit {
+            static final Map<Identifier, Integer> CHANNEL_VERSIONS = buildChannelVersions();
+        }
+        return LazyInit.CHANNEL_VERSIONS;
     }
 
     private static Map<Identifier, Integer> buildChannelVersions() {
+        var instances = getInstances();
         var ret = new HashMap<Identifier, Integer>(instances.size(), 1.0f);
         for (var net : instances.values()) {
             ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
@@ -209,10 +228,14 @@ public class NetworkRegistry {
     }
 
     public static List<Identifier> getRegisterList() {
-        return registerList;
+        final class LazyInit {
+            static final List<Identifier> REGISTER_LIST = buildRegisterList();
+        }
+        return LazyInit.REGISTER_LIST;
     }
 
     private static List<Identifier> buildRegisterList() {
+        var byName = getByName();
         var ret = new ArrayList<Identifier>(byName.size());
         for (var name : byName.keySet())
             if (!"minecraft".equals(name.getNamespace()))

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import io.netty.util.Attribute;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,13 +29,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
 
 /**
  * Tracks channels created by {@link ChannelBuilder}. This class is not intended for use by modders.
@@ -169,15 +166,15 @@ public class NetworkRegistry {
         return true;
     }
 
-    static boolean lock = false;
+    static final AtomicBoolean LOCK = new AtomicBoolean(false);
     public static synchronized void lock() {
-        byName = unmodifiableMap(byName);
-        instances = unmodifiableMap(instances);
+        byName = Map.copyOf(byName);
+        instances = Map.copyOf(instances);
 
         channelVersions = buildChannelVersions();
         registerList = buildRegisterList();
 
-        lock = true;
+        LOCK.setRelease(true);
     }
 
     @SuppressWarnings("unchecked")
@@ -197,12 +194,12 @@ public class NetworkRegistry {
     }
 
     private static Map<Identifier, Integer> buildChannelVersions() {
-        var ret = new Object2IntOpenHashMap<Identifier>(instances.size(), 1.0f);
+        var ret = new HashMap<Identifier, Integer>(instances.size(), 1.0f);
         for (var net : instances.values()) {
             ret.put(net.getChannelName(), net.getNetworkProtocolVersion());
         }
 
-        return unmodifiableMap(ret);
+        return Map.copyOf(ret);
     }
 
     public static List<Identifier> getRegisterList() {
@@ -215,7 +212,7 @@ public class NetworkRegistry {
             if (!"minecraft".equals(name.getNamespace()))
                 ret.add(name);
 
-        return unmodifiableList(registerList);
+        return List.copyOf(ret);
     }
 
     static void register(NetworkInstance instance, Identifier name) {
@@ -235,7 +232,7 @@ public class NetworkRegistry {
     }
 
     private static void checkLock(NetworkInstance instance) {
-        if (NetworkRegistry.lock)
+        if (LOCK.getAcquire())
             error("Attempted to register channel " + instance.getChannelName() + " even though registry phase is over");
     }
 

--- a/src/main/java/net/minecraftforge/network/ServerStatusPing.java
+++ b/src/main/java/net/minecraftforge/network/ServerStatusPing.java
@@ -102,7 +102,7 @@ public record ServerStatusPing(
 
     public ServerStatusPing() {
         this(
-            NetworkRegistry.buildChannelVersionsForListPing(),
+            NetworkRegistry.getChannelVersionsForListPing(),
             Util.make(new HashMap<>(), map -> ModList.forEachModContainer((modid, mc) ->
                 map.put(modid, mc.getCustomExtension(IExtensionPoint.DisplayTest.class)
                     .map(IExtensionPoint.DisplayTest::suppliedVersion)

--- a/src/main/java/net/minecraftforge/network/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/network/SimpleChannel.java
@@ -321,8 +321,9 @@ public class SimpleChannel extends Channel<Object> implements SimpleConnection<O
          */
         public MessageBuilder<MSG, BUF> consumerMainThread(BiConsumer<MSG, CustomPayloadEvent.Context> consumer) {
             this.consumer = (msg, context) -> {
-                context.enqueueWork(() -> consumer.accept(msg, context));
-                context.setPacketHandled(true);
+                var ctx = context;
+                ctx.enqueueWork(() -> consumer.accept(msg, context));
+                ctx.setPacketHandled(true);
             };
             return this;
         }

--- a/src/main/java/net/minecraftforge/network/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/network/SimpleChannel.java
@@ -321,9 +321,8 @@ public class SimpleChannel extends Channel<Object> implements SimpleConnection<O
          */
         public MessageBuilder<MSG, BUF> consumerMainThread(BiConsumer<MSG, CustomPayloadEvent.Context> consumer) {
             this.consumer = (msg, context) -> {
-                var ctx = context;
-                ctx.enqueueWork(() -> consumer.accept(msg, context));
-                ctx.setPacketHandled(true);
+                context.enqueueWork(() -> consumer.accept(msg, context));
+                context.setPacketHandled(true);
             };
             return this;
         }

--- a/src/main/java/net/minecraftforge/network/packets/ChannelVersions.java
+++ b/src/main/java/net/minecraftforge/network/packets/ChannelVersions.java
@@ -19,7 +19,7 @@ public record ChannelVersions(Map<Identifier, @NotNull Integer> channels) {
     public static StreamCodec<FriendlyByteBuf, ChannelVersions> STREAM_CODEC = StreamCodec.ofMember(ChannelVersions::encode, ChannelVersions::decode);
 
     public ChannelVersions() {
-        this(NetworkRegistry.buildChannelVersions());
+        this(NetworkRegistry.getChannelVersions());
     }
 
     public static ChannelVersions decode(FriendlyByteBuf buf) {


### PR DESCRIPTION
- Fixed race conditions around `instances` and `byName`
- Minor performance improvements to prevent rehashing and the allocation of a keyset

There is one thing we could do as an improvement. After `lock` is called, we can replace the maps with unmodifiable ones, this should keep the thread-safety for startup but get rid of its overhead past that.