### PR TITLE
[26.1.x] Add `c:drink_containing/bottle` and `c:drink_containing/bucket`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 }
 
 changelog {
-    from '47.999'
+    from '64.0'
 }
 
 tasks.register('setup') {

--- a/src/main/generated/data/c/tags/item/drink_containing/bottle.json
+++ b/src/main/generated/data/c/tags/item/drink_containing/bottle.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:potion",
+    "minecraft:honey_bottle",
+    "minecraft:ominous_bottle"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/drink_containing/bucket.json
+++ b/src/main/generated/data/c/tags/item/drink_containing/bucket.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:milk_bucket"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -12,11 +12,13 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemUseAnimation;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
@@ -415,14 +417,48 @@ public class Tags {
         public static final TagKey<Item> DUSTS_REDSTONE = cTag("dusts/redstone");
         public static final TagKey<Item> DUSTS_GLOWSTONE = cTag("dusts/glowstone");
 
+        /**
+         * Drinks are defined as (1) consumable items that (2) use the
+         * {@linkplain ItemUseAnimation#DRINK drink item use animation}, (3) can be consumed regardless of the
+         * player's current hunger.
+         *
+         * <p>Drinks may provide nutrition and saturation, but are not required to do so.
+         *
+         * <p>More specific types of drinks, such as Water, Milk, or Juice should be placed in a sub-tag, such as
+         * {@code #c:drinks/water}, {@code #c:drinks/milk}, and {@code #c:drinks/juice}.
+         */
         public static final TagKey<Item> DRINKS = cTag("drinks");
         public static final TagKey<Item> DRINKS_HONEY = cTag("drinks/honey");
+        /**
+         * Plant based fruit and vegetable juices belong in this tag, for example apple juice and carrot juice.
+         *
+         * <p>If tags for specific types of juices are desired, they may go in a sub-tag, using their regular name such as
+         * {@code #c:drinks/apple_juice}.
+         */
         public static final TagKey<Item> DRINKS_JUICE = cTag("drinks/juice");
         public static final TagKey<Item> DRINKS_MAGIC = cTag("drinks/magic");
         public static final TagKey<Item> DRINKS_MILK = cTag("drinks/milk");
+        /**
+         * For drinks that always grant the {@linkplain MobEffects#BAD_OMEN Bad Omen} effect.
+         */
         public static final TagKey<Item> DRINKS_OMINOUS = cTag("drinks/ominous");
+        /**
+         * For consumable drinks that contain only water.
+         */
         public static final TagKey<Item> DRINKS_WATER = cTag("drinks/water");
+        /**
+         * For consumable drinks that are generally watery (such as potions).
+         */
         public static final TagKey<Item> DRINKS_WATERY = cTag("drinks/watery");
+
+        /**
+         * For non-empty bottles that are {@linkplain #DRINKS drinkable}.
+         */
+        public static final TagKey<Item> DRINK_CONTAINING_BOTTLE = cTag("drink_containing/bottle");
+        /**
+         * For non-empty buckets that are {@linkplain #DRINKS drinkable}.
+         */
+        public static final TagKey<Item> DRINK_CONTAINING_BUCKET = cTag("drink_containing/bucket");
 
         /**
          * Tag that holds all blocks and items that can be dyed a specific color.

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -84,6 +84,10 @@ public final class ForgeItemTagsProvider extends VanillaItemTagsProvider {
         tag(Tags.Items.CROPS_SUGAR_CANE).add(Items.SUGAR_CANE);
         tag(Tags.Items.CROPS_WHEAT)
                 .add(Items.WHEAT);
+        tag(Tags.Items.DRINK_CONTAINING_BOTTLE)
+                .add(Items.POTION, Items.HONEY_BOTTLE, Items.OMINOUS_BOTTLE);
+        tag(Tags.Items.DRINK_CONTAINING_BUCKET)
+                .add(Items.MILK_BUCKET);
         tag(Tags.Items.DRINKS)
                 .addTags(Tags.Items.DRINKS_HONEY, Tags.Items.DRINKS_JUICE, Tags.Items.DRINKS_MAGIC, Tags.Items.DRINKS_MILK,
                         Tags.Items.DRINKS_OMINOUS, Tags.Items.DRINKS_WATER, Tags.Items.DRINKS_WATERY);


### PR DESCRIPTION
Syncs with https://github.com/neoforged/NeoForge/pull/3044, https://github.com/neoforged/NeoForge/pull/1862 and https://github.com/FabricMC/fabric-api/pull/4384

These were initially added to Fabric about a year ago but appears to have been missing in Neo due to an oversight until recently. Now that both loaders have these tags, Forge is implementing it, in accordance with our policy made during our initial c tag work for Forge back in the 1.21.1 days.

I forgot to copy over some code comments on some related TagKey fields, this PR also does that.

Confirmed match with NeoForge 26.1.2.11-beta and Fabric API 0.146.0+26.1.2 using dumps generated by [CommonTagsDumper](https://github.com/PaintNinja/CommonTagsDumper)