### PR TITLE
Add filter for GLFW Wayland window position error

### DIFF
--- a/patches/minecraft/com/mojang/blaze3d/platform/GLX.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/platform/GLX.java.patch
@@ -1,15 +1,13 @@
 --- a/com/mojang/blaze3d/platform/GLX.java
 +++ b/com/mojang/blaze3d/platform/GLX.java
-@@ -43,7 +_,11 @@
+@@ -43,6 +_,10 @@
  
      public static LongSupplier _initGlfw(final BackendOptions options) {
          Window.checkGlfwError((errorx, description) -> {
--            throw new IllegalStateException(String.format(Locale.ROOT, "GLFW error before init: [0x%X]%s", errorx, description));
 +            if(errorx == GLFW.GLFW_FEATURE_UNAVAILABLE && description.equals("Wayland: The platform does not provide the window position")) {
 +                LOGGER.warn(String.format(Locale.ROOT, "Ignoring GLFW error before init: [0x%X]%s", errorx, description));
-+            } else {
-+                throw new IllegalStateException(String.format(Locale.ROOT, "GLFW error before init: [0x%X]%s", errorx, description));
++                return;
 +            }
+             throw new IllegalStateException(String.format(Locale.ROOT, "GLFW error before init: [0x%X]%s", errorx, description));
          });
          GLFWErrorCapture collectedErrors = new GLFWErrorCapture();
- 

--- a/patches/minecraft/com/mojang/blaze3d/platform/GLX.java.patch
+++ b/patches/minecraft/com/mojang/blaze3d/platform/GLX.java.patch
@@ -1,0 +1,15 @@
+--- a/com/mojang/blaze3d/platform/GLX.java
++++ b/com/mojang/blaze3d/platform/GLX.java
+@@ -43,7 +_,11 @@
+ 
+     public static LongSupplier _initGlfw(final BackendOptions options) {
+         Window.checkGlfwError((errorx, description) -> {
+-            throw new IllegalStateException(String.format(Locale.ROOT, "GLFW error before init: [0x%X]%s", errorx, description));
++            if(errorx == GLFW.GLFW_FEATURE_UNAVAILABLE && description.equals("Wayland: The platform does not provide the window position")) {
++                LOGGER.warn(String.format(Locale.ROOT, "Ignoring GLFW error before init: [0x%X]%s", errorx, description));
++            } else {
++                throw new IllegalStateException(String.format(Locale.ROOT, "GLFW error before init: [0x%X]%s", errorx, description));
++            }
+         });
+         GLFWErrorCapture collectedErrors = new GLFWErrorCapture();
+ 


### PR DESCRIPTION
I've added a crude filter to the GLFW error check in `GLX._initGlfw` that ignores the `[0x1000C]Wayland: The platform does not provide the window position` error that occurs on systems running Wayland. Ignoring this error doesn't appear to cause any noticeable side effects, but I can now start the game again.