### PR TITLE
[26.1.2] Handle glfw window pos errors gracefully for wayland

### DIFF
--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -459,6 +459,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         this.winWidth = x[0];
         this.winHeight = y[0];
 
+        // Setting the window position isn't supported on wayland, so check the error here
         glfwSetWindowPos(window, (vidmode.width() - this.winWidth) / 2 + monitorX, (vidmode.height() - this.winHeight) / 2 + monitorY);
         handleLastGLFWError();
 
@@ -483,8 +484,10 @@ public class DisplayWindow implements ImmediateWindowProvider {
 
         // Show the window
         glfwShowWindow(window);
+        // Getting the window position isn't supported on wayland, so check the error here
         glfwGetWindowPos(window, x, y);
         handleLastGLFWError();
+        
         this.winX = x[0];
         this.winY = y[0];
         glfwGetFramebufferSize(window, x, y);

--- a/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
+++ b/fmlearlydisplay/src/main/java/net/minecraftforge/fml/earlydisplay/DisplayWindow.java
@@ -460,6 +460,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         this.winHeight = y[0];
 
         glfwSetWindowPos(window, (vidmode.width() - this.winWidth) / 2 + monitorX, (vidmode.height() - this.winHeight) / 2 + monitorY);
+        handleLastGLFWError();
 
         // Attempt setting the icon
 //        int[] channels = new int[1];
@@ -483,12 +484,25 @@ public class DisplayWindow implements ImmediateWindowProvider {
         // Show the window
         glfwShowWindow(window);
         glfwGetWindowPos(window, x, y);
+        handleLastGLFWError();
         this.winX = x[0];
         this.winY = y[0];
         glfwGetFramebufferSize(window, x, y);
         this.fbWidth = x[0];
         this.fbHeight = y[0];
         glfwPollEvents();
+    }
+
+    private static void handleLastGLFWError() {
+        handleLastGLFWError((error, description) -> {
+            if (error == GLFW_FEATURE_UNAVAILABLE) {
+                // suppress window pos errors for unsupported platforms (wayland)
+                LOGGER.debug(String.format("Suppressing GLFW error: [0x%X]%s", error, description));
+                return;
+            }
+
+            throw new IllegalStateException(String.format("GLFW error: [0x%X]%s", error, description));
+        });
     }
 
     private void winResize(long window, int width, int height) {


### PR DESCRIPTION
Fixes #10823
Gracefully handles Feature Unavailable errors after window pos calls and bails out for anything else. 