### PR TITLE
[26.2] fixed shearing sulfur cubes with custom shears

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
@@ -11,3 +11,12 @@
          if (this.hasBodyItem() && this.floatsInLiquids) {
              float vibeAmount = 0.2F * Mth.sin(this.tickCount * 0.4F);
              double immersion = this.getFluidHeight(this.isInWater() ? FluidTags.WATER : FluidTags.LAVA) - this.getFluidJumpThreshold() + vibeAmount;
+@@ -452,7 +_,7 @@
+             }
+ 
+             if (!this.canExplode() || !heldItem.is(Items.FLINT_AND_STEEL) && !heldItem.is(Items.FIRE_CHARGE)) {
+-                if (heldItem.is(Items.SHEARS) && this.readyForShearing()) {
++                if (heldItem.canPerformAction(net.minecraftforge.common.ToolActions.SHEARS_HARVEST) && this.readyForShearing()) {
+                     if (this.level() instanceof ServerLevel level) {
+                         ItemStack itemStackToShear = this.getItemBySlot(EquipmentSlot.BODY);
+                         this.shear(level, SoundSource.PLAYERS, heldItem);

--- a/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_shear_sulfur_cube_block.json
+++ b/src/test/generated/shears_behavior/data/forge/test_instance/shears_behavior/custom_shears_shear_sulfur_cube_block.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:function",
+  "environment": "minecraft:default",
+  "function": "forge:shears_behavior/custom_shears_shear_sulfur_cube_block",
+  "max_ticks": 100,
+  "structure": "forge:empty3x3x3"
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ShearsBehaviorTest.java
@@ -9,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityTypes;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.animal.golem.CopperGolem;
 import net.minecraft.world.entity.decoration.LeashFenceKnotEntity;
 import net.minecraft.world.item.Item;
@@ -123,6 +124,30 @@ public class ShearsBehaviorTest extends BaseTestMod {
         helper.assertTrue(result.consumesAction(), "Using custom shears on copper golem should result in consume action");
         helper.assertTrue(golem.getItemBySlot(CopperGolem.EQUIPMENT_SLOT_ANTENNA).isEmpty(), "Copper golem poppy should be sheared off with custom shears");
         helper.assertItemEntityPresent(Items.POPPY);
+
+        helper.succeed();
+    }
+
+    @GameTest
+    public static void custom_shears_shear_sulfur_cube_block(GameTestHelper helper) {
+        helper.makeFloor();
+
+        // setup: sulfur cube with block
+        var pos = new BlockPos(1, 1, 1);
+        var sulfurCube = helper.spawnWithNoFreeWill(EntityTypes.SULFUR_CUBE, pos);
+        sulfurCube.setItemSlot(EquipmentSlot.BODY, new ItemStack(Items.DIRT));
+        helper.assertTrue(sulfurCube.readyForShearing(), "Sulfur cube should start shearable (has dirt block)");
+
+        // act: interact with sulfur cube using custom shears
+        var player = helper.makeMockServerPlayer(GameType.SURVIVAL);
+        var shears = CUSTOM_SHEARS_ITEM.get().getDefaultInstance();
+        player.setItemInHand(InteractionHand.MAIN_HAND, shears);
+        var result = player.interactOn(sulfurCube, InteractionHand.MAIN_HAND, Vec3.ZERO);
+
+        // assert
+        helper.assertTrue(result.consumesAction(), "Using custom shears on sulfur cube should result in consume action");
+        helper.assertTrue(sulfurCube.getItemBySlot(EquipmentSlot.BODY).isEmpty(), "Sulfur cube block should be sheared off with custom shears");
+        helper.assertItemEntityPresent(Items.DIRT);
 
         helper.succeed();
     }


### PR DESCRIPTION
This PR fixes shearing sulfur cubes with custom shears. Interacting with sulfur cubes containing a block didn't result in shearing off the block as vanilla shears.

I reused the tool action SHEARS_HARVEST, because I don't think an extra tool action for handling sulfur cube shearing is necessary.

I also added a corresponding automated test.