### PR TITLE
[26.2] Fixed ItemTooltipEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -97,7 +97,7 @@
              List<Component> lines = Lists.newArrayList();
              lines.add(this.getStyledHoverName());
              this.addDetailsToTooltip(context, display, player, tooltipFlag, lines::add);
-+            net.minecraftforge.event.ForgeEventFactory.onItemTooltip(this, player, lines, tooltipFlag);
++            net.minecraftforge.event.ForgeEventFactory.onItemTooltip(this, player, lines, tooltipFlag, context, display);
              return lines;
          }
      }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -21,6 +21,7 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.util.random.WeightedList;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraftforge.common.util.Result;
 import org.jetbrains.annotations.ApiStatus;
@@ -354,8 +355,8 @@ public final class ForgeEventFactory {
         return BlockEvent.FluidPlaceBlockEvent.BUS.fire(new BlockEvent.FluidPlaceBlockEvent(level, pos, liquidPos, state)).getNewState();
     }
 
-    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags) {
-        return ItemTooltipEvent.BUS.fire(new ItemTooltipEvent(itemStack, entityPlayer, list, flags));
+    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context, TooltipDisplay display) {
+        return ItemTooltipEvent.BUS.fire(new ItemTooltipEvent(itemStack, entityPlayer, list, flags, context, display));
     }
 
     public static SummonAidEvent fireZombieSummonAid(Zombie zombie, Level level, int x, int y, int z, LivingEntity attacker, double summonChance) {

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -16,6 +16,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +36,7 @@ public final class ItemTooltipEvent extends MutableEvent implements PlayerEvent 
      * This event is fired in {@link ItemStack#getTooltipLines(Item.TooltipContext, Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
      * Tooltips are also gathered with a null player during startup by {@link Minecraft#createSearchTrees()}.
      */
+    @ApiStatus.Internal
     public ItemTooltipEvent(@NotNull ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags, Item.TooltipContext context, TooltipDisplay display)
     {
         this.player = player;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -8,10 +8,12 @@ package net.minecraftforge.event.entity.player;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.NotNull;
@@ -25,17 +27,39 @@ public final class ItemTooltipEvent extends MutableEvent implements PlayerEvent 
     @NotNull
     private final ItemStack itemStack;
     private final List<Component> toolTip;
+    private final Item.TooltipContext context;
+    private final TooltipDisplay display;
 
     /**
-     * This event is fired in {@link ItemStack#getTooltipLines(Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
+     *
+     * This event is fired in {@link ItemStack#getTooltipLines(Item.TooltipContext, Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
      * Tooltips are also gathered with a null player during startup by {@link Minecraft#createSearchTrees()}.
      */
-    public ItemTooltipEvent(@NotNull ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags)
+    public ItemTooltipEvent(@NotNull ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags, Item.TooltipContext context, TooltipDisplay display)
     {
         this.player = player;
         this.itemStack = itemStack;
         this.toolTip = list;
         this.flags = flags;
+        this.context = context;
+        this.display = display;
+    }
+
+
+    /**
+     * The {@link net.minecraft.world.item.Item.TooltipContext} for this tooltip.
+     */
+    public Item.TooltipContext getContext()
+    {
+        return context;
+    }
+
+    /**
+     * The {@link net.minecraft.world.item.component.TooltipDisplay} for this tooltip.
+     */
+    public TooltipDisplay getDisplay()
+    {
+        return display;
     }
 
     /**


### PR DESCRIPTION
Fixed ItemToolTipEvent to allow modders to access the Tooltip Context and Display objects.

