### PR TITLE
Resolve model data for `#getParticleIcon`

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/BlockModelShaper.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/BlockModelShaper.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/block/BlockModelShaper.java
 +++ b/net/minecraft/client/renderer/block/BlockModelShaper.java
-@@ -17,8 +_,13 @@
+@@ -17,8 +_,15 @@
          this.modelManager = p_110880_;
      }
  
@@ -11,7 +11,9 @@
 +    }
 +
 +    public TextureAtlasSprite getParticleIcon(BlockState p_110883_, net.minecraft.world.level.Level level, net.minecraft.core.BlockPos pos) {
-+       return this.getBlockModel(p_110883_).particleIcon(level.getModelDataManager().getAt(pos));
++        net.minecraftforge.client.model.data.ModelData data = level.getModelDataManager().getAtOrEmpty(pos);
++        BlockStateModel model = this.getBlockModel(p_110883_);
++        return model.particleIcon(model.getModelData(level, pos, p_110883_, data));
      }
  
      public BlockStateModel getBlockModel(BlockState p_110894_) {


### PR DESCRIPTION
It seems the `BlockModelShaper` patch was incorrectly updated during the port to 1.21.5 (d50a3b5ab77299727e0e099fea3ff08907a5b60d).

`BlockModelShaper` is patched to call `IForgeBlockStateModel#getParticleIcon` with the model data argument, rather than the vanilla `#getParticleIcon` without context.

Before 1.21.5, the patch obtained the block entity model data from the level, then updated the model data through the model and used that as an argument to `#getParticleIcon`.
https://github.com/MinecraftForge/MinecraftForge/blob/5d4438b0e3e5145ed322f2d3cbe2874c35809190/patches/minecraft/net/minecraft/client/renderer/block/BlockModelShaper.java.patch#L13-L17
In 1.21.5, only the block entity model data is obtained from the level and then directly given to `#getParticleIcon`.
https://github.com/MinecraftForge/MinecraftForge/blob/1ae17d5a0406d0d0c6537e154c6e30ed6f9b0881/patches/minecraft/net/minecraft/client/renderer/block/BlockModelShaper.java.patch#L13-L15
Since the result of `ModelDataManager#getAt` may be `null` and is directly given to `#getParticleIcon`, this also means the model data received may be `null` rather than the empty model data instance.

This PR updates the behaviour to match pre-1.21.5.

The PR is targeted at 1.21.11, but should be applicable to 1.21.5 - 1.21.11 without changes. Let me know if I should create pull requests for the other branches as well, or if it is easy enough to cherry pick to those.