### PR TITLE
[1.20.1] Update equality check for RegistryObject to include RegistryObject#key.

### DIFF
--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -486,7 +486,7 @@ public final class RegistryObject<T> implements Supplier<T>
     {
         if (this == obj) return true;
         if (obj instanceof RegistryObject) {
-            return Objects.equals(((RegistryObject<?>)obj).name, name);
+            return Objects.equals(((RegistryObject<?>)obj).key, key) && Objects.equals(((RegistryObject<?>)obj).name, name);
         }
         return false;
     }

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -485,8 +485,8 @@ public final class RegistryObject<T> implements Supplier<T>
     public boolean equals(Object obj)
     {
         if (this == obj) return true;
-        if (obj instanceof RegistryObject) {
-            return Objects.equals(((RegistryObject<?>)obj).key, key) && Objects.equals(((RegistryObject<?>)obj).name, name);
+        if (obj instanceof RegistryObject o) {
+            return o.key == key && Objects.equals(o.name, name);
         }
         return false;
     }


### PR DESCRIPTION
As the PR name (and commit message) suggests, RegistryObject's override of #equals currently doesn't account for the key, which results in false positives for objects across different registries.


Making the PR for 1.20.1 because that's the version I need it on. Thanks in advance.