### PR TITLE
[26.2] Fixed getToolModifiedState for AXE_SCRAPE

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/AxeItem.java.patch
@@ -25,7 +25,7 @@
              return strippedBlock;
          } else {
 -            Optional<BlockState> scrapedBlock = WeatheringCopper.getPrevious(oldState);
-+            var scrape = ctx == null ? null : oldState.getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.AXE_STRIP, false);
++            var scrape = ctx == null ? null : oldState.getToolModifiedState(ctx, net.minecraftforge.common.ToolActions.AXE_SCRAPE, false);
 +            Optional<BlockState> scrapedBlock = scrape != null ? Optional.of(scrape) : WeatheringCopper.getPrevious(oldState);
              if (scrapedBlock.isPresent()) {
                  spawnSoundAndParticle(level, pos, player, oldState, SoundEvents.AXE_SCRAPE, 3005);


### PR DESCRIPTION
Noticed that the AXE_STRIP ToolAction is called twice, once for the strip action and again for the scrape action. Fixed so that there can be custom scrapes.