### PR TITLE
[26.1.2] Toml parsing errors are now visible in the latest log.

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
@@ -6,11 +6,13 @@
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import com.electronwill.nightconfig.core.file.FileConfig;
+import com.electronwill.nightconfig.core.io.ParsingException;
 import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.loading.LogMarkers;
 import net.minecraftforge.forgespi.language.IModFileInfo;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.ModFileFactory;
+import net.minecraftforge.forgespi.locating.ModFileLoadingException;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -24,6 +26,7 @@ public class ModFileParser {
         return parser.build(modFile);
     }
 
+    // Note: Although @Nullable, several other places in FML assume ModFileInfo is not null. Keep this in mind
     public static @Nullable IModFileInfo modsTomlParser(final IModFile imodFile) {
         ModFile modFile = (ModFile) imodFile;
         LOGGER.debug(LogMarkers.LOADING,"Considering mod file candidate {}", modFile.getFilePath());
@@ -34,9 +37,15 @@ public class ModFileParser {
         }
 
         final FileConfig fileConfig = FileConfig.builder(modsjson).build();
-        fileConfig.load();
-        fileConfig.close();
-        final NightConfigWrapper configWrapper = new NightConfigWrapper(fileConfig);
-        return new ModFileInfo(modFile, configWrapper, configWrapper::setFile);
+        try {
+            fileConfig.load();
+            fileConfig.close();
+            final NightConfigWrapper configWrapper = new NightConfigWrapper(fileConfig);
+            return new ModFileInfo(modFile, configWrapper, configWrapper::setFile);
+        } catch (ParsingException e) {
+            LOGGER.error("Mod candidate {} contains a corrupt or misconfigured toml.", modFile.getFileName());
+            throw new ModFileLoadingException("Mod candidate " + modFile.getFileName() + " contains a corrupt or misconfigured toml.");
+        }
+
     }
 }


### PR DESCRIPTION
Will backport at some point.