### PR TITLE
[1.21.4] Update equality check for RegistryObject to include RegistryObject#key.

### DIFF
--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -467,8 +467,8 @@ public final class RegistryObject<T> implements Supplier<T> {
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
-        if (obj instanceof RegistryObject o) {
-            return Objects.equals(o.name, name);
+        if (obj instanceof RegistryObject<?> o) {
+            return o.key == key && Objects.equals(o.name, name);
         }
         return false;
     }


### PR DESCRIPTION
See #10854 and #10856 for original PR reason and details.