### PR TITLE
[26.1.x] Add `c:bars/copper` and `c:bars/iron` tags

### DIFF
--- a/src/main/generated/data/c/tags/block/bars.json
+++ b/src/main/generated/data/c/tags/block/bars.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#c:bars/copper",
+    "#c:bars/iron",
+    "#minecraft:bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/bars/copper.json
+++ b/src/main/generated/data/c/tags/block/bars/copper.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:copper_bars",
+    "minecraft:waxed_copper_bars",
+    "minecraft:exposed_copper_bars",
+    "minecraft:waxed_exposed_copper_bars",
+    "minecraft:weathered_copper_bars",
+    "minecraft:waxed_weathered_copper_bars",
+    "minecraft:oxidized_copper_bars",
+    "minecraft:waxed_oxidized_copper_bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/bars/iron.json
+++ b/src/main/generated/data/c/tags/block/bars/iron.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:iron_bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/bars.json
+++ b/src/main/generated/data/c/tags/item/bars.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#c:bars/copper",
+    "#c:bars/iron",
+    "#minecraft:bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/bars/copper.json
+++ b/src/main/generated/data/c/tags/item/bars/copper.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:copper_bars",
+    "minecraft:waxed_copper_bars",
+    "minecraft:exposed_copper_bars",
+    "minecraft:waxed_exposed_copper_bars",
+    "minecraft:weathered_copper_bars",
+    "minecraft:waxed_weathered_copper_bars",
+    "minecraft:oxidized_copper_bars",
+    "minecraft:waxed_oxidized_copper_bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/bars/iron.json
+++ b/src/main/generated/data/c/tags/item/bars/iron.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:iron_bars"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -60,6 +60,12 @@ public class Tags {
         //       Forge only adopts `c` tags that are common across all loaders.
         public static final TagKey<Block> BARRELS = cTag("barrels");
         public static final TagKey<Block> BARRELS_WOODEN = cTag("barrels/wooden");
+        /**
+         * Equivalent to the "minecraft:bars" block tag.
+         */
+        public static final TagKey<Block> BARS = cTag("bars");
+        public static final TagKey<Block> BARS_COPPER = cTag("bars/copper");
+        public static final TagKey<Block> BARS_IRON = cTag("bars/iron");
         public static final TagKey<Block> BOOKSHELVES = cTag("bookshelves");
         /**
          * For blocks that are similar to amethyst where their budding block produces buds and cluster blocks
@@ -347,6 +353,12 @@ public class Tags {
         //       Forge only adopts `c` tags that are common across all loaders.
         public static final TagKey<Item> BARRELS = cTag("barrels");
         public static final TagKey<Item> BARRELS_WOODEN = cTag("barrels/wooden");
+        /**
+         * Equivalent to the "minecraft:bars" item tag.
+         */
+        public static final TagKey<Item> BARS = cTag("bars");
+        public static final TagKey<Item> BARS_COPPER = cTag("bars/copper");
+        public static final TagKey<Item> BARS_IRON = cTag("bars/iron");
         public static final TagKey<Item> BONES = cTag("bones");
         public static final TagKey<Item> BOOKSHELVES = cTag("bookshelves");
         public static final TagKey<Item> BRICKS = cTag("bricks");

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockItemTagsProvider.java
@@ -28,6 +28,12 @@ public abstract class ForgeBlockItemTagsProvider extends BlockItemTagsProvider {
             .addTag(Tags.Blocks.BARRELS_WOODEN);
         tag(Tags.Blocks.BARRELS_WOODEN, Tags.Items.BARRELS_WOODEN)
             .add(Blocks.BARREL);
+        tag(Tags.Blocks.BARS_COPPER, Tags.Items.BARS_COPPER)
+                .addAll(Blocks.COPPER_BARS.asList());
+        tag(Tags.Blocks.BARS_IRON, Tags.Items.BARS_IRON)
+                .add(Blocks.IRON_BARS);
+        tag(Tags.Blocks.BARS, Tags.Items.BARS)
+                .addTags(Tags.Blocks.BARS_COPPER, Tags.Blocks.BARS_IRON, BlockTags.BARS);
         tag(Tags.Blocks.BOOKSHELVES, Tags.Items.BOOKSHELVES)
             .add(Blocks.BOOKSHELF);
         tag(Tags.Blocks.BUDDING_BLOCKS, Tags.Items.BUDDING_BLOCKS)

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -70,7 +70,7 @@ public final class ForgeBlockTagsProvider extends VanillaBlockTagsProvider {
     private void addColored(TagKey<Block> group, String pattern) {
         String prefix = group.location().getPath().toUpperCase(Locale.ENGLISH) + '_';
         for (var color : DyeColor.values()) {
-            var key = Identifier.fromNamespaceAndPath("minecraft", pattern.replace("{color}", color.getName()));
+            var key = Identifier.withDefaultNamespace(pattern.replace("{color}", color.getName()));
             TagKey<Block> tag = getTag(prefix + color.getName());
             var block = ForgeRegistries.BLOCKS.getValue(key);
             if (block == null || block == Blocks.AIR)


### PR DESCRIPTION
Syncs with https://github.com/neoforged/NeoForge/pull/3054 and https://github.com/FabricMC/fabric-api/pull/5297

Confirmed match with NeoForge 26.1.2.11-beta and Fabric API 0.146.0+26.1.2 using dumps generated by [CommonTagsDumper](https://github.com/PaintNinja/CommonTagsDumper)