### PR TITLE
[1.20.1] Added forge data datagen for block elements

### DIFF
--- a/src/generated_test/resources/assets/new_model_loader_test/models/block/test_forge_data.json
+++ b/src/generated_test/resources/assets/new_model_loader_test/models/block/test_forge_data.json
@@ -1,0 +1,68 @@
+{
+  "elements": [
+    {
+      "faces": {
+        "down": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        },
+        "east": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        },
+        "north": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        },
+        "south": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        },
+        "up": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        },
+        "west": {
+          "forge_data": {
+            "block_light": 10,
+            "sky_light": 10
+          },
+          "texture": "#all"
+        }
+      },
+      "forge_data": {
+        "block_light": 15,
+        "sky_light": 15
+      },
+      "from": [
+        0,
+        0,
+        0
+      ],
+      "to": [
+        16,
+        16,
+        16
+      ]
+    }
+  ],
+  "render_type": "minecraft:cutout",
+  "textures": {
+    "all": "minecraft:block/diamond_ore"
+  }
+}

--- a/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
+++ b/src/generated_test/resources/assets/new_model_loader_test/models/item/item_layers.json
@@ -10,6 +10,7 @@
   },
   "loader": "forge:item_layers",
   "render_types": {},
+  "render_types_fast": {},
   "textures": {
     "layer0": "minecraft:item/coal",
     "layer1": "minecraft:item/stick",

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -361,6 +361,10 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
                     partObj.addProperty("shade", part.shade);
                 }
 
+                if (!part.getFaceData().equals(ForgeFaceData.DEFAULT)) {
+                    partObj.add("forge_data", ForgeFaceData.CODEC.encodeStart(JsonOps.INSTANCE, part.getFaceData()).result().get());
+                }
+
                 JsonObject faces = new JsonObject();
                 for (Direction dir : Direction.values()) {
                     BlockElementFace face = part.faces.get(dir);

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -247,6 +247,12 @@ public class NewModelLoaderTest
                             .with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH)
                             .addModels(new ConfiguredModel(model, 0, 180, false))
                     .partialState();
+            models().getBuilder("test_forge_data")
+                    .texture("all", mcLoc("block/diamond_ore"))
+                    .element().from(0.0F, 0.0F, 0.0F).to(16.0F, 16.0F, 16.0F)
+                    .allFaces((dir, face) -> face.texture("#all").emissivity(10, 10))
+                    .emissivity(15, 15).end()
+                    .renderType("cutout");
         }
     }
 }


### PR DESCRIPTION
Added `forge_data` datagen for block elements. This was previously only working for block element faces.