### PR TITLE
Require permission level for /chase command

### DIFF
--- a/patches/minecraft/net/minecraft/server/commands/ChaseCommand.java.patch
+++ b/patches/minecraft/net/minecraft/server/commands/ChaseCommand.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/commands/ChaseCommand.java
++++ b/net/minecraft/server/commands/ChaseCommand.java
+@@ -30,6 +_,7 @@
+     public static void register(final CommandDispatcher<CommandSourceStack> dispatcher) {
+         dispatcher.register(
+             Commands.literal("chase")
++                .requires(Commands.hasPermission(Commands.LEVEL_OWNERS)) // Forge - add permission requirement for consistency.
+                 .then(
+                     Commands.literal("follow")
+                         .then(


### PR DESCRIPTION
In the base game for Java Edition, there is a security flaw with the "/chase" command. By default, it is available to all players, even if they don't have operator privileges. This allows any player with malicious intentions to abuse the tool. I reported this to Mojang, but they refused to address the issue (https://imgur.com/a/chase-exploit-jXYUTD0).

This patch changes the required permission level to 4. This ensures that the command is restricted, which significantly reduces the risk of it being abused. However, the "minecraft.command.chase" permission node can still be used if a server owner wishes to customise who has access to "/chase".