### PR TITLE
[26.2] Toml parsing errors are now visible in the latest log (#10825)

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
@@ -6,11 +6,13 @@
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import com.electronwill.nightconfig.core.file.FileConfig;
+import com.electronwill.nightconfig.core.io.ParsingException;
 import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.loading.LogMarkers;
 import net.minecraftforge.forgespi.language.IModFileInfo;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.ModFileFactory;
+import net.minecraftforge.forgespi.locating.ModFileLoadingException;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -24,6 +26,7 @@ public class ModFileParser {
         return parser.build(modFile);
     }
 
+    // Note: Although @Nullable, several other places in FML assume ModFileInfo is not null. Keep this in mind
     public static @Nullable IModFileInfo modsTomlParser(final IModFile imodFile) {
         ModFile modFile = (ModFile) imodFile;
         LOGGER.debug(LogMarkers.LOADING,"Considering mod file candidate {}", modFile.getFilePath());
@@ -32,11 +35,19 @@ public class ModFileParser {
             LOGGER.warn(LogMarkers.LOADING, "Mod file {} is missing mods.toml file", modFile.getFilePath());
             return null;
         }
+        try {
+            final FileConfig fileConfig = FileConfig.builder(modsjson).build();
+            fileConfig.load();
+            fileConfig.close();
+            final NightConfigWrapper configWrapper = new NightConfigWrapper(fileConfig);
+            return new ModFileInfo(modFile, configWrapper, configWrapper::setFile);
+        } catch (ParsingException e) { // Handle landmine toml errors, e.g. incorrectly ported mods.
+            LOGGER.error("Mod candidate {} contains a corrupt or misconfigured toml.", modFile.getFileName());
+            throw new ModFileLoadingException("Mod candidate " + modFile.getFileName() + " contains a corrupt or misconfigured toml.");
+        } catch (Exception other) { // Otherwise this is just someone who (probably) forgot a comma or something.
+            LOGGER.error("Mod candidate {}'s toml .", modFile.getFileName());
+            throw new ModFileLoadingException("Mod candidate " + modFile.getFileName() + " contains broken toml, likely due to a typo.");
+        }
 
-        final FileConfig fileConfig = FileConfig.builder(modsjson).build();
-        fileConfig.load();
-        fileConfig.close();
-        final NightConfigWrapper configWrapper = new NightConfigWrapper(fileConfig);
-        return new ModFileInfo(modFile, configWrapper, configWrapper::setFile);
     }
 }


### PR DESCRIPTION
Apparently the original pr happened at a weird time, we missed putting this in 26.2. Also slightly improved the catch clause.